### PR TITLE
Fixes for items count, report and newsletter.

### DIFF
--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -29,7 +29,12 @@ class FactCheck < ApplicationRecord
     report = data[:options].to_a.find{ |o| o[:language] == language }
     unless report
       data[:options] ||= []
-      report = { language: language, use_text_message: true }
+      report = {
+        language: language,
+        use_text_message: true,
+        use_introduction: reports.report_design_team_setting_value('use_introduction', language),
+        introduction: reports.report_design_team_setting_value('introduction', language)
+      }
       data[:options] << report
     end
     report.merge!({

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -32,8 +32,8 @@ class FactCheck < ApplicationRecord
       report = {
         language: language,
         use_text_message: true,
-        use_introduction: reports.report_design_team_setting_value('use_introduction', language),
-        introduction: reports.report_design_team_setting_value('introduction', language)
+        use_introduction: !!reports.report_design_team_setting_value('use_introduction', language),
+        introduction: reports.report_design_team_setting_value('introduction', language).to_s
       }
       data[:options] << report
     end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -237,7 +237,7 @@ class Team < ApplicationRecord
   end
 
   def medias_count
-    ProjectMedia.where(team_id: self.id, archived: CheckArchivedFlags::FlagCodes::NONE).joins("LEFT JOIN relationships r ON r.target_id = project_medias.id AND r.relationship_type = '#{Relationship.confirmed_type.to_yaml}'").where('r.id IS NULL').count
+    ProjectMedia.where(team_id: self.id, archived: CheckArchivedFlags::FlagCodes::NONE).joins("LEFT JOIN relationships r ON r.target_id = project_medias.id AND r.relationship_type = '#{Team.sanitize_sql(Relationship.confirmed_type.to_yaml)}'").where('r.id IS NULL').count
   end
 
   def check_search_team

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -237,7 +237,7 @@ class Team < ApplicationRecord
   end
 
   def medias_count
-    ProjectMedia.where({ team_id: self.id, archived: CheckArchivedFlags::FlagCodes::NONE }).count
+    ProjectMedia.where(team_id: self.id, archived: CheckArchivedFlags::FlagCodes::NONE).joins("LEFT JOIN relationships r ON r.target_id = project_medias.id AND r.relationship_type = '#{Relationship.confirmed_type.to_yaml}'").where('r.id IS NULL').count
   end
 
   def check_search_team

--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -3,31 +3,40 @@ class TiplineNewsletterWorker
 
   def perform(team_id, language)
     tbi = TeamBotInstallation.where(user_id: BotUser.smooch_user&.id.to_i, team_id: team_id.to_i).last
+    count = 0
     unless tbi.nil?
       tbi.settings['smooch_workflows'].to_a.each do |workflow|
         if workflow['smooch_workflow_language'] == language
           newsletter = workflow['smooch_newsletter']
-          Rails.logger.info "[Smooch Bot] [Newsletter] [Team ##{team_id}] [Language #{language}] [#{Time.now}] Preparing newsletter to be sent..."
+          log team_id, language, 'Preparing newsletter to be sent...'
           if !newsletter.nil? && Bot::Smooch.newsletter_content_changed?(newsletter, language, team_id)
             date = I18n.l(Time.now.to_date, locale: language.to_s.tr('_', '-'), format: :long)
             TiplineSubscription.where(language: language, team_id: team_id).each do |ts|
-              Rails.logger.info "[Smooch Bot] [Newsletter] [Team ##{team_id}] [Language #{language}] [#{Time.now}] Sending newsletter to subscriber ##{ts.id}..."
+              log team_id, language, "Sending newsletter to subscriber ##{ts.id}..."
               begin
                 introduction = newsletter['smooch_newsletter_introduction'].to_s.gsub('{date}', date).gsub('{channel}', ts.platform)
                 content = Bot::Smooch.build_newsletter_content(newsletter, language, team_id).gsub('{date}', date).gsub('{channel}', ts.platform)
                 Bot::Smooch.get_installation { |i| i.id == tbi.id }
                 response = Bot::Smooch.send_final_message_to_user(ts.uid, content, workflow, language)
                 Bot::Smooch.save_smooch_response(response, nil, nil, 'newsletter', language, { introduction: introduction })
-                Rails.logger.info "[Smooch Bot] [Newsletter] [Team ##{team_id}] [Language #{language}] [#{Time.now}] Newsletter sent to subscriber ##{ts.id}, response: #{response.inspect}"
+                log team_id, language, "Newsletter sent to subscriber ##{ts.id}, response: #{response.inspect}"
+                count += 1
               rescue StandardError => e
-                Rails.logger.info "[Smooch Bot] [Newsletter] [Team ##{team_id}] [Language #{language}] [#{Time.now}] Could not send newsletter to subscriber ##{ts.id}: #{e.message}"
+                log team_id, language, "Could not send newsletter to subscriber ##{ts.id}: #{e.message}"
               end
             end
           else
-            Rails.logger.info "[Smooch Bot] [Newsletter] [Team ##{team_id}] [Language #{language}] [#{Time.now}] Not sending newsletter because content hasn't changed since the last delivery"
+            log team_id, language, 'Not sending newsletter because content has not changed since the last delivery'
           end
         end
       end
     end
+    count
+  end
+
+  private
+
+  def log(team_id, language, message)
+    Rails.logger.info "[Smooch Bot] [Newsletter] [Team ##{team_id}] [Language #{language}] [#{Time.now}] #{message}"
   end
 end

--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -7,15 +7,24 @@ class TiplineNewsletterWorker
       tbi.settings['smooch_workflows'].to_a.each do |workflow|
         if workflow['smooch_workflow_language'] == language
           newsletter = workflow['smooch_newsletter']
+          Rails.logger.info "[Smooch Bot] [Newsletter] [Team ##{team_id}] [Language #{language}] [#{Time.now}] Preparing newsletter to be sent..."
           if !newsletter.nil? && Bot::Smooch.newsletter_content_changed?(newsletter, language, team_id)
             date = I18n.l(Time.now.to_date, locale: language.to_s.tr('_', '-'), format: :long)
             TiplineSubscription.where(language: language, team_id: team_id).each do |ts|
-              introduction = newsletter['smooch_newsletter_introduction'].to_s.gsub('{date}', date).gsub('{channel}', ts.platform)
-              content = Bot::Smooch.build_newsletter_content(newsletter, language, team_id).gsub('{date}', date).gsub('{channel}', ts.platform)
-              Bot::Smooch.get_installation { |i| i.id == tbi.id }
-              response = Bot::Smooch.send_final_message_to_user(ts.uid, content, workflow, language)
-              Bot::Smooch.save_smooch_response(response, nil, nil, 'newsletter', language, { introduction: introduction })
+              Rails.logger.info "[Smooch Bot] [Newsletter] [Team ##{team_id}] [Language #{language}] [#{Time.now}] Sending newsletter to subscriber ##{ts.id}..."
+              begin
+                introduction = newsletter['smooch_newsletter_introduction'].to_s.gsub('{date}', date).gsub('{channel}', ts.platform)
+                content = Bot::Smooch.build_newsletter_content(newsletter, language, team_id).gsub('{date}', date).gsub('{channel}', ts.platform)
+                Bot::Smooch.get_installation { |i| i.id == tbi.id }
+                response = Bot::Smooch.send_final_message_to_user(ts.uid, content, workflow, language)
+                Bot::Smooch.save_smooch_response(response, nil, nil, 'newsletter', language, { introduction: introduction })
+                Rails.logger.info "[Smooch Bot] [Newsletter] [Team ##{team_id}] [Language #{language}] [#{Time.now}] Newsletter sent to subscriber ##{ts.id}, response: #{response.inspect}"
+              rescue StandardError => e
+                Rails.logger.info "[Smooch Bot] [Newsletter] [Team ##{team_id}] [Language #{language}] [#{Time.now}] Could not send newsletter to subscriber ##{ts.id}: #{e.message}"
+              end
             end
+          else
+            Rails.logger.info "[Smooch Bot] [Newsletter] [Team ##{team_id}] [Language #{language}] [#{Time.now}] Not sending newsletter because content hasn't changed since the last delivery"
           end
         end
       end

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -2673,4 +2673,15 @@ class TeamTest < ActiveSupport::TestCase
     assert_equal [t.name, t2.name].sort, t.country_teams.values.sort
     assert_empty t4.country_teams
   end
+
+  test "should return number of items" do
+    t = create_team
+    single = create_project_media team: t
+    main = create_project_media team: t
+    suggested = create_project_media team: t
+    confirmed = create_project_media team: t
+    create_relationship source_id: main.id, target_id: suggested.id, relationship_type: Relationship.suggested_type
+    create_relationship source_id: main.id, target_id: confirmed.id, relationship_type: Relationship.confirmed_type
+    assert_equal 3, t.reload.medias_count
+  end
 end

--- a/test/workers/tipline_newsletter_worker_test.rb
+++ b/test/workers/tipline_newsletter_worker_test.rb
@@ -5,15 +5,28 @@ class TiplineNewsletterWorkerTest < ActiveSupport::TestCase
     super
     require 'sidekiq/testing'
     Sidekiq::Testing.inline!
-  end
-
-  test "should send newsletter" do
     setup_smooch_bot(true)
     create_tipline_subscription team_id: @team.id
     rss = '<rss version="1"><channel><title>x</title><link>x</link><description>x</description><item><title>x</title><link>x</link></item></channel></rss>'
     WebMock.stub_request(:get, 'http://test.com/feed.rss').to_return(status: 200, body: rss)
+  end
+
+  test "should send newsletter" do
     assert_nothing_raised do
       TiplineNewsletterWorker.perform_async(@team.id, 'en')
     end
+  end
+
+  test "should not crash if error happens when sending newsletter to some subscriber" do
+    Bot::Smooch.stubs(:send_final_message_to_user).raises(StandardError)
+    assert_nothing_raised do
+      TiplineNewsletterWorker.perform_async(@team.id, 'en')
+    end
+    Bot::Smooch.unstub(:send_final_message_to_user)
+  end
+
+  test "should skip sending newsletter if content hasn't changed" do
+    assert_equal 1, TiplineNewsletterWorker.new.perform(@team.id, 'en')
+    assert_equal 0, TiplineNewsletterWorker.new.perform(@team.id, 'en')
   end
 end


### PR DESCRIPTION
**Include default introduction when creating a report from a fact-check** 
When a fact-check is set, a report is created, if there isn't one yet. This report should inherit the default introduction settings from the workspace.

**Adding more logging to tipline newsletter delivery**
Adding more log messages to tipline newsletter delivery, so we have more information when debugging why some user didn't receive the newsletter.

**"All items" count should include suggestions but not confirmed matches**
In order to really reflect the items that are displayed by default under the "All Items" list, the counter should include suggestions but not confirmed matches.