### PR TITLE
Feature/5242 refactor embed annotation

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -38,7 +38,7 @@ class Account < ActiveRecord::Base
 
   def data
     em = self.annotations('embed').last
-    em.embed
+    JSON.parse(em.embed)
   end
 
   private

--- a/app/models/annotations/embed.rb
+++ b/app/models/annotations/embed.rb
@@ -1,11 +1,31 @@
 class Embed
   include AnnotationBase
 
-  attribute :embed, String, presence: true
-  validates_presence_of :embed
+  attribute :title, String
+  attribute :description, String
+  attribute :username, String
+  attribute :published_at,  Integer
+  attribute :quote, String
+  attribute :embed, String
+  validate :exist_of_title_or_embed
 
   def content
-    { embed: self.embed }.to_json
+    {
+      title: self.title,
+      description: self.description,
+      username: self.username,
+      published_at: self.published_at,
+      quote: self.quote,
+      embed: self.embed
+    }.to_json
+  end
+
+  private
+
+  def exist_of_title_or_embed
+    if self.embed.blank? and self.title.blank?
+      errors.add(:base, "Should fill at least one filed [title or embed]")
+    end
   end
 
 end

--- a/app/models/annotations/embed.rb
+++ b/app/models/annotations/embed.rb
@@ -24,7 +24,7 @@ class Embed
 
   def exist_of_title_or_embed
     if self.embed.blank? and self.title.blank?
-      errors.add(:base, "Should fill at least one filed [title or embed]")
+      errors.add(:base, "Should fill at least one field [title or embed]")
     end
   end
 

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -43,14 +43,13 @@ class Media < ActiveRecord::Base
   def data(context = nil)
     #TODO:: change the assumsion for a one Pender result
     em_pender = self.annotations('embed').last
-    embed = em_pender.embed unless em_pender.nil?
+    embed = JSON.parse(em_pender.embed) unless em_pender.nil?
     em_u = self.annotations('embed')
     context_id = context.nil? ? nil : context.id
     em_u.reverse.each do |obj|
       if obj.context_id.to_i == context_id.to_i
-        obj.embed.each do |k, v|
-          # any key can be overriden including URL
-          embed[k] = v
+        ['title', 'description', 'quote'].each do |k|
+          embed[k] = obj[k] unless obj[k].nil?
         end
       end
     end
@@ -94,7 +93,10 @@ class Media < ActiveRecord::Base
   def information=(info)
     info = JSON.parse(info)
     em = Embed.new
-    em.embed = info
+    ['title', 'description', 'quote'].each do |k|
+      em[k] = info[k] unless info[k].blank?
+    end
+    em.embed = {"oembed": info}.to_json
     em.annotated = self
     em.annotator = self.current_user unless self.current_user.nil?
     em.context = self.project unless self.project.nil?

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -44,6 +44,7 @@ class Media < ActiveRecord::Base
     #TODO:: change the assumsion for a one Pender result
     em_pender = self.annotations('embed').last
     embed = JSON.parse(em_pender.embed) unless em_pender.nil?
+    # TODO: call annotations with context
     em_u = self.annotations('embed')
     context_id = context.nil? ? nil : context.id
     em_u.reverse.each do |obj|

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -96,7 +96,7 @@ class Media < ActiveRecord::Base
     ['title', 'description', 'quote'].each do |k|
       em[k] = info[k] unless info[k].blank?
     end
-    em.embed = {"oembed": info}.to_json
+    em.embed = info.to_json
     em.annotated = self
     em.annotator = self.current_user unless self.current_user.nil?
     em.context = self.project unless self.project.nil?

--- a/db/migrate/20160927082810_remove_data_from_medias.rb
+++ b/db/migrate/20160927082810_remove_data_from_medias.rb
@@ -1,12 +1,8 @@
 class RemoveDataFromMedias < ActiveRecord::Migration
   def change
-    pender = Bot.where(name: 'Pender').last
     Media.find_each do |media|
-      em = Embed.new
-      em.embed = media.read_attribute(:data)
-      em.annotated = media
-      em.annotator = pender unless pender.nil?
-      em.save!
+      media.pender_data= media.read_attribute(:data)
+      media.set_pender_result_as_annotation
      end
 
     remove_column :medias, :data

--- a/db/migrate/20160927085541_remove_data_from_accounts.rb
+++ b/db/migrate/20160927085541_remove_data_from_accounts.rb
@@ -2,11 +2,8 @@ class RemoveDataFromAccounts < ActiveRecord::Migration
   def change
     pender = Bot.where(name: 'Pender').last
     Account.find_each do |account|
-      em = Embed.new
-      em.embed = account.read_attribute(:data)
-      em.annotated = account
-      em.annotator = pender unless pender.nil?
-      em.save!
+      account.pender_data= account.read_attribute(:data)
+      account.set_pender_result_as_annotation
     end
 
     remove_column :accounts, :data

--- a/lib/pender_data.rb
+++ b/lib/pender_data.rb
@@ -15,9 +15,14 @@ module PenderData
 
   def set_pender_result_as_annotation
     unless self.pender_data.nil?
+      data = self.pender_data
       pender = Bot.where(name: 'Pender').last
       em = Embed.new
-      em.embed = self.pender_data
+      ['title', 'description', 'username'].each do |k|
+        em[k] = data[k]
+      end
+      em.published_at = data['published_at'].to_time.to_i unless data['published_at'].nil?
+      em.embed = data.to_json
       em.annotated = self
       em.annotator = pender unless pender.nil?
       em.save!

--- a/test/models/embed_test.rb
+++ b/test/models/embed_test.rb
@@ -23,15 +23,25 @@ class EmbedTest < ActiveSupport::TestCase
     assert_equal 'embed', em.annotation_type
   end
 
-  test "should have embed" do
+  test "should have embed or title" do
     assert_no_difference 'Embed.length' do
       em = Embed.new
       assert_raise RuntimeError do
-         em.embed = nil; em.save!
+         em.embed = nil; em.title = nil
+         em.save!
       end
       assert_raise RuntimeError do
-         em.embed = ''; em.save!
+         em.embed = ''; em.title = ''
+         em.save!
       end
+    end
+    assert_difference 'Embed.length' do
+      em = Embed.new
+      em.title = 'test'; em.save!
+    end
+    assert_difference 'Embed.length' do
+      em = Embed.new
+      em.embed = 'test'; em.save!
     end
   end
 
@@ -124,7 +134,7 @@ class EmbedTest < ActiveSupport::TestCase
 
   test "should have content" do
     em = create_embed
-    assert_equal ['embed'], JSON.parse(em.content).keys
+    assert_equal ["title", "description", "username", "published_at", "quote", "embed"].sort, JSON.parse(em.content).keys.sort
   end
 
   test "should have annotators" do


### PR DESCRIPTION
* Added new fields to embed annotations: 
  - `title`: string
  - `description`: string
  - `username`: string
  - `published_at`: integer (UNIX timestamp)
  - `quote`: string
* Populate the above fields by reading them from the Pender data
* Re-write migration