### PR TITLE
Ticket #6599: Fix errors on team duplication

### DIFF
--- a/app/models/annotations/comment.rb
+++ b/app/models/annotations/comment.rb
@@ -3,7 +3,7 @@ class Comment < ActiveRecord::Base
   include HasImage
 
   field :text
-  validates_presence_of :text, if: proc { |comment| comment.file.blank? }
+  validates_presence_of :text, if: proc { |comment| comment.file.blank? && !comment.is_being_copied }
 
   before_save :extract_check_entities
   after_save :add_update_elasticsearch_comment, :send_slack_notification

--- a/app/models/annotations/status.rb
+++ b/app/models/annotations/status.rb
@@ -140,7 +140,8 @@ class Status < ActiveRecord::Base
     if !self.annotated_type.blank?
       annotated, context = get_annotated_and_context
       values = Status.possible_values(annotated, context)
-      errors.add(:base, 'Status not valid') unless values[:statuses].collect{ |s| s[:id] }.include?(self.status)
+      return if values[:statuses].collect{ |s| s[:id] }.include?(self.status)
+      self.is_being_copied ? self.status = Status.default_id(annotated, context) : errors.add(:status, 'Status not valid')
     end
   end
 
@@ -163,6 +164,7 @@ class Status < ActiveRecord::Base
   end
 
   def send_terminal_email_notification
+    return if self.is_being_copied
     if self.status != self.previous_annotated_status && self.is_terminal?
       TerminalStatusMailer.delay.notify(self.annotated, self.annotator, self.id_to_label(self.status))
     end

--- a/app/models/concerns/team_duplication.rb
+++ b/app/models/concerns/team_duplication.rb
@@ -86,8 +86,10 @@ module TeamDuplication
       PaperTrail::Version.skip_callback(:create, :after, :increment_project_association_annotations_count)
       versions_mapping.each_pair do |original, copy|
         log = PaperTrail::Version.find(original).dup
+        log.is_being_copied = true
         log.associated_id = copy.id
-        log.item_id = @mapping[log.item_type.to_sym][log.item_id.to_i].id.to_s
+        item = @mapping[log.item_type.to_sym][log.item_id.to_i]
+        log.item_id = item.id if item
         log.save!
       end
       PaperTrail::Version.set_callback(:create, :after, :increment_project_association_annotations_count)

--- a/config/initializers/location_search.rb
+++ b/config/initializers/location_search.rb
@@ -32,6 +32,7 @@ end
 
 Dynamic.class_eval do
   def add_update_elasticsearch_dynamic_annotation_task_response_geolocation
+    return if self.get_field(:response_geolocation).nil?
     location = {}
     geojson = JSON.parse(self.get_field_value(:response_geolocation))
     coordinates = geojson['geometry']['coordinates']

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -13,7 +13,8 @@ module PaperTrail
   module CheckExtensions
     def self.included(base)
       base.class_eval do
-        before_create :set_object_after, :set_user, :set_event_type, :set_project_association, :set_meta
+        attr_accessor :is_being_copied
+        before_create :set_object_after, :set_user, :set_event_type, :set_project_association, :set_meta, unless: proc { |pt| pt.is_being_copied }
         after_create :increment_project_association_annotations_count
         after_destroy :decrement_project_association_annotations_count
       end


### PR DESCRIPTION
- skip `paper trail`s callbacks if it is being copied
- add default status on project media if the original status is invalid
- don't notify if copied status is terminal
- check if file `response_geolocation` exist before trying to get its value
- skip validation of comment text when being copied
- check if element is present on mapping before set it as `item` on PaperTrail::Version copy