### PR TITLE
Ticket #7550: Enhancements and fixes on team dump

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
 - export RECORD_RUNTIME=true
 - export PATH=/tmp/bundler/ruby/2.3.0/bin:$PATH
 - export GEM_PATH=/tmp/bundler/ruby/2.3.0/gems:$GEM_PATH
-- sudo rm /etc/apt/sources.list.d/mongodb*
+- sudo rm -f /etc/apt/sources.list.d/mongodb*
 - sudo apt-get -qq update
 - sudo apt-get install wget openjdk-7-jre redis-server imagemagick fontconfig libfontconfig
 - mkdir -p /tmp/downloads &&


### PR DESCRIPTION
- Include data from users that created items on teams but are not members
  - Sensitive data are replaced by default values
- Fix: avoid crash when query tables that are related to other tables and `get_ids(<other table>)` is empty
- Dump the database in batches to avoid problems with big tables
- Allow adding list of tables to not include on dump