### PR TITLE
URL Annotation

### DIFF
--- a/app/models/annotations/task.rb
+++ b/app/models/annotations/task.rb
@@ -19,7 +19,7 @@ class Task < ApplicationRecord
 
   field :type
   def self.task_types
-    ['free_text', 'yes_no', 'single_choice', 'multiple_choice', 'geolocation', 'datetime', 'file_upload', 'number']
+    ['free_text', 'yes_no', 'single_choice', 'multiple_choice', 'geolocation', 'datetime', 'file_upload', 'number', 'url']
   end
   validates :type, included: { values: self.task_types }
 

--- a/config/initializers/field_formatters.rb
+++ b/config/initializers/field_formatters.rb
@@ -19,6 +19,10 @@ DynamicAnnotation::Field.class_eval do
     value
   end
 
+  def field_formatter_type_url
+    url = JSON.parse(self.value).url
+  end
+
   def field_formatter_type_datetime
     # Capture TZ abbreviation manually because DateTime does not parse it
     # http://rubular.com/r/wOfJTCSxlI

--- a/config/initializers/field_formatters.rb
+++ b/config/initializers/field_formatters.rb
@@ -20,7 +20,7 @@ DynamicAnnotation::Field.class_eval do
   end
 
   def field_formatter_type_url
-    url = JSON.parse(self.value).url
+    urls = self.value.map { |item| item['url'] }.join(",")
   end
 
   def field_formatter_type_datetime
@@ -33,7 +33,7 @@ DynamicAnnotation::Field.class_eval do
     I18n.l(DateTime.parse(self.value), format: :task).gsub('[TZ]', abbr)
   end
 
-  ['free_text', 'yes_no', 'single_choice', 'multiple_choice', 'geolocation', 'datetime', 'file_upload', 'number'].each do |type|
+  ['free_text', 'yes_no', 'single_choice', 'multiple_choice', 'geolocation', 'datetime', 'file_upload', 'number', 'url'].each do |type|
     define_method "field_formatter_name_suggestion_#{type}" do
       JSON.parse(self.value)['suggestion']
     end

--- a/config/initializers/field_formatters.rb
+++ b/config/initializers/field_formatters.rb
@@ -20,7 +20,7 @@ DynamicAnnotation::Field.class_eval do
   end
 
   def field_formatter_type_url
-    urls = self.value.map { |item| item['url'] }.join(",")
+    urls = JSON.generate(self.value)
   end
 
   def field_formatter_type_datetime

--- a/config/initializers/field_searches.rb
+++ b/config/initializers/field_searches.rb
@@ -54,6 +54,13 @@ Dynamic.class_eval do
     { keys: [:language, :indexable], data: data }
   end
 
+  def get_elasticsearch_options_dynamic_annotation_url
+    return {} if self.get_field(:url).nil?
+    url = self.get_field_value(:url)
+    data = { url: url, indexable: url }
+    { keys: [:url, :indexable], data: data }
+  end
+
   def get_elasticsearch_options_dynamic_annotation_geolocation
     return {} if self.get_field(:geolocation).nil?
     location = {}

--- a/config/initializers/field_validators.rb
+++ b/config/initializers/field_validators.rb
@@ -14,12 +14,10 @@ DynamicAnnotation::Field.class_eval do
 
   def field_validator_type_url
     errormsg = I18n.t(:url_invalid_value)
-    begin
-      json = JSON.parse(self.value)
-      url = json.url
-      url.is_a?(URI::HTTP) && !url.host.nil?
-    rescue
-      errors.add(:base, errormsg)
+    urls = self.value
+    urls.each do |item|
+      url = URI.parse(item['url'])
+      errors.add(:base, errormsg + ' ' + url.to_s) unless url.is_a?(URI::HTTP) && !url.host.nil?
     end
   end
 

--- a/config/initializers/field_validators.rb
+++ b/config/initializers/field_validators.rb
@@ -12,6 +12,17 @@ DynamicAnnotation::Field.class_eval do
     end
   end
 
+  def field_validator_type_url
+    errormsg = I18n.t(:url_invalid_value)
+    begin
+      json = JSON.parse(self.value)
+      url = json.url
+      url.is_a?(URI::HTTP) && !url.host.nil?
+    rescue
+      errors.add(:base, errormsg)
+    end
+  end
+
   def field_validator_type_datetime
     self.value.tr!('۰١۲۳۴۵۶۷۸۹','0123456789')
     begin

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -285,7 +285,7 @@ en:
   duplicate_source: Source already exists
   geolocation_invalid_value: Invalid location. Expecting a valid GeoJSON structure
     (http://geojson.org/)
-  url_invalid_value: Invalid URL
+  url_invalid_value: The following submitted URL is invalid
   datetime_invalid_date: Invalid date
   error_team_archived: Sorry, you can't add a folder to a trashed workspace
   error_project_archived: Sorry, you can't add an item to a trashed folder

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -285,6 +285,7 @@ en:
   duplicate_source: Source already exists
   geolocation_invalid_value: Invalid location. Expecting a valid GeoJSON structure
     (http://geojson.org/)
+  url_invalid_value: Invalid URL
   datetime_invalid_date: Invalid date
   error_team_archived: Sorry, you can't add a folder to a trashed workspace
   error_project_archived: Sorry, you can't add an item to a trashed folder

--- a/db/migrate/20220124165559_create_url_task_type.rb
+++ b/db/migrate/20220124165559_create_url_task_type.rb
@@ -1,0 +1,13 @@
+class CreateUrlTaskType < ActiveRecord::Migration[5.2]
+  require 'sample_data'
+  include SampleData
+
+  def change
+    url = create_field_type field_type: 'url', label: 'URL'
+    json = DynamicAnnotation::FieldType.where(field_type: 'json').last || create_field_type(field_type: 'json', label: 'JSON')
+    at = create_annotation_type annotation_type: 'task_response_url', label: 'Task Response URL'
+    create_field_instance annotation_type_object: at, name: 'response_url', label: 'Response', field_type_object: url, optional: true
+    create_field_instance annotation_type_object: at, name: 'suggestion_url', label: 'Suggestion', field_type_object: json, optional: true
+    create_field_instance annotation_type_object: at, name: 'review_url', label: 'Review', field_type_object: json, optional: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_14_195539) do
+ActiveRecord::Schema.define(version: 2022_01_24_165559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -248,7 +248,6 @@ ActiveRecord::Schema.define(version: 2022_01_14_195539) do
     t.integer "user_id"
     t.integer "team_id"
     t.string "title"
-    t.boolean "is_default", default: false
     t.text "description"
     t.string "lead_image"
     t.datetime "created_at", null: false
@@ -259,6 +258,7 @@ ActiveRecord::Schema.define(version: 2022_01_14_195539) do
     t.integer "assignments_count", default: 0
     t.integer "project_group_id"
     t.integer "privacy", default: 0, null: false
+    t.boolean "is_default", default: false
     t.index ["id"], name: "index_projects_on_id"
     t.index ["is_default"], name: "index_projects_on_is_default"
     t.index ["privacy"], name: "index_projects_on_privacy"


### PR DESCRIPTION
This creates a new annotation type called `"url"`. The data structure that it expects to store is an array of objects, each containing two strings, `"url"`, and `"title"`. The `title` is optional and may be an empty string. The `title` property should always be there, and if "empty" should be an empty string and never `null`.

```json
[
  { "url": "http://example.com", "title": "Example Web Site" },
  { "url": "https://meedan.com", "title": "Meedan" },
]
```

The formatted output (aka `Task.first_response_value`) is the JSON string of the object above.

Validation checks to see if if each `url` in each object in the array is a valid http or https url. If one or more urls is invalid, it returns an error and specifies each invalid url in the error message.

Tests coming in a future PR.