### PR TITLE
Some changes as per product review of the feeds API feature.

### DIFF
--- a/app/models/concerns/project_media_getters.rb
+++ b/app/models/concerns/project_media_getters.rb
@@ -137,12 +137,20 @@ module ProjectMediaGetters
     self.claim_description&.description
   end
 
+  def claim_description_context
+    self.claim_description&.context
+  end
+
   def fact_check_title
     self.claim_description&.fact_check&.title
   end
 
   def fact_check_summary
     self.claim_description&.fact_check&.summary
+  end
+
+  def fact_check_published_on
+    self.claim_description&.fact_check&.updated_at
   end
 
   def get_title

--- a/app/resources/api/v2/feed_resource.rb
+++ b/app/resources/api/v2/feed_resource.rb
@@ -4,24 +4,28 @@ module Api
       model_name 'ProjectMedia'
 
       attribute :claim, delegate: :claim_description_content
-      attribute :title, delegate: :fact_check_title
-      attribute :summary, delegate: :fact_check_summary
-      attribute :url, delegate: :published_url
-      attribute :report_title, delegate: :report_text_title
-      attribute :report_summary, delegate: :report_text_content
+      attribute :claim_context, delegate: :claim_description_context
+      attribute :claim_tags, delegate: :tags_as_sentence
+      attribute :fact_check_title
+      attribute :fact_check_summary
+      attribute :fact_check_published_on
+      attribute :fact_check_rating, delegate: :status
+      attribute :published_article_url, delegate: :published_url
       attribute :organization, delegate: :team_name
-      attribute :rating, delegate: :status
 
       filter :type, default: 'text', apply: ->(records, _value, _options) { records }
       filter :query, apply: ->(records, _value, _options) { records }
+      filter :after, apply: ->(records, _value, _options) { records }
 
       def self.records(options = {})
         team_ids = self.workspaces(options).map(&:id)
         filters = options[:filters] || {}
         query = filters.dig(:query, 0)
         type = filters.dig(:type, 0)
+        after = filters.dig(:after, 0)
+        after = Time.parse(after) unless after.blank?
         return ProjectMedia.none if team_ids.blank? || query.blank?
-        results = Bot::Smooch.search_for_similar_published_fact_checks(type, CGI.unescape(query), team_ids)
+        results = Bot::Smooch.search_for_similar_published_fact_checks(type, CGI.unescape(query), team_ids, after)
         ProjectMedia.where(id: results.map(&:id))
       end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,14 +27,14 @@ ActiveRecord::Schema.define(version: 2022_04_10_043747) do
   create_table "accounts", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.string "url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "team_id"
     t.text "omniauth_info"
     t.string "uid"
     t.string "provider"
     t.string "token"
     t.string "email"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "team_id"
     t.index ["uid", "provider", "token", "email"], name: "index_accounts_on_uid_and_provider_and_token_and_email"
     t.index ["url"], name: "index_accounts_on_url", unique: true
     t.index ["user_id"], name: "index_accounts_on_user_id"
@@ -273,7 +273,6 @@ ActiveRecord::Schema.define(version: 2022_04_10_043747) do
     t.integer "user_id"
     t.integer "team_id"
     t.string "title"
-    t.boolean "is_default", default: false
     t.text "description"
     t.string "lead_image"
     t.datetime "created_at", null: false
@@ -284,6 +283,7 @@ ActiveRecord::Schema.define(version: 2022_04_10_043747) do
     t.integer "assignments_count", default: 0
     t.integer "project_group_id"
     t.integer "privacy", default: 0, null: false
+    t.boolean "is_default", default: false
     t.index ["id"], name: "index_projects_on_id"
     t.index ["is_default"], name: "index_projects_on_is_default"
     t.index ["privacy"], name: "index_projects_on_privacy"
@@ -381,15 +381,15 @@ ActiveRecord::Schema.define(version: 2022_04_10_043747) do
     t.integer "team_id"
     t.integer "user_id"
     t.string "type"
-    t.integer "invited_by_id"
-    t.string "invitation_token"
-    t.string "raw_invitation_token"
-    t.datetime "invitation_accepted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "role"
     t.string "status", default: "member"
     t.text "settings"
+    t.integer "invited_by_id"
+    t.string "invitation_token"
+    t.string "raw_invitation_token"
+    t.datetime "invitation_accepted_at"
     t.string "invitation_email"
     t.string "file"
     t.index ["team_id", "user_id"], name: "index_team_users_on_team_id_and_user_id", unique: true
@@ -435,7 +435,6 @@ ActiveRecord::Schema.define(version: 2022_04_10_043747) do
     t.string "name", default: "", null: false
     t.string "login", default: "", null: false
     t.string "token", default: "", null: false
-    t.boolean "default", default: false
     t.string "email"
     t.string "encrypted_password", default: ""
     t.string "reset_password_token"
@@ -446,14 +445,6 @@ ActiveRecord::Schema.define(version: 2022_04_10_043747) do
     t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
-    t.string "invitation_token"
-    t.string "raw_invitation_token"
-    t.datetime "invitation_created_at"
-    t.datetime "invitation_sent_at"
-    t.datetime "invitation_accepted_at"
-    t.integer "invitation_limit"
-    t.integer "invited_by_id"
-    t.string "invited_by_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "image"
@@ -470,6 +461,14 @@ ActiveRecord::Schema.define(version: 2022_04_10_043747) do
     t.string "unconfirmed_email"
     t.integer "current_project_id"
     t.boolean "is_active", default: true
+    t.string "invitation_token"
+    t.string "raw_invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer "invitation_limit"
+    t.integer "invited_by_id"
+    t.string "invited_by_type"
     t.datetime "last_accepted_terms_at"
     t.string "encrypted_otp_secret"
     t.string "encrypted_otp_secret_iv"
@@ -477,6 +476,7 @@ ActiveRecord::Schema.define(version: 2022_04_10_043747) do
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.string "otp_backup_codes", array: true
+    t.boolean "default", default: false
     t.boolean "completed_signup", default: true
     t.datetime "last_active_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/public/api-docs.json
+++ b/public/api-docs.json
@@ -31,6 +31,13 @@
               "required": true,
               "type": "string",
               "paramType": "query"
+            },
+            {
+              "name": "filter[after]",
+              "description": "Optional date filter. If provided, only fact-checks created after that date will be considered. Format: YYYY-MM-DD.",
+              "required": false,
+              "type": "date",
+              "paramType": "query"
             }
           ],
           "responseMessages": [

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -20,7 +20,7 @@ class FeedsControllerTest < ActionController::TestCase
     create_project_media quote: 'Bar 1', media: nil, team: t1
     create_project_media quote: 'Bar 2', media: nil, team: t2
     create_project_media quote: 'Foo Bar', media: nil, team: t3
-    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [t1.id, t2.id]).returns([pm1, pm2])
+    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [t1.id, t2.id], nil).returns([pm1, pm2])
   end
 
   def teardown

--- a/test/models/project_media_test.rb
+++ b/test/models/project_media_test.rb
@@ -2857,4 +2857,15 @@ class ProjectMediaTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should get claim description and fact-check data" do
+    pm = create_project_media
+    assert_nil pm.claim_description_content
+    assert_nil pm.claim_description_context
+    cd = create_claim_description project_media: pm, description: 'Foo', context: 'Bar'
+    fc = create_fact_check claim_description: cd
+    assert_equal 'Foo', pm.claim_description_content
+    assert_equal 'Bar', pm.claim_description_context
+    assert_not_nil pm.fact_check_published_on
+  end
 end


### PR DESCRIPTION
Requested changes for the feeds resource were:

* Remove attributes report_title and report_summary
* Add attributes claim_context, claim_tags and fact_check_published_on
* Add an "after" (date) filter, exposed in Swagger UI as well
* Rename a few other attributes

References: CHECK-1748.