### PR TITLE
Expose on GraphQL API if an item is suggested or confirmed to another item

### DIFF
--- a/app/graph/types/project_media_type.rb
+++ b/app/graph/types/project_media_type.rb
@@ -37,12 +37,16 @@ ProjectMediaType = GraphqlCrudOperations.define_default_type do
   field :channel, JsonStringType
   field :cluster_id, types.Int
   field :cluster, ClusterType
+  field :is_suggested, types.Boolean
+  field :is_confirmed, types.Boolean
+
   field :claim_description, ClaimDescriptionType do
     resolve -> (project_media, _args, _ctx) {
       pm = Relationship.where('relationship_type = ?', Relationship.confirmed_type.to_yaml).where(target_id: project_media.id).first&.source || project_media
       pm.claim_description
     }
   end
+
   field :is_read, types.Boolean do
     argument :by_me, types.Boolean
 

--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -69,6 +69,15 @@ module ProjectMediaCachedFields
         update_on: [SIMILARITY_EVENT]
     end
 
+    { is_suggested: Relationship.suggested_type, is_confirmed: Relationship.confirmed_type }.each do |field_name, type|
+      cached_field field_name,
+        start_as: false,
+        update_es: false,
+        recalculate: proc { |pm| Relationship.where('relationship_type = ?', type.to_yaml).where(target_id: pm.id).exists? },
+        update_on: [SIMILARITY_EVENT]
+    end
+
+
     cached_field :related_count,
       start_as: 0,
       update_es: true,

--- a/test/models/project_media_test.rb
+++ b/test/models/project_media_test.rb
@@ -2851,4 +2851,23 @@ class ProjectMediaTest < ActiveSupport::TestCase
     assert_equal 'Bar', pm.claim_description_context
     assert_not_nil pm.fact_check_published_on
   end
+
+  test "should cache if item is suggested or confirmed" do
+    RequestStore.store[:skip_cached_field_update] = false
+    t = create_team
+    main = create_project_media team: t
+    pm = create_project_media team: t
+    assert !pm.is_suggested
+    assert !pm.is_confirmed
+    r = create_relationship source_id: main.id, target_id: pm.id, relationship_type: Relationship.suggested_type
+    assert pm.is_suggested
+    assert !pm.is_confirmed
+    r.relationship_type = Relationship.confirmed_type
+    r.save!
+    assert !pm.is_suggested
+    assert pm.is_confirmed
+    r.destroy!
+    assert !pm.is_suggested
+    assert !pm.is_confirmed
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -154,11 +154,11 @@ class ActiveSupport::TestCase
   # This will run before any test
 
   def setup
-    # puts "Starting test #{self.class.name}/#{self.method_name}"
     [Account, Media, ProjectMedia, User, Source, Annotation, Team, TeamUser, Relationship, Project, BotResource].each{ |klass| klass.delete_all }
     DynamicAnnotation::AnnotationType.where.not(annotation_type: 'metadata').delete_all
     DynamicAnnotation::FieldType.where.not(field_type: 'json').delete_all
     DynamicAnnotation::FieldInstance.where.not(name: 'metadata_value').delete_all
+    ENV['BOOTSNAP_CACHE_DIR'] = "#{Rails.root}/tmp/cache#{ENV['TEST_ENV_NUMBER']}"
     FileUtils.rm_rf(File.join(Rails.root, 'tmp', "cache<%= ENV['TEST_ENV_NUMBER'] %>", '*'))
     Rails.application.reload_routes!
     I18n.locale = :en
@@ -173,8 +173,6 @@ class ActiveSupport::TestCase
     WebMock.stub_request(:get, /#{CheckConfig.get('narcissus_url')}/).to_return(body: '{"url":"http://screenshot/test/test.png"}')
     WebMock.stub_request(:get, /api\.smooch\.io/)
     RequestStore.store[:skip_cached_field_update] = true
-    # Bot::Alegre.stubs(:request_api).returns({"success" => true})
-    # Bot::Alegre.stubs(:request_api).returns({"_index"=>"alegre_similarity", "_type"=>"_doc", "_id"=>"Y2hlY2stcHJvamVjdF9tZWRpYS0xOTUwLWRlc2NyaXB0aW9u", "_version"=>3, "result"=>"deleted", "_shards"=>{"total"=>2, "successful"=>1, "failed"=>0}, "_seq_no"=>39, "_primary_term"=>176})
   end
 
   # This will run after any test
@@ -188,8 +186,6 @@ class ActiveSupport::TestCase
     User.current = nil
     RequestStore.clear!
     CONFIG.unstub(:[])
-    # Bot::Alegre.unstub(:request_api)
-    # puts "Finished test #{self.class.name}/#{self.method_name}"
   end
 
   def valid_flags_data(random = true)


### PR DESCRIPTION
Two new boolean fields are available for the `ProjectMedia` type on GraphQL API: `is_suggested` and `is_confirmed`. They will be true when an item is a suggested similar or confirmed similar to another item, respectively. Both fields are cached, so N + 1 queries problems are avoided when many items are requested at the same time.

Reference: CHECK-1613.