### PR TITLE
Fixing methods that count the number of items in a folder or workspace

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -47,7 +47,7 @@ class Project < ApplicationRecord
     start_as: 0,
     update_es: false,
     recalculate: proc { |p|
-      ProjectMedia.where({ archived: CheckArchivedFlags::FlagCodes::NONE, project_id: p.id, sources_count: 0 }).count
+      ProjectMedia.where(project_id: p.id, archived: [CheckArchivedFlags::FlagCodes::NONE, CheckArchivedFlags::FlagCodes::UNCONFIRMED]).joins("LEFT JOIN relationships r ON r.target_id = project_medias.id AND r.relationship_type = '#{Project.sanitize_sql(Relationship.confirmed_type.to_yaml)}'").where('r.id IS NULL').count
     },
     update_on: [
       {

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -236,7 +236,7 @@ class Team < ApplicationRecord
   end
 
   def medias_count
-    ProjectMedia.where(team_id: self.id, archived: CheckArchivedFlags::FlagCodes::NONE).joins("LEFT JOIN relationships r ON r.target_id = project_medias.id AND r.relationship_type = '#{Team.sanitize_sql(Relationship.confirmed_type.to_yaml)}'").where('r.id IS NULL').count
+    ProjectMedia.where(team_id: self.id, archived: [CheckArchivedFlags::FlagCodes::NONE, CheckArchivedFlags::FlagCodes::UNCONFIRMED]).joins("LEFT JOIN relationships r ON r.target_id = project_medias.id AND r.relationship_type = '#{Team.sanitize_sql(Relationship.confirmed_type.to_yaml)}'").where('r.id IS NULL').count
   end
 
   def check_search_team

--- a/lib/tasks/migrate/20220602140010_update_medias_count_cache.rake
+++ b/lib/tasks/migrate/20220602140010_update_medias_count_cache.rake
@@ -1,0 +1,15 @@
+namespace :check do
+  namespace :migrate do
+    task update_medias_count_cache: :environment do
+      started = Time.now.to_i
+      n = Project.count
+      i = 0
+      Project.find_each do |p|
+        i += 1
+        puts "[#{Time.now}] [#{i}/#{n}] Updating medias_count (#{p.medias_count(true)}) for project ##{p.id}..."
+      end
+      minutes = ((Time.now.to_i - started) / 60).to_i
+      puts "[#{Time.now}] Done in #{minutes} minutes."
+    end
+  end
+end

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -1281,7 +1281,7 @@ class TeamTest < ActiveSupport::TestCase
     create_project_media project: p2, archived: CheckArchivedFlags::FlagCodes::UNCONFIRMED
     create_project_media
     t = t.reload
-    assert_equal 3, t.medias_count
+    assert_equal 4, t.medias_count
     assert_equal 2, t.trash_count
     assert_equal 1, t.unconfirmed_count
   end


### PR DESCRIPTION
Recently, "unconfirmed" items started to be displayed by default on lists. So the counters need to be updated accordingly.

Fixes CHECK-1946.