### PR TITLE
Avoid using Nokogiri precompiled native gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,9 +40,9 @@ RUN python -m pip install -U setuptools wheel
 WORKDIR /app
 COPY Gemfile /app/Gemfile
 COPY Gemfile.lock /app/Gemfile.lock
-RUN echo "gem: --no-rdoc --no-ri" > ~/.gemrc \
-    gem install bundler -v "< 2.0" \
-    && bundle install --jobs 20 --retry 5
+RUN echo "gem: --no-rdoc --no-ri" > ~/.gemrc && gem install bundler -v "< 2.0"
+RUN bundle config force_ruby_platform true
+RUN bundle install --jobs 20 --retry 5
 COPY . /app
 
 # remember the Rails console history


### PR DESCRIPTION
In the Docker container on M1 Macs, I was running into an issue when
installing Nokogiri that a required library, glibc 2.29, was not
available. This prevented running check-api on my machine, though the image built successfully.
Nokogiri's recommended approach for addressing this is to force
using the Ruby platform gem. For our version of Bundler (<2.0), it
is only possible to do this at the bundler config level (vs gem
level, which is supported in Bundler >=2.3.18).

https://nokogiri.org/tutorials/installing_nokogiri.html#how-can-i-avoid-using-a-precompiled-native-gem

CHECK-2147

For folks I've tagged for review, I'd love thoughts on:
* If there's a way we could address this at the container level (like making sure glibc is available)
* Any concerns about using ruby platform gem / checking for any problems building and running on non-M1 machine