### PR TITLE
Ticket #6897: Fix Admin UI permissions

### DIFF
--- a/app/models/admin_ability.rb
+++ b/app/models/admin_ability.rb
@@ -26,16 +26,17 @@ class AdminAbility
       (obj.team ||= obj.project.team) if obj.project
       @teams.include?(obj.team.id) if obj.team
     end
-    %w(comment dynamic flag tag task).each do |annotation_type|
+    %w(annotation comment flag tag dynamic task).each do |annotation_type|
       can :destroy, annotation_type.classify.constantize, ['annotation_type = ?', annotation_type] do |obj|
-        !(obj.get_team && @teams).empty?
+        !(obj.get_team & @teams).empty?
       end
     end
+
     can :update, Embed, ['annotation_type = ?', 'embed'] do |obj|
-      !(obj.get_team && @teams).empty?
+      !(obj.get_team & @teams).empty?
     end
     can :destroy, DynamicAnnotation::Field do |obj|
-      !(obj.annotation.get_team && @teams).empty?
+      !(obj.annotation.get_team & @teams).empty?
     end
 
     can :create, PaperTrail::Version


### PR DESCRIPTION
Team owners can manage only objects of their teams