### PR TITLE
Ticket #7526: Send project export link only to owners with member status

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -3,7 +3,7 @@ class AdminMailer < ApplicationMailer
     
   def send_download_link(type, obj, email, password)
     if obj.is_a?(Project)
-      return unless !email.blank? && requestor = User.find_by_email(email)
+      return unless !email.blank?
       link = obj.export_filepath(type).gsub(/^.*\/public/, CONFIG['checkdesk_base_url'])
       Rails.logger.info "Sending e-mail to #{email} with download link #{link} related to project #{obj.title}"
       @project = obj.title

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -58,8 +58,8 @@ class Team < ActiveRecord::Base
     }
   end
 
-  def owners(role)
-    self.users.where('team_users.role' => role)
+  def owners(role, statuses = TeamUser.status_types)
+    self.users.joins(:team_users).where({'team_users.role': role, 'team_users.status': statuses})
   end
 
   def recent_projects

--- a/test/controllers/elastic_search_2_test.rb
+++ b/test/controllers/elastic_search_2_test.rb
@@ -384,7 +384,6 @@ class ElasticSearch2Test < ActionController::TestCase
       projects: [p.id]
     }
     result = CheckSearch.new(other_query.to_json)
-    puts result
     assert_equal 1, result.medias.size
     assert_equal ids['es'], result.medias.first.id
   end

--- a/test/mailers/admin_mailer_test.rb
+++ b/test/mailers/admin_mailer_test.rb
@@ -3,11 +3,37 @@ require_relative '../test_helper'
 class AdminMailerTest < ActionMailer::TestCase
   test "should send download link" do
     p = create_project
-    email = AdminMailer.send_download_link(:csv, p, 'test@test.com', 'password')
+    requestor = create_user
+    email = AdminMailer.send_download_link(:csv, p, requestor.email, 'password')
     assert_emails 1 do
       email.deliver_now
     end
-    assert_equal ['test@test.com'], email.to
+    assert_equal [requestor.email], email.to
+  end
+
+  test "should include on download link cc only members with notifications enabled" do
+    t = create_team
+    p = create_project team: t
+    requestor = create_user
+    member = create_user
+    member_without_notifications = create_user
+    member_without_notifications.set_send_email_notifications = false; member_without_notifications.save!
+    requested = create_user
+    invited = create_user
+    banned = create_user
+    create_team_user team: t, user: requestor, role: 'owner', status: 'member'
+    create_team_user team: t, user: member, role: 'owner', status: 'member'
+    create_team_user team: t, user: member_without_notifications, role: 'owner', status: 'member'
+    create_team_user team: t, user: requested, role: 'owner', status: 'requested'
+    create_team_user team: t, user: invited, role: 'owner', status: 'invited'
+    create_team_user team: t, user: banned, role: 'owner', status: 'banned'
+
+    email = AdminMailer.send_download_link(:csv, p, requestor.email, 'password')
+    assert_emails 1 do
+      email.deliver_now
+    end
+    assert_equal [requestor.email], email.to
+    assert_equal [member.email], email.cc
   end
 
   test "should notify import completed" do


### PR DESCRIPTION
The owners with emails notifications disabled don't receive a copy of download link