### PR TITLE
Pause uptime checks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
-    - pause-uptime-checks
 
 deploy_qa:
   image: docker:latest
@@ -53,16 +52,13 @@ deploy_qa:
     - aws ecs wait tasks-stopped --cluster ecs-qa --tasks $taskArn
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-c $NAME /qa/check-api/$NAME " >> qa-check-api-c.env.args; done
     - echo -n "-s qa-check-api-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-c.env.args
-    - python3 scripts/uptime-maintenance.py on
     - ecs deploy ecs-qa qa-check-api --image qa-check-api-c $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e qa-check-api-c APP check-api -e qa-check-api-c DEPLOY_ENV qa -e qa-check-api-c AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-check-api-c.env.args`
-    - python3 scripts/uptime-maintenance.py off
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-background $NAME /qa/check-api/$NAME " >> qa-check-api-background.env.args; done
     - echo -n "-s qa-check-api-background GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-background.env.args
     - ecs deploy ecs-qa qa-check-api-background --image qa-check-api-background $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e qa-check-api-background APP check-api -e qa-check-api-background DEPLOY_ENV qa -e qa-check-api-background AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-check-api-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
-    - pause-uptime-checks
 
 build_live:
   image: docker:latest
@@ -114,7 +110,9 @@ deploy_live:
     - aws ecs wait tasks-stopped --cluster ecs-live --tasks $taskArn
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-c $NAME /live/check-api/$NAME " >> live-check-api-c.env.args; done
     - echo -n "-s live-check-api-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-check-api-c.env.args
+    - python3 scripts/uptime-maintenance.py on
     - ecs deploy ecs-live  live-check-api --image live-check-api-c $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e live-check-api-c APP check-api -e live-check-api-c DEPLOY_ENV live -e live-check-api-c AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat live-check-api-c.env.args`
+    - python3 scripts/uptime-maintenance.py off
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-background $NAME /live/check-api/$NAME " >> live-check-api-background.env.args; done
     - echo -n "-s live-check-api-background GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-check-api-background.env.args
     - ecs deploy ecs-live  live-check-api-background --image live-check-api-background $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e live-check-api-background APP check-api -e live-check-api-background DEPLOY_ENV live -e live-check-api-background AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat live-check-api-background.env.args`

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - pause-uptime-checks
 
 deploy_qa:
   image: docker:latest
@@ -52,13 +53,16 @@ deploy_qa:
     - aws ecs wait tasks-stopped --cluster ecs-qa --tasks $taskArn
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-c $NAME /qa/check-api/$NAME " >> qa-check-api-c.env.args; done
     - echo -n "-s qa-check-api-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-c.env.args
+    - python3 scripts/uptime-maintenance.py on
     - ecs deploy ecs-qa qa-check-api --image qa-check-api-c $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e qa-check-api-c APP check-api -e qa-check-api-c DEPLOY_ENV qa -e qa-check-api-c AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-check-api-c.env.args`
+    - python3 scripts/uptime-maintenance.py off
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-background $NAME /qa/check-api/$NAME " >> qa-check-api-background.env.args; done
     - echo -n "-s qa-check-api-background GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-background.env.args
     - ecs deploy ecs-qa qa-check-api-background --image qa-check-api-background $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e qa-check-api-background APP check-api -e qa-check-api-background DEPLOY_ENV qa -e qa-check-api-background AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-check-api-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - pause-uptime-checks
 
 build_live:
   image: docker:latest

--- a/scripts/uptime-maintenance.py
+++ b/scripts/uptime-maintenance.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+# This script is used to toggle the Uptime API and Transaction tests
+# during deployment so that we don't generate spurious alarms when
+# deploying check-api updates to Live.
+#
+# Usage:
+# 1.) Set the UPTIME_TOKEN environment variable.
+#     See https://uptime.com/api/tokens for instructions.
+# 2.) Call ./uptime-maintenance.py on
+#       [ deployment performed here ]
+# 3.) Call ./uptime-maintenance.py off
+#
+# NOTE: exit status always zero as we don't want to fail builds if
+#       the Uptime check pause fails.
+#
+import os
+import sys
+import requests
+
+def usage():
+    print("Usage: %s [on|off]" % (sys.argv[0]))
+    print("Environment variable UPTIME_TOKEN must also be set.")
+    exit(0)
+
+def bad_resp():
+    print("Received unsuccessful response from Uptime API.")
+    print("Check your UPTIME_TOKEN value.")
+    exit(0)
+
+def set_pause(state):
+    pause_status = 'false'
+    if state == 'on':
+        pause_status = 'true'
+
+    my_headers = {'Authorization' : 'Token %s' % (os.environ.get('UPTIME_TOKEN'))}
+
+    current_page = 'https://uptime.com/api/v1/checks/'
+    while current_page != None:
+        response = requests.get(current_page, headers=my_headers)
+        if response.status_code != 200:
+            bad_resp()
+
+        rdata = response.json()
+        current_page = rdata.get('next')
+
+        for row in rdata['results']:
+            if row['check_type'] == 'TRANSACTION' or row['check_type'] == 'API':
+                row['is_paused'] = pause_status
+                print("Updating check %s ..." % (row['name']))
+                mresp = requests.put(row['url'], headers=my_headers, data=row)
+                rdata = response.json()
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        usage()
+
+    token = os.environ.get('UPTIME_TOKEN')
+    if token == None or len(token) < 40:
+        usage()
+
+    cmd = sys.argv[1]
+    if cmd == "on" or cmd == "off":
+        set_pause(cmd)
+    else:
+        usage()
+
+    exit(0)


### PR DESCRIPTION
This change invokes a script to pause the Uptime checks when check-api deploys a new revision. This will avoid false alarms during deployment.