### PR TITLE
Update newsletter cron conversion

### DIFF
--- a/app/models/concerns/smooch_newsletter.rb
+++ b/app/models/concerns/smooch_newsletter.rb
@@ -77,8 +77,13 @@ module SmoochNewsletter
 
     def newsletter_cron(newsletter)
       hour = newsletter['smooch_newsletter_time'].to_i
-      timezone = newsletter['smooch_newsletter_timezone'].to_s.upcase
-      # Mapping for timezones not supported by Ruby's DateTime
+      # If an offset is being passed, it's in the new format
+      if newsletter['smooch_newsletter_timezone'].match?(/\W\d\d:\d\d/)
+        timezone = newsletter['smooch_newsletter_timezone'].match(/\W\d\d:\d\d/)
+      else
+        timezone = newsletter['smooch_newsletter_timezone'].to_s.upcase
+      end
+      # Mapping for old-style timezones not supported by Ruby's DateTime
       timezone = {
         'PHT' => '+0800',
         'CAT' => '+0200'

--- a/test/models/bot/smooch_5_test.rb
+++ b/test/models/bot/smooch_5_test.rb
@@ -285,18 +285,26 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
   end
 
   test "should format newsletter time as cron" do
-    # Regular time
+    # Offset
     settings = {
       'smooch_newsletter_time' => '10',
-      'smooch_newsletter_timezone' => 'BRT',
-      'smooch_newsletter_day' => 'sunday'
+      'smooch_newsletter_timezone' => 'America/Chicago (GMT-05:00)',
+      'smooch_newsletter_day' => 'friday'
     }
-    assert_equal '0 13 * * 0', Bot::Smooch.newsletter_cron(settings)
+    assert_equal '0 15 * * 5', Bot::Smooch.newsletter_cron(settings)
+
+    # Offset, other direction
+    settings = {
+      'smooch_newsletter_time' => '10',
+      'smooch_newsletter_timezone' => 'Indian/Maldives (GMT+05:00)',
+      'smooch_newsletter_day' => 'friday'
+    }
+    assert_equal '0 5 * * 5', Bot::Smooch.newsletter_cron(settings)
 
     # Non-integer hours offset, but still same day as UTC
     settings = {
       'smooch_newsletter_time' => '19',
-      'smooch_newsletter_timezone' => 'IST',
+      'smooch_newsletter_timezone' => 'Asia/Kolkata (GMT+05:30)',
       'smooch_newsletter_day' => 'sunday'
     }
     assert_equal '30 13 * * 0', Bot::Smooch.newsletter_cron(settings)
@@ -304,7 +312,7 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
     # Non-integer hours offset and not same day as UTC
     settings = {
       'smooch_newsletter_time' => '1',
-      'smooch_newsletter_timezone' => 'IST',
+      'smooch_newsletter_timezone' => 'Asia/Kolkata (GMT+05:30)',
       'smooch_newsletter_day' => 'sunday'
     }
     assert_equal '30 19 * * 6', Bot::Smooch.newsletter_cron(settings)
@@ -312,50 +320,10 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
     # Integer hours offset and not same day as UTC
     settings = {
       'smooch_newsletter_time' => '23',
-      'smooch_newsletter_timezone' => 'PDT',
+      'smooch_newsletter_timezone' => 'America/Los Angeles (GMT-07:00)',
       'smooch_newsletter_day' => 'sunday'
     }
     assert_equal '0 6 * * 1', Bot::Smooch.newsletter_cron(settings)
-
-    # PHT, which is not supported by Ruby's DateTime
-    settings = {
-      'smooch_newsletter_time' => '7',
-      'smooch_newsletter_timezone' => 'PHT',
-      'smooch_newsletter_day' => 'sunday'
-    }
-    assert_equal '0 23 * * 6', Bot::Smooch.newsletter_cron(settings)
-
-    # CET
-    settings = {
-      'smooch_newsletter_time' => '10',
-      'smooch_newsletter_timezone' => 'CET',
-      'smooch_newsletter_day' => 'friday'
-    }
-    assert_equal '0 9 * * 5', Bot::Smooch.newsletter_cron(settings)
-
-    # CAT
-    settings = {
-      'smooch_newsletter_time' => '10',
-      'smooch_newsletter_timezone' => 'CAT',
-      'smooch_newsletter_day' => 'friday'
-    }
-    assert_equal '0 8 * * 5', Bot::Smooch.newsletter_cron(settings)
-
-    # CST
-    settings = {
-      'smooch_newsletter_time' => '10',
-      'smooch_newsletter_timezone' => 'CST',
-      'smooch_newsletter_day' => 'friday'
-    }
-    assert_equal '0 16 * * 5', Bot::Smooch.newsletter_cron(settings)
-
-    # EST
-    settings = {
-      'smooch_newsletter_time' => '10',
-      'smooch_newsletter_timezone' => 'EST',
-      'smooch_newsletter_day' => 'friday'
-    }
-    assert_equal '0 15 * * 5', Bot::Smooch.newsletter_cron(settings)
 
     # Everyday
     settings = {

--- a/test/models/bot/smooch_5_test.rb
+++ b/test/models/bot/smooch_5_test.rb
@@ -328,10 +328,18 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
     # Everyday
     settings = {
       'smooch_newsletter_time' => '10',
-      'smooch_newsletter_timezone' => 'EST',
+      'smooch_newsletter_timezone' => 'America/New York (GMT-04:00)',
       'smooch_newsletter_day' => 'everyday'
     }
-    assert_equal '0 15 * * *', Bot::Smooch.newsletter_cron(settings)
+    assert_equal '0 14 * * *', Bot::Smooch.newsletter_cron(settings)
+
+    # Legacy 3 letter codes
+    settings = {
+      'smooch_newsletter_time' => '10',
+      'smooch_newsletter_timezone' => 'EST',
+      'smooch_newsletter_day' => 'sunday'
+    }
+    assert_equal '0 15 * * 0', Bot::Smooch.newsletter_cron(settings)
   end
 
   test "should not timeout after subscribing to newsletter" do


### PR DESCRIPTION
The API now accepts any string with an explicit offset in the format `(+|-)hh:mm`.

All time zones provided clientside are guaranteed to work via the API -- for example, even though Ruby doesn't support PHT, the string that comes in will say `Pacific/Phillippines (GMT+08:00)`, which simply gets converted to `+08:00` so `DateTime` doesn't have to know anything about the 3-letter codes. This means we can have fewer unit tests. I now test for positive and negative offsets, and kept the tests for non-integer offsets, and offsets where the day changes.

CHECK-1139