### PR TITLE
Ask for feedback on tipline search results only after all results are received

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -288,6 +288,7 @@ class Bot::Smooch < BotUser
         true
       when 'message:delivery:channel'
         self.user_received_report(json)
+        self.user_received_search_result(json)
         true
       else
         false

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -18,8 +18,7 @@ module SmoochSearch
           self.send_search_results_to_user(uid, results)
           sm.go_to_search_result
           self.save_search_results_for_user(uid, results.map(&:id))
-          sleep 7 # Be sure that the user has enough time to take a look at the results before answering if they are relevant
-          self.send_message_for_state(uid, workflow, 'search_result', language)
+          self.delay_for(1.second).ask_for_feedback_when_all_search_results_are_received(app_id, language, workflow, uid, 1)
         end
       rescue StandardError => e
         self.handle_search_error(uid, e, language)
@@ -134,11 +133,32 @@ module SmoochSearch
     end
 
     def send_search_results_to_user(uid, results)
+      redis = Redis.new(REDIS_CONFIG)
       results = results.collect { |r| Relationship.confirmed_parent(r) }.uniq
       results.each do |result|
         report = result.get_dynamic_annotation('report_design')
-        self.send_message_to_user(uid, '', { 'type' => 'image', 'mediaUrl' => report&.report_design_image_url }) if report && report.report_design_field_value('use_visual_card')
-        self.send_message_to_user(uid, report.report_design_text) if report && !report.report_design_field_value('use_visual_card') && report.report_design_field_value('use_text_message')
+        response = nil
+        response = self.send_message_to_user(uid, '', { 'type' => 'image', 'mediaUrl' => report&.report_design_image_url }) if report && report.report_design_field_value('use_visual_card')
+        response = self.send_message_to_user(uid, report.report_design_text) if report && !report.report_design_field_value('use_visual_card') && report.report_design_field_value('use_text_message')
+        id = self.get_id_from_send_response(response)
+        redis.rpush("smooch:search:#{uid}", id) unless id.blank?
+      end
+    end
+
+    def user_received_search_result(message)
+      uid = message['appUser']['_id']
+      id = message['message']['_id']
+      redis = Redis.new(REDIS_CONFIG)
+      redis.lrem("smooch:search:#{uid}", 0, id) if redis.exists("smooch:search:#{uid}") == 1
+    end
+
+    def ask_for_feedback_when_all_search_results_are_received(app_id, language, workflow, uid, attempts)
+      redis = Redis.new(REDIS_CONFIG)
+      if redis.llen("smooch:search:#{uid}") == 0 && CheckStateMachine.new(uid).state.value == 'search_result'
+        self.get_installation(self.installation_setting_id_keys, app_id) if self.config.blank?
+        self.send_message_for_state(uid, workflow, 'search_result', language)
+      else
+        self.delay_for(1.second).ask_for_feedback_when_all_search_results_are_received(app_id, language, workflow, uid, attempts + 1) if attempts < 30 # Try for 30 seconds
       end
     end
   end


### PR DESCRIPTION
Currently, after search results are delivered by the tipline bot, the bot waits for 7 seconds before asking for feedback from the user on whether the results are relevant. But sometimes (for example, when the search results are report visual cards or contain external links, both of which need to be parsed by WhatsApp) it can happen that the feedback message is delivered before the actual search results. So, any hard-coded interval we put is not reliable. This change implements a different approach for that, explained below:

* When each search result is delivered, save the sent message ID in a Redis list, where the key contains the user ID
* Start a Sidekiq job that verifies each second, up to 30 attempts, if that list is empty
* When the user receives a search result, we receive a delivered event... when it happens, delete the message ID from the list
* The list will be empty after all search results are received, and then the Sidekiq job will send the feedback message to the user

The idea of having a separate Sidekiq job for that is to avoid race condition if two search results are received at the same time.

Reference: CHECK-1835.