### PR TITLE
pg_export: nix most of the versions table

### DIFF
--- a/lib/tasks/data/pg_export.rb
+++ b/lib/tasks/data/pg_export.rb
@@ -398,7 +398,12 @@ module PgExport
 
     class Version < Base
       def where_clause
-        "WHERE team_id = #{team_id}"
+        # This table gets quite big. Limit it so anything unused by the
+        # Workbench module isn't included.
+        #
+        # 2021-05-27 This reduces sqlite3 file size by ~45%, both before and
+        # after LZ4 compression.
+        "WHERE team_id = #{team_id} AND event_type IN ('update_projectmedia', 'create_dynamic', 'update_dynamic', 'update_dynamicannotationfield') AND associated_type = 'ProjectMedia'"
       end
 
       protected


### PR DESCRIPTION
The Workbench Check module is seeing long delays, and the `versions` table is a prime culprit.

By only SELECTing the data the Workbench module needs, a Workbench "Items" sqlite3 query of today's India Today database dropped from 34s to 13s on my dev machine. File size shrank 45%, too.

The downside: this new export format doesn't capture "all the data". If we ever want to extend the Workbench module's capabilities, we'll need to alter `pg_export`.