### PR TITLE
Cut honeycomb sample rate by half, as we are again exceeding limits.

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -3,7 +3,7 @@ class CustomSampler
 
   def self.sample(fields)
     if ['http_request', 'sql.active_record'].include?(fields['name']) && should_sample(1, fields['trace.trace_id'])
-      return [true, 8]
+      return [true, 16]
     end
     return [false, 0]
   end


### PR DESCRIPTION
We received another notice that we're exceeding limits. The increase in both Tipline and Check Web activity seems to be driving the increase. This cuts sample rate by half, which should bring us back under limits with additional spare capacity.