### PR TITLE
Ticket #6599: Update json fields on PaperTrail when copy team

### DIFF
--- a/app/models/concerns/annotation_base.rb
+++ b/app/models/concerns/annotation_base.rb
@@ -80,7 +80,7 @@ module AnnotationBase
     after_save :touch_annotated, unless: proc { |a| a.is_being_copied }
     after_destroy :touch_annotated
 
-    has_paper_trail on: [:create, :update, :destroy], save_changes: true, ignore: [:updated_at, :created_at, :id, :entities, :lock_version], if: proc { |_x| User.current.present? }
+    has_paper_trail on: [:create, :update, :destroy], save_changes: true, ignore: [:updated_at, :created_at, :id, :entities, :lock_version], if: proc { |a| User.current.present? && !a.is_being_copied }
 
     serialize :data, HashWithIndifferentAccess
     serialize :entities, Array

--- a/app/models/concerns/team_duplication.rb
+++ b/app/models/concerns/team_duplication.rb
@@ -92,7 +92,22 @@ module TeamDuplication
         log.is_being_copied = true
         log.associated_id = copy.id
         item = @mapping[log.item_type.to_sym][log.item_id.to_i]
-        log.item_id = item.id if item
+        if item
+          original_item = log.item_id
+          log.item_id = item.id
+          object = log.get_object
+          unless object.blank?
+            object['id'] = item.id if object['id']
+            object['annotated_id'] = item.annotated_id if object['annotated_id']
+            log.object = object.to_json
+          end
+          changes = log.get_object_changes
+          unless changes.blank?
+            changes['annotated_id'].map! {|a| a == original_item ? item.annotated_id : a } if changes['annotated_id']
+            log.object_changes = changes.to_json
+          end
+          log.set_object_after
+        end
         log.save(validate: false)
       end
       PaperTrail::Version.set_callback(:create, :after, :increment_project_association_annotations_count)


### PR DESCRIPTION
The fields `object`, `object_changes` and `object_after` now have
the values of the copied item