### PR TITLE
Cut honeycomb sample rate by half again, as we are exceeding daily burst protection limits.

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -3,7 +3,7 @@ class CustomSampler
 
   def self.sample(fields)
     if ['http_request', 'sql.active_record'].include?(fields['name']) && should_sample(1, fields['trace.trace_id'])
-      return [true, 128]
+      return [true, 256]
     end
     return [false, 0]
   end


### PR DESCRIPTION
With usage increasing we're now hitting daily burst protection limits again. Cut sample rate by half to ensure we stay under threshold.