### PR TITLE
Use exclusive secrets option when deploying task updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,7 @@ build_qa:
 
   script:
     - apk add --no-cache curl python3 py3-pip
-    - pip install awscli==1.18.188
+    - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
     - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA" .
     - docker push "$ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
@@ -39,10 +39,9 @@ deploy_qa:
     GITHUB_TOKEN: $GITHUB_TOKEN
   script:
     - apk add --no-cache curl python3 py3-pip git
-    - pip install boto3==1.16.28
-    - pip install botocore==1.19.48
-    - pip install docutils==0.16
-    - pip install awscli==1.18.188
+    - pip install awscli==1.18.194
+    - pip install botocore==1.17.47
+    - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
     - alias aws='docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION --rm amazon/aws-cli'
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/check-api/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/check-api/##' > env.qa.names
@@ -73,8 +72,7 @@ build_live:
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
   script:
     - apk add --no-cache curl python3 py3-pip git
-    - pip install docutils==0.14
-    - pip install awscli==1.18.188
+    - pip install awscli==1.18.194
     - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
     - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA" .
     - docker push "$ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA"
@@ -97,10 +95,9 @@ deploy_live:
     GITHUB_TOKEN: $GITHUB_TOKEN
   script:
     - apk add --no-cache curl python3 py3-pip git
-    - pip install boto3==1.16.28
-    - pip install botocore==1.19.48
-    - pip install docutils==0.16
-    - pip install awscli==1.18.188
+    - pip install awscli==1.18.194
+    - pip install botocore==1.17.47
+    - pip install boto3==1.14.47
     - pip install ecs-deploy==1.11.0
     - alias aws='docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION --rm amazon/aws-cli'
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/check-api/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/check-api/##' > env.live.names

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,14 +46,14 @@ deploy_qa:
     - alias aws='docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION --rm amazon/aws-cli'
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/check-api/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/check-api/##' > env.qa.names
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-migration $NAME /qa/check-api/$NAME " >> qa-check-api-migration.env.args; done
-    - ecs update qa-check-api-migration --image qa-check-api-migration $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA --exclusive-secrets `cat qa-check-api-migration.env.args`
+    - ecs update qa-check-api-migration --image qa-check-api-migration $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA -e qa-check-api-migration GITHUB_TOKEN null --exclusive-secrets `cat qa-check-api-migration.env.args`
     - taskArn=$(aws ecs run-task --cluster ecs-qa --task-definition qa-check-api-migration --query 'tasks[].taskArn' --output text)
     - echo "Migration task started - $taskArn"
     - aws ecs wait tasks-stopped --cluster ecs-qa --tasks $taskArn
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-c $NAME /qa/check-api/$NAME " >> qa-check-api-c.env.args; done
-    - ecs deploy ecs-qa qa-check-api --image qa-check-api-c $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-check-api-c.env.args`
+    - ecs deploy ecs-qa qa-check-api --image qa-check-api-c $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 -e qa-check-api-c GITHUB_TOKEN null --exclusive-secrets `cat qa-check-api-c.env.args`
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-background $NAME /qa/check-api/$NAME " >> qa-check-api-background.env.args; done
-    - ecs deploy ecs-qa qa-check-api-background --image qa-check-api-background $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-check-api-background.env.args`
+    - ecs deploy ecs-qa qa-check-api-background --image qa-check-api-background $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 -e qa-check-api-background GITHUB_TOKEN null --exclusive-secrets `cat qa-check-api-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
@@ -102,16 +102,16 @@ deploy_live:
     - alias aws='docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION --rm amazon/aws-cli'
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/check-api/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/check-api/##' > env.live.names
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-workbench $NAME /live/check-api/$NAME " >> live-check-api-workbench.env.args; done
-    - ecs update live-check-api-workbench --image live-check-api-workbench $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA --exclusive-secrets `cat live-check-api-workbench.env.args`
+    - ecs update live-check-api-workbench --image live-check-api-workbench $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA -e live-check-api-workbench GITHUB_TOKEN null --exclusive-secrets `cat live-check-api-workbench.env.args`
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-migration $NAME /live/check-api/$NAME " >> live-check-api-migration.env.args; done
-    - ecs update live-check-api-migration --image live-check-api-migration $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA --exclusive-secrets `cat live-check-api-migration.env.args`
+    - ecs update live-check-api-migration --image live-check-api-migration $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA -e live-check-api-migration GITHUB_TOKEN null --exclusive-secrets `cat live-check-api-migration.env.args`
     - taskArn=$(aws ecs run-task --cluster ecs-live --task-definition live-check-api-migration --query 'tasks[].taskArn' --output text)
     - echo "Migration task started - $taskArn"
     - aws ecs wait tasks-stopped --cluster ecs-live --tasks $taskArn
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-c $NAME /live/check-api/$NAME " >> live-check-api-c.env.args; done
-    - ecs deploy ecs-live  live-check-api --image live-check-api-c $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-check-api-c.env.args`
+    - ecs deploy ecs-live  live-check-api --image live-check-api-c $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 -e live-check-api-c GITHUB_TOKEN null --exclusive-secrets `cat live-check-api-c.env.args`
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-background $NAME /live/check-api/$NAME " >> live-check-api-background.env.args; done
-    - ecs deploy ecs-live  live-check-api-background --image live-check-api-background $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-check-api-background.env.args`
+    - ecs deploy ecs-live  live-check-api-background --image live-check-api-background $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 -e live-check-api-background GITHUB_TOKEN null --exclusive-secrets `cat live-check-api-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA"
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -46,14 +46,17 @@ deploy_qa:
     - alias aws='docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION --rm amazon/aws-cli'
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/check-api/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/check-api/##' > env.qa.names
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-migration $NAME /qa/check-api/$NAME " >> qa-check-api-migration.env.args; done
-    - ecs update qa-check-api-migration --image qa-check-api-migration $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA -e qa-check-api-migration GITHUB_TOKEN null --exclusive-secrets `cat qa-check-api-migration.env.args`
+    - echo -n "-s qa-check-api-migration GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-migration.env.args
+    - ecs update qa-check-api-migration --image qa-check-api-migration $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA --exclusive-secrets `cat qa-check-api-migration.env.args`
     - taskArn=$(aws ecs run-task --cluster ecs-qa --task-definition qa-check-api-migration --query 'tasks[].taskArn' --output text)
     - echo "Migration task started - $taskArn"
     - aws ecs wait tasks-stopped --cluster ecs-qa --tasks $taskArn
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-c $NAME /qa/check-api/$NAME " >> qa-check-api-c.env.args; done
-    - ecs deploy ecs-qa qa-check-api --image qa-check-api-c $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 -e qa-check-api-c GITHUB_TOKEN null --exclusive-secrets `cat qa-check-api-c.env.args`
+    - echo -n "-s qa-check-api-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-c.env.args
+    - ecs deploy ecs-qa qa-check-api --image qa-check-api-c $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-check-api-c.env.args`
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-background $NAME /qa/check-api/$NAME " >> qa-check-api-background.env.args; done
-    - ecs deploy ecs-qa qa-check-api-background --image qa-check-api-background $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 -e qa-check-api-background GITHUB_TOKEN null --exclusive-secrets `cat qa-check-api-background.env.args`
+    - echo -n "-s qa-check-api-background GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-background.env.args
+    - ecs deploy ecs-qa qa-check-api-background --image qa-check-api-background $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-check-api-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
@@ -102,16 +105,20 @@ deploy_live:
     - alias aws='docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION --rm amazon/aws-cli'
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/check-api/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/check-api/##' > env.live.names
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-workbench $NAME /live/check-api/$NAME " >> live-check-api-workbench.env.args; done
-    - ecs update live-check-api-workbench --image live-check-api-workbench $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA -e live-check-api-workbench GITHUB_TOKEN null --exclusive-secrets `cat live-check-api-workbench.env.args`
+    - echo -n "-s live-check-api-workbench GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-workbench.env.args
+    - ecs update live-check-api-workbench --image live-check-api-workbench $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA --exclusive-secrets `cat live-check-api-workbench.env.args`
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-migration $NAME /live/check-api/$NAME " >> live-check-api-migration.env.args; done
-    - ecs update live-check-api-migration --image live-check-api-migration $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA -e live-check-api-migration GITHUB_TOKEN null --exclusive-secrets `cat live-check-api-migration.env.args`
+    - echo -n "-s live-check-api-migration GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-migration.env.args
+    - ecs update live-check-api-migration --image live-check-api-migration $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA --exclusive-secrets `cat live-check-api-migration.env.args`
     - taskArn=$(aws ecs run-task --cluster ecs-live --task-definition live-check-api-migration --query 'tasks[].taskArn' --output text)
     - echo "Migration task started - $taskArn"
     - aws ecs wait tasks-stopped --cluster ecs-live --tasks $taskArn
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-c $NAME /live/check-api/$NAME " >> live-check-api-c.env.args; done
-    - ecs deploy ecs-live  live-check-api --image live-check-api-c $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 -e live-check-api-c GITHUB_TOKEN null --exclusive-secrets `cat live-check-api-c.env.args`
+    - echo -n "-s live-check-api-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-check-api-c.env.args
+    - ecs deploy ecs-live  live-check-api --image live-check-api-c $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-check-api-c.env.args`
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-background $NAME /live/check-api/$NAME " >> live-check-api-background.env.args; done
-    - ecs deploy ecs-live  live-check-api-background --image live-check-api-background $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 -e live-check-api-background GITHUB_TOKEN null --exclusive-secrets `cat live-check-api-background.env.args`
+    - echo -n "-s live-check-api-background GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-background.env.args
+    - ecs deploy ecs-live  live-check-api-background --image live-check-api-background $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-check-api-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA"
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,16 +47,16 @@ deploy_qa:
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/check-api/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/check-api/##' > env.qa.names
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-migration $NAME /qa/check-api/$NAME " >> qa-check-api-migration.env.args; done
     - echo -n "-s qa-check-api-migration GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-migration.env.args
-    - ecs update qa-check-api-migration --image qa-check-api-migration $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA --exclusive-secrets `cat qa-check-api-migration.env.args`
+    - ecs update qa-check-api-migration --image qa-check-api-migration $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA --exclusive-env -e qa-check-api-migration APP check-api -e qa-check-api-migration DEPLOY_ENV qa -e qa-check-api-migration AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-check-api-migration.env.args`
     - taskArn=$(aws ecs run-task --cluster ecs-qa --task-definition qa-check-api-migration --query 'tasks[].taskArn' --output text)
     - echo "Migration task started - $taskArn"
     - aws ecs wait tasks-stopped --cluster ecs-qa --tasks $taskArn
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-c $NAME /qa/check-api/$NAME " >> qa-check-api-c.env.args; done
     - echo -n "-s qa-check-api-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-c.env.args
-    - ecs deploy ecs-qa qa-check-api --image qa-check-api-c $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-check-api-c.env.args`
+    - ecs deploy ecs-qa qa-check-api --image qa-check-api-c $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e qa-check-api-c APP check-api -e qa-check-api-c DEPLOY_ENV qa -e qa-check-api-c AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-check-api-c.env.args`
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-background $NAME /qa/check-api/$NAME " >> qa-check-api-background.env.args; done
     - echo -n "-s qa-check-api-background GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-background.env.args
-    - ecs deploy ecs-qa qa-check-api-background --image qa-check-api-background $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-check-api-background.env.args`
+    - ecs deploy ecs-qa qa-check-api-background --image qa-check-api-background $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e qa-check-api-background APP check-api -e qa-check-api-background DEPLOY_ENV qa -e qa-check-api-background AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-check-api-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
@@ -106,19 +106,19 @@ deploy_live:
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/check-api/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/check-api/##' > env.live.names
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-workbench $NAME /live/check-api/$NAME " >> live-check-api-workbench.env.args; done
     - echo -n "-s live-check-api-workbench GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-workbench.env.args
-    - ecs update live-check-api-workbench --image live-check-api-workbench $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA --exclusive-secrets `cat live-check-api-workbench.env.args`
+    - ecs update live-check-api-workbench --image live-check-api-workbench $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA --exclusive-env -e live-check-api-workbench APP check-api -e live-check-api-workbench DEPLOY_ENV qa -e live-check-api-workbench AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat live-check-api-workbench.env.args`
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-migration $NAME /live/check-api/$NAME " >> live-check-api-migration.env.args; done
     - echo -n "-s live-check-api-migration GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-migration.env.args
-    - ecs update live-check-api-migration --image live-check-api-migration $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA --exclusive-secrets `cat live-check-api-migration.env.args`
+    - ecs update live-check-api-migration --image live-check-api-migration $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA --exclusive-env -e live-check-api-migration APP check-api -e live-check-api-migration DEPLOY_ENV qa -e live-check-api-migration AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat live-check-api-migration.env.args`
     - taskArn=$(aws ecs run-task --cluster ecs-live --task-definition live-check-api-migration --query 'tasks[].taskArn' --output text)
     - echo "Migration task started - $taskArn"
     - aws ecs wait tasks-stopped --cluster ecs-live --tasks $taskArn
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-c $NAME /live/check-api/$NAME " >> live-check-api-c.env.args; done
     - echo -n "-s live-check-api-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-check-api-c.env.args
-    - ecs deploy ecs-live  live-check-api --image live-check-api-c $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-check-api-c.env.args`
+    - ecs deploy ecs-live  live-check-api --image live-check-api-c $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e live-check-api-c APP check-api -e live-check-api-c DEPLOY_ENV qa -e live-check-api-c AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat live-check-api-c.env.args`
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-background $NAME /live/check-api/$NAME " >> live-check-api-background.env.args; done
     - echo -n "-s live-check-api-background GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-background.env.args
-    - ecs deploy ecs-live  live-check-api-background --image live-check-api-background $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-check-api-background.env.args`
+    - ecs deploy ecs-live  live-check-api-background --image live-check-api-background $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e live-check-api-background APP check-api -e live-check-api-background DEPLOY_ENV qa -e live-check-api-background AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat live-check-api-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA"
   only:
     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - use-exclusive-secrets
 
 deploy_qa:
   image: docker:latest
@@ -46,17 +47,18 @@ deploy_qa:
     - alias aws='docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION --rm amazon/aws-cli'
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/check-api/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/check-api/##' > env.qa.names
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-migration $NAME /qa/check-api/$NAME " >> qa-check-api-migration.env.args; done
-    - ecs update qa-check-api-migration --image qa-check-api-migration $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  `cat qa-check-api-migration.env.args`
+    - ecs update qa-check-api-migration --image qa-check-api-migration $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA --exclusive-secrets `cat qa-check-api-migration.env.args`
     - taskArn=$(aws ecs run-task --cluster ecs-qa --task-definition qa-check-api-migration --query 'tasks[].taskArn' --output text)
     - echo "Migration task started - $taskArn"
     - aws ecs wait tasks-stopped --cluster ecs-qa --tasks $taskArn
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-c $NAME /qa/check-api/$NAME " >> qa-check-api-c.env.args; done
-    - ecs deploy ecs-qa qa-check-api --image qa-check-api-c $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-check-api-c.env.args`
+    - ecs deploy ecs-qa qa-check-api --image qa-check-api-c $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-check-api-c.env.args`
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-background $NAME /qa/check-api/$NAME " >> qa-check-api-background.env.args; done
-    - ecs deploy ecs-qa qa-check-api-background --image qa-check-api-background $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 `cat qa-check-api-background.env.args`
+    - ecs deploy ecs-qa qa-check-api-background --image qa-check-api-background $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat qa-check-api-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - use-exclusive-secrets
 
 build_live:
   image: docker:latest
@@ -103,16 +105,16 @@ deploy_live:
     - alias aws='docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION --rm amazon/aws-cli'
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/check-api/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/check-api/##' > env.live.names
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-workbench $NAME /live/check-api/$NAME " >> live-check-api-workbench.env.args; done
-    - ecs update live-check-api-workbench --image live-check-api-workbench $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  `cat live-check-api-workbench.env.args`
+    - ecs update live-check-api-workbench --image live-check-api-workbench $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA --exclusive-secrets `cat live-check-api-workbench.env.args`
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-migration $NAME /live/check-api/$NAME " >> live-check-api-migration.env.args; done
-    - ecs update live-check-api-migration --image live-check-api-migration $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  `cat live-check-api-migration.env.args`
+    - ecs update live-check-api-migration --image live-check-api-migration $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA --exclusive-secrets `cat live-check-api-migration.env.args`
     - taskArn=$(aws ecs run-task --cluster ecs-live --task-definition live-check-api-migration --query 'tasks[].taskArn' --output text)
     - echo "Migration task started - $taskArn"
     - aws ecs wait tasks-stopped --cluster ecs-live --tasks $taskArn
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-c $NAME /live/check-api/$NAME " >> live-check-api-c.env.args; done
-    - ecs deploy ecs-live  live-check-api --image live-check-api-c $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 `cat live-check-api-c.env.args`
+    - ecs deploy ecs-live  live-check-api --image live-check-api-c $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-check-api-c.env.args`
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-background $NAME /live/check-api/$NAME " >> live-check-api-background.env.args; done
-    - ecs deploy ecs-live  live-check-api-background --image live-check-api-background $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 `cat live-check-api-background.env.args`
+    - ecs deploy ecs-live  live-check-api-background --image live-check-api-background $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-secrets `cat live-check-api-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA"
   only:
     - master


### PR DESCRIPTION
This change uses the `--exclusive-secrets` option when deploying new task definitions via `ecs-deploy`. This allows us to remove deprecated SSM parameters from the parameter store without encountering hung deployments.