### PR TITLE
Refactoring method that returns statuses from a workspace.

### DIFF
--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -63,12 +63,12 @@ TeamType = GraphqlCrudOperations.define_default_type do
 
   field :verification_statuses do
     type JsonStringType
-    argument :items_count, types.Boolean
-    argument :published_reports_count, types.Boolean
+    argument :items_count_for_status, types.String
+    argument :published_reports_count_for_status, types.String
 
     resolve -> (team, args, _ctx) do
-      team = team.reload if args['items_count'] || args['published_reports_count']
-      team.send('verification_statuses', 'media', nil, args['items_count'], args['published_reports_count'])
+      team = team.reload if args['items_count_for_status'] || args['published_reports_count_for_status']
+      team.send('verification_statuses', 'media', nil, args['items_count_for_status'], args['published_reports_count_for_status'])
     end
   end
 

--- a/test/controllers/graphql_controller_3_test.rb
+++ b/test/controllers/graphql_controller_3_test.rb
@@ -1109,7 +1109,7 @@ class GraphqlController3Test < ActionController::TestCase
       ]
     }
 
-    query = 'mutation { updateTeam(input: { clientMutationId: "1", id: "' + t.graphql_id + '", language: "pt_BR", media_verification_statuses: ' + custom_statuses.to_json.to_json + ' }) { team { id, verification_statuses_with_counters: verification_statuses(items_count: true, published_reports_count: true), verification_statuses } } }'
+    query = 'mutation { updateTeam(input: { clientMutationId: "1", id: "' + t.graphql_id + '", language: "pt_BR", media_verification_statuses: ' + custom_statuses.to_json.to_json + ' }) { team { id, verification_statuses_with_counters: verification_statuses(items_count_for_status: "1", published_reports_count_for_status: "1"), verification_statuses } } }'
     post :create, params: { query: query, team: t.slug }
     assert_response :success
     data = JSON.parse(@response.body).dig('data', 'updateTeam', 'team')


### PR DESCRIPTION
Previously, this method could take two optional boolean arguments, which were both false by default. When true, each status would be returned with the number of (published) items with that status. But that is very costly, since that number of items is calculated on the fly. This refactoring turns those two arguments into strings, which are supposed to contain a status ID, this way, the counters are returned only for that requested status.

Reference: CHECK-2150.