### PR TITLE
Ticket #5580: Handle denied access and not authed on AdminUI

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,14 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   skip_before_filter :verify_authenticity_token
 
+  rescue_from CanCan::AccessDenied do |exception|
+    redirect_to '/403.html'
+  end
+
+  def authenticated?
+    redirect_to('/') unless signed_in?
+  end
+
   private
 
   def render_success(type = 'success', object = nil)

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -2,10 +2,10 @@ RailsAdmin.config do |config|
 
   ### Popular gems integration
 
+  config.parent_controller = 'ApplicationController'
+
   ## == Devise ==
-  config.authenticate_with do
-    warden.authenticate!
-  end
+  config.authenticate_with(&:authenticated?)
   config.current_user_method(&:current_api_user)
 
   # == Cancan ==

--- a/public/403.html
+++ b/public/403.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Forbidden (403)</title>
+  <style>
+  body {
+    background-color: #EFEFEF;
+    color: #2E2F30;
+    text-align: center;
+    font-family: arial, sans-serif;
+  }
+
+  div.dialog {
+    width: 25em;
+    margin: 4em auto 0 auto;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-left-color: #999;
+    border-bottom-color: #BBB;
+    border-top: #B00100 solid 4px;
+    border-top-left-radius: 9px;
+    border-top-right-radius: 9px;
+    background-color: white;
+    padding: 7px 4em 0 4em;
+  }
+
+  h1 {
+    font-size: 100%;
+    color: #730E15;
+    line-height: 1.5em;
+  }
+
+  body > p {
+    width: 33em;
+    margin: 0 auto 1em;
+    padding: 1em 0;
+    background-color: #F7F7F7;
+    border: 1px solid #CCC;
+    border-right-color: #999;
+    border-bottom-color: #999;
+    border-bottom-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-top-color: #DADADA;
+    color: #666;
+    box-shadow:0 3px 8px rgba(50, 50, 50, 0.17);
+  }
+  </style>
+</head>
+
+<body>
+  <!-- This file lives in public/403.html -->
+  <div class="dialog">
+    <h1>You don't have access to this page.</h1>
+    <p>Sorry, but you tried to access something that you don't have access to.</p>
+  </div>
+  <p>You can ask some administrator for help.</p>
+</body>
+</html>


### PR DESCRIPTION
On denied access the user is redirect to a Forbidden page
When not authed the user is redirected to the login page