### PR TITLE
Set locale to C.UTF-8 rather than en_US.UTF-8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ before_install:
 - export RECORD_RUNTIME=true
 - export PATH=/tmp/bundler/ruby/2.4.0/bin:$PATH
 - export GEM_PATH=/tmp/bundler/ruby/2.4.0/gems:$GEM_PATH
-- export LC_ALL=en_US.UTF-8
-- export LANG=en_US.UTF-8
-- export LANGUAGE=en_US.UTF-8
+- export LC_ALL=C.UTF-8
+- export LANG=C.UTF-8
+- export LANGUAGE=C.UTF-8
 - sudo rm -f /etc/apt/sources.list.d/mongodb*
 - docker run -d -p 9000:9000 -e "MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE" -e "MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" minio/minio server /data
 - docker run -d --name elasticsearch -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.9.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,12 +7,10 @@ ENV RAILS_ENV development
 # https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat/
 ENV MALLOC_ARENA_MAX 2
 
-# Set the default locale to en_US.UTF8
-# Note that language specific locales may not be supported; then try: C.UTF-8
-#
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
+# Set a UTF-8 capabable locale
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+ENV LANGUAGE C.UTF-8
 
 RUN apt-get update -qq && apt-get install -y --no-install-recommends curl
 

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -17,12 +17,10 @@ ENV DEPLOYUSER=checkdeploy \
     # MALLOC_ARENA MAX is needed because of https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat/
     # MIN_INSTANCES and MAX_POOL_SIZE control the pool size of passenger
 
-# Set the default locale to en_US.UTF8
-# Note that language specific locales may not be supported; then try: C.UTF-8
-#
-ENV LC_ALL en_US.UTF-8
-ENV LANG en_US.UTF-8
-ENV LANGUAGE en_US.UTF-8
+# Set a UTF-8 capable locale
+ENV LC_ALL C.UTF-8
+ENV LANG C.UTF-8
+ENV LANGUAGE C.UTF-8
 
 #
 # USER CONFIG


### PR DESCRIPTION
Set UTF-8 capable locale. Avoid installing region specific locales to conserve storage.