### PR TITLE
Downsample Honeycomb events by half. 

### DIFF
--- a/config/initializers/honeycomb.rb
+++ b/config/initializers/honeycomb.rb
@@ -3,7 +3,7 @@ class CustomSampler
 
   def self.sample(fields)
     if ['http_request', 'sql.active_record'].include?(fields['name']) && should_sample(1, fields['trace.trace_id'])
-      return [true, 256]
+      return [true, 512]
     end
     return [false, 0]
   end


### PR DESCRIPTION
This change reduces Honeycomb events by half as we're approaching monthly limits due to increased usage.