### PR TITLE
Fuzzy matching for keyword search

### DIFF
--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -1,28 +1,37 @@
 class CheckSearch
   def initialize(options, file = nil, team_id = Team.current.id)
-    # options include keywords, projects, tags, status, report status
+    # Options include keywords, projects, tags, status, report status
     options = begin JSON.parse(options) rescue {} end
     @options = options.clone.with_indifferent_access
     @options['input'] = options.clone
     @options['team_id'] = team_condition(team_id)
     @options['operator'] ||= 'AND' # AND or OR
-    # set sort options
+
+    # Set sort options
     smooch_bot_installed = TeamBotInstallation.where(team_id: @options['team_id'], user_id: BotUser.smooch_user&.id).exists?
     @options['sort'] ||= (smooch_bot_installed ? 'last_seen' : 'recent_added')
     @options['sort_type'] ||= 'desc'
-    # set show options
+
+    # Set show options
     @options['show'] ||= MEDIA_TYPES
-    # set show similar
+
+    # Set show similar
     @options['show_similar'] ||= false
     @options['eslimit'] ||= 50
     @options['esoffset'] ||= 0
     adjust_es_window_size
+
     # Check for non project
     @options['none_project'] = @options['projects'].include?('-1') unless @options['projects'].blank?
     adjust_project_filter
     adjust_channel_filter
     adjust_numeric_range_filter
     adjust_archived_filter
+
+    # Set fuzzy matching for keyword search, right now hard-coding with a Levenshtein Edit Distance of 1
+    # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
+    @options['keyword'] = "#{@options['keyword']}~1" unless @options['keyword'].blank?
+
     # set es_id option
     @options['es_id'] = Base64.encode64("ProjectMedia/#{@options['id']}") if @options['id'] && ['String', 'Integer'].include?(@options['id'].class.name)
     Project.current = Project.where(id: @options['projects'].last).last if @options['projects'].to_a.size == 1 && Project.current.nil?

--- a/test/controllers/elastic_search_8_test.rb
+++ b/test/controllers/elastic_search_8_test.rb
@@ -429,4 +429,22 @@ class ElasticSearch8Test < ActionController::TestCase
       assert_queries(0, '=') { assert_equal data, pm.published_by }
     end
   end
+
+  test "should search for keywords with typos" do
+    t = create_team
+    p = create_project team: t
+    u = create_user
+    create_team_user team: t, user: u, role: 'admin'
+    with_current_user_and_team(u ,t) do
+      pm1 = create_project_media team: t, quote: 'Foobar 1', disable_es_callbacks: false
+      pm2 = create_project_media team: t, quote: 'Fobar 2', disable_es_callbacks: false
+      pm3 = create_project_media team: t, quote: 'Test 3', disable_es_callbacks: false
+      results = CheckSearch.new({ keyword: 'Foobar' }.to_json)
+      assert_equal [pm1.id, pm2.id].sort, results.medias.map(&:id).sort
+      results = CheckSearch.new({ keyword: 'Fobar' }.to_json)
+      assert_equal [pm1.id, pm2.id].sort, results.medias.map(&:id).sort
+      results = CheckSearch.new({ keyword: 'Test' }.to_json)
+      assert_equal [pm3.id], results.medias.map(&:id)
+    end
+  end
 end


### PR DESCRIPTION
When search for items by keyword, enable fuzzy matching. Right now with a Levenshtein Edit Distance of 1. For now, this is enabled for all keyword searches, maybe that should be a search options. More on that:

* https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness
* https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html

Reference: CHECK-1903.