### PR TITLE
Use a log level of info in Live.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,10 +44,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :info
-
   # Prepend all log lines with the following tags.
   config.log_tags = [ :subdomain, :uuid ]
 
@@ -65,7 +61,8 @@ Rails.application.configure do
     options
   end
   config.lograge.formatter = Lograge::Formatters::Json.new
-  config.log_level = :warn
+  config.log_level = :info
+
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store


### PR DESCRIPTION
For Live deployments, set the log level to `info`. See CHECK-760.