### PR TITLE
Avoid `Rails.cache.delete_matched` method in foreground code

### DIFF
--- a/app/models/concerns/smooch_team_bot_installation.rb
+++ b/app/models/concerns/smooch_team_bot_installation.rb
@@ -34,6 +34,7 @@ module SmoochTeamBotInstallation
         end
       end
 
+      # This method runs in background
       def self.reset_smooch_users_states(team_id)
         Rails.cache.delete_matched("smooch:user_language:#{team_id}:*:confirmed")
         DynamicAnnotation::Field.joins("INNER JOIN annotations a ON a.id = dynamic_annotation_fields.annotation_id INNER JOIN teams t ON t.id = a.annotated_id AND a.annotated_type = 'Team'").where(field_name: 'smooch_user_id', 't.id' => team_id).find_each { |f| CheckStateMachine.new(f.value).reset }

--- a/app/models/concerns/team_associations.rb
+++ b/app/models/concerns/team_associations.rb
@@ -19,6 +19,10 @@ module TeamAssociations
     has_annotations
   end
 
+  def team
+    self
+  end
+
   def team_bot_installations
     TeamBotInstallation.where(id: self.team_users.where(type: 'TeamBotInstallation').map(&:id))
   end
@@ -33,5 +37,17 @@ module TeamAssociations
       bots << bot.id if bot.get_team_author_id == self.id
     end
     BotUser.where(id: bots.uniq)
+  end
+
+  def country_teams
+    data = {}
+    unless self.country.nil?
+      Team.where(country: self.country).find_each{ |t| data[t.id] = t.name }
+    end
+    data
+  end
+
+  def recent_projects
+    self.projects
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -48,24 +48,12 @@ class Team < ApplicationRecord
     CheckConfig.get('checkdesk_client') + '/' + self.slug
   end
 
-  def team
-    self
-  end
-
   def members_count
     self.team_users.where(status: 'member').permissioned(self).count
   end
 
   def projects_count
     self.projects.allowed(self).permissioned.count
-  end
-
-  def country_teams
-    data = {}
-    unless self.country.nil?
-      Team.where(country: self.country).find_each{ |t| data[t.id] = t.name }
-    end
-    data
   end
 
   def as_json(_options = {})
@@ -81,10 +69,6 @@ class Team < ApplicationRecord
 
   def owners(role, statuses = TeamUser.status_types)
     self.users.where({ 'team_users.role': role, 'team_users.status': statuses })
-  end
-
-  def recent_projects
-    self.projects
   end
 
   def team_graphql_id

--- a/app/models/team_task.rb
+++ b/app/models/team_task.rb
@@ -138,13 +138,13 @@ class TeamTask < ApplicationRecord
   private
 
   def add_teamwide_tasks
-    Rails.cache.delete_matched("list_columns:team:*:#{self.id}")
+    self.team&.clear_list_columns_cache
     projects = { new: self.project_ids }
     TeamTaskWorker.perform_in(1.second, 'add', self.id, YAML::dump(User.current), YAML::dump({}), YAML::dump(projects))
   end
 
   def update_teamwide_tasks
-    Rails.cache.delete_matched("list_columns:team:*:#{self.id}")
+    self.team&.clear_list_columns_cache
     options = {
       label: self.saved_change_to_label?,
       description: self.saved_change_to_description?,
@@ -164,7 +164,7 @@ class TeamTask < ApplicationRecord
   end
 
   def delete_teamwide_tasks
-    Rails.cache.delete("list_columns:team:#{self.team_id}")
+    self.team&.clear_list_columns_cache
     self.keep_completed_tasks = self.keep_completed_tasks.nil? ? false : self.keep_completed_tasks
     TeamTaskWorker.perform_in(1.second, 'destroy', self.id, YAML::dump(User.current), YAML::dump({}), YAML::dump({}), self.keep_completed_tasks)
   end

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -18,6 +18,12 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
     create_flag_annotation_type
     create_extracted_text_annotation_type
     Sidekiq::Testing.inline!
+    Bot::Alegre.stubs(:should_get_similar_items_of_type?).returns(true)
+  end
+
+  def teardown
+    super
+    Bot::Alegre.unstub(:should_get_similar_items_of_type?)
   end
 
   test "should relate project media to similar items as video" do


### PR DESCRIPTION
We're using Redis as a backend for Rails.cache. The `delete_matched` method uses Redis' `KEYS`, which has an O(n) complexity. It gets really slow in production because we have too many keys stored in Redis. So, we should avoid using that method in code that runs in foreground, otherwise things can get really slow. This commit replaces these use cases by individual `Rails.cache.delete` calls, which are O(1).

References:

* https://api.rubyonrails.org/classes/ActiveSupport/Cache/RedisCacheStore.html#method-i-delete_matched
* https://redis.io/commands/keys/

Related tickets: CHECK-1905, CHECK-1907 and CHECK-1922.