### PR TITLE
Fix travis initialization

### DIFF
--- a/config/initializers/02_sidekiq.rb
+++ b/config/initializers/02_sidekiq.rb
@@ -8,9 +8,15 @@ require "sidekiq/cloudwatchmetrics"
 Airbrake.add_filter(Airbrake::Sidekiq::RetryableJobsFilter.new)
 
 Sidekiq::Extensions.enable_delay!
-Sidekiq::CloudWatchMetrics.enable!(
-  namespace: "sidekiq_checkapi_#{Rails.env}",
-  additional_dimensions: { "ClusterName" => "Sidekiq-#{ENV['DEPLOY_ENV']}" } )
+
+# Only enable CloudWatch metrics for QA and Live, not Travis or other
+# integration test environments.
+#
+if "#{ENV['DEPLOY_ENV']}" == 'qa' || "#{ENV['DEPLOY_ENV']}" == 'live'
+  Sidekiq::CloudWatchMetrics.enable!(
+    namespace: "sidekiq_checkapi_#{Rails.env}",
+    additional_dimensions: { "ClusterName" => "Sidekiq-#{ENV['DEPLOY_ENV']}" } )
+end
 
 REDIS_CONFIG = {}
 if File.exist?(file)

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -67,7 +67,7 @@ COPY --chown=checkdeploy:www-data . ${DEPLOYDIR}
 USER ${DEPLOYUSER}
 RUN cp production/config.yml.dockerfile config/config.yml && \
     printf "production:\n adapter: sqlite3\n database: /tmp/db.sqlite\n" > config/database.yml && \
-    SECRET_KEY_BASE=bogus bundle exec rake assets:precompile && \
+    SECRET_KEY_BASE=bogus AWS_SECRET_ACCESS_KEY=bogus AWS_ACCESS_KEY_ID=bogus SECRET_KEY_BASE=bogus bundle exec rake assets:precompile && \
     rm config/config.yml
 
 EXPOSE 3300

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -67,7 +67,7 @@ COPY --chown=checkdeploy:www-data . ${DEPLOYDIR}
 USER ${DEPLOYUSER}
 RUN cp production/config.yml.dockerfile config/config.yml && \
     printf "production:\n adapter: sqlite3\n database: /tmp/db.sqlite\n" > config/database.yml && \
-    SECRET_KEY_BASE=bogus AWS_SECRET_ACCESS_KEY=bogus AWS_ACCESS_KEY_ID=bogus SECRET_KEY_BASE=bogus bundle exec rake assets:precompile && \
+    AWS_REGION=null AWS_SECRET_ACCESS_KEY=null AWS_ACCESS_KEY_ID=null SECRET_KEY_BASE=bogus bundle exec rake assets:precompile && \
     rm config/config.yml
 
 EXPOSE 3300


### PR DESCRIPTION
Debugging issues with @danielevalverde and we tracked it down to the new Sidekiq CloudWatch Metrics collection trying to initialize when running Travis integration tests. In addition, builds may fail if the AWS ENV vars are not set when trying to install gem `aws-sdk-cloudwatch 1.62.0` as it checks for these variables.