### PR TITLE
Ticket #6599: Check if field `response_geolocation` exist before tryi…

### DIFF
--- a/config/initializers/datetime_search.rb
+++ b/config/initializers/datetime_search.rb
@@ -4,6 +4,7 @@ end
 
 Dynamic.class_eval do
   def add_update_elasticsearch_dynamic_annotation_task_response_datetime
+    return if self.get_field(:response_datetime).nil?
     datetime = DateTime.parse(self.get_field_value(:response_datetime))
     add_update_media_search_child('dynamic_search', [:datetime, :indexable], { datetime: datetime.to_i, indexable: datetime.to_s })
   end

--- a/test/models/dynamic_test.rb
+++ b/test/models/dynamic_test.rb
@@ -328,4 +328,15 @@ class DynamicTest < ActiveSupport::TestCase
       a.save!
     end
   end
+
+  test "should check if field response datetime exist before get field" do
+    u = create_user
+    pm = create_project_media
+
+    d = create_dynamic_annotation annotation_type: 'task_response_datetime', annotator: u, annotated: pm
+    assert d.get_field(:response_datetime).nil?
+    assert_nothing_raised do
+      d.send(:add_update_elasticsearch_dynamic_annotation_task_response_datetime)
+    end
+  end
 end


### PR DESCRIPTION
…ng to get its value

On team duplication the annotation is copied before the fields and was raising error