### PR TITLE
Feature/7776 refactor archive annotation

### DIFF
--- a/app/models/bot/keep.rb
+++ b/app/models/bot/keep.rb
@@ -17,7 +17,8 @@ class Bot::Keep < BotUser
       'keep_backup',    # VideoVault
       'pender_archive', # Screenshot
       'archive_is',     # Archive.is
-      'archive_org'     # Archive.org
+      'archive_org',    # Archive.org
+      'perma_cc'        # Perma.cc
     ]
   end
 
@@ -66,9 +67,9 @@ class Bot::Keep < BotUser
         m.save!
 
         ProjectMedia.where(media_id: link.id).each do |pm|
-          annotation = pm.annotations.where(annotation_type: type).last
+          annotation = pm.annotations.where(annotation_type: 'archiver').last
 
-          unless annotation.nil?
+          unless annotation.nil? || !DynamicAnnotation::Field.where(field_name: "#{type}_response", annotation_id: annotation.id).exists?
             annotation = annotation.load
             annotation.skip_check_ability = true
             annotation.disable_es_callbacks = Rails.env.to_s == 'test'
@@ -95,22 +96,23 @@ class Bot::Keep < BotUser
       bot = BotUser.where(login: 'keep').last
       installation = TeamBotInstallation.where(team_id: team.id, user_id: bot&.id.to_i).last
       getter = "get_archive_#{type}_enabled"
-      !DynamicAnnotation::AnnotationType.where(annotation_type: type).exists? || !self.media.is_a?(Link) || installation.nil? || !installation.send(getter)
+      !DynamicAnnotation::AnnotationType.where(annotation_type: 'archiver').exists? || !DynamicAnnotation::FieldInstance.where(name: "#{type}_response").exists? || !self.media.is_a?(Link) || installation.nil? || !installation.send(getter)
     end
 
     def create_archive_annotation(type)
       return if self.should_skip_create_archive_annotation?(type)
-
       data = begin JSON.parse(self.media.metadata_annotation.get_field_value('metadata_value')) rescue self.media.pender_data end
 
       return unless data.has_key?('archives')
-
-      a = Dynamic.new
-      a.skip_check_ability = true
-      a.skip_notifications = true
-      a.disable_es_callbacks = Rails.env.to_s == 'test'
-      a.annotation_type = type
-      a.annotated = self
+      a = Dynamic.where(annotation_type: 'archiver', annotated_type: self.class_name, annotated_id: self.id).last
+      if a.nil?
+        a = Dynamic.new
+        a.skip_check_ability = true
+        a.skip_notifications = true
+        a.disable_es_callbacks = Rails.env.to_s == 'test'
+        a.annotation_type = 'archiver'
+        a.annotated = self
+      end
 
       archives = data['archives']
       response = Bot::Keep.set_response_based_on_pender_data(type, archives[Bot::Keep.annotation_type_to_archiver(type)])
@@ -118,12 +120,12 @@ class Bot::Keep < BotUser
       a.save!
     end
 
-    def reset_archive_response(annotation)
-      return if self.should_skip_create_archive_annotation?(annotation.annotation_type)
+    def reset_archive_response(annotation, archiver)
+      return if self.should_skip_create_archive_annotation?(archiver)
       a = annotation.load || annotation
       a.skip_check_ability = true
       a.disable_es_callbacks = Rails.env.to_s == 'test'
-      a.set_fields = { "#{a.annotation_type}_response" => {}.to_json }.to_json
+      a.set_fields = { "#{archiver}_response" => {}.to_json }.to_json
       a.save!
     end
 

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -171,8 +171,8 @@ class ProjectMedia < ActiveRecord::Base
 
   def refresh_media=(_refresh)
     Bot::Keep.archiver_annotation_types.each do |type|
-      a = self.annotations.where(annotation_type: type).last
-      a.nil? ? self.create_archive_annotation(type) : self.reset_archive_response(a)
+      a = self.annotations.where(annotation_type: 'archiver').last
+      a.nil? ? self.create_archive_annotation(type) : self.reset_archive_response(a, type)
     end
     self.media.refresh_pender_data
     self.updated_at = Time.now

--- a/db/migrate/20191212164640_add_perma_cc_archiver_setting_on_keep_bot.rb
+++ b/db/migrate/20191212164640_add_perma_cc_archiver_setting_on_keep_bot.rb
@@ -1,0 +1,10 @@
+class AddPermaCcArchiverSettingOnKeepBot < ActiveRecord::Migration
+  def change
+    bot = BotUser.where(login: 'keep').last
+    settings = bot.get_settings
+    settings << { "name" => "archive_perma_cc_enabled",  "label" => "Enable Perma.cc",  "type" => "boolean", "default" => "false" }
+    bot.set_settings(settings)
+
+    bot.save!
+  end
+end

--- a/db/migrate/20191212174338_create_archiver_annotation_and_fields.rb
+++ b/db/migrate/20191212174338_create_archiver_annotation_and_fields.rb
@@ -1,0 +1,16 @@
+require 'sample_data'
+include SampleData
+
+class CreateArchiverAnnotationAndFields < ActiveRecord::Migration
+  def change
+    at = DynamicAnnotation::AnnotationType.where(annotation_type: 'archiver').first || create_annotation_type(annotation_type: 'archiver', label: 'Archivers')
+    json = DynamicAnnotation::FieldType.where(field_type: 'json').last
+
+    name = 'perma_cc_response'
+    create_field_instance annotation_type_object: at, name: name, label: name.titleize, field_type_object: json, optional: true unless DynamicAnnotation::FieldInstance.where(name: name).exists?
+
+    Bot::Keep.archiver_annotation_types.each do |type|
+      DynamicAnnotation::FieldInstance.where(name: "#{type}_response").last.update_columns(optional: true)
+    end
+  end
+end

--- a/db/migrate/20191212185909_merge_archive_fields_in_one_archiver_annotation.rb
+++ b/db/migrate/20191212185909_merge_archive_fields_in_one_archiver_annotation.rb
@@ -1,0 +1,5 @@
+class MergeArchiveFieldsInOneArchiverAnnotation < ActiveRecord::Migration
+  def change
+    Rails.cache.write('check:merge_archive_fields_in_one_archiver_annotation:progress', nil)
+  end
+end

--- a/lib/check_export.rb
+++ b/lib/check_export.rb
@@ -120,7 +120,7 @@ module CheckExport
     ProjectMedia.order(:id).joins(:media).where('medias.type' => 'Link', 'project_id' => self.id).find_each(start: last_id + 1) do |pm|
       key = [self.team.slug, self.title.parameterize, pm.id, 'screenshot'].join('_') + '.png'
       begin
-        screenshot_url = JSON.parse(pm.get_annotations('pender_archive').last.get_fields.select{ |f| f.field_name == 'pender_archive_response' }.last.value)['screenshot_url'].gsub(CONFIG['pender_url'], CONFIG['pender_url_private'])
+        screenshot_url = JSON.parse(pm.get_annotations('archiver').last.get_fields.select{ |f| f.field_name == 'pender_archive_response' }.last.value)['screenshot_url'].gsub(CONFIG['pender_url'], CONFIG['pender_url_private'])
         output[key] = open(screenshot_url).read
       rescue
         output[key] = nil

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -708,7 +708,7 @@ module SampleData
     t
   end
 
-  def create_annotation_type_and_fields(annotation_type_label, fields, options = {})
+  def create_annotation_type_and_fields(annotation_type_label, fields)
     # annotation_type_label = 'Annotation Type'
     # fields = {
     #   Name => [Type Label, optional = true, settings (optional)],

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -708,13 +708,18 @@ module SampleData
     t
   end
 
-  def create_annotation_type_and_fields(annotation_type_label, fields)
+  def create_annotation_type_and_fields(annotation_type_label, fields, options = {})
     # annotation_type_label = 'Annotation Type'
     # fields = {
     #   Name => [Type Label, optional = true, settings (optional)],
     #   ...
     # }
     annotation_type_name = annotation_type_label.parameterize.tr('-', '_')
+    if Bot::Keep.archiver_annotation_types.include?(annotation_type_name)
+      field_name_prefix = annotation_type_name
+      annotation_type_name = 'archiver'
+      annotation_type_label = 'Archiver'
+    end
     at = DynamicAnnotation::AnnotationType.where(annotation_type: annotation_type_name).last || create_annotation_type(annotation_type: annotation_type_name, label: annotation_type_label)
     fts = fields.values.collect{ |v| v.first }
     fts.each do |label|
@@ -723,7 +728,7 @@ module SampleData
     end
     fields.each do |label, type|
       field_label = annotation_type_label + ' ' + label
-      field_name = annotation_type_name + '_' + label.parameterize.tr('-', '_')
+      field_name = (field_name_prefix || annotation_type_name) + '_' + label.parameterize.tr('-', '_')
       optional = type[1].nil? ? true : type[1]
       settings = type[2] || {}
       field_type = type[0].parameterize.tr('-', '_')

--- a/lib/tasks/migrate/20191212185909_merge_archive_fields_in_one_archiver_annotation.rake
+++ b/lib/tasks/migrate/20191212185909_merge_archive_fields_in_one_archiver_annotation.rake
@@ -1,0 +1,55 @@
+namespace :check do
+  namespace :migrate do
+    task merge_archive_fields_in_one_archiver_annotation: :environment do
+      RequestStore.store[:skip_notifications] = true
+      archiver_annotation_types = Bot::Keep.archiver_annotation_types 
+      total = Annotation.where(annotation_type: archiver_annotation_types).count
+      total_fields = DynamicAnnotation::Field.where(annotation_type: archiver_annotation_types).count
+      puts "[#{Time.now}] Starting to convert #{total} specific archive annotations into archiver annotations and update #{total_fields} annotation fields..."
+
+      LIMIT = 1000
+
+      sum = 0
+      n = Annotation.where(annotation_type: archiver_annotation_types).limit(LIMIT).count
+      nf = DynamicAnnotation::Field.where(annotation_type: archiver_annotation_types).limit(LIMIT).count
+      while n > 0 || nf > 0
+        puts "[#{Time.now}] Starting to convert #{n} specific archive annotations into archiver annotations, #{sum} converted, #{total - sum} remaining..."
+        sum += n
+        i = 0
+        ids = []
+        Annotation.where(annotation_type: archiver_annotation_types).limit(LIMIT).order('id ASC').each do |a|
+          i += 1
+          print "#{i}/#{n}\r"
+          $stdout.flush
+          archiver = Annotation.where(annotation_type: 'archiver', annotated_type: a.annotated_type, annotated_id: a.annotated_id).last
+          if archiver.nil?
+            a.update_columns(annotation_type: 'archiver')
+          else
+            ids << a.id
+            DynamicAnnotation::Field.where(annotation_id: a.id).update_all(annotation_id: archiver.id)
+          end
+        end
+
+        puts "[#{Time.now}] Updating #{nf} annotation fields..."
+        fid = DynamicAnnotation::Field.where(annotation_type: archiver_annotation_types).order('id ASC').limit(LIMIT).last&.id&.to_i
+        DynamicAnnotation::Field.where(annotation_type: archiver_annotation_types).where("id <= #{fid}").update_all(annotation_type: 'archiver')
+
+        puts "[#{Time.now}] Deleting #{ids.size} specific annotations..."
+        Annotation.delete_all(id: ids)
+
+        n = Annotation.where(annotation_type: archiver_annotation_types).limit(LIMIT).count
+        nf = DynamicAnnotation::Field.where(annotation_type: archiver_annotation_types).limit(LIMIT).count
+      end
+
+      total_archivers = Annotation.where(annotation_type: 'archiver').count
+      total_archivers_fields = DynamicAnnotation::Field.where(annotation_type: 'archiver').count
+      puts "[#{Time.now}] #{total} specific archive annotations converted to #{total_archivers} archiver annotations and #{total_archivers_fields} annotation fields updated."
+
+      puts "[#{Time.now}] Done! Verifying (the queries below should return zero results)..."
+      puts "[#{Time.now}] Specific archive annotations: #{Annotation.where(annotation_type: archiver_annotation_types).count}"
+      puts "[#{Time.now}] Fields with specific annotation type #{DynamicAnnotation::Field.where(annotation_type: archiver_annotation_types).count}"
+
+      RequestStore.store[:skip_notifications] = false
+    end
+  end
+end

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -73,7 +73,7 @@ class WebhooksControllerTest < ActionController::TestCase
     p = create_project team: t
     pm = create_project_media media: l, project: p
     pm.create_all_archive_annotations
-    f = JSON.parse(pm.get_annotations('pender_archive').last.load.get_field_value('pender_archive_response'))
+    f = JSON.parse(pm.get_annotations('archiver').last.load.get_field_value('pender_archive_response'))
     assert_equal [], f.keys
 
     payload = { type: 'screenshot', url: url, screenshot_taken: 1, screenshot_url: 'http://pender/screenshot.png' }.to_json
@@ -83,7 +83,7 @@ class WebhooksControllerTest < ActionController::TestCase
     post :index, name: :keep
     @request.env.delete('RAW_POST_DATA')
     assert_response :success
-    f = JSON.parse(pm.get_annotations('pender_archive').last.load.get_field_value('pender_archive_response'))
+    f = JSON.parse(pm.get_annotations('archiver').last.load.get_field_value('pender_archive_response'))
     assert_equal 'http://pender/screenshot.png', f['screenshot_url']
     Team.any_instance.unstub(:get_limits_keep)
   end
@@ -107,7 +107,7 @@ class WebhooksControllerTest < ActionController::TestCase
     p = create_project team: t
     pm = create_project_media media: l, project: p
     pm.create_all_archive_annotations
-    f = JSON.parse(pm.get_annotations('pender_archive').last.load.get_field_value('pender_archive_response'))
+    f = JSON.parse(pm.get_annotations('archiver').last.load.get_field_value('pender_archive_response'))
     assert_equal [], f.keys
 
     payload = { url: 'http://anothertest.com', screenshot_taken: 1, screenshot_url: 'http://pender/screenshot.png' }.to_json
@@ -117,7 +117,7 @@ class WebhooksControllerTest < ActionController::TestCase
     post :index, name: :keep
     @request.env.delete('RAW_POST_DATA')
     assert_response :success
-    f = JSON.parse(pm.get_annotations('pender_archive').last.load.get_field_value('pender_archive_response'))
+    f = JSON.parse(pm.get_annotations('archiver').last.load.get_field_value('pender_archive_response'))
     assert_equal [], f.keys
     Team.any_instance.unstub(:get_limits_keep)
   end
@@ -158,7 +158,8 @@ class WebhooksControllerTest < ActionController::TestCase
     p = create_project team: t
     pm = create_project_media media: l, project: p
     pm.create_all_archive_annotations
-    a = pm.get_annotations('pender_archive').last
+    archiver = pm.get_annotations('archiver').last
+    a = DynamicAnnotation::Field.where(field_name: 'pender_archive_response', annotation_id: archiver.id).last
     a.destroy
 
     payload = { url: url, screenshot_taken: 1, screenshot_url: 'http://pender/screenshot.png' }.to_json

--- a/test/models/annotation_test.rb
+++ b/test/models/annotation_test.rb
@@ -234,13 +234,13 @@ class AnnotationTest < ActiveSupport::TestCase
     p = create_project team: t
     pm = create_project_media media: l, project: p
     pm.create_all_archive_annotations
-    a = pm.get_annotations('pender_archive').last.load
+    a = pm.get_annotations('archiver').last.load
     f = a.get_field('pender_archive_response')
     f.value = '{"foo":"bar"}'
     f.save!
     v = a.reload.get_field('pender_archive_response').reload.value
     assert_not_equal "{}", v
-    pm.reset_archive_response(a)
+    pm.reset_archive_response(a, 'pender_archive')
     v = a.reload.get_field('pender_archive_response').reload.value
     assert_equal "{}", v
   end
@@ -259,7 +259,7 @@ class AnnotationTest < ActiveSupport::TestCase
     p = create_project team: t
     pm = create_project_media media: l, project: p
     pm.create_all_archive_annotations
-    a = pm.get_annotations('pender_archive').last.load
+    a = pm.get_annotations('archiver').last.load
     f = a.get_field('pender_archive_response')
     f.value = '{"foo":"bar"}'
     f.save!
@@ -268,7 +268,7 @@ class AnnotationTest < ActiveSupport::TestCase
     tbi.save!
     v = a.reload.get_field('pender_archive_response').reload.value
     pm = ProjectMedia.find(pm.id)
-    pm.reset_archive_response(a)
+    pm.reset_archive_response(a, 'pender_archive')
     v = a.reload.get_field('pender_archive_response').reload.value
     assert_equal '{"foo":"bar"}', v
   end

--- a/test/models/bot/keep_test.rb
+++ b/test/models/bot/keep_test.rb
@@ -38,8 +38,11 @@ class Bot::KeepTest < ActiveSupport::TestCase
     l = create_link
     p = create_project team: t
     pm = create_project_media project: p, media: l
-    pm.create_all_archive_annotations
-    assert_not_nil pm.annotations.where(annotation_type: 'keep_backup').last
+    assert_difference 'Dynamic.where(annotation_type: "archiver").count' do
+      assert_difference 'DynamicAnnotation::Field.where(annotation_type: "archiver", field_name: "keep_backup_response").count' do
+        pm.create_all_archive_annotations
+      end
+    end
   end
 
   test "should not create Keep annotations if media is not a link" do
@@ -54,8 +57,11 @@ class Bot::KeepTest < ActiveSupport::TestCase
     c = create_claim_media
     p = create_project team: t
     pm = create_project_media project: p, media: c
-    pm.create_all_archive_annotations
-    assert_nil pm.annotations.where(annotation_type: 'keep_backup').last
+    assert_no_difference 'Dynamic.where(annotation_type: "archiver").count' do
+      assert_no_difference 'DynamicAnnotation::Field.where(annotation_type: "archiver", field_name: "keep_backup_response").count' do
+        pm.create_all_archive_annotations
+      end
+    end
   end
 
   test "should create Keep annotations when bot runs" do
@@ -71,8 +77,11 @@ class Bot::KeepTest < ActiveSupport::TestCase
     p = create_project team: t
     pm = create_project_media project: p, media: l
     u = create_user is_admin: true
-    Bot::Keep.run({ data: { dbid: pm.id }, user_id: u.id })
-    assert_not_nil pm.annotations.where(annotation_type: 'keep_backup').last
+    assert_difference 'Dynamic.where(annotation_type: "archiver").count' do
+      assert_difference 'DynamicAnnotation::Field.where(annotation_type: "archiver", field_name: "keep_backup_response").count' do
+        Bot::Keep.run({ data: { dbid: pm.id }, user_id: u.id })
+      end
+    end
   end
 
   test "should parse webhook payload" do

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -747,12 +747,14 @@ class ProjectTest < ActiveSupport::TestCase
       l1 = create_link
       pm3 = create_project_media media: l1, project: p
       pm3.create_all_archive_annotations
-      f = DynamicAnnotation::Field.last
+      archiver = Annotation.where(annotation_type: 'archiver', annotated_id: pm3.id).last
+      f = DynamicAnnotation::Field.where(field_name: "pender_archive_response", annotation_id: archiver.id).last
       f.value = { screenshot_url: 'http://pender/images/test.png' }.to_json
       f.save!
       l2 = create_link
       pm4 = create_project_media media: l2, project: p
       pm4.create_all_archive_annotations
+
       assert_equal 2, p.export_images.values.reject{ |x| x.nil? }.size
     end
     Team.any_instance.unstub(:get_limits_keep)


### PR DESCRIPTION
Add Perma.cc as option on keep bot
Create new archiver annotation "archiver" to replace the specific archivers (archive_org, archive_is, perma_cc)
Change the archivers field instances to be optional
Add a migration and task to replace the specific archivers annotation:
  * There will be one of type "archiver"
  * On DynamicAnnotation::Field, replaced the annotation with the new annotation type 'archiver'