### PR TITLE
Fixing report received confirmation for visual cards

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -908,14 +908,13 @@ class Bot::Smooch < BotUser
       last_smooch_response = nil
       if report.report_design_field_value('use_introduction', lang)
         introduction = report.report_design_introduction(data, lang)
-        last_smooch_response = self.send_message_to_user(uid, introduction)
-        Rails.logger.info "[Smooch Bot] Sent report introduction to user #{uid} for item with ID #{pm.id}, response was: #{last_smooch_response.to_json}"
+        smooch_intro_response = self.send_message_to_user(uid, introduction)
+        Rails.logger.info "[Smooch Bot] Sent report introduction to user #{uid} for item with ID #{pm.id}, response was: #{smooch_intro_response.to_json}"
         sleep 1
       end
       if report.report_design_field_value('use_visual_card', lang)
         last_smooch_response = self.send_message_to_user(uid, '', { 'type' => 'image', 'mediaUrl' => report.report_design_image_url(lang) })
         Rails.logger.info "[Smooch Bot] Sent report visual card to user #{uid} for item with ID #{pm.id}, response was: #{last_smooch_response.to_json}"
-        sleep 3
       end
       if report.report_design_field_value('use_text_message', lang)
         workflow = self.get_workflow(lang)


### PR DESCRIPTION
Funny race condition. The reported bug: when a report is a visual card, the counter for sent reports was
not incrementing and the report received confirmation was not displayed on the request card. There was a
3 seconds delay between sending the visual card and the text report. That delay means that if the received
confirmation was received in less than 3 seconds, the information was not stored. Deleting the "sleep 3"
fixes the problem, and it's not needed anymore because now it's either a visual card or a text report... it's
not possible to have both anymore.

Fixes CHECK-1764.