### PR TITLE
Fix language in which newsletter is sent

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -391,9 +391,10 @@ class Bot::Smooch < BotUser
     # Shortcut
     if self.message_is_a_newsletter_request?(message)
       newsletter_language = self.newsletter_request(message, language)[:language]
+      newsletter_workflow = self.get_workflow(newsletter_language)
       date = I18n.l(Time.now.to_date, locale: newsletter_language.to_s.tr('_', '-'), format: :short)
-      newsletter = Bot::Smooch.build_newsletter_content(workflow['smooch_newsletter'], newsletter_language, self.config['team_id']).gsub('{date}', date).gsub('{channel}', self.get_platform_from_message(message))
-      Bot::Smooch.send_final_message_to_user(uid, newsletter, self.get_workflow(newsletter_language), newsletter_language)
+      newsletter = Bot::Smooch.build_newsletter_content(newsletter_workflow['smooch_newsletter'], newsletter_language, self.config['team_id']).gsub('{date}', date).gsub('{channel}', self.get_platform_from_message(message))
+      Bot::Smooch.send_final_message_to_user(uid, newsletter, newsletter_workflow, newsletter_language)
       return true
     end
 


### PR DESCRIPTION
After "Read now" is clicked, the newsletter needs to be sent in the correct language.
So, the right workflow needs to be picked up.

Reference: CHECK-1759