### PR TITLE
CHECK-1651: New error mapping

### DIFF
--- a/app/controllers/api/v1/graphql_controller.rb
+++ b/app/controllers/api/v1/graphql_controller.rb
@@ -116,7 +116,8 @@ module Api
         mapping = {
           CheckPermissions::AccessDenied => ::LapisConstants::ErrorCodes::ID_NOT_FOUND,
           ActiveRecord::RecordNotFound => ::LapisConstants::ErrorCodes::ID_NOT_FOUND,
-          ActiveRecord::StaleObjectError => ::LapisConstants::ErrorCodes::CONFLICT
+          ActiveRecord::StaleObjectError => ::LapisConstants::ErrorCodes::CONFLICT,
+          ActiveRecord::RecordNotUnique => ::LapisConstants::ErrorCodes::CONFLICT
         }
         errors = []
         message = e.message.kind_of?(Array) ? e.message : [e.message]


### PR DESCRIPTION
This categorizes an `ActiveRecords::RecordNotUnique` as an error of type `CONFLICT`, so that on the client it will ultimately be rendered as "There was a database conflict." or similar.