### PR TITLE
Cut honeycomb sample rate by half again, as we are now exceeding daily limits.

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -3,7 +3,7 @@ class CustomSampler
 
   def self.sample(fields)
     if ['http_request', 'sql.active_record'].include?(fields['name']) && should_sample(1, fields['trace.trace_id'])
-      return [true, 16]
+      return [true, 32]
     end
     return [false, 0]
   end


### PR DESCRIPTION
As noted, there is a daily quota derived from monthly limits. We've been exceeding the daily quota the last few days, and this will ensure we're below both the daily and monthly limits.