### PR TITLE
Fixing race condition on tipline bot when user query submission times out

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -950,7 +950,7 @@ class Bot::Smooch < BotUser
 
   def self.refresh_smooch_menu_timeout(message, app_id)
     uid = message['authorId']
-    time = Time.now.to_i
+    time = Time.now.to_f
     Rails.cache.write("smooch:last_message_from_user:#{uid}", time)
     self.delay_for(15.minutes).timeout_smooch_menu(time, message, app_id)
   end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -211,20 +211,22 @@ class VersionTest < ActiveSupport::TestCase
       assert_equal 'update_tag', v.event_type
 
       # Concurrency
+      user_pool = []
+      20.times { user_pool << create_user(is_admin: true) }
       10.times do
         threads = []
         @v1 = nil
         @v2 = nil
         @tag = tag
         threads << Thread.start do
-          User.current = create_user(is_admin: true)
+          User.current = user_pool.pop
           tag1 = Tag.find(@tag.id)
           tag1.tag = random_string
           tag1.save_with_version!
           @v1 = tag1.version_object
         end
         threads << Thread.start do
-          User.current = create_user(is_admin: true)
+          User.current = user_pool.pop
           tag2 = Tag.find(@tag.id)
           tag2.tag = random_string
           tag2.save_with_version!


### PR DESCRIPTION
If two or more messages are sent at the same second, when the user session times out, more than one request would be created in Check. Changing to a more granular check avoids this situation.

Also fixing a flaky test.

Fixes CHECK-2022.