### PR TITLE
Adding "team_task" GraphQL field to "TeamType"

### DIFF
--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -150,6 +150,13 @@ TeamType = GraphqlCrudOperations.define_default_type do
     }
   end
 
+  field :team_task do
+    type TeamTaskType
+    argument :dbid, !types.Int
+
+    resolve -> (team, args, _ctx) { team.team_tasks.where(id: args['dbid']).first }
+  end
+
   field :default_folder do
     type ProjectType
 

--- a/test/controllers/graphql_controller_2_test.rb
+++ b/test/controllers/graphql_controller_2_test.rb
@@ -1105,4 +1105,23 @@ class GraphqlController2Test < ActionController::TestCase
       assert_response :success
     end
   end
+
+  test "should get team task" do
+    t = create_team
+    t2 = create_team
+    u = create_user
+    create_team_user user: u, team: t, role: 'admin'
+    authenticate_with_user(u)
+    tt = create_team_task team_id: t.id, order: 3
+
+    query = "query GetById { team(id: \"#{t.id}\") { team_task(dbid: #{tt.id}) { dbid } } }"
+    post :create, params: { query: query, team: t.slug }
+    assert_response :success
+    assert_equal tt.id, JSON.parse(@response.body)['data']['team']['team_task']['dbid']
+
+    query = "query GetById { team(id: \"#{t2.id}\") { team_task(dbid: #{tt.id}) { dbid } } }"
+    post :create, params: { query: query, team: t2.slug }
+    assert_response :success
+    assert_nil JSON.parse(@response.body)['data']['team']['team_task']
+  end
 end


### PR DESCRIPTION
This way, it's possible to retrieve a single team task by passing its database ID.

Reference: CHECK-2089.