### PR TITLE
Ticket #6831: Remove `profile_image` from User page

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -73,7 +73,7 @@ class Source < ActiveRecord::Base
     self.accounts.empty? ? '' : self.accounts.first.data['description'].to_s
   end
 
-  def set_image(image)
+  def set_avatar(image)
     self.update_columns(avatar: image)
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -107,12 +107,13 @@ class User < ActiveRecord::Base
 
   def set_source_image
     return if self.source.nil?
-    image = self.omniauth_info.dig('info', 'image') if self.omniauth_info
-    if image.blank?
-      self.source.set_image(CONFIG['checkdesk_base_url'] + self.image.url)
-    else
-      self.source.set_image(image.gsub(/^http:/, 'https:'))
+    if !self.image.nil? && self.image.url != '/images/user.png'
+      self.source.file = self.image
+      self.source.save
     end
+    image = self.omniauth_info.dig('info', 'image') if self.omniauth_info
+    avatar = image ? image.gsub(/^http:/, 'https:') : CONFIG['checkdesk_base_url'] + self.image.url
+    self.source.set_avatar(avatar)
   end
 
   def update_account(url)

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -539,8 +539,11 @@ RailsAdmin.config do |config|
         end
       end
       field :email
-      field :profile_image
-      field :image
+      field :image do
+        show do
+          bindings[:object].new_record?
+        end
+      end
       field :current_team_id
       field :is_admin do
         visible do
@@ -587,8 +590,11 @@ RailsAdmin.config do |config|
     edit do
       field :name
       field :login
-      field :profile_image
-      field :image
+      field :image do
+        show do
+          bindings[:object].new_record?
+        end
+      end
       field :api_key
     end
   end

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -58,7 +58,7 @@ module SampleData
     end
 
     u.save!
-    u.source.set_image(options[:profile_image]) if options.has_key?(:profile_image) && u.source
+    u.source.set_avatar(options[:profile_image]) if options.has_key?(:profile_image) && u.source
 
     if options[:team]
       create_team_user team: options[:team], user: u
@@ -98,7 +98,7 @@ module SampleData
     u.skip_confirmation! if options.has_key?(:skip_confirmation) && options[:skip_confirmation] == true
 
     u.save!
-    u.source.set_image(options[:profile_image]) if options.has_key?(:profile_image) && u.source
+    u.source.set_avatar(options[:profile_image]) if options.has_key?(:profile_image) && u.source
 
     if options[:team]
       create_team_user team: options[:team], user: u

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -706,5 +706,15 @@ class UserTest < ActiveSupport::TestCase
     User.any_instance.unstub(:omniauth_info)
   end
 
+  test "should set user image as source image" do
+    omniauth_info = {"info"=> { "image"=>"https://avatars.slack-edge.com/2016-08-30/74454572532_7b40a563ce751e1c1d50_192.jpg"} }
+    stub_config 'checkdesk_base_url', 'http://check.url' do
+      u = create_user image: 'rails.png', omniauth_info: omniauth_info
+      source = u.source
+      assert_match /uploads\/source\/.*\/rails.png/, source.file.url
+      assert_equal omniauth_info['info']['image'], source.avatar
+      assert_match /uploads\/source\/.*\/rails.png/, source.image
+    end
+  end
 
 end


### PR DESCRIPTION
Also:
- the image added on User registration will be set as source file
- the image on omniauth_info will be set as source avatar