### PR TITLE
Feed API

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -189,13 +189,15 @@ class Bot::Alegre < BotUser
   end
 
   def self.get_items_from_similar_text(team_id, text, field = nil, threshold = nil, model = nil, fuzzy = false)
+    team_ids = [team_id].flatten
     return {} if text.blank? || self.get_number_of_words(text) < 3
     field ||= ALL_TEXT_SIMILARITY_FIELDS
     threshold ||= self.get_threshold_for_query('text', nil, true)
-    model ||= self.matching_model_to_use(ProjectMedia.new(team_id: team_id))
+    pm = team_ids.size == 1 ? ProjectMedia.new(team_id: team_ids[0]) : nil
+    model ||= self.matching_model_to_use(pm)
     Hash[self.get_similar_items_from_api(
       '/text/similarity/',
-      self.similar_texts_from_api_conditions(text, model, fuzzy, team_id, field, threshold),
+      self.similar_texts_from_api_conditions(text, model, fuzzy, team_ids, field, threshold),
       threshold
     ).collect{|k,v| [k, v.merge(model: model)]}]
   end

--- a/app/models/concerns/alegre_similarity.rb
+++ b/app/models/concerns/alegre_similarity.rb
@@ -172,16 +172,16 @@ module AlegreSimilarity
       description.blank? ? {} : self.get_merged_similar_items(pm, threshold, ['original_description', 'report_text_content', 'report_visual_card_content', 'extracted_text', 'transcription', 'claim_description_content', 'fact_check_summary'], description)
     end
 
-    def get_merged_similar_items(pm, threshold, fields, value)
+    def get_merged_similar_items(pm, threshold, fields, value, team_ids = [pm&.team_id])
       output = {}
       fields.each do |field|
-        response = self.get_items_with_similar_text(pm, field, threshold, value, self.default_matching_model)
+        response = self.get_items_with_similar_text(pm, field, threshold, value, self.default_matching_model, team_ids)
         output[field] = response unless response.blank?
       end
 
       if self.matching_model_to_use(pm) != self.default_matching_model
         fields.each do |field|
-          response = self.get_items_with_similar_text(pm, field, threshold, value)
+          response = self.get_items_with_similar_text(pm, field, threshold, value, nil, team_ids)
           output[field] = response unless response.blank?
         end
       end
@@ -212,9 +212,9 @@ module AlegreSimilarity
       !team_id || [team_id].flatten.include?(ProjectMedia.find_by_id(pmid)&.team_id)
     end
 
-    def get_items_with_similar_text(pm, field, threshold, text, model = nil)
+    def get_items_with_similar_text(pm, field, threshold, text, model = nil, team_ids = [pm&.team_id])
       model ||= self.matching_model_to_use(pm)
-      self.get_items_from_similar_text(pm&.team_id, text, field, threshold, model).reject{ |id, _score_with_context| pm&.id == id }
+      self.get_items_from_similar_text(team_ids, text, field, threshold, model).reject{ |id, _score_with_context| pm&.id == id }
     end
 
     def similar_texts_from_api_conditions(text, model, fuzzy, team_id, field, threshold, match_across_content_types=true)

--- a/app/models/concerns/alegre_similarity.rb
+++ b/app/models/concerns/alegre_similarity.rb
@@ -186,9 +186,11 @@ module AlegreSimilarity
         end
       end
       es_matches = output.values.reduce({}, :merge)
-      # set matched fields to use in short-text suggestion
-      pm.alegre_matched_fields ||= []
-      pm.alegre_matched_fields.concat(output.keys)
+      unless pm.nil?
+        # Set matched fields to use in short-text suggestion
+        pm.alegre_matched_fields ||= []
+        pm.alegre_matched_fields.concat(output.keys)
+      end
       es_matches
     end
 
@@ -212,7 +214,7 @@ module AlegreSimilarity
 
     def get_items_with_similar_text(pm, field, threshold, text, model = nil)
       model ||= self.matching_model_to_use(pm)
-      self.get_items_from_similar_text(pm.team_id, text, field, threshold, model).reject{ |id, _score_with_context| pm.id == id }
+      self.get_items_from_similar_text(pm&.team_id, text, field, threshold, model).reject{ |id, _score_with_context| pm&.id == id }
     end
 
     def similar_texts_from_api_conditions(text, model, fuzzy, team_id, field, threshold, match_across_content_types=true)

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -120,7 +120,7 @@ module SmoochSearch
           results = CheckSearch.new(filters.merge({ show_similar: true }).to_json, nil, team_ids).medias if results.empty?
           Rails.logger.info "[Smooch Bot] Keyword search got #{results.count} results (including secondary items) while looking for '#{text}' after date #{after.inspect} for teams #{team_ids}"
         else
-          results = self.parse_search_results_from_alegre(Bot::Alegre.get_merged_similar_items(pm, { value: self.get_text_similarity_threshold }, Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS, text), team_ids)
+          results = self.parse_search_results_from_alegre(Bot::Alegre.get_merged_similar_items(pm, { value: self.get_text_similarity_threshold }, Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS, text, team_ids), team_ids)
           Rails.logger.info "[Smooch Bot] Text similarity search got #{results.count} results while looking for '#{text}' after date #{after.inspect} for teams #{team_ids}"
         end
       else


### PR DESCRIPTION
Exposes a new API endpoint on the REST API v2. This allows the API client to query published fact-checks from permissioned workspaces the provided API key has access to. The input to the endpoint is an image, audio, video or text. Published fact-checks will be returned if they are similar to the input query. Most of the logic is not new here... it's mostly code reuse from the search feature provided by the tipline bot v2.

References: CHECK- 1748.