### PR TITLE
No more truncation for fact-check URL

### DIFF
--- a/app/models/bot/fetch.rb
+++ b/app/models/bot/fetch.rb
@@ -225,7 +225,7 @@ class Bot::Fetch < BotUser
       fc.title = self.get_title(claim_review).truncate(140)
       summary = self.parse_text(claim_review['text'].to_s.blank? ? claim_review['headline'] : claim_review['text'])
       fc.summary = summary.to_s.truncate(620)
-      fc.url = claim_review['url'].to_s.truncate(140)
+      fc.url = claim_review['url'].to_s
       fc.user = user
       fc.skip_report_update = true
       fc.save!
@@ -294,7 +294,7 @@ class Bot::Fetch < BotUser
           status_label: pm.status_i18n(pm.reload.last_verification_status),
           description: summary,
           title: title,
-          published_article_url: claim_review['url'].truncate(140),
+          published_article_url: claim_review['url'],
           headline: title,
           use_visual_card: false,
           image: '',

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -8,7 +8,6 @@ class FactCheck < ApplicationRecord
 
   validates_presence_of :user, :claim_description
   validates_format_of :url, with: URI.regexp, allow_blank: true, allow_nil: true
-  validates :url, length: { maximum: 140 }, allow_blank: true, allow_nil: true
   validates :title, length: { maximum: 140 }, allow_blank: true, allow_nil: true
   validates :summary, length: { maximum: 620 }, allow_blank: true, allow_nil: true
 


### PR DESCRIPTION
Keep the truncation only for title and summary. We can't truncate the URL because a broken link won't take the user to the full fact-check.

Fixes CHECK-1985.