### PR TITLE
Try to process tipline menu option instead of sending greetings on new sessions

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -26,6 +26,7 @@ class Bot::Smooch < BotUser
   include SmoochStrings
   include SmoochMenus
   include SmoochFields
+  include SmoochLanguage
 
   ::ProjectMedia.class_eval do
     attr_accessor :smooch_message
@@ -319,46 +320,6 @@ class Bot::Smooch < BotUser
     workflow || default_workflow
   end
 
-  def self.get_user_language(message, state = nil)
-    uid = message['authorId']
-    team = Team.find(self.config['team_id'])
-    default_language = team.default_language
-    supported_languages = self.get_supported_languages
-    guessed_language = nil
-    if state == 'waiting_for_message'
-      Rails.cache.fetch("smooch:user_language:#{uid}") do
-        guessed_language = self.get_language(message, default_language)
-        guessed_language
-      end
-    end
-    user_language = Rails.cache.read("smooch:user_language:#{uid}") || guessed_language || default_language
-    supported_languages.include?(user_language) ? user_language : default_language
-  end
-
-  def self.reset_user_language(uid)
-    Rails.cache.delete("smooch:user_language:#{uid}")
-    Rails.cache.delete("smooch:user_language:#{self.config['team_id']}:#{uid}:confirmed")
-  end
-
-  def self.user_language_confirmed?(uid)
-    !Rails.cache.read("smooch:user_language:#{self.config['team_id']}:#{uid}:confirmed").blank?
-  end
-
-  def self.get_supported_languages
-    team = Team.find(self.config['team_id'])
-    team_languages = team.get_languages || ['en']
-    languages = []
-    self.config['smooch_workflows'].each do |w|
-      l = w['smooch_workflow_language']
-      languages << l if team_languages.include?(l)
-    end
-    languages.sort
-  end
-
-  def self.should_ask_for_language_confirmation?(uid)
-    self.is_v2? && self.get_supported_languages.size > 1 && !self.user_language_confirmed?(uid)
-  end
-
   def self.start_flow(workflow, language, uid)
     CheckStateMachine.new(uid).start
     if self.should_ask_for_language_confirmation?(uid)
@@ -606,13 +567,6 @@ class Bot::Smooch < BotUser
 
   def self.smooch_api_get_messages(app_id, user_id, opts = {})
     self.zendesk_api_get_messages(app_id, user_id, opts)
-  end
-
-  def self.get_language(message, fallback_language = 'en')
-    text = message['text'].to_s
-    lang = text.blank? ? nil : Bot::Alegre.get_language_from_alegre(text)
-    lang = fallback_language if lang == 'und' || lang.blank? || !I18n.available_locales.include?(lang.to_sym)
-    lang
   end
 
   def self.api_get_user_data(uid, payload)

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -406,7 +406,7 @@ class Bot::Smooch < BotUser
       self.bundle_message(message)
       has_main_menu = (workflow&.dig('smooch_state_main', 'smooch_menu_options').to_a.size > 0)
       if has_main_menu
-        self.process_menu_option(message, state, app_id) || self.start_flow(workflow, language, uid)
+        self.process_menu_option_or_send_greetings(message, state, app_id, workflow, language, uid)
       else
         self.clear_user_bundled_messages(uid)
         sm.go_to_query
@@ -424,6 +424,10 @@ class Bot::Smooch < BotUser
       self.bundle_message(message)
       self.go_to_state_and_ask_if_ready_to_submit(uid, language, workflow)
     end
+  end
+
+  def self.process_menu_option_or_send_greetings(message, state, app_id, workflow, language, uid)
+    self.process_menu_option(message, state, app_id) || self.start_flow(workflow, language, uid)
   end
 
   def self.time_to_send_request

--- a/app/models/concerns/smooch_language.rb
+++ b/app/models/concerns/smooch_language.rb
@@ -1,0 +1,54 @@
+require 'active_support/concern'
+
+module SmoochLanguage
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def get_user_language(message, state = nil)
+      uid = message['authorId']
+      team = Team.find(self.config['team_id'])
+      default_language = team.default_language
+      supported_languages = self.get_supported_languages
+      guessed_language = nil
+      if state == 'waiting_for_message'
+        Rails.cache.fetch("smooch:user_language:#{uid}") do
+          guessed_language = self.get_language(message, default_language)
+          guessed_language
+        end
+      end
+      user_language = Rails.cache.read("smooch:user_language:#{uid}") || guessed_language || default_language
+      supported_languages.include?(user_language) ? user_language : default_language
+    end
+
+    def reset_user_language(uid)
+      Rails.cache.delete("smooch:user_language:#{uid}")
+      Rails.cache.delete("smooch:user_language:#{self.config['team_id']}:#{uid}:confirmed")
+    end
+
+    def user_language_confirmed?(uid)
+      !Rails.cache.read("smooch:user_language:#{self.config['team_id']}:#{uid}:confirmed").blank?
+    end
+
+    def get_supported_languages
+      team = Team.find(self.config['team_id'])
+      team_languages = team.get_languages || ['en']
+      languages = []
+      self.config['smooch_workflows'].each do |w|
+        l = w['smooch_workflow_language']
+        languages << l if team_languages.include?(l)
+      end
+      languages.sort
+    end
+
+    def should_ask_for_language_confirmation?(uid)
+      self.is_v2? && self.get_supported_languages.size > 1 && !self.user_language_confirmed?(uid)
+    end
+
+    def get_language(message, fallback_language = 'en')
+      text = message['text'].to_s
+      lang = text.blank? ? nil : Bot::Alegre.get_language_from_alegre(text)
+      lang = fallback_language if lang == 'und' || lang.blank? || !I18n.available_locales.include?(lang.to_sym)
+      lang
+    end
+  end
+end

--- a/test/models/bot/smooch_5_test.rb
+++ b/test/models/bot/smooch_5_test.rb
@@ -112,7 +112,6 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
   end
 
   test "should create smooch annotation for user requests" do
-    MESSAGE_BOUNDARY = "\u2063"
     setup_smooch_bot(true)
     Sidekiq::Testing.fake! do
       now = Time.now
@@ -134,9 +133,9 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
       end
       a = Dynamic.where(conditions).last
       f = a.get_field_value('smooch_data')
-      text  = JSON.parse(f)['text'].split("\n#{MESSAGE_BOUNDARY}")
+      text  = JSON.parse(f)['text'].split("\n#{Bot::Smooch::MESSAGE_BOUNDARY}")
       # verify that all messages stored
-      assert_equal 3, text.size
+      assert_equal 4, text.size
       assert_equal '1', text.last
       send_message_to_smooch_bot(random_string, uid)
       assert_equal 'main', sm.state.value
@@ -150,9 +149,9 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
       end
       a = Dynamic.where(conditions).last
       f = a.get_field_value('smooch_data')
-      text  = JSON.parse(f)['text'].split("\n#{MESSAGE_BOUNDARY}")
+      text  = JSON.parse(f)['text'].split("\n#{Bot::Smooch::MESSAGE_BOUNDARY}")
       # verify that all messages stored
-      assert_equal 5, text.size
+      assert_equal 6, text.size
       assert_equal '1', text.last
       send_message_to_smooch_bot(random_string, uid)
       assert_equal 'main', sm.state.value


### PR DESCRIPTION
When a tipline user session has ended and the tipline user chooses an option from the main menu, the tipline bot was replying with the greetings instead of processing the menu option. This fix is to try to process a menu option even if the user is just starting a new session.

Fixes CHECK-1551.