### PR TITLE
Fix menus on reports and newsletters sent to users on non-WhatsApp platforms

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -884,6 +884,7 @@ class Bot::Smooch < BotUser
   end
 
   def self.send_correction_to_user(data, pm, subscribed_at, last_published_at, action, published_count = 0)
+    self.get_platform_from_message(data)
     uid = data['authorId']
     lang = data['language']
     # User received a report before
@@ -942,6 +943,7 @@ class Bot::Smooch < BotUser
     return if parent.nil? || child.nil?
     child.get_annotations('smooch').find_each do |annotation|
       data = JSON.parse(annotation.load.get_field_value('smooch_data'))
+      self.get_platform_from_message(data)
       self.get_installation(self.installation_setting_id_keys, data['app_id']) if self.config.blank?
       self.send_report_to_user(data['authorId'], data, parent, data['language'], 'fact_check_report')
     end

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -296,6 +296,7 @@ module SmoochMessages
       self.smooch_save_annotations(message, annotated, app_id, author, request_type, annotated_obj)
 
       # If item is published (or parent item), send a report right away
+      self.get_platform_from_message(message)
       self.send_report_to_user(message['authorId'], message, annotated, message['language'], 'fact_check_report') if self.should_try_to_send_report?(request_type, annotated)
     end
 

--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -14,6 +14,7 @@ class TiplineNewsletterWorker
             TiplineSubscription.where(language: language, team_id: team_id).each do |ts|
               log team_id, language, "Sending newsletter to subscriber ##{ts.id}..."
               begin
+                RequestStore.store[:smooch_bot_platform] = ts.platform
                 introduction = newsletter['smooch_newsletter_introduction'].to_s.gsub('{date}', date).gsub('{channel}', ts.platform)
                 content = Bot::Smooch.build_newsletter_content(newsletter, language, team_id).gsub('{date}', date).gsub('{channel}', ts.platform)
                 Bot::Smooch.get_installation { |i| i.id == tbi.id }


### PR DESCRIPTION
Set the platform when sending newsletters and reports, otherwise text-based menus will be rendered instead of buttons.

CHECK-1892.