### PR TITLE
Fix/6238 move sources with their reports

### DIFF
--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -13,7 +13,7 @@ class ProjectMedia < ActiveRecord::Base
   validate :is_unique, on: :create
 
   after_create :set_quote_embed, :set_initial_media_status, :add_elasticsearch_data, :create_auto_tasks, :create_reverse_image_annotation, :create_annotation, :get_language, :create_mt_annotation, :send_slack_notification, :set_project_source
-  after_update :update_elasticsearch_data
+  after_update :move_media_sources
 
   notifies_pusher on: :save,
                   event: 'media_updated',
@@ -85,16 +85,6 @@ class ProjectMedia < ActiveRecord::Base
     end
     ms.account = self.set_es_account_data unless self.media.account.nil?
     ms.save!
-  end
-
-  def update_elasticsearch_data
-    return if self.disable_es_callbacks
-    if self.project_id_changed?
-      keys = %w(project_id team_id)
-      data = {'project_id' => self.project_id, 'team_id' => self.project.team_id}
-      options = {keys: keys, data: data, parent: self.id}
-      ElasticSearchWorker.perform_in(1.second, YAML::dump(self), YAML::dump(options), 'update_parent')
-    end
   end
 
   def get_annotations(type = nil)
@@ -223,6 +213,15 @@ class ProjectMedia < ActiveRecord::Base
 
   def set_project_source
     self.create_project_source if self.media.type == 'Link'
+  end
+
+  def move_media_sources
+    if self.project_id_changed? && self.media.type == 'Link'
+      sources = self.media.account.sources.map(&:id)
+      ps = ProjectSource.where(project_id: self.project_id_was, source_id: sources).last
+      ps.project_id = self.project_id
+      ps.save!
+    end
   end
 
   protected

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -220,6 +220,7 @@ class ProjectMedia < ActiveRecord::Base
       sources = self.media.account.sources.map(&:id)
       ps = ProjectSource.where(project_id: self.project_id_was, source_id: sources).last
       ps.project_id = self.project_id
+      ps.skip_check_ability = true
       ps.save!
     end
   end

--- a/db/migrate/20170821175600_update_project_for_project_source.rb
+++ b/db/migrate/20170821175600_update_project_for_project_source.rb
@@ -1,0 +1,11 @@
+class UpdateProjectForProjectSource < ActiveRecord::Migration
+  def change
+    ProjectSource.find_each do |ps|
+      pm =  ps.source.medias.first
+      if !pm.nil? && ps.project_id != pm.project_id
+        ps.project_id = pm.project_id
+        ps.save!
+      end
+    end
+  end
+end

--- a/db/migrate/20170821175600_update_project_for_project_source.rb
+++ b/db/migrate/20170821175600_update_project_for_project_source.rb
@@ -4,7 +4,7 @@ class UpdateProjectForProjectSource < ActiveRecord::Migration
       pm =  ps.source.medias.first
       if !pm.nil? && ps.project_id != pm.project_id
         ps.project_id = pm.project_id
-        ps.save!
+        ps.save
       end
     end
   end

--- a/test/models/project_media_test.rb
+++ b/test/models/project_media_test.rb
@@ -463,6 +463,19 @@ class ProjectMediaTest < ActiveSupport::TestCase
     end
   end
 
+  test "should move related sources after move media to other projects" do
+    t = create_team
+    p = create_project team: t
+    m = create_valid_media
+    pm = create_project_media project: p, media: m
+    sources = pm.media.account.sources.map(&:id)
+    ps = ProjectSource.where(project_id: pm.project_id, source_id: sources).last
+    t2 = create_team
+    p2 = create_project team: t2
+    pm.project = p2; pm.save!
+    assert_equal ps.reload.project_id, p2.id
+  end
+
   test "should update es after move media to other projects" do
     t = create_team
     p = create_project team: t

--- a/test/models/project_source_test.rb
+++ b/test/models/project_source_test.rb
@@ -209,4 +209,24 @@ class ProjectSourceTest < ActiveSupport::TestCase
     ps = create_project_source
     assert_not_nil ps.as_json
   end
+
+  test "should update es after move source to other projects" do
+    t = create_team
+    p = create_project team: t
+    s = create_source
+    ps = create_project_source project: p, source: s, disable_es_callbacks: false
+    sleep 1
+    id = Base64.encode64("ProjectSource/#{ps.id}")
+    ms = MediaSearch.find(id)
+    assert_equal ms.project_id.to_i, p.id
+    assert_equal ms.team_id.to_i, t.id
+    t2 = create_team
+    p2 = create_project team: t2
+    ps.project = p2; ps.save!
+    ElasticSearchWorker.drain
+    sleep 1
+    ms = MediaSearch.find(id)
+    assert_equal ms.project_id.to_i, p2.id
+    assert_equal ms.team_id.to_i, t2.id
+  end
 end


### PR DESCRIPTION
- Update related project sources
- Update ES after move project source
- Add a migration to update `ProjectSources` with a right `project_id` value