### PR TITLE
CHECK-607 resolve missing cases in tests, fix query sent to alegre on image similarity lookup

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -410,13 +410,21 @@ class Bot::Alegre < BotUser
     field ||= ['original_title', 'original_description', 'analysis_title', 'analysis_description']
     threshold ||= self.get_threshold_for_text_query(nil, true)
     model ||= self.matching_model_to_use(ProjectMedia.new(team_id: team_id))
-    self.get_similar_items_from_api('/text/similarity/', {
+    self.get_similar_items_from_api(
+      '/text/similarity/',
+      self.similar_texts_from_api_conditions(text, model, fuzzy, team_id, field, threshold),
+      threshold
+    )
+  end
+
+  def self.similar_texts_from_api_conditions(text, model, fuzzy, team_id, field, threshold)
+    {
       text: text,
       model: model,
       fuzzy: fuzzy == 'true' || fuzzy.to_i == 1,
       context: self.build_context(team_id, field),
       threshold: threshold[:value]
-    }, threshold)
+    }
   end
 
   def self.get_items_with_similar_image(pm, threshold)
@@ -424,11 +432,18 @@ class Bot::Alegre < BotUser
   end
 
   def self.get_items_from_similar_image(team_id, image_url, threshold)
-    self.get_similar_items_from_api('/image/similarity/', {
+    self.get_similar_items_from_api(
+      '/image/similarity/',
+      self.similar_images_from_api_conditions(team_id, image_url, threshold)
+    )
+  end
+  
+  def self.similar_images_from_api_conditions(team_id, image_url, threshold)
+    {
       url: image_url,
       context: self.build_context(team_id),
-      threshold: threshold
-    })
+      threshold: threshold[:value]
+    }
   end
 
   def self.add_relationships(pm, pm_id_scores)

--- a/test/models/bot/alegre_test.rb
+++ b/test/models/bot/alegre_test.rb
@@ -97,7 +97,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
       pm2 = create_project_media team: @pm.team, media: create_uploaded_image
       response = {pm1.id => 0}
       Bot::Alegre.stubs(:media_file_url).with(pm2).returns("some/path")
-      assert_equal response, Bot::Alegre.get_items_with_similar_image(pm2, 0.9)
+      assert_equal response, Bot::Alegre.get_items_with_similar_image(pm2, Bot::Alegre.get_threshold_for_image_query(pm2))
       assert_nil pm2.get_annotations('flag').last
       Bot::Alegre.unstub(:media_file_url)
       WebMock.stub_request(:get, 'http://alegre/image/classification/').to_return(body: {

--- a/test/models/bot/alegre_test.rb
+++ b/test/models/bot/alegre_test.rb
@@ -306,6 +306,16 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     Bot::Alegre.unstub(:request_api)
   end
 
+  test "should generate correct text conditions for api request" do
+    conditions = Bot::Alegre.similar_texts_from_api_conditions("blah", "elasticsearch", 'true', 1, 'original_title', {value: 0.7, key: 'text_similarity_threshold', automatic: false})
+    assert_equal conditions, {:text=>"blah", :model=>"elasticsearch", :fuzzy=>true, :context=>{:has_custom_id=>true, :field=>"original_title", :team_id=>1}, :threshold=>0.7}
+  end
+
+  test "should generate correct image conditions for api request" do
+    conditions = Bot::Alegre.similar_images_from_api_conditions(1, "https://upload.wikimedia.org/wikipedia/en/7/7d/Lenna_%28test_image%29.png", {value: 0.7, key: 'image_similarity_threshold', automatic: false})
+    assert_equal conditions, {:url=>"https://upload.wikimedia.org/wikipedia/en/7/7d/Lenna_%28test_image%29.png", :context=>{:has_custom_id=>true, :team_id=>1}, :threshold=>0.7}
+  end
+
   test "should get similar items when they are text-based" do
     create_verification_status_stuff
     RequestStore.store[:skip_cached_field_update] = false


### PR DESCRIPTION
We recently changed the `threshold` variable throughout alegre to a dictionary rather than a float so we could pack more metadata about the provenance of the threshold into the variable (and could make more conditional decisions based on that metadata). When I did this, I did not update the conditions sent to the *image* similarity endpoint, nor did I test it in QA (as we were only updating text cases. We have many tests on image similarity, but none that confirm the data being sent to alegre. we now have a fix for the bug as well as test cases to cover this situation.