### PR TITLE
Cut honeycomb sample rate by half since we are starting to hit burst protection limits.

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -3,7 +3,7 @@ class CustomSampler
 
   def self.sample(fields)
     if ['http_request', 'sql.active_record'].include?(fields['name']) && should_sample(1, fields['trace.trace_id'])
-      return [true, 4]
+      return [true, 8]
     end
     return [false, 0]
   end


### PR DESCRIPTION
For the past two days we've hit burst protection limits on Honeycomb.

This change cuts the sample rate in half, which should work well for the near future.