### PR TITLE
Ticket #7696: Normalize the URL when receiving a GraphQL query

### DIFF
--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -78,6 +78,7 @@ QueryType = GraphQL::ObjectType.define do
     resolve -> (_obj, args, _ctx) {
       return [] if User.current.nil?
       m = Link.where(url: args['url']).last
+      m = Link.where(url: Link.normalized(args['url'])).last if m.nil?
       return [] if m.nil?
       tids = User.current.team_ids
       ProjectMedia.joins(:project).where('project_medias.media_id' => m.id, 'projects.team_id' => tids)

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -89,12 +89,8 @@ module ProjectMediaCreators
   end
 
   def create_link
-    m = Link.new
-    m.url = self.url
-    # call m.valid? to get normalized URL before caling 'find_or_create_by'
-    m.valid?
-    m = Link.find_or_create_by(url: m.url)
-    m
+    url = Link.normalized(self.url)
+    Link.find_or_create_by(url: url)
   end
 
   def create_media

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -46,6 +46,12 @@ class Link < Media
     self.get_saved_pender_data['provider']
   end
 
+  def self.normalized(url)
+    l = Link.new url: url
+    l.valid?
+    l.url
+  end
+
   private
 
   def set_account


### PR DESCRIPTION
Only normalize it when the original is not found