### PR TITLE
Ticket #5755: Add AdminAbility to be used on Admin UI

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -47,5 +47,6 @@ exclude_paths:
 - "app/graphql"
 - "doc"
 - "app/models/ability.rb"
+- "app/models/admin_ability.rb"
 - "config/initializers/rails_admin.rb"
 - ".codeclimate.yml"

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,5 +1,5 @@
 class Ability
-  include CanCan::Ability
+  include CheckBasicAbilities
 
   def initialize(user = nil)
     alias_action :create, :update, :destroy, :to => :cud
@@ -29,12 +29,6 @@ class Ability
   end
 
   private
-
-  def global_admin_perms
-    can :access, :rails_admin
-    can :dashboard
-    can :manage, :all
-  end
 
   def owner_perms
     can :access, :rails_admin
@@ -155,67 +149,5 @@ class Ability
       v_obj = obj.item_type.constantize.find(obj.item_id) if obj.item_type == 'ProjectMedia'
       !v_obj.nil? and v_obj.project.team_id == @context_team.id and v_obj.media.user_id = @user.id
     end
-  end
-
-  def authenticated_perms
-    can :create, Team
-    can :create, TeamUser, :user_id => @user.id, status: ['member', 'requested']
-
-    # Permissions for registration and login
-    can :create, Source, :user_id => @user.id
-    can :update, User, :id => @user.id
-    can :create, Account, :user_id => @user.id
-    can :create, Embed, :annotated_id => @user.account_ids
-  end
-
-  # Extra permissions for all users
-  def extra_perms_for_all_users
-    can :create, User
-    can :create, PaperTrail::Version
-    can :read, Team, :private => false
-    can :read, Team, :private => true, :team_users => { :user_id => @user.id, :status => 'member' }
-
-    # A @user can read a user if:
-    # 1) @user is the same as target user
-    # 2) target user is a member of at least one public team
-    # 3) @user is a member of at least one same team as the target user
-    can :read, User, id: @user.id
-    can :read, User, teams: { private: false }
-    can :read, User, team_users: { status: 'member', team: { team_users: { user_id: @user.id, status: 'member' }}}
-
-    # A @user can read contact, project or team user if:
-    # 1) team is private and @user is a member of that team
-    # 2) team user is not private
-    can :read, [Contact, Project, TeamUser], team: { team_users: { user_id: @user.id, status: 'member'} }
-    can :read, [Contact, Project, TeamUser], team: { private: false }
-
-    # A @user can read any of those objects if:
-    # 1) it's a source related to him/her or not related to any user
-    # 2) it's related to at least one public team
-    # 3) it's related to a private team which the @user has access to
-    can :read, [Account, ProjectMedia, Source], user_id: [@user.id, nil]
-    can :read, [Source, Media, Link, Claim], projects: { team: { private: false }}
-    can :read, [Source, Media, Link, Claim], projects: { team: { team_users: { user_id: @user.id, status: 'member' }}}
-
-    can :read, [Account, ProjectSource], source: { user_id: [@user.id, nil] }
-    can :read, Account, source: { projects: { team: { private: false, team_users: { user_id: @user.id }}}}
-    can :read, Account, source: { projects: { team: { team_users: { user_id: @user.id, status: 'member' }}}}
-    can :read, [ProjectMedia, ProjectSource], project: { team: { private: false } }
-    can :read, [ProjectMedia, ProjectSource], project: { team: { team_users: { user_id: @user.id, status: 'member' }}}
-
-    %w(comment flag status embed tag dynamic task annotation).each do |annotation_type|
-      can :read, annotation_type.classify.constantize, ['annotation_type = ?', annotation_type] do |obj|
-        team_ids = obj.get_team
-        teams = Team.where(id: team_ids, private: false)
-        if teams.empty?
-          tu = TeamUser.where(user_id: @user.id, team_id: team_ids, status: 'member')
-          TeamUser.where(user_id: @user.id, team_id: team_ids, status: 'member').exists?
-        else
-          teams.any?
-        end
-      end
-    end
-
-    cannot :manage, ApiKey
   end
 end

--- a/app/models/admin_ability.rb
+++ b/app/models/admin_ability.rb
@@ -1,5 +1,5 @@
 class AdminAbility
-  include CanCan::Ability
+  include CheckBasicAbilities
 
   def initialize(user = nil)
     @user = User.current ||= user || User.new
@@ -19,12 +19,6 @@ class AdminAbility
   end
 
   private
-
-  def global_admin_perms
-    can :access, :rails_admin
-    can :dashboard
-    can :manage, :all
-  end
 
   def owner_perms
     can :access, :rails_admin
@@ -90,65 +84,4 @@ class AdminAbility
     end
   end
 
-  def authenticated_perms
-    can :create, Team
-    can :create, TeamUser, :user_id => @user.id, status: ['member', 'requested']
-
-    # Permissions for registration and login
-    can :create, Source, :user_id => @user.id
-    can :update, User, :id => @user.id
-    can :create, Account, :user_id => @user.id
-    can :create, Embed, :annotated_id => @user.account_ids
-  end
-
-  # Extra permissions for all users
-  def extra_perms_for_all_users
-    can :create, User
-    can :create, PaperTrail::Version
-    can :read, Team, :private => false
-    can :read, Team, :private => true, :team_users => { :user_id => @user.id, :status => 'member' }
-
-    # A @user can read a user if:
-    # 1) @user is the same as target user
-    # 2) target user is a member of at least one public team
-    # 3) @user is a member of at least one same team as the target user
-    can :read, User, id: @user.id
-    can :read, User, teams: { private: false }
-    can :read, User, team_users: { status: 'member', team: { team_users: { user_id: @user.id, status: 'member' }}}
-
-    # A @user can read contact, project or team user if:
-    # 1) team is private and @user is a member of that team
-    # 2) team user is not private
-    can :read, [Contact, Project, TeamUser], team: { team_users: { user_id: @user.id, status: 'member'} }
-    can :read, [Contact, Project, TeamUser], team: { private: false }
-
-    # A @user can read any of those objects if:
-    # 1) it's a source related to him/her or not related to any user
-    # 2) it's related to at least one public team
-    # 3) it's related to a private team which the @user has access to
-    can :read, [Account, ProjectMedia, Source], user_id: [@user.id, nil]
-    can :read, [Source, Media, Link, Claim], projects: { team: { private: false }}
-    can :read, [Source, Media, Link, Claim], projects: { team: { team_users: { user_id: @user.id, status: 'member' }}}
-
-    can :read, [Account, ProjectSource], source: { user_id: [@user.id, nil] }
-    can :read, Account, source: { projects: { team: { private: false, team_users: { user_id: @user.id }}}}
-    can :read, Account, source: { projects: { team: { team_users: { user_id: @user.id, status: 'member' }}}}
-    can :read, [ProjectMedia, ProjectSource], project: { team: { private: false } }
-    can :read, [ProjectMedia, ProjectSource], project: { team: { team_users: { user_id: @user.id, status: 'member' }}}
-
-    %w(comment flag status embed tag dynamic task annotation).each do |annotation_type|
-      can :read, annotation_type.classify.constantize, ['annotation_type = ?', annotation_type] do |obj|
-        team_ids = obj.get_team
-        teams = Team.where(id: team_ids, private: false)
-        if teams.empty?
-          tu = TeamUser.where(user_id: @user.id, team_id: team_ids, status: 'member')
-          TeamUser.where(user_id: @user.id, team_id: team_ids, status: 'member').exists?
-        else
-          teams.any?
-        end
-      end
-    end
-
-    cannot :manage, ApiKey
-  end
 end

--- a/app/models/admin_ability.rb
+++ b/app/models/admin_ability.rb
@@ -1,0 +1,154 @@
+class AdminAbility
+  include CanCan::Ability
+
+  def initialize(user = nil)
+    @user = User.current ||= user || User.new
+    @teams = @user.teams_owned.map(&:id)
+    # Define User abilities
+    if @user.is_admin?
+      global_admin_perms
+    else
+      extra_perms_for_all_users
+      if @user.id
+        authenticated_perms
+      end
+      if @teams.any?
+        owner_perms
+      end
+    end
+  end
+
+  private
+
+  def global_admin_perms
+    can :access, :rails_admin
+    can :dashboard
+    can :manage, :all
+  end
+
+  def owner_perms
+    can :access, :rails_admin
+    can :dashboard
+
+    can [:update, :destroy], User, :team_users => { :team_id => @teams, role: ['owner', 'editor', 'journalist', 'contributor'] }
+
+    can :create, Team
+    can [:update, :destroy], Team, :id => @teams
+    can :create, TeamUser, :team_id => @teams, role: ['owner', 'editor', 'journalist', 'contributor']
+    can :update, TeamUser, team_id: @teams
+    can :destroy, TeamUser, user_id: @user.id
+    cannot :update, TeamUser, team_id: @teams, user_id: @user.id
+    can [:create, :update, :destroy], Contact, :team_id => @teams
+    can [:create, :update], Project, :team_id => @teams
+    can :update, Project, :team_id => @teams, :user_id => @user.id
+    can :destroy, Project, :team_id => @teams
+    can :export_project, Project, team_id: @teams
+
+    can :create, [Media, Account, Source, Comment, Embed, Link, Claim, Dynamic]
+    can :update, [Media, Link, Claim], :user_id => @user.id
+    can :update, [Media, Link, Claim], projects: { team: { id: @teams }}
+    can [:update, :destroy], [Media, Link, Claim] do |obj|
+      (obj.get_team & @teams).any?
+    end
+    can :update, [Account, Source, Embed]
+    can [:create, :update], [ProjectSource, ProjectMedia], project: { team: { id: @teams }}
+    can :destroy, [ProjectMedia, ProjectSource], project: { team: { id: @teams }}
+    %w(annotation comment flag status tag embed dynamic task).each do |annotation_type|
+      can [:create, :destroy], annotation_type.classify.constantize, ['annotation_type = ?', annotation_type] do |obj|
+        (obj.get_team & @teams).any?
+      end
+    end
+    %w(annotation comment flag status embed dynamic task).each do |annotation_type|
+      can [:update], annotation_type.classify.constantize, ['annotation_type = ?', annotation_type] do |obj|
+        (obj.get_team & @teams).any?
+      end
+    end
+    can [:destroy, :update], [Dynamic, Annotation, Task] do |obj|
+      obj.annotator_id.to_i == @user.id
+    end
+    can [:create, :update, :destroy], DynamicAnnotation::Field do |obj|
+      obj.annotation.annotator_id == @user.id
+    end
+    can :update, [Dynamic, Annotation] do |obj|
+      (obj.get_team & @teams).any?
+    end
+    can :update, DynamicAnnotation::Field do |obj|
+      (obj.annotation.get_team & @teams).any?
+    end
+    can :update, Task, ['annotation_type = ?', 'task'] do |obj|
+      before, after = obj.data_change
+      changes = (after.to_a - before.to_a).to_h
+      (obj.get_team & @teams).any? && changes.keys == ['status']
+    end
+    can :destroy, PaperTrail::Version do |obj|
+      teams = []
+      v_obj = obj.item_type.constantize.find(obj.item_id)
+      teams = v_obj.get_team if v_obj.respond_to?(:get_team)
+      teams << v_obj.team_id if teams.blank? and v_obj.respond_to?(:team)
+      teams << v_obj.project.team_id if teams.blank? and v_obj.respond_to?(:project)
+      (teams & @teams).any?
+    end
+  end
+
+  def authenticated_perms
+    can :create, Team
+    can :create, TeamUser, :user_id => @user.id, status: ['member', 'requested']
+
+    # Permissions for registration and login
+    can :create, Source, :user_id => @user.id
+    can :update, User, :id => @user.id
+    can :create, Account, :user_id => @user.id
+    can :create, Embed, :annotated_id => @user.account_ids
+  end
+
+  # Extra permissions for all users
+  def extra_perms_for_all_users
+    can :create, User
+    can :create, PaperTrail::Version
+    can :read, Team, :private => false
+    can :read, Team, :private => true, :team_users => { :user_id => @user.id, :status => 'member' }
+
+    # A @user can read a user if:
+    # 1) @user is the same as target user
+    # 2) target user is a member of at least one public team
+    # 3) @user is a member of at least one same team as the target user
+    can :read, User, id: @user.id
+    can :read, User, teams: { private: false }
+    can :read, User, team_users: { status: 'member', team: { team_users: { user_id: @user.id, status: 'member' }}}
+
+    # A @user can read contact, project or team user if:
+    # 1) team is private and @user is a member of that team
+    # 2) team user is not private
+    can :read, [Contact, Project, TeamUser], team: { team_users: { user_id: @user.id, status: 'member'} }
+    can :read, [Contact, Project, TeamUser], team: { private: false }
+
+    # A @user can read any of those objects if:
+    # 1) it's a source related to him/her or not related to any user
+    # 2) it's related to at least one public team
+    # 3) it's related to a private team which the @user has access to
+    can :read, [Account, ProjectMedia, Source], user_id: [@user.id, nil]
+    can :read, [Source, Media, Link, Claim], projects: { team: { private: false }}
+    can :read, [Source, Media, Link, Claim], projects: { team: { team_users: { user_id: @user.id, status: 'member' }}}
+
+    can :read, [Account, ProjectSource], source: { user_id: [@user.id, nil] }
+    can :read, Account, source: { projects: { team: { private: false, team_users: { user_id: @user.id }}}}
+    can :read, Account, source: { projects: { team: { team_users: { user_id: @user.id, status: 'member' }}}}
+    can :read, [ProjectMedia, ProjectSource], project: { team: { private: false } }
+    can :read, [ProjectMedia, ProjectSource], project: { team: { team_users: { user_id: @user.id, status: 'member' }}}
+
+    %w(comment flag status embed tag dynamic task annotation).each do |annotation_type|
+      can :read, annotation_type.classify.constantize, ['annotation_type = ?', annotation_type] do |obj|
+        team_ids = obj.get_team
+        teams = Team.where(id: team_ids, private: false)
+        if teams.empty?
+          tu = TeamUser.where(user_id: @user.id, team_id: team_ids, status: 'member')
+          TeamUser.where(user_id: @user.id, team_id: team_ids, status: 'member').exists?
+        else
+          teams.any?
+        end
+      end
+    end
+
+    cannot :manage, ApiKey
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,6 +43,10 @@ class User < ActiveRecord::Base
     role
   end
 
+  def teams_owned
+    self.teams.joins(:team_users).where({'team_users.role': 'owner', 'team_users.status': 'member'})
+  end
+
   def self.from_omniauth(auth)
     # Update uuid for facebook account if match email and provider
     self.update_facebook_uuid(auth) if auth.provider == 'facebook'

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -16,7 +16,7 @@ RailsAdmin.config do |config|
   config.current_user_method(&:current_api_user)
 
   # == Cancan ==
-  config.authorize_with :cancan
+  config.authorize_with :cancan, AdminAbility
 
   ## == Pundit ==
   # config.authorize_with :pundit

--- a/lib/check_basic_abilities.rb
+++ b/lib/check_basic_abilities.rb
@@ -58,7 +58,6 @@ module CheckBasicAbilities
         team_ids = obj.get_team
         teams = Team.where(id: team_ids, private: false)
         if teams.empty?
-          tu = TeamUser.where(user_id: @user.id, team_id: team_ids, status: 'member')
           TeamUser.where(user_id: @user.id, team_id: team_ids, status: 'member').exists?
         else
           teams.any?

--- a/lib/check_basic_abilities.rb
+++ b/lib/check_basic_abilities.rb
@@ -1,0 +1,72 @@
+module CheckBasicAbilities
+  include CanCan::Ability
+
+  def global_admin_perms
+    can :access, :rails_admin
+    can :dashboard
+    can :manage, :all
+  end
+
+  def authenticated_perms
+    can :create, Team
+    can :create, TeamUser, :user_id => @user.id, status: ['member', 'requested']
+
+    # Permissions for registration and login
+    can :create, Source, :user_id => @user.id
+    can :update, User, :id => @user.id
+    can :create, Account, :user_id => @user.id
+    can :create, Embed, :annotated_id => @user.account_ids
+  end
+
+  # Extra permissions for all users
+  def extra_perms_for_all_users
+    can :create, User
+    can :create, PaperTrail::Version
+    can :read, Team, :private => false
+    can :read, Team, :private => true, :team_users => { :user_id => @user.id, :status => 'member' }
+
+    # A @user can read a user if:
+    # 1) @user is the same as target user
+    # 2) target user is a member of at least one public team
+    # 3) @user is a member of at least one same team as the target user
+    can :read, User, id: @user.id
+    can :read, User, teams: { private: false }
+    can :read, User, team_users: { status: 'member', team: { team_users: { user_id: @user.id, status: 'member' }}}
+
+    # A @user can read contact, project or team user if:
+    # 1) team is private and @user is a member of that team
+    # 2) team user is not private
+    can :read, [Contact, Project, TeamUser], team: { team_users: { user_id: @user.id, status: 'member'} }
+    can :read, [Contact, Project, TeamUser], team: { private: false }
+
+    # A @user can read any of those objects if:
+    # 1) it's a source related to him/her or not related to any user
+    # 2) it's related to at least one public team
+    # 3) it's related to a private team which the @user has access to
+    can :read, [Account, ProjectMedia, Source], user_id: [@user.id, nil]
+    can :read, [Source, Media, Link, Claim], projects: { team: { private: false }}
+    can :read, [Source, Media, Link, Claim], projects: { team: { team_users: { user_id: @user.id, status: 'member' }}}
+
+    can :read, [Account, ProjectSource], source: { user_id: [@user.id, nil] }
+    can :read, Account, source: { projects: { team: { private: false, team_users: { user_id: @user.id }}}}
+    can :read, Account, source: { projects: { team: { team_users: { user_id: @user.id, status: 'member' }}}}
+    can :read, [ProjectMedia, ProjectSource], project: { team: { private: false } }
+    can :read, [ProjectMedia, ProjectSource], project: { team: { team_users: { user_id: @user.id, status: 'member' }}}
+
+    %w(comment flag status embed tag dynamic task annotation).each do |annotation_type|
+      can :read, annotation_type.classify.constantize, ['annotation_type = ?', annotation_type] do |obj|
+        team_ids = obj.get_team
+        teams = Team.where(id: team_ids, private: false)
+        if teams.empty?
+          tu = TeamUser.where(user_id: @user.id, team_id: team_ids, status: 'member')
+          TeamUser.where(user_id: @user.id, team_id: team_ids, status: 'member').exists?
+        else
+          teams.any?
+        end
+      end
+    end
+
+    cannot :manage, ApiKey
+  end
+
+end

--- a/test/models/admin_ability_test.rb
+++ b/test/models/admin_ability_test.rb
@@ -1,0 +1,443 @@
+require File.join(File.expand_path(File.dirname(__FILE__)), '..', 'test_helper')
+
+class AdminAbilityTest < ActiveSupport::TestCase
+
+  test "owner permissions for project" do
+    u = create_user
+    t = create_team
+    tu = create_team_user user: u , team: t, role: 'owner'
+    p = create_project team: t
+    own_project = create_project team: t, user: u
+    p2 = create_project
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:create, Project)
+      assert ability.can?(:update, p)
+      assert ability.can?(:update, own_project)
+      assert ability.can?(:destroy, p)
+      assert ability.can?(:destroy, own_project)
+      assert ability.cannot?(:update, p2)
+      assert ability.cannot?(:destroy, p2)
+    end
+  end
+
+  test "owner permissions for media" do
+    u = create_user
+    t = create_team
+    tu = create_team_user team: t, user: u , role: 'owner'
+    m = create_valid_media
+    p = create_project team: t
+    pm = create_project_media project: p, media: m
+    own_media = create_valid_media user_id: u.id
+    own_pm = create_project_media project: p, media: own_media
+    m2 = create_valid_media
+    pm2 = create_project_media media: m2
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:create, Media)
+      assert ability.can?(:update, m)
+      assert ability.can?(:update, own_media)
+      assert ability.can?(:destroy, m)
+      assert ability.can?(:destroy, own_media)
+      assert ability.can?(:update, pm)
+      assert ability.can?(:update, own_pm)
+      assert ability.can?(:destroy, pm)
+      assert ability.can?(:destroy, own_pm)
+      assert ability.cannot?(:update, m2)
+      assert ability.cannot?(:destroy, m2)
+      assert ability.cannot?(:update, pm2)
+      assert ability.cannot?(:destroy, pm2)
+    end
+  end
+
+  test "owner permissions for team" do
+    u = create_user
+    t = create_team
+    tu = create_team_user user: u, team: t , role: 'owner'
+    t2 = create_team
+    tu_test = create_team_user team: t2, role: 'owner'
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:create, Team)
+      assert ability.can?(:update, t)
+      assert ability.can?(:destroy, t)
+      assert ability.cannot?(:update, t2)
+      assert ability.cannot?(:destroy, t2)
+    end
+  end
+
+  test "owner permissions for teamUser" do
+    u = create_user
+    t = create_team
+    tu = create_team_user user: u, team: t , role: 'owner'
+    u2 = create_user
+    tu2 = create_team_user team: t, role: 'editor'
+    tu_other = create_team_user
+
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:create, TeamUser)
+      assert ability.can?(:update, tu2)
+      assert ability.cannot?(:destroy, tu2)
+      assert ability.cannot?(:update, tu_other)
+      assert ability.cannot?(:destroy, tu_other)
+    end
+  end
+
+  test "owner permissions for contact" do
+    u = create_user
+    t = create_team
+    tu = create_team_user user: u, team: t , role: 'owner'
+    c = create_contact team: t
+    c1 = create_contact
+
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:create, Contact)
+      assert ability.can?(:update, c)
+      assert ability.can?(:destroy, c)
+      assert ability.cannot?(:update, c1)
+      assert ability.cannot?(:destroy, c1)
+    end
+  end
+
+  test "owner permissions for user" do
+    u = create_user
+    t = create_team
+    tu = create_team_user team: t, user: u, role: 'owner'
+    u2_test = create_user
+    tu2_test = create_team_user user: u2_test , role: 'contributor'
+    u_test1 = create_user
+    tu_test1 = create_team_user team: t, user: u_test1, role: 'editor'
+
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:update, u)
+      assert ability.can?(:destroy, u)
+      assert ability.can?(:update, u_test1)
+      assert ability.can?(:destroy, u_test1)
+
+      tu_test1.update_column(:role, 'journalist')
+
+      assert ability.can?(:update, u_test1)
+      assert ability.can?(:destroy, u_test1)
+
+      tu_test1.update_column(:role, 'contributor')
+
+      assert ability.can?(:update, u_test1)
+      assert ability.can?(:destroy, u_test1)
+
+      assert ability.cannot?(:update, u2_test)
+      assert ability.cannot?(:destroy, u2_test)
+    end
+  end
+
+  test "owner permissions for comment" do
+    u = create_user
+    t = create_team
+    tu = create_team_user team: t, user: u, role: 'owner'
+    p = create_project team: t
+    pm = create_project_media project: p
+    mc = create_comment
+    pm.add_annotation mc
+
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:create, Comment)
+      assert ability.can?(:update, mc)
+      assert ability.can?(:destroy, mc)
+    end
+  end
+
+  test "check annotation permissions" do
+    # test the create/update/destroy operations
+    u = create_user
+    t = create_team
+    tu = create_team_user team: t, user: u, role: 'journalist'
+    p = create_project team: t
+    pm = create_project_media project: p
+    c = create_comment annotated: pm
+
+    with_current_user_and_team(u) do
+      assert_raise RuntimeError do
+        c.save
+      end
+      assert_raise RuntimeError do
+        c.destroy
+      end
+    end
+
+    tu.role = 'owner'; tu.save!
+
+    with_current_user_and_team(u) do
+      assert_raise RuntimeError do
+        c.save
+      end
+    end
+
+    Rails.cache.clear
+    c.text = 'for testing';c.save!
+    assert_equal c.text, 'for testing'
+
+    with_current_user_and_team(u) do
+      assert_nothing_raised RuntimeError do
+        c.destroy
+      end
+    end
+  end
+
+  test "owner permissions for flag" do
+    u = create_user
+    t = create_team
+    tu = create_team_user team: t, user: u, role: 'owner'
+    p = create_project team: t
+    m = create_valid_media
+    pm = create_project_media project: p, media: m
+    f = create_flag flag: 'Mark as graphic', annotator: u, annotated: pm
+
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:create, f)
+      f.flag = 'Graphic content'
+      assert ability.can?(:create, f)
+      p.update_column(:team_id, nil)
+      assert ability.cannot?(:create, f)
+    end
+  end
+
+  test "owner permissions for status" do
+    u = create_user
+    t = create_team
+    tu = create_team_user team: t, user: u, role: 'owner'
+    p = create_project team: t
+    m = create_valid_media
+    pm = create_project_media project: p, media: m
+    s = create_status status: 'verified', annotated: pm
+
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:create, s)
+      assert ability.can?(:update, s)
+      assert ability.can?(:destroy, s)
+      p.update_column(:team_id, nil)
+      assert ability.cannot?(:create, s)
+      assert ability.cannot?(:destroy, s)
+    end
+  end
+
+  test "owner permissions for embed" do
+    u = create_user
+    t = create_team
+    tu = create_team_user team: t, user: u, role: 'owner'
+    p = create_project team: t
+    pm = create_project_media project: p
+    em = create_embed annotated: pm
+
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:create, em)
+      assert ability.can?(:update, em)
+      assert ability.can?(:destroy, em)
+      p.update_column(:team_id, nil)
+      assert ability.cannot?(:destroy, em)
+    end
+  end
+
+  test "owner permissions for tag" do
+    u = create_user
+    t = create_team
+    tu = create_team_user team: t, user: u, role: 'owner'
+    p = create_project team: t
+    pm = create_project_media project: p
+    tg = create_tag tag: 'media_tag', annotated: pm
+
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:create, tg)
+      assert ability.cannot?(:update, tg)
+      assert ability.can?(:destroy, tg)
+      p.update_column(:team_id, nil)
+      assert ability.cannot?(:create, tg)
+      assert ability.cannot?(:destroy, tg)
+    end
+  end
+
+  test "only admin users can manage all" do
+    u = create_user
+    u.is_admin = true
+    u.save
+    ability = AdminAbility.new(u)
+    assert ability.can?(:manage, :all)
+  end
+
+  test "admins can do anything" do
+    u = create_user
+    u.is_admin = true
+    u.save
+    t = create_team
+    tu = create_team_user user: u , team: t
+    p = create_project team: t
+    own_project = create_project team: t, user: u
+    p2 = create_project
+
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:create, Project)
+      assert ability.can?(:update, p)
+      assert ability.can?(:update, own_project)
+      assert ability.can?(:destroy, p)
+      assert ability.can?(:destroy, own_project)
+      assert ability.can?(:update, p2)
+      assert ability.can?(:destroy, p2)
+    end
+  end
+
+  test "should read source without user" do
+    u = create_user
+    t = create_team
+    tu = create_team_user team: t, user: u, role: 'owner'
+    s = create_source user: nil
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:read, s)
+    end
+  end
+
+  test "should read own source" do
+    u = create_user
+    t = create_team
+    tu = create_team_user team: t, user: u, role: 'owner'
+    s = create_source user: u
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:read, s)
+    end
+  end
+
+  test "should not read source from other user" do
+    u = create_user
+    t = create_team
+    tu = create_team_user team: t, user: u, role: 'owner'
+    s = create_source user: create_user
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.cannot?(:read, s)
+    end
+  end
+
+  test "should owner destroy annotation from any project from his team" do
+    u = create_user
+    t = create_team
+    create_team_user user: u, team: t, role: 'owner'
+    p1 = create_project team: t
+    p2 = create_project team: t
+    pm1 = create_project_media project: p1
+    pm2 = create_project_media project: p2
+    a1 = create_annotation annotated: pm1
+    a2 = create_annotation annotated: pm2
+    a3 = create_annotation annotated: create_project_media
+    with_current_user_and_team(u) do
+      a = AdminAbility.new
+      assert a.can?(:destroy, a1)
+      assert a.can?(:destroy, a2)
+      assert a.cannot?(:destroy, a3)
+    end
+  end
+
+  test "should owner destroy annotation versions" do
+    u = create_user
+    t = create_team
+    tu = create_team_user team: t, user: u, role: 'owner'
+    p = create_project team: t
+    pm = create_project_media project: p
+    with_current_user_and_team(u) do
+      s = create_status annotated: pm, status: 'verified'
+      em = create_embed annotated: pm
+      s_v = s.versions.last
+      em_v = em.versions.last
+      ability = AdminAbility.new
+      # Status versions
+      assert ability.can?(:create, s_v)
+      assert ability.cannot?(:update, s_v)
+      assert ability.can?(:destroy, s_v)
+      # Embed versions
+      assert ability.can?(:create, em_v)
+      assert ability.cannot?(:update, em_v)
+      assert ability.can?(:destroy, em_v)
+    end
+  end
+
+  test "should access rails_admin if user is team owner" do
+    u = create_user
+    t = create_team
+    tu = create_team_user user: u , team: t, role: 'owner'
+    p = create_project team: t
+
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:access, :rails_admin)
+    end
+  end
+
+  test "should not access rails_admin if user not team owner or admin" do
+    u = create_user
+    t = create_team
+    tu = create_team_user user: u , team: t
+    p = create_project team: t
+
+    %w(contributor journalist editor).each do |role|
+      tu.role = role; tu.save!
+      with_current_user_and_team(u) do
+        ability = AdminAbility.new
+        assert !ability.can?(:access, :rails_admin)
+      end
+    end
+  end
+
+  test "owner permissions for task" do
+    u = create_user
+    t = create_team
+    tu = create_team_user team: t, user: u, role: 'owner'
+    p = create_project team: t
+    m = create_valid_media
+    pm = create_project_media project: p, media: m
+    tk = create_task annotator: u, annotated: pm
+
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:create, tk)
+      p.update_column(:team_id, nil)
+      assert ability.cannot?(:create, tk)
+    end
+  end
+
+  test "owner permissions for dynamic annotation" do
+    u = create_user
+    t = create_team
+    tu = create_team_user team: t, user: u, role: 'owner'
+    p = create_project team: t
+    pm = create_project_media project: p
+    da = create_dynamic_annotation annotated: pm
+    own_da = create_dynamic_annotation annotated: pm, annotator: u
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:create, Dynamic)
+      assert ability.can?(:update, da)
+      assert ability.can?(:destroy, da)
+      assert ability.can?(:update, own_da)
+      assert ability.can?(:destroy, own_da)
+    end
+  end
+
+  test "owner permissions for export project data" do
+    u = create_user
+    t = create_team
+    tu = create_team_user team: t, user: u, role: 'owner'
+    p = create_project team: t
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:export_project, Project)
+    end
+  end
+
+end

--- a/test/models/admin_ability_test.rb
+++ b/test/models/admin_ability_test.rb
@@ -2,10 +2,14 @@ require File.join(File.expand_path(File.dirname(__FILE__)), '..', 'test_helper')
 
 class AdminAbilityTest < ActiveSupport::TestCase
 
+  def setup
+    @u = create_user
+    @t = create_team
+    @tu = create_team_user user: u , team: t, role: 'owner'
+  end
+  attr_reader :u, :t, :tu
+
   test "owner permissions for project" do
-    u = create_user
-    t = create_team
-    tu = create_team_user user: u , team: t, role: 'owner'
     p = create_project team: t
     own_project = create_project team: t, user: u
     p2 = create_project
@@ -22,9 +26,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "owner permissions for media" do
-    u = create_user
-    t = create_team
-    tu = create_team_user team: t, user: u , role: 'owner'
     m = create_valid_media
     p = create_project team: t
     pm = create_project_media project: p, media: m
@@ -51,9 +52,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "owner permissions for team" do
-    u = create_user
-    t = create_team
-    tu = create_team_user user: u, team: t , role: 'owner'
     t2 = create_team
     tu_test = create_team_user team: t2, role: 'owner'
     with_current_user_and_team(u) do
@@ -67,9 +65,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "owner permissions for teamUser" do
-    u = create_user
-    t = create_team
-    tu = create_team_user user: u, team: t , role: 'owner'
     u2 = create_user
     tu2 = create_team_user team: t, role: 'editor'
     tu_other = create_team_user
@@ -85,9 +80,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "owner permissions for contact" do
-    u = create_user
-    t = create_team
-    tu = create_team_user user: u, team: t , role: 'owner'
     c = create_contact team: t
     c1 = create_contact
 
@@ -102,9 +94,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "owner permissions for user" do
-    u = create_user
-    t = create_team
-    tu = create_team_user team: t, user: u, role: 'owner'
     u2_test = create_user
     tu2_test = create_team_user user: u2_test , role: 'contributor'
     u_test1 = create_user
@@ -133,9 +122,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "owner permissions for comment" do
-    u = create_user
-    t = create_team
-    tu = create_team_user team: t, user: u, role: 'owner'
     p = create_project team: t
     pm = create_project_media project: p
     mc = create_comment
@@ -151,9 +137,8 @@ class AdminAbilityTest < ActiveSupport::TestCase
 
   test "check annotation permissions" do
     # test the create/update/destroy operations
-    u = create_user
-    t = create_team
-    tu = create_team_user team: t, user: u, role: 'journalist'
+    tu.role = 'journalist'
+    tu.save
     p = create_project team: t
     pm = create_project_media project: p
     c = create_comment annotated: pm
@@ -187,9 +172,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "owner permissions for flag" do
-    u = create_user
-    t = create_team
-    tu = create_team_user team: t, user: u, role: 'owner'
     p = create_project team: t
     m = create_valid_media
     pm = create_project_media project: p, media: m
@@ -206,9 +188,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "owner permissions for status" do
-    u = create_user
-    t = create_team
-    tu = create_team_user team: t, user: u, role: 'owner'
     p = create_project team: t
     m = create_valid_media
     pm = create_project_media project: p, media: m
@@ -226,9 +205,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "owner permissions for embed" do
-    u = create_user
-    t = create_team
-    tu = create_team_user team: t, user: u, role: 'owner'
     p = create_project team: t
     pm = create_project_media project: p
     em = create_embed annotated: pm
@@ -244,9 +220,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "owner permissions for tag" do
-    u = create_user
-    t = create_team
-    tu = create_team_user team: t, user: u, role: 'owner'
     p = create_project team: t
     pm = create_project_media project: p
     tg = create_tag tag: 'media_tag', annotated: pm
@@ -293,9 +266,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "should read source without user" do
-    u = create_user
-    t = create_team
-    tu = create_team_user team: t, user: u, role: 'owner'
     s = create_source user: nil
     with_current_user_and_team(u) do
       ability = AdminAbility.new
@@ -304,9 +274,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "should read own source" do
-    u = create_user
-    t = create_team
-    tu = create_team_user team: t, user: u, role: 'owner'
     s = create_source user: u
     with_current_user_and_team(u) do
       ability = AdminAbility.new
@@ -315,9 +282,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "should not read source from other user" do
-    u = create_user
-    t = create_team
-    tu = create_team_user team: t, user: u, role: 'owner'
     s = create_source user: create_user
     with_current_user_and_team(u) do
       ability = AdminAbility.new
@@ -326,9 +290,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "should owner destroy annotation from any project from his team" do
-    u = create_user
-    t = create_team
-    create_team_user user: u, team: t, role: 'owner'
     p1 = create_project team: t
     p2 = create_project team: t
     pm1 = create_project_media project: p1
@@ -345,9 +306,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "should owner destroy annotation versions" do
-    u = create_user
-    t = create_team
-    tu = create_team_user team: t, user: u, role: 'owner'
     p = create_project team: t
     pm = create_project_media project: p
     with_current_user_and_team(u) do
@@ -368,9 +326,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "should access rails_admin if user is team owner" do
-    u = create_user
-    t = create_team
-    tu = create_team_user user: u , team: t, role: 'owner'
     p = create_project team: t
 
     with_current_user_and_team(u) do
@@ -380,9 +335,8 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "should not access rails_admin if user not team owner or admin" do
-    u = create_user
-    t = create_team
-    tu = create_team_user user: u , team: t
+    tu.role = 'contributor'
+    tu.save
     p = create_project team: t
 
     %w(contributor journalist editor).each do |role|
@@ -395,9 +349,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "owner permissions for task" do
-    u = create_user
-    t = create_team
-    tu = create_team_user team: t, user: u, role: 'owner'
     p = create_project team: t
     m = create_valid_media
     pm = create_project_media project: p, media: m
@@ -412,9 +363,6 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "owner permissions for dynamic annotation" do
-    u = create_user
-    t = create_team
-    tu = create_team_user team: t, user: u, role: 'owner'
     p = create_project team: t
     pm = create_project_media project: p
     da = create_dynamic_annotation annotated: pm
@@ -430,13 +378,32 @@ class AdminAbilityTest < ActiveSupport::TestCase
   end
 
   test "owner permissions for export project data" do
-    u = create_user
-    t = create_team
-    tu = create_team_user team: t, user: u, role: 'owner'
     p = create_project team: t
     with_current_user_and_team(u) do
       ability = AdminAbility.new
       assert ability.can?(:export_project, Project)
+    end
+  end
+
+  test "owner permissions to task" do
+    task = create_task annotator: u
+    create_annotation_type annotation_type: 'response'
+    task.response = { annotation_type: 'response', set_fields: {} }.to_json
+    task.save!
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:update, Task)
+      assert ability.can?(:update, task)
+    end
+  end
+
+  test "owner permissions to dynamic annotation" do
+    task = create_task annotator: u
+    dynamic_field = create_field annotation_id: task.id
+    with_current_user_and_team(u) do
+      ability = AdminAbility.new
+      assert ability.can?(:update, DynamicAnnotation::Field)
+      assert ability.can?(:update, dynamic_field)
     end
   end
 


### PR DESCRIPTION
The abilities used on Admin UI will not use context_team and check
permissions based on the teams that the logged in user is admin