### PR TITLE
Pagination changes to v2 endpoints

### DIFF
--- a/app/resources/api/v2/workspace_resource.rb
+++ b/app/resources/api/v2/workspace_resource.rb
@@ -3,6 +3,7 @@ module Api
     class WorkspaceResource < BaseResource
       model_name 'Team'
       attributes :name, :slug
+      paginator :none
 
       def self.records(options = {})
         self.workspaces(options)

--- a/config/initializers/jsonapi_resources.rb
+++ b/config/initializers/jsonapi_resources.rb
@@ -1,6 +1,6 @@
 JSONAPI.configure do |config|
   # Built in paginators are :none, :offset, :paged
-  config.default_paginator = :offset
+  config.default_paginator = :paged
   config.default_page_size = 10
   config.maximum_page_size = 50
   config.top_level_meta_include_record_count = true


### PR DESCRIPTION
I am changing the default paginator to type `paged`, which works better with the material-ui pagination system, and changing `WorkspaceResource` to be unpaginated because I need the names of all available workspaces to do fast autocompletion and selection clientside.