### PR TITLE
Configuring JSONAPI to return record count

### DIFF
--- a/config/initializers/jsonapi_resources.rb
+++ b/config/initializers/jsonapi_resources.rb
@@ -3,4 +3,6 @@ JSONAPI.configure do |config|
   config.default_paginator = :offset
   config.default_page_size = 10
   config.maximum_page_size = 50
+  config.top_level_meta_include_record_count = true
+  config.top_level_meta_record_count_key = :record_count
 end


### PR DESCRIPTION
This appears on the top level of every query response in a `meta` object, per the JSONAPI spec.