### PR TITLE
Improvements and fixes for tipline bot v2

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -413,10 +413,6 @@ class Bot::Smooch < BotUser
     value.to_i.seconds
   end
 
-  def self.is_v2?
-    self.config['smooch_version'] == 'v2'
-  end
-
   def self.get_menu_options(state, workflow, uid)
     if state == 'ask_if_ready'
       [

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -723,7 +723,7 @@ class Bot::Smooch < BotUser
         raise SecurityError if m.pender_error_code == PenderClient::ErrorCodes::UNSAFE
         nil
       else
-        m.url
+        m
       end
     rescue URI::InvalidURIError
       nil
@@ -770,20 +770,20 @@ class Bot::Smooch < BotUser
     return team unless self.is_a_valid_text_message?(text)
 
     begin
-      url = self.extract_url(text)
+      link = self.extract_url(text)
       pm = nil
       extra = {}
-      if url.nil?
+      if link.nil?
         claim = self.extract_claim(text)
         extra = { quote: claim }
         pm = ProjectMedia.joins(:media).where('lower(quote) = ?', claim.downcase).where('project_medias.team_id' => team.id).last
       else
-        extra = { url: url }
-        pm = ProjectMedia.joins(:media).where('medias.url' => url, 'project_medias.team_id' => team.id).last
+        extra = { url: link.url }
+        pm = ProjectMedia.joins(:media).where('medias.url' => link.url, 'project_medias.team_id' => team.id).last
       end
 
       if pm.nil?
-        type = url.nil? ? 'Claim' : 'Link'
+        type = link.nil? ? 'Claim' : 'Link'
         pm = self.create_project_media(message, type, extra)
       end
 

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -443,7 +443,7 @@ class Bot::Smooch < BotUser
   def self.get_custom_menu_options(state, workflow, uid)
     options = workflow.dig("smooch_state_#{state}", 'smooch_menu_options').to_a.clone
     if state == 'main' && self.is_v2?
-      unless self.user_language_confirmed?(uid)
+      if self.should_ask_for_language_confirmation?(uid)
         options = []
         self.get_supported_languages.each_with_index do |l, i|
           options << {

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -324,6 +324,7 @@ class Bot::Smooch < BotUser
 
   def self.reset_user_language(uid)
     Rails.cache.delete("smooch:user_language:#{uid}")
+    Rails.cache.delete("smooch:user_language:#{uid}:confirmed")
   end
 
   def self.user_language_confirmed?(uid)

--- a/app/models/concerns/smooch_menus.rb
+++ b/app/models/concerns/smooch_menus.rb
@@ -102,12 +102,12 @@ module SmoochMenus
         # Default values for customizable strings
         cancelled: 'OK! Your submission is canceled.',
         ask_if_ready_state: 'Are you ready to submit?',
-        add_more_details_state: 'OK! Please add more content.',
-        search_state: 'Thank you! Looking for fact-checks.',
-        search_no_results: 'No result has been found. Journalists on our team have been notified and you will receive an update in this thread if the information is fact-checked.',
+        add_more_details_state: 'Please add more content.',
+        search_state: 'Thank you! Looking for fact-checks, it may take a minute.',
+        search_no_results: 'No fact-checks have been found. Journalists on our team have been notified and you will receive an update in this thread if the information is fact-checked.',
         search_result_state: 'Are these fact-checks answering your question?',
-        search_submit: 'Thank you for your feedback. Journalists on our team have been notified and you will receive an update in this thread if the information is fact-checked.',
-        search_result_is_relevant: 'Thank you! Spread the word about this tipline to help us fight misinformation!',
+        search_submit: 'Thank you for your feedback. Journalists on our team have been notified and you will receive an update in this thread if a new fact-check is published.',
+        search_result_is_relevant: 'Thank you! Spread the word about this tipline to help us fight misinformation! *insert_entry_point_link*',
         newsletter_optin_optout: '{subscription_status}',
       }[key.to_sym] || key
       label.truncate(truncate_at)

--- a/app/models/concerns/smooch_menus.rb
+++ b/app/models/concerns/smooch_menus.rb
@@ -4,6 +4,10 @@ module SmoochMenus
   extend ActiveSupport::Concern
 
   module ClassMethods
+    def is_v2?
+      self.config['smooch_version'] == 'v2'
+    end
+
     def send_message_to_user_with_main_menu_appended(uid, text, workflow, language)
       main = []
       counter = 1

--- a/app/models/concerns/smooch_menus.rb
+++ b/app/models/concerns/smooch_menus.rb
@@ -198,14 +198,16 @@ module SmoochMenus
 
     def ask_for_language_confirmation(workflow, language, uid)
       self.reset_user_language(uid)
-      text = [workflow['smooch_message_smooch_bot_greetings'], self.get_menu_string(:confirm_preferred_language, language)].join("\n\n")
+      text = [workflow['smooch_message_smooch_bot_greetings']]
       options = []
       self.get_supported_languages.sort.each_with_index do |l, i|
+        text << self.get_menu_string(:confirm_preferred_language, l)
         options << {
           value: { state: 'main', keyword: (i + 1) }.to_json,
           label: ::CheckCldr.language_code_to_name(l, l).truncate(20)
         }
       end
+      text = text.join("\n\n")
       if options.size > 3
         self.send_message_to_user_with_single_section_menu(uid, text, options, self.get_menu_string(:languages, language))
       else

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -11,7 +11,7 @@ module SmoochMessages
         self.refresh_smooch_slack_timeout(uid)
         return
       end
-      self.refresh_smooch_menu_timeout(message, app_id)
+      self.refresh_smooch_menu_timeout(message, app_id) unless self.is_v2?
       redis = Redis.new(REDIS_CONFIG)
       key = "smooch:bundle:#{uid}"
       self.delay_for(1.second).save_user_information(app_id, uid, payload.to_json) if redis.llen(key) == 0

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -11,7 +11,7 @@ module SmoochMessages
         self.refresh_smooch_slack_timeout(uid)
         return
       end
-      self.refresh_smooch_menu_timeout(message, app_id) unless self.is_v2?
+      self.refresh_smooch_menu_timeout(message, app_id)
       redis = Redis.new(REDIS_CONFIG)
       key = "smooch:bundle:#{uid}"
       self.delay_for(1.second).save_user_information(app_id, uid, payload.to_json) if redis.llen(key) == 0
@@ -38,16 +38,18 @@ module SmoochMessages
       redis.lrange(key, 0, redis.llen(key))
     end
 
-    def bundle_messages(uid, id, app_id, type = 'default_requests', annotated = nil, force = false)
-      list = self.list_of_bundled_messages_from_user(uid)
+    def bundle_messages(uid, id, app_id, type = 'default_requests', annotated = nil, force = false, bundle = nil)
+      list = bundle || self.list_of_bundled_messages_from_user(uid)
       unless list.empty?
         last = JSON.parse(list.last)
         if last['_id'] == id || ['menu_options_requests'].include?(type) || force
           self.get_installation(self.installation_setting_id_keys, app_id) if self.config.blank?
           self.handle_bundle_messages(type, list, last, app_id, annotated, !force)
-          Redis.new(REDIS_CONFIG).del("smooch:bundle:#{uid}")
-          sm = CheckStateMachine.new(uid)
-          sm.reset unless sm.state.value == 'main'
+          if bundle.nil?
+            self.clear_user_bundled_messages(uid)
+            sm = CheckStateMachine.new(uid)
+            sm.reset unless sm.state.value == 'main'
+          end
         end
       end
     end
@@ -64,9 +66,13 @@ module SmoochMessages
     def send_message_for_state(uid, workflow, state, language, pretext = '')
       message = self.utmize_urls(self.get_message_for_state(workflow, state, language, uid).to_s, 'resource')
       text = [pretext, message].reject{ |part| part.blank? }.join("\n\n")
-      # On v2, when we go to the "main" state, we need to show the main menu
       if self.is_v2?
-        state == 'main' ? self.send_message_to_user_with_main_menu_appended(uid, text, workflow, language) : self.send_message_for_state_with_buttons(uid, text, workflow, state, language)
+        if self.should_ask_for_language_confirmation?(uid)
+          self.ask_for_language_confirmation(workflow, language, uid)
+        else
+          # On v2, when we go to the "main" state, we need to show the main menu
+          state == 'main' ? self.send_message_to_user_with_main_menu_appended(uid, text, workflow, language) : self.send_message_for_state_with_buttons(uid, text, workflow, state, language)
+        end
       else
         self.send_message_to_user(uid, text)
       end
@@ -177,11 +183,12 @@ module SmoochMessages
       Redis.new(REDIS_CONFIG).del("smooch:bundle:#{uid}")
     end
 
-    def bundle_list_of_messages(list, last)
+    def bundle_list_of_messages(list, last, reject_payload = false)
       bundle = last.clone
       text = []
       media = nil
       list.collect{ |m| JSON.parse(m) }.sort_by{ |m| m['received'].to_f }.each do |message|
+        next if reject_payload && message['payload']
         if media.nil?
           media = message['mediaUrl']
           bundle['type'] = message['type']
@@ -201,7 +208,7 @@ module SmoochMessages
       elsif ['timeout_requests', 'menu_options_requests', 'resource_requests', 'relevant_search_result_requests'].include?(type)
         key = "smooch:banned:#{bundle['authorId']}"
         if Rails.cache.read(key).nil?
-          [annotated].flatten.each { |a| self.save_message_later(bundle, app_id, type, a) }
+          [annotated].flatten.uniq.each { |a| self.save_message_later(bundle, app_id, type, a) }
         end
       end
     end

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -83,7 +83,7 @@ module SmoochSearch
       begin
         list = self.list_of_bundled_messages_from_user(uid)
         message = self.bundle_list_of_messages(list, last_message, true)
-        type = message['type'] || 'text'
+        type = message['type']
         after = self.date_filter(team_id)
         pm = ProjectMedia.new(team_id: team_id)
         if type == 'text'
@@ -101,8 +101,9 @@ module SmoochSearch
             filters = { keyword: words.join('+'), eslimit: 3, report_status: ['published'] }
             filters.merge!({ range: { updated_at: { start_time: after.strftime('%Y-%m-%dT%H:%M:%S.%LZ') } } }) if after
             results = CheckSearch.new(filters.to_json, nil, team_id).medias
-            Rails.logger.info "[Smooch Bot] Keyword search got #{results.count} results while looking for '#{text}' after date #{after.inspect} for team #{team_id}"
+            Rails.logger.info "[Smooch Bot] Keyword search got #{results.count} results (only main items) while looking for '#{text}' after date #{after.inspect} for team #{team_id}"
             results = CheckSearch.new(filters.merge({ show_similar: true }).to_json, nil, team_id).medias if results.empty?
+            Rails.logger.info "[Smooch Bot] Keyword search got #{results.count} results (including secondary items) while looking for '#{text}' after date #{after.inspect} for team #{team_id}"
           else
             results = self.parse_search_results_from_alegre(Bot::Alegre.get_merged_similar_items(pm, { value: self.get_text_similarity_threshold }, Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS, text), team_id)
             Rails.logger.info "[Smooch Bot] Text similarity search got #{results.count} results while looking for '#{text}' after date #{after.inspect} for team #{team_id}"

--- a/db/migrate/20220221205147_add_tipline_bot_v2_settings_to_smooch_bot.rb
+++ b/db/migrate/20220221205147_add_tipline_bot_v2_settings_to_smooch_bot.rb
@@ -1,0 +1,22 @@
+class AddTiplineBotV2SettingsToSmoochBot < ActiveRecord::Migration[5.2]
+  def change
+    tb = BotUser.smooch_user
+    unless tb.nil?
+      settings = tb.get_settings.clone || []
+      settings << {
+        name: 'smooch_search_text_similarity_threshold',
+        label: 'Similarity threshold to be used when searching for similar texts',
+        type: 'string',
+        default: '0.9'
+      }
+      settings << {
+        name: 'smooch_search_max_keyword',
+        label: 'Maximum number of words to perform a keyword search instead of a similarity search',
+        type: 'number',
+        default: 3
+      }
+      tb.set_settings(settings)
+      tb.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_14_055345) do
+ActiveRecord::Schema.define(version: 2022_02_21_205147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/test/models/bot/smooch_5_test.rb
+++ b/test/models/bot/smooch_5_test.rb
@@ -257,14 +257,14 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
     Bot::Smooch.stubs(:bundle_list_of_messages).returns({ 'type' => 'text', 'text' => 'Foo bar foo bar foo bar' })
     ProjectMedia.any_instance.stubs(:report_status).returns('published')
     ProjectMedia.any_instance.stubs(:analysis_published_article_url).returns(random_url)
-    Bot::Alegre.stubs(:get_similar_texts).returns({ pm.id => 0.9 })
+    Bot::Alegre.stubs(:get_merged_similar_items).returns({ pm.id => 0.9 })
 
     assert_equal [pm], Bot::Smooch.get_search_results(random_string, {}, pm.team_id, 'en')
 
     Bot::Smooch.unstub(:bundle_list_of_messages)
     ProjectMedia.any_instance.unstub(:report_status)
     ProjectMedia.any_instance.unstub(:analysis_published_article_url)
-    Bot::Alegre.unstub(:get_similar_texts)
+    Bot::Alegre.unstub(:get_merged_similar_items)
   end
 
   test "should perform a media similarity search" do

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -19,6 +19,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     @sm = CheckStateMachine.new(@uid)
     @sm.reset
     Bot::Smooch.clear_user_bundled_messages(@uid)
+    Bot::Smooch.reset_user_language(@uid)
     Sidekiq::Testing.fake!
     @search_result = create_project_media team: @team
 
@@ -179,7 +180,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
   test "should submit query and get relevant text similarity search results on tipline bot v2" do
     ProjectMedia.any_instance.stubs(:report_status).returns('published')
     ProjectMedia.any_instance.stubs(:analysis_published_article_url).returns(random_url)
-    Bot::Alegre.stubs(:get_similar_texts).returns({ create_project_media.id => { score: 0.9 } })
+    Bot::Alegre.stubs(:get_merged_similar_items).returns({ create_project_media.id => { score: 0.9 } })
     Sidekiq::Testing.inline! do
       send_message 'hello', '1', '1', 'Foo bar foo bar foo bar', '1'
       assert_state 'search_result'
@@ -188,7 +189,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
       end
       assert_state 'main'
     end
-    Bot::Alegre.unstub(:get_similar_texts)
+    Bot::Alegre.unstub(:get_merged_similar_items)
     ProjectMedia.any_instance.unstub(:report_status)
     ProjectMedia.any_instance.unstub(:analysis_published_article_url)
   end
@@ -208,7 +209,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
       end
       assert_state 'main'
     end
-    Bot::Alegre.unstub(:get_similar_texts)
+    Bot::Alegre.unstub(:get_merged_similar_items)
     Bot::Smooch.unstub(:bundle_list_of_messages)
     ProjectMedia.any_instance.unstub(:report_status)
     ProjectMedia.any_instance.unstub(:analysis_published_article_url)
@@ -238,7 +239,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
       assert_difference 'Dynamic.count + ProjectMedia.count', 3 do
         send_message '2'
       end
-      assert_state 'main'
+      assert_state 'waiting_for_message'
     end
     CheckSearch.any_instance.unstub(:medias)
   end


### PR DESCRIPTION
* Search for URLs and their content (CHECK-1408)
* Fixing race condition when two search queries are submitted by the same user in a short interval (CHECK-1415)
* Do not ask for language confirmation all the time and don't timeout too often (CHECK-1405)
* Append "please confirm your language" localized in all supported languages (CHECK-1460)
* Evoke both vector model and ElasticSearch when looking for similar texts (CHECK-1419)
* New tipline search settings: similarity threshold and maximum number of words for keyword search (CHECK-1441)
* Updated copy for default messages in English (CHECK-1461)