### PR TITLE
Avoid duplicate Fetch import

### DIFF
--- a/app/models/bot/fetch.rb
+++ b/app/models/bot/fetch.rb
@@ -237,7 +237,7 @@ class Bot::Fetch < BotUser
       s.skip_notifications = true
       s.disable_es_callbacks = Rails.env.to_s == 'test'
       s.set_fields = {
-        external_id: claim_review['identifier'].to_s,
+        external_id: "#{claim_review['identifier']}:#{pm.team_id}", # The same external_id can exist across teams
         raw: claim_review.to_json
       }.to_json
       s.save!
@@ -309,6 +309,7 @@ class Bot::Fetch < BotUser
       }
       report.set_fields = fields.to_json
       report.action = 'save'
+      report.skip_check_ability = true
       report.save!
       FileUtils.rm_f(tmp_file_path) if tmp_file_path
     end

--- a/db/migrate/20220610222339_add_unique_index_for_fetch_external_id_field.rb
+++ b/db/migrate/20220610222339_add_unique_index_for_fetch_external_id_field.rb
@@ -1,5 +1,5 @@
 class AddUniqueIndexForFetchExternalIdField < ActiveRecord::Migration[5.2]
   def change
-    add_index :dynamic_annotation_fields, :value, name: 'index_fetch_unique_id', unique: true, where: "field_name = 'external_id'"
+    execute %{CREATE UNIQUE INDEX fetch_unique_id ON dynamic_annotation_fields (value) WHERE field_name = 'external_id' AND value <> '' AND value <> '""'}
   end
 end

--- a/db/migrate/20220610222339_add_unique_index_for_fetch_external_id_field.rb
+++ b/db/migrate/20220610222339_add_unique_index_for_fetch_external_id_field.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexForFetchExternalIdField < ActiveRecord::Migration[5.2]
+  def change
+    add_index :dynamic_annotation_fields, :value, name: 'index_fetch_unique_id', unique: true, where: "field_name = 'external_id'"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_10_222340) do
+ActiveRecord::Schema.define(version: 2022_06_10_222339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_10_222339) do
+ActiveRecord::Schema.define(version: 2022_06_10_222340) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -169,7 +169,7 @@ ActiveRecord::Schema.define(version: 2022_06_10_222339) do
     t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
     t.index ["field_type"], name: "index_dynamic_annotation_fields_on_field_type"
-    t.index ["value"], name: "index_fetch_unique_id", unique: true, where: "((field_name)::text = 'external_id'::text)"
+    t.index ["value"], name: "fetch_unique_id", unique: true, where: "(((field_name)::text = 'external_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
     t.index ["value"], name: "index_status", where: "((field_name)::text = 'verification_status_status'::text)"
     t.index ["value_json"], name: "index_dynamic_annotation_fields_on_value_json", using: :gin
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_05_06_001039) do
+ActiveRecord::Schema.define(version: 2022_06_10_222339) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -169,6 +169,7 @@ ActiveRecord::Schema.define(version: 2022_05_06_001039) do
     t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
     t.index ["field_type"], name: "index_dynamic_annotation_fields_on_field_type"
+    t.index ["value"], name: "index_fetch_unique_id", unique: true, where: "((field_name)::text = 'external_id'::text)"
     t.index ["value"], name: "index_status", where: "((field_name)::text = 'verification_status_status'::text)"
     t.index ["value_json"], name: "index_dynamic_annotation_fields_on_value_json", using: :gin
   end

--- a/test/models/bot/fetch_test.rb
+++ b/test/models/bot/fetch_test.rb
@@ -182,7 +182,7 @@ class Bot::FetchTest < ActiveSupport::TestCase
     end
     statuses = ['false', 'verified', 'in_progress']
     ['first', 'second', 'third'].each_with_index do |id, i|
-      d = DynamicAnnotation::Field.where(field_name: 'external_id', value: id).last
+      d = DynamicAnnotation::Field.where(field_name: 'external_id', value: "#{id}:#{@team.id}").last
       assert_not_nil d
       assert_equal statuses[i], d.annotation.annotated.last_status
       assert_equal "Earth isn't flat", d.annotation.annotated.title


### PR DESCRIPTION
* Append the team ID when saving an "external_id" annotation field (this way they can be unique within teams)
* Add a unique PostgreSQL index for the "value" column of "external_id" annotation fields
* Adding automated tests for all the cases
* Skip permission check when creating imported reports

Before deployment, it's necessary to delete existing duplicate "external_id" annotation fields, otherwise the migration that adds the unique index will fail:

On Rails console: `ActiveRecord::Base.connection.execute("DELETE FROM dynamic_annotation_fields daf1 USING dynamic_annotation_fields daf2 WHERE daf1.field_name = 'external_id' AND daf2.field_name = 'external_id' AND daf1.value = daf2.value AND daf1.id < daf2.id")`

Fixes CHECK-1980.