### PR TITLE
CHECK-1587: context field in claim_descriptions

### DIFF
--- a/app/graph/mutations/claim_description_mutations.rb
+++ b/app/graph/mutations/claim_description_mutations.rb
@@ -1,11 +1,13 @@
 module ClaimDescriptionMutations
   create_fields = {
-    description: '!str',
+    description: 'str',
     project_media_id: '!int',
+    context: 'str',
   }
 
   update_fields = {
-    description: '!str',
+    description: 'str',
+    context: 'str',
   }
 
   Create, Update, Destroy = GraphqlCrudOperations.define_crud_operations('claim_description', create_fields, update_fields, ['project_media'])

--- a/app/graph/types/claim_description_type.rb
+++ b/app/graph/types/claim_description_type.rb
@@ -6,6 +6,7 @@ ClaimDescriptionType = GraphqlCrudOperations.define_default_type do
 
   field :dbid, types.Int
   field :description, types.String
+  field :context, types.String
   field :user, UserType
   field :project_media, ProjectMediaType
   field :fact_check, FactCheckType

--- a/app/models/claim_description.rb
+++ b/app/models/claim_description.rb
@@ -4,7 +4,7 @@ class ClaimDescription < ApplicationRecord
   belongs_to :project_media
   has_one :fact_check
 
-  validates_presence_of :description, :user, :project_media
+  validates_presence_of :user, :project_media
 
   # FIXME: Required by GraphQL API
   def fact_checks

--- a/db/migrate/20220317210706_add_context_to_claim_descriptions.rb
+++ b/db/migrate/20220317210706_add_context_to_claim_descriptions.rb
@@ -1,0 +1,5 @@
+class AddContextToClaimDescriptions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :claim_descriptions, :context, :text
+  end
+end

--- a/db/migrate/20220318160448_remove_null_constraint_from_claim_description.rb
+++ b/db/migrate/20220318160448_remove_null_constraint_from_claim_description.rb
@@ -1,0 +1,5 @@
+class RemoveNullConstraintFromClaimDescription < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :claim_descriptions, :description, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_10_045323) do
+ActiveRecord::Schema.define(version: 2022_03_18_160448) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -108,11 +108,12 @@ ActiveRecord::Schema.define(version: 2022_03_10_045323) do
   end
 
   create_table "claim_descriptions", force: :cascade do |t|
-    t.text "description", null: false
+    t.text "description"
     t.bigint "user_id", null: false
     t.bigint "project_media_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "context"
     t.index ["project_media_id"], name: "index_claim_descriptions_on_project_media_id"
     t.index ["user_id"], name: "index_claim_descriptions_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,14 +27,14 @@ ActiveRecord::Schema.define(version: 2022_03_18_160448) do
   create_table "accounts", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.string "url"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "team_id"
     t.text "omniauth_info"
     t.string "uid"
     t.string "provider"
     t.string "token"
     t.string "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "team_id"
     t.index ["uid", "provider", "token", "email"], name: "index_accounts_on_uid_and_provider_and_token_and_email"
     t.index ["url"], name: "index_accounts_on_url", unique: true
     t.index ["user_id"], name: "index_accounts_on_user_id"
@@ -273,6 +273,7 @@ ActiveRecord::Schema.define(version: 2022_03_18_160448) do
     t.integer "user_id"
     t.integer "team_id"
     t.string "title"
+    t.boolean "is_default", default: false
     t.text "description"
     t.string "lead_image"
     t.datetime "created_at", null: false
@@ -283,7 +284,6 @@ ActiveRecord::Schema.define(version: 2022_03_18_160448) do
     t.integer "assignments_count", default: 0
     t.integer "project_group_id"
     t.integer "privacy", default: 0, null: false
-    t.boolean "is_default", default: false
     t.index ["id"], name: "index_projects_on_id"
     t.index ["is_default"], name: "index_projects_on_is_default"
     t.index ["privacy"], name: "index_projects_on_privacy"
@@ -381,15 +381,15 @@ ActiveRecord::Schema.define(version: 2022_03_18_160448) do
     t.integer "team_id"
     t.integer "user_id"
     t.string "type"
+    t.integer "invited_by_id"
+    t.string "invitation_token"
+    t.string "raw_invitation_token"
+    t.datetime "invitation_accepted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "role"
     t.string "status", default: "member"
     t.text "settings"
-    t.integer "invited_by_id"
-    t.string "invitation_token"
-    t.string "raw_invitation_token"
-    t.datetime "invitation_accepted_at"
     t.string "invitation_email"
     t.index ["team_id", "user_id"], name: "index_team_users_on_team_id_and_user_id", unique: true
     t.index ["type"], name: "index_team_users_on_type"
@@ -434,6 +434,7 @@ ActiveRecord::Schema.define(version: 2022_03_18_160448) do
     t.string "name", default: "", null: false
     t.string "login", default: "", null: false
     t.string "token", default: "", null: false
+    t.boolean "default", default: false
     t.string "email"
     t.string "encrypted_password", default: ""
     t.string "reset_password_token"
@@ -444,6 +445,14 @@ ActiveRecord::Schema.define(version: 2022_03_18_160448) do
     t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
+    t.string "invitation_token"
+    t.string "raw_invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer "invitation_limit"
+    t.integer "invited_by_id"
+    t.string "invited_by_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "image"
@@ -460,14 +469,6 @@ ActiveRecord::Schema.define(version: 2022_03_18_160448) do
     t.string "unconfirmed_email"
     t.integer "current_project_id"
     t.boolean "is_active", default: true
-    t.string "invitation_token"
-    t.string "raw_invitation_token"
-    t.datetime "invitation_created_at"
-    t.datetime "invitation_sent_at"
-    t.datetime "invitation_accepted_at"
-    t.integer "invitation_limit"
-    t.integer "invited_by_id"
-    t.string "invited_by_type"
     t.datetime "last_accepted_terms_at"
     t.string "encrypted_otp_secret"
     t.string "encrypted_otp_secret_iv"
@@ -475,7 +476,6 @@ ActiveRecord::Schema.define(version: 2022_03_18_160448) do
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.string "otp_backup_codes", array: true
-    t.boolean "default", default: false
     t.boolean "completed_signup", default: true
     t.datetime "last_active_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -961,6 +961,7 @@ module SampleData
   def create_claim_description(options = {})
     ClaimDescription.create!({
       description: random_string,
+      context: random_string,
       user: options[:user] || create_user,
       project_media: options[:project_media] || create_project_media
     }.merge(options))

--- a/test/models/claim_description_test.rb
+++ b/test/models/claim_description_test.rb
@@ -12,14 +12,6 @@ class ClaimDescriptionTest < ActiveSupport::TestCase
     end
   end
 
-  test "should not create claim description without description" do
-    assert_no_difference 'ClaimDescription.count' do
-      assert_raises ActiveRecord::RecordInvalid do
-        create_claim_description description: nil
-      end
-    end
-  end
-
   test "should not create claim description without user" do
     assert_no_difference 'ClaimDescription.count' do
       assert_raises ActiveRecord::RecordInvalid do
@@ -80,7 +72,19 @@ class ClaimDescriptionTest < ActiveSupport::TestCase
     pm = create_project_media team: t
     with_current_user_and_team(u, t) do
       assert_difference 'ClaimDescription.count' do
-        create_claim_description user: u, project_media: pm
+        cd = create_claim_description user: u, project_media: pm
+      end
+    end
+  end
+
+  test "should create a claim description with context only if has permission" do
+    t = create_team
+    u = create_user
+    create_team_user team: t, user: u
+    pm = create_project_media team: t
+    with_current_user_and_team(u, t) do
+      assert_difference 'ClaimDescription.count' do
+        cd = create_claim_description user: u, project_media: pm, description: nil
       end
     end
   end


### PR DESCRIPTION
 * add a new `context` field to `claim_description` of type `text`
 * make `description` and `context` both optional fields in `claim_description`
 * Tests, including removing a test that checked for `description` to not be empty