### PR TITLE
Updated dockerfile to use Ruby 2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-slim
+FROM ruby:2.5-slim
 MAINTAINER Meedan <sysops@meedan.com>
 
 # the Rails stage can be overridden from the caller


### PR DESCRIPTION
Ruby 2.4 is now EOL as of 31st March 2020.