### PR TITLE
Feature/6251 retrieve annotations from source

### DIFF
--- a/app/graph/types/project_source_type.rb
+++ b/app/graph/types/project_source_type.rb
@@ -42,21 +42,5 @@ ProjectSourceType = GraphqlCrudOperations.define_default_type do
     }
   end
 
-  connection :tags, -> { TagType.connection_type } do
-    resolve ->(project_source, _args, _ctx) {
-      project_source.get_annotations('tag')
-    }
-  end
-
-  instance_exec :project_source, &GraphqlCrudOperations.field_log
-
-  instance_exec :project_source, &GraphqlCrudOperations.field_log_count
-
-  instance_exec :project_source, &GraphqlCrudOperations.field_published
-
-  instance_exec :project_source, &GraphqlCrudOperations.field_annotations
-
-  instance_exec :project_source, &GraphqlCrudOperations.field_annotations_count
-
 # End of fields
 end

--- a/app/graph/types/source_type.rb
+++ b/app/graph/types/source_type.rb
@@ -36,12 +36,6 @@ SourceType = GraphqlCrudOperations.define_default_type do
     }
   end
 
-  connection :annotations, -> { AnnotationType.connection_type } do
-    resolve ->(source, _args, _ctx) {
-      source.annotations
-    }
-  end
-
   connection :medias, -> { ProjectMediaType.connection_type } do
     resolve ->(source, _args, _ctx) {
       source.medias
@@ -54,21 +48,21 @@ SourceType = GraphqlCrudOperations.define_default_type do
     }
   end
 
-  connection :comments, -> { CommentType.connection_type } do
+  connection :tags, -> { TagType.connection_type } do
     resolve ->(source, _args, _ctx) {
-      source.comments
+      source.get_annotations('tag')
     }
   end
 
-  connection :tags, -> { TagType.connection_type } do
-    resolve ->(source, _args, _ctx) {
-      source.tags
-    }
-  end
+  instance_exec :source, &GraphqlCrudOperations.field_annotations
+
+  instance_exec :source, &GraphqlCrudOperations.field_annotations_count
 
   instance_exec :source, &GraphqlCrudOperations.field_log
 
   instance_exec :source, &GraphqlCrudOperations.field_log_count
 
   instance_exec :source, &GraphqlCrudOperations.field_verification_statuses
+
+  instance_exec :project_source, &GraphqlCrudOperations.field_published
 end

--- a/app/models/project_source.rb
+++ b/app/models/project_source.rb
@@ -22,14 +22,6 @@ class ProjectSource < ActiveRecord::Base
     p.nil? ? [] : [p.team_id]
   end
 
-  def tags
-    self.annotations('tag')
-  end
-
-  def comments
-    self.annotations('comment')
-  end
-
   def collaborators
     self.annotators
   end

--- a/app/models/project_source.rb
+++ b/app/models/project_source.rb
@@ -34,10 +34,6 @@ class ProjectSource < ActiveRecord::Base
     self.annotators
   end
 
-  def get_annotations(type = nil)
-    self.annotations.where(annotation_type: type)
-  end
-
   def add_elasticsearch_data
     return if self.disable_es_callbacks
     p = self.project

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -58,8 +58,11 @@ class Source < ActiveRecord::Base
   end
 
   def get_annotations(type = nil)
-    project_sources = get_project_sources
-    Annotation.where(annotation_type: type, annotated_type: 'ProjectSource', annotated_id: project_sources.map(&:id))
+    conditions = {}
+    conditions[:annotation_type] = type unless type.nil?
+    conditions[:annotated_type] = 'ProjectSource'
+    conditions[:annotated_id] = get_project_sources.map(&:id)
+    Annotation.where(conditions)
   end
 
   def file_mandatory?

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -57,12 +57,9 @@ class Source < ActiveRecord::Base
     self.annotators
   end
 
-  def tags
-    self.annotations('tag')
-  end
-
-  def comments
-    self.annotations('comment')
+  def get_annotations(type = nil)
+    project_sources = get_project_sources
+    Annotation.where(annotation_type: type, annotated_type: 'ProjectSource', annotated_id: project_sources.map(&:id))
   end
 
   def file_mandatory?
@@ -81,11 +78,11 @@ class Source < ActiveRecord::Base
   end
 
   def get_versions_log
-    PaperTrail::Version.where(associated_type: 'ProjectSource', associated_id: self.project_sources).order('created_at ASC')
+    PaperTrail::Version.where(associated_type: 'ProjectSource', associated_id: get_project_sources).order('created_at ASC')
   end
 
   def get_versions_log_count
-    self.project_sources.sum(:cached_annotations_count)
+    get_project_sources.sum(:cached_annotations_count)
   end
 
   private
@@ -96,5 +93,11 @@ class Source < ActiveRecord::Base
 
   def set_team
     self.team = Team.current unless Team.current.nil?
+  end
+
+  def get_project_sources
+    conditions = {}
+    conditions[:project_id] = Team.current.projects unless Team.current.nil?
+    self.project_sources.where(conditions)
   end
 end

--- a/public/relay.json
+++ b/public/relay.json
@@ -3373,11 +3373,52 @@
                     "ofType": null
                   },
                   "defaultValue": null
+                },
+                {
+                  "name": "annotation_type",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "Non-Null",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
                 }
               ],
               "type": {
                 "kind": "OBJECT",
                 "name": "AnnotationConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "annotations_count",
+              "description": null,
+              "args": [
+                {
+                  "name": "annotation_type",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": "Non-Null",
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -3431,59 +3472,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "UserConnection",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "comments",
-              "description": null,
-              "args": [
-                {
-                  "name": "first",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "last",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "before",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "CommentConnection",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -3820,6 +3808,20 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "ProjectConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "published",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -4428,100 +4430,6 @@
           "description": "ProjectSource type",
           "fields": [
             {
-              "name": "annotations",
-              "description": null,
-              "args": [
-                {
-                  "name": "first",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "last",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "before",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "annotation_type",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": "Non-Null",
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "AnnotationConnection",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "annotations_count",
-              "description": null,
-              "args": [
-                {
-                  "name": "annotation_type",
-                  "description": null,
-                  "type": {
-                    "kind": "NON_NULL",
-                    "name": "Non-Null",
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "String",
-                      "ofType": null
-                    }
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "created_at",
               "description": null,
               "args": [
@@ -4563,73 +4471,6 @@
                   "name": "ID",
                   "ofType": null
                 }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "log",
-              "description": null,
-              "args": [
-                {
-                  "name": "first",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "last",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "before",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "VersionConnection",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "log_count",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "Int",
-                "ofType": null
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -4677,20 +4518,6 @@
               "deprecationReason": null
             },
             {
-              "name": "published",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "source",
               "description": null,
               "args": [
@@ -4713,59 +4540,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "tags",
-              "description": null,
-              "args": [
-                {
-                  "name": "first",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "after",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "last",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                },
-                {
-                  "name": "before",
-                  "description": null,
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "TagConnection",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -7855,96 +7629,6 @@
         },
         {
           "kind": "OBJECT",
-          "name": "VersionConnection",
-          "description": null,
-          "fields": [
-            {
-              "name": "edges",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "LIST",
-                "name": "List",
-                "ofType": {
-                  "kind": "OBJECT",
-                  "name": "VersionEdge",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "pageInfo",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "PageInfo",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
-          "name": "VersionEdge",
-          "description": null,
-          "fields": [
-            {
-              "name": "cursor",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "NON_NULL",
-                "name": "Non-Null",
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "node",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "Version",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            }
-          ],
-          "inputFields": null,
-          "interfaces": [
-
-          ],
-          "enumValues": null,
-          "possibleTypes": null
-        },
-        {
-          "kind": "OBJECT",
           "name": "AnnotationConnection",
           "description": null,
           "fields": [
@@ -8020,6 +7704,96 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Annotation",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "VersionConnection",
+          "description": null,
+          "fields": [
+            {
+              "name": "edges",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": "List",
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "VersionEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "PageInfo",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "VersionEdge",
+          "description": null,
+          "fields": [
+            {
+              "name": "cursor",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": "Non-Null",
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "node",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "Version",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/test/controllers/graphql_controller_test.rb
+++ b/test/controllers/graphql_controller_test.rb
@@ -795,7 +795,7 @@ class GraphqlControllerTest < ActionController::TestCase
 
     query = "query { project(id: \"#{p.id}\") { project_medias(first: 10000) { edges { node { permissions, log(first: 10000) { edges { node { permissions, annotation { permissions, medias { edges { node { id } } } } } }  } } } } } }"
 
-    assert_queries (5 * n + n * m + 16) do
+    assert_queries (5 * n + n * m + 18) do
       post :create, query: query, team: 'team'
     end
 

--- a/test/controllers/graphql_controller_test.rb
+++ b/test/controllers/graphql_controller_test.rb
@@ -288,17 +288,15 @@ class GraphqlControllerTest < ActionController::TestCase
     create_tag annotated: ps
     create_comment annotated: ps2
     create_tag annotated: ps2
-    query = "query GetById { project_source(ids: \"#{ps.id},#{p.id}\") { source { log(first: 1000) { edges { node { event_type } } }, log_count }, log(first: 1000) { edges { node { event_type } } }, log_count, published, user{id}, team{id}, tags { edges { node { dbid } } },annotations_count(annotation_type: \"comment,tag\"), annotations(annotation_type: \"comment,tag\") { edges { node { dbid } } } } }"
+    query = "query GetById { project_source(ids: \"#{ps.id},#{p.id}\") { source { log(first: 1000) { edges { node { event_type } } }, log_count, published,tags { edges { node { dbid } } }, annotations_count(annotation_type: \"comment,tag\"), annotations(annotation_type: \"comment,tag\") { edges { node { dbid } } } }, user{id}, team{id} } }"
     post :create, query: query, team: @team.slug
     assert_response :success
     data = JSON.parse(@response.body)['data']['project_source']
-    assert_not_empty data['published']
     assert_not_empty data['user']['id']
     assert_not_empty data['team']['id']
-    assert_equal 2, data['annotations']['edges'].size
-    assert_equal 2, data['annotations_count']
-    assert_equal 2, data['log']['edges'].size
-    assert_equal 2, data['log_count']
+    assert_equal 4, data['source']['annotations']['edges'].size
+    assert_equal 4, data['source']['annotations_count']
+    assert_not_empty data['source']['published']
     assert_equal 4, data['source']['log']['edges'].size
     assert_equal 4, data['source']['log_count']
   end
@@ -422,8 +420,7 @@ class GraphqlControllerTest < ActionController::TestCase
   test "should read collection from source" do
     User.delete_all
     assert_graphql_read_collection('source', { 'projects' => 'title', 'accounts' => 'url', 'project_sources' => 'project_id',
-     'annotations' => 'content', 'medias' => 'media_id', 'collaborators' => 'name',
-     'tags'=> 'tag', 'comments' => 'text' }, 'DESC')
+      'medias' => 'media_id', 'collaborators' => 'name' }, 'DESC')
   end
 
   test "should read collection from project" do

--- a/test/controllers/graphql_controller_test.rb
+++ b/test/controllers/graphql_controller_test.rb
@@ -795,7 +795,7 @@ class GraphqlControllerTest < ActionController::TestCase
 
     query = "query { project(id: \"#{p.id}\") { project_medias(first: 10000) { edges { node { permissions, log(first: 10000) { edges { node { permissions, annotation { permissions, medias { edges { node { id } } } } } }  } } } } } }"
 
-    assert_queries (5 * n + n * m + 18) do
+    assert_queries (5 * n + n * m + 16) do
       post :create, query: query, team: 'team'
     end
 

--- a/test/models/project_source_test.rb
+++ b/test/models/project_source_test.rb
@@ -16,21 +16,7 @@ class ProjectSourceTest < ActiveSupport::TestCase
     end
   end
 
-  test "should get tags" do
-    s = create_project_source
-    t = create_tag annotated: s
-    c = create_comment annotated: s
-    assert_equal [t], s.tags
-  end
-
-  test "should get comments" do
-    s = create_project_source
-    t = create_tag annotated: s
-    c = create_comment annotated: s
-    assert_equal [c], s.comments
-  end
-
-   test "should get collaborators" do
+  test "should get collaborators" do
     u1 = create_user
     u2 = create_user
     u3 = create_user

--- a/test/models/source_test.rb
+++ b/test/models/source_test.rb
@@ -159,21 +159,21 @@ class SourceTest < ActiveSupport::TestCase
   end
 
   test "should get tags" do
+    t = create_team
+    t2 = create_team
+    p = create_project team: t
+    p2 = create_project team: t2
     s = create_source
-    t = create_tag
-    c = create_comment
-    s.add_annotation t
-    s.add_annotation c
-    assert_equal [t], s.tags
-  end
-
-  test "should get comments" do
-    s = create_source
-    t = create_tag
-    c = create_comment
-    s.add_annotation t
-    s.add_annotation c
-    assert_equal [c], s.comments
+    ps = create_project_source project: p, source: s
+    ps2 = create_project_source project: p2, source: s
+    tag = create_tag annotated: ps
+    tag2 = create_tag annotated: ps2
+    assert_equal [tag, tag2], s.get_annotations('tag')
+    Team.stubs(:current).returns(t)
+    assert_equal [tag], s.get_annotations('tag')
+    Team.stubs(:current).returns(t2)
+    assert_equal [tag2], s.get_annotations('tag')
+    Team.unstub(:current)
   end
 
   test "should get db id" do


### PR DESCRIPTION
- Removed `log` and `log_count` from `ProjectSource`
- Moved `tags`, `annotations`, `annotations_count` and `published` from `ProjectSource` to `Source`
- Added required tests