### PR TITLE
CHECK-1537 - Prefer vector models to Elasticsearch results

### DIFF
--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -58,7 +58,7 @@ module SmoochSearch
 
     def parse_search_results_from_alegre(results, team_id)
       after = self.date_filter(team_id)
-      results.sort_by{|a| [a[1][:model], a[1][:score]]}.to_h.keys.reverse.collect{ |id| Relationship.confirmed_parent(ProjectMedia.find_by_id(id)) }.select{ |pm| pm&.report_status == 'published' && pm&.updated_at.to_i > after.to_i }.uniq(&:id).first(3)
+      results.sort_by{|a| [a[1][:model]==Bot::Alegre::ELASTICSEARCH_MODEL ? 1:0, a[1][:score]]}.to_h.keys.reverse.collect{ |id| Relationship.confirmed_parent(ProjectMedia.find_by_id(id)) }.select{ |pm| pm&.report_status == 'published' && pm&.updated_at.to_i > after.to_i }.uniq(&:id).first(3)
     end
 
     def date_filter(team_id)


### PR DESCRIPTION
I earlier committed code for this improvement already, but I think it is better to explicitly compare against the `Bot::Alegre::ELASTICSEARCH_MODEL` constant when ordering results. We don't have any vector model that alphabetically comes before "e", but we could in the future and that would break the previous fix without warning, which is bad. This PR fixes that.