### PR TITLE
Fact-checks and reports should be in sync

### DIFF
--- a/app/models/bot/fetch.rb
+++ b/app/models/bot/fetch.rb
@@ -226,6 +226,7 @@ class Bot::Fetch < BotUser
       fc.summary = self.parse_text(claim_review['text'].to_s.blank? ? claim_review['headline'] : claim_review['text'])
       fc.url = claim_review['url'].to_s
       fc.user = user
+      fc.skip_report_update = true
       fc.save!
     end
 

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -137,9 +137,8 @@ module SmoochSearch
       results = results.collect { |r| Relationship.confirmed_parent(r) }.uniq
       results.each do |result|
         report = result.get_dynamic_annotation('report_design')
-        next if report.nil?
-        self.send_message_to_user(uid, '', { 'type' => 'image', 'mediaUrl' => report.report_design_image_url }) if report.report_design_field_value('use_visual_card')
-        self.send_message_to_user(uid, report.report_design_text) if !report.report_design_field_value('use_visual_card') && report.report_design_field_value('use_text_message')
+        self.send_message_to_user(uid, '', { 'type' => 'image', 'mediaUrl' => report&.report_design_image_url }) if report && report.report_design_field_value('use_visual_card')
+        self.send_message_to_user(uid, report.report_design_text) if report && !report.report_design_field_value('use_visual_card') && report.report_design_field_value('use_text_message')
       end
     end
   end

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -15,9 +15,10 @@ module SmoochSearch
           self.bundle_messages(uid, '', app_id, 'default_requests', nil, true)
           self.send_final_message_to_user(uid, self.get_menu_string('search_no_results', language), workflow, language)
         else
-          self.send_message_to_user(uid, self.format_search_results(results))
+          self.send_search_results_to_user(uid, results)
           sm.go_to_search_result
           self.save_search_results_for_user(uid, results.map(&:id))
+          sleep 3 # Be sure that the user has enough time to take a look at the results before answering if they are relevant
           self.send_message_for_state(uid, workflow, 'search_result', language)
         end
       rescue StandardError => e
@@ -132,12 +133,14 @@ module SmoochSearch
       results
     end
 
-    def format_search_results(results)
+    def send_search_results_to_user(uid, results)
       results = results.collect { |r| Relationship.confirmed_parent(r) }.uniq
-      results.collect do |r|
-        title = r.fact_check_title || r.report_text_title || r.title
-        "#{title}\n#{r.published_url}"
-      end.join("\n\n")
+      results.each do |result|
+        report = result.get_dynamic_annotation('report_design')
+        next if report.nil?
+        self.send_message_to_user(uid, '', { 'type' => 'image', 'mediaUrl' => report.report_design_image_url }) if report.report_design_field_value('use_visual_card')
+        self.send_message_to_user(uid, report.report_design_text) if !report.report_design_field_value('use_visual_card') && report.report_design_field_value('use_text_message')
+      end
     end
   end
 end

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -1,10 +1,14 @@
 class FactCheck < ApplicationRecord
   include ClaimAndFactCheck
 
+  attr_accessor :skip_report_update
+
   belongs_to :claim_description
 
   validates_presence_of :summary, :title, :user, :claim_description
   validates_format_of :url, with: URI.regexp, allow_blank: true, allow_nil: true
+
+  after_save :update_report
 
   def text_fields
     ['fact_check_title', 'fact_check_summary']
@@ -12,5 +16,32 @@ class FactCheck < ApplicationRecord
 
   def project_media
     self.claim_description.project_media
+  end
+
+  private
+
+  def update_report
+    return if self.skip_report_update
+    pm = self.project_media
+    reports = pm.get_dynamic_annotation('report_design') || Dynamic.new(annotation_type: 'report_design', annotated: pm)
+    data = reports.data ? reports.data.with_indifferent_access : {}.with_indifferent_access
+    language = data[:default_language] || pm.team.default_language || 'en'
+    report = data[:options].to_a.find{ |o| o[:language] == language }
+    unless report
+      data[:options] ||= []
+      report = { language: language, use_text_message: true }
+      data[:options] << report
+    end
+    report.merge!({
+      title: self.title,
+      headline: self.title,
+      text: self.summary,
+      description: self.summary,
+      published_article_url: self.url,
+      theme_color: '#333333'
+    })
+    reports.annotator = self.user || User.current
+    reports.set_fields = data.to_json
+    reports.save!
   end
 end

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -21,7 +21,7 @@ class FactCheck < ApplicationRecord
   private
 
   def update_report
-    return if self.skip_report_update
+    return if self.skip_report_update || !DynamicAnnotation::AnnotationType.where(annotation_type: 'report_design').exists?
     pm = self.project_media
     reports = pm.get_dynamic_annotation('report_design') || Dynamic.new(annotation_type: 'report_design', annotated: pm)
     data = reports.data ? reports.data.with_indifferent_access : {}.with_indifferent_access

--- a/app/workers/report_designer_worker.rb
+++ b/app/workers/report_designer_worker.rb
@@ -29,7 +29,7 @@ class ReportDesignerWorker
     d = Dynamic.where(id: id).last
     data = d.data.with_indifferent_access
     data[:options].each_with_index do |option, i|
-      data[:options][i][:previous_published_status_label] = option[:status_label]
+      data[:options][i][:previous_published_status_label] = option[:status_label].to_s
     end
     data[:first_published] ||= Time.now.to_i.to_s
     data[:last_published] = Time.now.to_i.to_s

--- a/config/initializers/report_designer.rb
+++ b/config/initializers/report_designer.rb
@@ -146,7 +146,7 @@ Dynamic.class_eval do
       temp_name = 'temp-' + self.id.to_s + '-' + language + '.html'
       temp = File.join(Rails.root, 'public', 'report_design', temp_name)
       output = File.open(temp, 'w+')
-      output.puts doc.to_s.gsub(/#CCCCCC/, self.report_design_field_value('theme_color', language).to_s).gsub('%IMAGE_URL%', image).gsub('%AVATAR_URL%', avatar)
+      output.puts doc.to_s.gsub(/#CCCCCC/, self.report_design_field_value('theme_color', language).to_s).gsub('%IMAGE_URL%', image.to_s).gsub('%AVATAR_URL%', avatar.to_s)
       output.close
 
       # Upload the HTML to S3

--- a/config/initializers/report_designer.rb
+++ b/config/initializers/report_designer.rb
@@ -3,6 +3,32 @@ Dynamic.class_eval do
     self.keep_file = true if self.annotation_type == 'report_design'
   end
 
+  after_save do
+    if self.annotation_type == 'report_design' && (self.action == 'save' || self.action =~ /publish/) && self.annotated&.claim_description
+      fc = self.annotated.claim_description.fact_check
+      user = self.annotator || User.current
+      fields = { user: user, skip_report_update: true }
+      if self.report_design_field_value('use_text_message')
+        fields.merge!({
+          title: self.report_design_field_value('title'),
+          summary: self.report_design_field_value('text'),
+          url: self.report_design_field_value('published_article_url')
+        })
+      elsif self.report_design_field_value('use_visual_card')
+        fields.merge!({
+          title: self.report_design_field_value('headline'),
+          summary: self.report_design_field_value('description')
+        })
+      end
+      if fc.nil?
+        FactCheck.create!({ claim_description: self.annotated.claim_description }.merge(fields))
+      else
+        fields.each { |field, value| fc.send("#{field}=", value) }
+        fc.save!
+      end
+    end
+  end
+
   def report_design_introduction(data, language)
     if self.annotation_type == 'report_design'
       introduction = self.report_design_field_value('introduction', language).to_s
@@ -33,24 +59,28 @@ Dynamic.class_eval do
     footer.join("\n")
   end
 
-  def report_design_text(language)
+  def report_design_text(language = nil)
     if self.annotation_type == 'report_design'
       text = []
       title = self.report_design_field_value('title', language)
       text << "*#{title}*" unless title.blank?
       text << Bot::Smooch.utmize_urls(self.report_design_field_value('text', language).to_s, 'report')
-      footer = self.report_design_text_footer(language)
-      text << footer if !footer.blank? && self.report_design_team_setting_value('use_signature', language)
+      url = self.report_design_field_value('published_article_url', language)
+      text << Bot::Smooch.utmize_urls(url, 'report') unless url.blank?
+      unless language.nil?
+        footer = self.report_design_text_footer(language)
+        text << footer if !footer.blank? && self.report_design_team_setting_value('use_signature', language)
+      end
       text.join("\n\n")
     end
   end
 
-  def report_design_field_value(field, language)
+  def report_design_field_value(field, language = nil)
     value = nil
     default = nil
     if self.annotation_type == 'report_design'
       data = self.data.with_indifferent_access
-      default_language = data[:default_language] || self.annotated&.team&.default_language
+      default_language = data[:default_language] || self.annotated&.team&.default_language || 'en'
       data[:options].to_a.each do |option|
         value = option[field] if option[:language] == language
         default = option[field] if option[:language] == default_language
@@ -59,7 +89,7 @@ Dynamic.class_eval do
     value.blank? ? default : value
   end
 
-  def report_design_image_url(language)
+  def report_design_image_url(language = nil)
     self.annotation_type == 'report_design' ? Dynamic.find(self.id).report_design_field_value('visual_card_url', language) : nil
   end
 

--- a/config/initializers/report_designer.rb
+++ b/config/initializers/report_designer.rb
@@ -146,7 +146,7 @@ Dynamic.class_eval do
       temp_name = 'temp-' + self.id.to_s + '-' + language + '.html'
       temp = File.join(Rails.root, 'public', 'report_design', temp_name)
       output = File.open(temp, 'w+')
-      output.puts doc.to_s.gsub(/#CCCCCC/, self.report_design_field_value('theme_color', language)).gsub('%IMAGE_URL%', image).gsub('%AVATAR_URL%', avatar)
+      output.puts doc.to_s.gsub(/#CCCCCC/, self.report_design_field_value('theme_color', language).to_s).gsub('%IMAGE_URL%', image).gsub('%AVATAR_URL%', avatar)
       output.close
 
       # Upload the HTML to S3

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,14 +27,14 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
   create_table "accounts", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.string "url"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "team_id"
     t.text "omniauth_info"
     t.string "uid"
     t.string "provider"
     t.string "token"
     t.string "email"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "team_id"
     t.index ["uid", "provider", "token", "email"], name: "index_accounts_on_uid_and_provider_and_token_and_email"
     t.index ["url"], name: "index_accounts_on_url", unique: true
     t.index ["user_id"], name: "index_accounts_on_user_id"
@@ -273,6 +273,7 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
     t.integer "user_id"
     t.integer "team_id"
     t.string "title"
+    t.boolean "is_default", default: false
     t.text "description"
     t.string "lead_image"
     t.datetime "created_at", null: false
@@ -283,7 +284,6 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
     t.integer "assignments_count", default: 0
     t.integer "project_group_id"
     t.integer "privacy", default: 0, null: false
-    t.boolean "is_default", default: false
     t.index ["id"], name: "index_projects_on_id"
     t.index ["is_default"], name: "index_projects_on_is_default"
     t.index ["privacy"], name: "index_projects_on_privacy"
@@ -387,15 +387,15 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
     t.integer "team_id"
     t.integer "user_id"
     t.string "type"
+    t.integer "invited_by_id"
+    t.string "invitation_token"
+    t.string "raw_invitation_token"
+    t.datetime "invitation_accepted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "role"
     t.string "status", default: "member"
     t.text "settings"
-    t.integer "invited_by_id"
-    t.string "invitation_token"
-    t.string "raw_invitation_token"
-    t.datetime "invitation_accepted_at"
     t.string "invitation_email"
     t.string "file"
     t.index ["team_id", "user_id"], name: "index_team_users_on_team_id_and_user_id", unique: true
@@ -441,6 +441,7 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
     t.string "name", default: "", null: false
     t.string "login", default: "", null: false
     t.string "token", default: "", null: false
+    t.boolean "default", default: false
     t.string "email"
     t.string "encrypted_password", default: ""
     t.string "reset_password_token"
@@ -451,6 +452,14 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
     t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
+    t.string "invitation_token"
+    t.string "raw_invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer "invitation_limit"
+    t.integer "invited_by_id"
+    t.string "invited_by_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "image"
@@ -467,14 +476,6 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
     t.string "unconfirmed_email"
     t.integer "current_project_id"
     t.boolean "is_active", default: true
-    t.string "invitation_token"
-    t.string "raw_invitation_token"
-    t.datetime "invitation_created_at"
-    t.datetime "invitation_sent_at"
-    t.datetime "invitation_accepted_at"
-    t.integer "invitation_limit"
-    t.integer "invited_by_id"
-    t.string "invited_by_type"
     t.datetime "last_accepted_terms_at"
     t.string "encrypted_otp_secret"
     t.string "encrypted_otp_secret_iv"
@@ -482,7 +483,6 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.string "otp_backup_codes", array: true
-    t.boolean "default", default: false
     t.boolean "completed_signup", default: true
     t.datetime "last_active_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,14 +27,14 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
   create_table "accounts", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.string "url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "team_id"
     t.text "omniauth_info"
     t.string "uid"
     t.string "provider"
     t.string "token"
     t.string "email"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "team_id"
     t.index ["uid", "provider", "token", "email"], name: "index_accounts_on_uid_and_provider_and_token_and_email"
     t.index ["url"], name: "index_accounts_on_url", unique: true
     t.index ["user_id"], name: "index_accounts_on_user_id"
@@ -273,7 +273,6 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
     t.integer "user_id"
     t.integer "team_id"
     t.string "title"
-    t.boolean "is_default", default: false
     t.text "description"
     t.string "lead_image"
     t.datetime "created_at", null: false
@@ -284,6 +283,7 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
     t.integer "assignments_count", default: 0
     t.integer "project_group_id"
     t.integer "privacy", default: 0, null: false
+    t.boolean "is_default", default: false
     t.index ["id"], name: "index_projects_on_id"
     t.index ["is_default"], name: "index_projects_on_is_default"
     t.index ["privacy"], name: "index_projects_on_privacy"
@@ -387,15 +387,15 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
     t.integer "team_id"
     t.integer "user_id"
     t.string "type"
-    t.integer "invited_by_id"
-    t.string "invitation_token"
-    t.string "raw_invitation_token"
-    t.datetime "invitation_accepted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "role"
     t.string "status", default: "member"
     t.text "settings"
+    t.integer "invited_by_id"
+    t.string "invitation_token"
+    t.string "raw_invitation_token"
+    t.datetime "invitation_accepted_at"
     t.string "invitation_email"
     t.string "file"
     t.index ["team_id", "user_id"], name: "index_team_users_on_team_id_and_user_id", unique: true
@@ -441,7 +441,6 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
     t.string "name", default: "", null: false
     t.string "login", default: "", null: false
     t.string "token", default: "", null: false
-    t.boolean "default", default: false
     t.string "email"
     t.string "encrypted_password", default: ""
     t.string "reset_password_token"
@@ -452,14 +451,6 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
     t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
-    t.string "invitation_token"
-    t.string "raw_invitation_token"
-    t.datetime "invitation_created_at"
-    t.datetime "invitation_sent_at"
-    t.datetime "invitation_accepted_at"
-    t.integer "invitation_limit"
-    t.integer "invited_by_id"
-    t.string "invited_by_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "image"
@@ -476,6 +467,14 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
     t.string "unconfirmed_email"
     t.integer "current_project_id"
     t.boolean "is_active", default: true
+    t.string "invitation_token"
+    t.string "raw_invitation_token"
+    t.datetime "invitation_created_at"
+    t.datetime "invitation_sent_at"
+    t.datetime "invitation_accepted_at"
+    t.integer "invitation_limit"
+    t.integer "invited_by_id"
+    t.string "invited_by_type"
     t.datetime "last_accepted_terms_at"
     t.string "encrypted_otp_secret"
     t.string "encrypted_otp_secret_iv"
@@ -483,6 +482,7 @@ ActiveRecord::Schema.define(version: 2022_04_18_074142) do
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.string "otp_backup_codes", array: true
+    t.boolean "default", default: false
     t.boolean "completed_signup", default: true
     t.datetime "last_active_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true

--- a/test/data/oembed-verification_status.html
+++ b/test/data/oembed-verification_status.html
@@ -1,24 +1,13 @@
-<!doctype html>
-<html>
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Claim</title>
-    <link href="http://api:3000/css/oembed.css?t=201904021148" rel="stylesheet" type="text/css">
-    <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha256-hwg4gsxgFZhOsEEamdOYGBf13FyQuiTwlAQgxVSNgt4=" crossorigin="anonymous"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jQuery-linkify/2.1.8/linkify.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jQuery-linkify/2.1.8/linkify-jquery.min.js"></script>
-  </head>
-  <body>
-    <article id="container">
-      <div id="content">
-          <div id="text" class="linkify">
-            <p><p><b>This</b> <i>is</i> a <strike>test</strike>!</p></p>
-          </div>
+<body>
+  <article id="container">
+    <div id="content">
+      <div id="text" class="linkify">
+        <p><p><b>Title</b></p>
+        <p><b>This</b> <i>is</i> a <strike>test</strike>!</p>
+        <p>http://foo.bar?utm<i>source=check</i>report</p></p>
       </div>
-    </article>
-
-    <script src="http://localhost:3000/javascripts/oembed.js?t=201904021148"></script>
-
-  </body>
+    </div>
+  </article>
+  <script src="http://check/javascripts/oembed.js?t=201904021148"></script>
+</body>
 </html>

--- a/test/models/project_media_test.rb
+++ b/test/models/project_media_test.rb
@@ -1030,13 +1030,13 @@ class ProjectMediaTest < ActiveSupport::TestCase
         use_text_message: true,
         use_disclaimer: false,
         disclaimer: '',
-        text: '*This* _is_ a ~test~!'
+        title: 'Title',
+        text: '*This* _is_ a ~test~!',
+        published_article_url: 'http://foo.bar'
       })
       PenderClient::Request.unstub(:get_medias)
-      expected = File.read(File.join(Rails.root, 'test', 'data', "oembed-#{pm.default_project_media_status_type}.html"))
-        .gsub(/.*<body/m, '<body')
-        .gsub('https?://[^:]*:3000', CheckConfig.get('checkdesk_base_url'))
-      actual = ProjectMedia.find(pm.id).html.gsub(/.*<body/m, '<body')
+      expected = File.read(File.join(Rails.root, 'test', 'data', "oembed-#{pm.default_project_media_status_type}.html")).gsub(/^\s+/m, '')
+      actual = ProjectMedia.find(pm.id).html.gsub(/.*<body/m, '<body').gsub(/^\s+/m, '').gsub(/https?:\/\/[^:]*:3000/, 'http://check')
       assert_equal expected, actual
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1074,16 +1074,18 @@ class ActiveSupport::TestCase
       options: [{
         language: 'en',
         status_label: random_string,
-        description: random_string,
-        headline: random_string,
-        use_visual_card: true,
-        image: '',
         use_introduction: true,
         introduction: 'Regarding {{query_message}} on {{query_date}}, it is {{status}}.',
+        use_visual_card: true,
+        description: random_string,
+        headline: random_string,
+        image: '',
         theme_color: '#FF0000',
         url: random_url,
         use_text_message: true,
+        title: random_string,
         text: random_string,
+        published_article_url: random_url,
         use_disclaimer: true,
         disclaimer: random_string
       }.merge(option_data)]


### PR DESCRIPTION
Details:

* Text report now has a published article URL
* Report and fact-check are in sync: if one is changed, the other is changed too, and vice-versa (one exception: published article URL is not overwritten by a visual card)
* Tipline bot v2 search: one message per each of the up to 3 results... visual card or text report (title, summary and link)

Reference: CHECK-1697.