### PR TITLE
Upload to Workbench TUS URLs

### DIFF
--- a/lib/tasks/data/push_all_configured_teams_to_workbench.rake
+++ b/lib/tasks/data/push_all_configured_teams_to_workbench.rake
@@ -3,25 +3,26 @@ require 'csv'
 require_relative './pg_export'
 require_relative './workbench_upload'
 
-# Given {team_slug, workflow_id, step_id, api_token}, export that
+# Given {team_slug, workbench_step_url, api_token}, export that
 # team's data to a tempfile and upload that tempfile to Workbench.
-def upload_one(team_slug:, **workbench_params)
+def upload_one(team_slug:, workbench_step_url:, api_token:)
   Tempfile.open("#{team_slug}-sqlite3-lz4") do |f|
     f.close
     PgExport::export_team_to_sqlite_lz4_file(team_slug, f.path)
     WorkbenchUpload::upload_file_to_workbench(
-      **workbench_params,
+      step_files_url: workbench_step_url,
+      api_token: api_token,
       path: f.path,
       filename: "#{team_slug}-#{Date.today.iso8601}.sqlite3.lz4"
     )
   end
 end
 
-# Load rows from S3 as {team_slug, workflow_id, step_id, api_token}
+# Load rows from S3 as {team_slug, workbench_step_url, api_token}
 #
 # The CSV should look like:
 #
-#     team_slug,workflow_id,step_id,api_token
+#     team_slug,workbench_step_url,api_token
 #     my-team,1412,step-234fDdf,my-api-token
 #     ...
 def load_rows_from_s3_csv(bucket, key)
@@ -29,15 +30,14 @@ def load_rows_from_s3_csv(bucket, key)
   csv_io = s3.bucket(bucket).object(key).get.body
   CSV.parse(csv_io, headers: true)
     .map do |row|
-      team_slug, workflow_id, step_id, api_token = row.fields(*%w(team_slug workflow_id step_id api_token))
-      if team_slug.nil? || workflow_id.nil? || step_id.nil? || api_token.nil?
+      team_slug, workbench_step_url, api_token = row.fields(*%w(team_slug workbench_step_url api_token))
+      if team_slug.nil? || workbench_step_url.nil? || api_token.nil?
         puts "Skipping row because values are missing. Contents: #{row.to_s}"
         nil
       else
         {
           team_slug: team_slug,
-          workflow_id: workflow_id,
-          step_id: step_id,
+          workbench_step_url: workbench_step_url,
           api_token: api_token,
         }
       end
@@ -49,13 +49,36 @@ namespace :check do
   namespace :data do
     desc "Upload teams' data to Workbench, as specified in a CSV on S3"
     task :push_all_configured_teams_to_workbench => :environment do |task|
+      # To test:
+      #
+      #     aws s3 mb s3://my-test-bucket
+      #     aws s3 cp file.csv s3://my-test-bucket/workbench-upload-urls.csv
+      #     docker-compose up -d postgres
+      #     docker-compose run --rm --no-deps \
+      #         -e WORKBENCH_INTEGRATION_S3_BUCKET=my-test-bucket \
+      #         -e WORKBENCH_INTEGRATION_S3_KEY=workbench-upload-urls.csv \
+      #         -e AWS_ACCESS_KEY_ID="$AWS_ACCESS_KEY_ID" \
+      #         -e AWS_SECRET_ACCESS_KEY="$AWS_SECRET_ACCESS_KEY" \
+      #         -e AWS_REGION=us-east-1 \
+      #         -e storage_bucket_region=us-east-1 \
+      #         -e storage_access_key="$AWS_ACCESS_KEY_ID" \
+      #         -e storage_secret_key="$AWS_SECRET_ACCESS_KEY" \
+      #         -e storage_endpoint="https://s3.us-east-1.amazonaws.com" \
+      #         api bundle exec rake check:data:push_all_configured_teams_to_workbench
+
       s3_bucket = ENV["WORKBENCH_INTEGRATION_S3_BUCKET"]
       s3_key = ENV["WORKBENCH_INTEGRATION_S3_KEY"]
       raise "Must set WORKBENCH_INTEGRATION_S3_BUCKET environment variable" if s3_bucket.nil?
       raise "Must set WORKBENCH_INTEGRATION_S3_KEY environment variable" if s3_key.nil?
 
       load_rows_from_s3_csv(s3_bucket, s3_key).each do |values|
-        upload_one(**values)
+        begin
+          upload_one(**values)
+        rescue => err
+          puts "Skipping upload of #{values[:team_slug]} because of an error:"
+          puts err.message
+          puts err.backtrace
+        end
       end
     end
   end

--- a/lib/tasks/data/push_team_to_workbench.rake
+++ b/lib/tasks/data/push_team_to_workbench.rake
@@ -4,17 +4,16 @@ require_relative './workbench_upload'
 namespace :check do
   namespace :data do
     desc "Upload workspace data to Workbench Check module"
-    task :push_team_to_workbench, [:team_slug, :workflow_id, :step_id, :api_token] => :environment do |task, args|
-      raise "Usage: #{task.to_s}[team_slug,workflow_id,step_id,api_token]" unless (
-        args.team_slug && args.workflow_id && args.step_id && args.api_token
+    task :push_team_to_workbench, [:team_slug, :workbench_step_url, :api_token] => :environment do |task, args|
+      raise "Usage: #{task.to_s}[team_slug,workbench_step_url,api_token]" unless (
+        args.team_slug && args.workbench_step_url && args.api_token
       )
 
       Tempfile.open("#{args.team_slug}-sqlite3-lz4") do |f|
         f.close
         PgExport::export_team_to_sqlite_lz4_file(args.team_slug, f.path)
         WorkbenchUpload::upload_file_to_workbench(
-          workflow_id: args.workflow_id,
-          step_id: args.step_id,
+          workbench_step_url: args.workbench_step_url,
           api_token: args.api_token,
           path: f.path,
           filename: "#{args.team_slug}-#{Date.today.iso8601}.sqlite3.lz4"

--- a/lib/tasks/data/workbench_upload.rb
+++ b/lib/tasks/data/workbench_upload.rb
@@ -1,13 +1,27 @@
 # :nocov:
-require 'aws-sdk-s3'
 require 'typhoeus'
 
+N_RETRIES = 3
+
 module WorkbenchUpload
-  def self.upload_file_to_workbench(workflow_id:, step_id:, api_token:, path:, filename:)
-    s3_config = get_s3_config_from_workbench(workflow_id, step_id, api_token)
-    puts "Uploading to s3://#{s3_config['bucket']}/#{s3_config['key']}"
-    upload_file_to_s3(path, s3_config)
-    finish_workbench_upload(s3_config['finishUrl'], api_token, filename)
+  def self.upload_file_to_workbench(step_files_url:, api_token:, path:, filename:)
+    attempt = 0
+    begin
+      tus_upload_url = get_tus_upload_url_from_workbench(
+        step_files_url: step_files_url,
+        api_token: api_token,
+        filename: filename,
+        size: File.size(path)
+      )
+      tus_upload(path, tus_upload_url)
+    rescue Typhoeus::Errors::TyphoeusError
+      attempt += 1
+      if attempt < N_RETRIES
+        retry
+      else
+        raise
+      end
+    end
   end
 
   protected
@@ -15,55 +29,41 @@ module WorkbenchUpload
   def self.raise_on_http_problem(response)
     if not response.success?
       if response.timed_out?
-        raise 'HTTP request timed out'
+        raise Typhoeus::Errors::TyphoeusError, 'HTTP request timed out'
       elsif response.code == 0
-        raise "HTTP request did not complete: #{response.return_message}"
+        raise Typhoeus::Errors::TyphoeusError, "HTTP request did not complete: #{response.return_message}"
       else
-        puts response.inspect
-        raise "HTTP #{response.status_message}"
+        raise Typhoeus::Errors::TyphoeusError, "HTTP #{response.status_message}: #{response.inspect}"
       end
     end
   end
 
-  def self.get_s3_config_from_workbench(workflow_id, step_id, api_token)
-    url = "https://app.workbenchdata.com/api/v1/workflows/#{workflow_id}/steps/#{step_id}/uploads"
-    response = Typhoeus.post(url, headers: {Authorization: "Bearer #{api_token}"})
-    raise_on_http_problem(response)
-    JSON.parse(response.response_body)
-  end
-
-  def self.upload_file_to_s3(path, s3_config)
-    s3_client = Aws::S3::Client.new(
-      # Commented out: aws-sdk v3 format
-      # endpoint: s3_config['endpoint'],
-      # force_path_style: true,
-      # credentials: Aws::Credentials(
-      #   s3_config['credentials']['accessKeyId'],
-      #   s3_config['credentials']['secretAccessKey'],
-      #   s3_config['credentials']['sessionToken'],
-      # )
-      # aws-sdk v1 format:
-      endpoint: s3_config['endpoint'],
-      force_path_style: true,
-      access_key_id: s3_config['credentials']['accessKeyId'],
-      secret_access_key: s3_config['credentials']['secretAccessKey'],
-      session_token: s3_config['credentials']['sessionToken'],
-    )
-    s3_resource = Aws::S3::Resource.new(client: s3_client)
-    s3_resource.bucket(s3_config['bucket']).object(s3_config['key']).upload_file(path)
-  end
-
-  def self.finish_workbench_upload(finish_url, api_token, filename)
+  def self.get_tus_upload_url_from_workbench(step_files_url:, api_token:, filename:, size:)
+    puts "POST #{step_files_url}"
     response = Typhoeus.post(
-      finish_url,
-      body: JSON.dump({'filename': filename}),
+      step_files_url,
       headers: {
         Authorization: "Bearer #{api_token}",
-        'Content-Type': 'application/json'
-      }
+        "Content-Type": "application/json"
+      },
+      body: JSON.dump({ filename: filename, size: size })
     )
     raise_on_http_problem(response)
-    response
+    JSON.parse(response.response_body)['tusUploadUrl']
+  end
+
+  def self.tus_upload(path, url)
+    puts "PATCH #{url} (contents: #{path})"
+    response = Typhoeus.patch(
+      url,
+      headers: {
+        "Content-Type": "application/offset+octet-stream",
+        "Tus-Resumable": "1.0.0",
+        "Upload-Offset": "0"
+      },
+      body: File.open(path, "rb").read
+    )
+    raise_on_http_problem(response)
   end
 end
 # :nocov:


### PR DESCRIPTION
Also, retry uploads on failure and skip uploads when the retries fail.

**TO DEPLOY**, be sure to change the CSV to match the new schema. Instead
of `workflow_id` and `step_id`, there is now just one column,
`workbench_step_url`. To migrate your CSV, apply a formula:

```workbench_step_url = "https://app.workbenchdata.com/api/v1/workflows/" + workflow_id + "/steps/" + step_id + "/files"```

For instance, now a valid CSV looks like:

```
team_slug,workbench_step_url,api_token
my-team-1,https://app.workbenchdata.com/api/v1/workflows/123456/steps/step-abcdef/files,SoMe-Tok3n
my-team-1,https://app.workbenchdata.com/api/v1/workflows/123456/steps/step-bcdefg/files,4n0th3r-70k_n
```