### PR TITLE
Fix newsletter delivery in multiple languages.

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -390,9 +390,10 @@ class Bot::Smooch < BotUser
 
     # Shortcut
     if self.message_is_a_newsletter_request?(message)
-      date = I18n.l(Time.now.to_date, locale: language.to_s.tr('_', '-'), format: :short)
-      newsletter = Bot::Smooch.build_newsletter_content(workflow['smooch_newsletter'], language, self.config['team_id']).gsub('{date}', date).gsub('{channel}', self.get_platform_from_message(message))
-      Bot::Smooch.send_final_message_to_user(uid, newsletter, workflow, language)
+      newsletter_language = self.newsletter_request(message, language)[:language]
+      date = I18n.l(Time.now.to_date, locale: newsletter_language.to_s.tr('_', '-'), format: :short)
+      newsletter = Bot::Smooch.build_newsletter_content(workflow['smooch_newsletter'], newsletter_language, self.config['team_id']).gsub('{date}', date).gsub('{channel}', self.get_platform_from_message(message))
+      Bot::Smooch.send_final_message_to_user(uid, newsletter, workflow, newsletter_language)
       return true
     end
 

--- a/app/models/concerns/smooch_newsletter.rb
+++ b/app/models/concerns/smooch_newsletter.rb
@@ -98,8 +98,16 @@ module SmoochNewsletter
     end
 
     def message_is_a_newsletter_request?(message)
+      self.newsletter_request(message)[:type] == 'newsletter'
+    end
+
+    def newsletter_request(message, language = nil)
       quoted_id = message.dig('quotedMessage', 'content', '_id')
-      !quoted_id.blank? && Rails.cache.read("smooch:original:#{quoted_id}") == 'newsletter'
+      unless quoted_id.blank?
+        original = Rails.cache.read("smooch:original:#{quoted_id}").to_s.split(':')
+        { type: original[0], language: original[1] || language }
+      end
+      {}
     end
   end
 end

--- a/app/models/concerns/smooch_resend.rb
+++ b/app/models/concerns/smooch_resend.rb
@@ -70,7 +70,7 @@ module SmoochResend
       introduction = original['introduction']
       response = self.send_message_to_user(message['appUser']['_id'], self.format_template_message(template_name, [date, introduction], nil, introduction, language))
       id = self.get_id_from_send_response(response)
-      Rails.cache.write("smooch:original:#{id}", 'newsletter') # This way if "Read now" is clicked, the newsletter can be sent
+      Rails.cache.write("smooch:original:#{id}", "newsletter:#{language}") # This way if "Read now" is clicked, the newsletter can be sent
       return true
     end
   end


### PR DESCRIPTION
When the same tipline user is subscribed to more than one language for a given tipline newsletter,
currently they receive the newsletter is only one language, the one they are currently interacting
with the tipline on. This happens because the cache for the original message stores only "newsletter",
not the language information. The fix consists of:

* When the newsletter is sent and the user doesn't receive it because of the 24 hours window, store
  in the cache not only the "newsletter" information, but also the language
* When sending a newsletter when "Read now" is pushed, read the cached language and send the newsletter
  in that language

Fixes CHECK-1759.