### PR TITLE
Send either a text report or an image report.

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -914,14 +914,13 @@ class Bot::Smooch < BotUser
         Rails.logger.info "[Smooch Bot] Sent report introduction to user #{uid} for item with ID #{pm.id}, response was: #{smooch_intro_response.to_json}"
         sleep 1
       end
-      if report.report_design_field_value('use_visual_card', lang)
-        last_smooch_response = self.send_message_to_user(uid, '', { 'type' => 'image', 'mediaUrl' => report.report_design_image_url(lang) })
-        Rails.logger.info "[Smooch Bot] Sent report visual card to user #{uid} for item with ID #{pm.id}, response was: #{last_smooch_response.to_json}"
-      end
       if report.report_design_field_value('use_text_message', lang)
         workflow = self.get_workflow(lang)
         last_smooch_response = self.send_final_message_to_user(uid, report.report_design_text(lang), workflow, lang)
         Rails.logger.info "[Smooch Bot] Sent text report to user #{uid} for item with ID #{pm.id}, response was: #{last_smooch_response.to_json}"
+      elsif report.report_design_field_value('use_visual_card', lang)
+        last_smooch_response = self.send_message_to_user(uid, '', { 'type' => 'image', 'mediaUrl' => report.report_design_image_url(lang) })
+        Rails.logger.info "[Smooch Bot] Sent report visual card to user #{uid} for item with ID #{pm.id}, response was: #{last_smooch_response.to_json}"
       end
       self.save_smooch_response(last_smooch_response, parent, data['received'], fallback_template, lang)
     end

--- a/test/models/bot/smooch_4_test.rb
+++ b/test/models/bot/smooch_4_test.rb
@@ -596,7 +596,7 @@ class Bot::Smooch4Test < ActiveSupport::TestCase
 
   test "should not create duplicated project media and media on team" do
     Sidekiq::Testing.inline! do
-      # video
+      # Video
       message = {
         type: 'file',
         text: random_string,
@@ -623,6 +623,14 @@ class Bot::Smooch4Test < ActiveSupport::TestCase
        Bot::Smooch.save_message(message.to_json, @app_id)
       end
       assert_equal medias_count, Media.count
+    end
+  end
+
+  test "should send only visual card to user" do
+    pm = create_project_media
+    publish_report(pm, {}, nil, { use_text_message: false })
+    assert_nothing_raised do
+      Bot::Smooch.send_report_to_user(random_string, { 'received' => Time.now.to_i }, pm, 'report')
     end
   end
 end


### PR DESCRIPTION
This is mostly for legacy reasons, since today it's not possible, on the frontend side, to create both text report and visual card for the same item. But for some existing data, some items have both a text report and a visual card. Let's be sure that only one is sent for those cases.

Fixes CHECK-1897.