### PR TITLE
Maximum length for fact-check fields

### DIFF
--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -8,6 +8,9 @@ class FactCheck < ApplicationRecord
 
   validates_presence_of :user, :claim_description
   validates_format_of :url, with: URI.regexp, allow_blank: true, allow_nil: true
+  validates :url, length: { maximum: 140 }, allow_blank: true, allow_nil: true
+  validates :title, length: { maximum: 140 }, allow_blank: true, allow_nil: true
+  validates :summary, length: { maximum: 620 }, allow_blank: true, allow_nil: true
 
   after_save :update_report
 

--- a/test/models/bot/fetch_test.rb
+++ b/test/models/bot/fetch_test.rb
@@ -192,7 +192,7 @@ class Bot::FetchTest < ActiveSupport::TestCase
     assert_equal "Earth isn't flat", r.report_design_field_value('headline', 'en')
     assert_equal "Scientific evidences show that Earth is round", r.report_design_field_value('description', 'en')
     assert_equal "Earth isn't flat", r.report_design_field_value('title', 'en')
-    assert_equal "Scientific evidences show that Earth is round\n\nhttps://external.site/claim_review", r.report_design_field_value('text', 'en')
+    assert_equal "Scientific evidences show that Earth is round", r.report_design_field_value('text', 'en')
   end
 
   test "should notify Airbrake if can't import a claim review" do


### PR DESCRIPTION
Validate before saving that field values are under limits and truncate when importing through Fetch.

Reference: CHECK-1925.