### PR TITLE
Cache feed search results

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -192,8 +192,7 @@ class Bot::Alegre < BotUser
     return {} if text.blank? || self.get_number_of_words(text) < 3
     field ||= ALL_TEXT_SIMILARITY_FIELDS
     threshold ||= self.get_threshold_for_query('text', nil, true)
-    pm = team_ids.size == 1 ? ProjectMedia.new(team_id: team_ids[0]) : nil
-    models ||= [self.matching_model_to_use(pm)]
+    models ||= [self.matching_model_to_use(team_ids)].flatten
     Hash[self.get_similar_items_from_api(
       '/text/similarity/',
       self.similar_texts_from_api_conditions(text, models, fuzzy, team_ids, field, threshold),
@@ -251,7 +250,7 @@ class Bot::Alegre < BotUser
     similarity_level = automatic ? 'matching' : 'suggestion'
     setting_type = 'threshold'
     if media_type == 'text' && !pm.nil?
-      model = self.matching_model_to_use(pm)
+      model = self.matching_model_to_use(pm.team_id)
       similarity_method = 'vector' if model != Bot::Alegre::ELASTICSEARCH_MODEL
     end
     key = "#{media_type}_#{similarity_method}_#{similarity_level}_#{setting_type}"
@@ -385,9 +384,14 @@ class Bot::Alegre < BotUser
     tbi.nil? ? self.default_model : tbi.get_alegre_model_in_use || self.default_model
   end
 
-  def self.matching_model_to_use(pm)
-    tbi = self.get_alegre_tbi(pm&.team_id)
-    tbi.nil? ? self.default_matching_model : tbi.get_text_similarity_model || self.default_matching_model
+  def self.matching_model_to_use(team_ids)
+    models = []
+    [team_ids].flatten.each do |team_id|
+      tbi = self.get_alegre_tbi(team_id)
+      model = (tbi.nil? ? self.default_matching_model : tbi.get_text_similarity_model || self.default_matching_model)
+      models << model unless models.include?(model)
+    end
+    models.size == 1 ? models[0] : models
   end
 
   def self.get_alegre_tbi(team_id)

--- a/app/models/concerns/alegre_similarity.rb
+++ b/app/models/concerns/alegre_similarity.rb
@@ -175,7 +175,7 @@ module AlegreSimilarity
     def get_merged_similar_items(pm, threshold, fields, value, team_ids = [pm&.team_id])
       output = {}
       fields.each do |field|
-        response = self.get_items_with_similar_text(pm, field, threshold, value, [self.default_matching_model, self.matching_model_to_use(pm)].flatten.uniq, team_ids)
+        response = self.get_items_with_similar_text(pm, field, threshold, value, [self.default_matching_model, self.matching_model_to_use(team_ids)].flatten.uniq, team_ids)
         output[field] = response unless response.blank?
       end
       es_matches = output.values.reduce({}, :merge)
@@ -206,14 +206,14 @@ module AlegreSimilarity
     end
 
     def get_items_with_similar_text(pm, field, threshold, text, models = nil, team_ids = [pm&.team_id])
-      models ||= [self.matching_model_to_use(pm)]
+      models ||= [self.matching_model_to_use(team_ids)].flatten
       self.get_items_from_similar_text(team_ids, text, field, threshold, models).reject{ |id, _score_with_context| pm&.id == id }
     end
 
     def similar_texts_from_api_conditions(text, models, fuzzy, team_id, field, threshold, match_across_content_types=true)
       {
         text: text,
-        models: [models].flatten.empty? ? nil : [models].flatten,
+        models: [models].flatten.empty? ? nil : [models].flatten.uniq,
         fuzzy: fuzzy == 'true' || fuzzy.to_i == 1,
         context: self.build_context(team_id, field),
         threshold: threshold[:value],

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -98,38 +98,45 @@ module SmoochSearch
       results
     end
 
+    def normalized_query_hash(type, query, team_ids, after)
+      normalized_query = query.downcase.chomp.strip
+      Digest::MD5.hexdigest([type.to_s, normalized_query, [team_ids].flatten.join(','), after.to_s].join(':'))
+    end
+
     # "type" is text, video, audio or image
     # "query" is either a piece of text of a media URL
     def search_for_similar_published_fact_checks(type, query, team_ids, after = nil)
-      results = []
-      pm = nil
-      pm = ProjectMedia.new(team_id: team_ids[0]) if team_ids.size == 1 # We'll use the settings of a team instead of global settings when there is only one team
-      if type == 'text'
-        link = self.extract_url(query)
-        text = ::Bot::Smooch.extract_claim(query)
-        unless link.nil?
-          Rails.logger.info "[Smooch Bot] Search query (URL): #{link.url}"
-          result = ProjectMedia.joins(:media).where('medias.url' => link.url, 'project_medias.team_id' => team_ids).last
-          return [result] if result&.report_status == 'published'
-          text = link.pender_data['description'].to_s
-        end
-        return [] if text.blank?
-        words = text.split(/\s+/)
-        Rails.logger.info "[Smooch Bot] Search query (text): #{text}"
-        if words.size <= self.max_number_of_words_for_keyword_search
-          results = self.search_by_keywords_for_similar_published_fact_checks(words, after, team_ids)
+      Rails.cache.fetch("smooch:search_results:#{self.normalized_query_hash(type, query, team_ids, after)}", expires_in: 2.hours) do
+        results = []
+        pm = nil
+        pm = ProjectMedia.new(team_id: team_ids[0]) if team_ids.size == 1 # We'll use the settings of a team instead of global settings when there is only one team
+        if type == 'text'
+          link = self.extract_url(query)
+          text = ::Bot::Smooch.extract_claim(query)
+          unless link.nil?
+            Rails.logger.info "[Smooch Bot] Search query (URL): #{link.url}"
+            result = ProjectMedia.joins(:media).where('medias.url' => link.url, 'project_medias.team_id' => team_ids).last
+            return [result] if result&.report_status == 'published'
+            text = link.pender_data['description'].to_s
+          end
+          return [] if text.blank?
+          words = text.split(/\s+/)
+          Rails.logger.info "[Smooch Bot] Search query (text): #{text}"
+          if words.size <= self.max_number_of_words_for_keyword_search
+            results = self.search_by_keywords_for_similar_published_fact_checks(words, after, team_ids)
+          else
+            alegre_results = Bot::Alegre.get_merged_similar_items(pm, { value: self.get_text_similarity_threshold }, Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS, text, team_ids)
+            results = self.parse_search_results_from_alegre(alegre_results, after)
+            Rails.logger.info "[Smooch Bot] Text similarity search got #{results.count} results while looking for '#{text}' after date #{after.inspect} for teams #{team_ids}"
+          end
         else
-          alegre_results = Bot::Alegre.get_merged_similar_items(pm, { value: self.get_text_similarity_threshold }, Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS, text, team_ids)
+          threshold = Bot::Alegre.get_threshold_for_query(type, pm)[:value]
+          alegre_results = Bot::Alegre.get_items_with_similar_media(query, { value: threshold }, team_ids, "/#{type}/similarity/")
           results = self.parse_search_results_from_alegre(alegre_results, after)
-          Rails.logger.info "[Smooch Bot] Text similarity search got #{results.count} results while looking for '#{text}' after date #{after.inspect} for teams #{team_ids}"
+          Rails.logger.info "[Smooch Bot] Media similarity search got #{results.count} results while looking for '#{query}' after date #{after.inspect} for teams #{team_ids}"
         end
-      else
-        threshold = Bot::Alegre.get_threshold_for_query(type, pm)[:value]
-        alegre_results = Bot::Alegre.get_items_with_similar_media(query, { value: threshold }, team_ids, "/#{type}/similarity/")
-        results = self.parse_search_results_from_alegre(alegre_results, after)
-        Rails.logger.info "[Smooch Bot] Media similarity search got #{results.count} results while looking for '#{query}' after date #{after.inspect} for teams #{team_ids}"
+        results
       end
-      results
     end
 
     def search_by_keywords_for_similar_published_fact_checks(words, after, team_ids)

--- a/test/models/bot/alegre_test.rb
+++ b/test/models/bot/alegre_test.rb
@@ -428,7 +428,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   test "should get similar items" do
     p = create_project
     pm1 = create_project_media project: p
-    Bot::Alegre.stubs(:matching_model_to_use).with(pm1).returns(Bot::Alegre::ELASTICSEARCH_MODEL)
+    Bot::Alegre.stubs(:matching_model_to_use).with(pm1.team_id).returns(Bot::Alegre::ELASTICSEARCH_MODEL)
     response = Bot::Alegre.get_similar_items(pm1)
     assert_equal response.class, Hash
     Bot::Alegre.unstub(:matching_model_to_use)
@@ -489,8 +489,8 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     pm2 = create_project_media quote: "Blah2", team: @team
     pm2.analysis = { title: 'This is also a long enough Title so as to allow an actual check of other titles' }
     pm2.save!
-    Bot::Alegre.stubs(:matching_model_to_use).with(pm).returns(Bot::Alegre::ELASTICSEARCH_MODEL)
-    Bot::Alegre.stubs(:matching_model_to_use).with(pm2).returns(Bot::Alegre::ELASTICSEARCH_MODEL)
+    Bot::Alegre.stubs(:matching_model_to_use).with(pm.team_id).returns(Bot::Alegre::ELASTICSEARCH_MODEL)
+    Bot::Alegre.stubs(:matching_model_to_use).with(pm2.team_id).returns(Bot::Alegre::ELASTICSEARCH_MODEL)
     Bot::Alegre.stubs(:request_api).returns({"result" => [{
         "_index" => "alegre_similarity",
         "_type" => "_doc",
@@ -680,7 +680,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
       }
       ]
     })
-    Bot::Alegre.stubs(:matching_model_to_use).with(pm).returns(Bot::Alegre::MEAN_TOKENS_MODEL)
+    Bot::Alegre.stubs(:matching_model_to_use).with(pm.team_id).returns(Bot::Alegre::MEAN_TOKENS_MODEL)
     response = Bot::Alegre.get_items_with_similar_title(pm, {key: 'text_elasticsearch_suggestion_threshold', value: 0.1, automatic: false})
     assert_equal response.class, Hash
     Bot::Alegre.unstub(:request_api)
@@ -718,7 +718,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         Bot::Alegre.stubs(:request_api).with("get", "/text/similarity/", {:text=>"Blah foo bar", :models=>["elasticsearch", Bot::Alegre::MEAN_TOKENS_MODEL], :fuzzy=>false, :context=>{:has_custom_id=>true, :field=>field, :team_id=>[pm.team_id]}, :threshold=>threshold, :match_across_content_types=>true}, "body").returns(response)
       end
     end
-    Bot::Alegre.stubs(:matching_model_to_use).with(pm).returns(Bot::Alegre::MEAN_TOKENS_MODEL)
+    Bot::Alegre.stubs(:matching_model_to_use).with(pm.team_id).returns(Bot::Alegre::MEAN_TOKENS_MODEL)
     response = Bot::Alegre.relate_project_media_to_similar_items(pm)
     assert_equal response.model, Bot::Alegre::MEAN_TOKENS_MODEL
     assert_equal response.weight, 0.9
@@ -784,7 +784,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     pm.save!
     BotUser.stubs(:alegre_user).returns(User.new)
     TeamBotInstallation.stubs(:find_by_team_id_and_user_id).returns(TeamBotInstallation.new)
-    assert_equal Bot::Alegre.matching_model_to_use(pm), Bot::Alegre.default_matching_model
+    assert_equal Bot::Alegre.matching_model_to_use(pm.team_id), Bot::Alegre.default_matching_model
     BotUser.unstub(:alegre_user)
     TeamBotInstallation.unstub(:find_by_team_id_and_user_id)
   end

--- a/test/models/bot/smooch_5_test.rb
+++ b/test/models/bot/smooch_5_test.rb
@@ -397,4 +397,25 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
     CheckSearch.any_instance.unstub(:medias)
     Bot::Smooch.unstub(:bundle_list_of_messages)
   end
+
+  test "should cache search results" do
+    ProjectMedia.any_instance.stubs(:report_status).returns('published')
+
+    t = create_team
+    pm = create_project_media team: t
+    CheckSearch.any_instance.stubs(:medias).returns([pm])
+    query = 'foo bar'
+
+    assert_queries '>', 1 do
+      assert_equal [pm], Bot::Smooch.search_for_similar_published_fact_checks('text', query, [t.id], nil)
+    end
+
+    assert_queries '=', 0 do
+      assert_equal [pm], Bot::Smooch.search_for_similar_published_fact_checks('text', query, [t.id], nil)
+    end
+
+    ProjectMedia.any_instance.unstub(:report_status)
+    CheckSearch.any_instance.unstub(:medias)
+    Bot::Smooch.unstub(:bundle_list_of_messages)
+  end
 end

--- a/test/models/bot/smooch_5_test.rb
+++ b/test/models/bot/smooch_5_test.rb
@@ -416,6 +416,5 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
 
     ProjectMedia.any_instance.unstub(:report_status)
     CheckSearch.any_instance.unstub(:medias)
-    Bot::Smooch.unstub(:bundle_list_of_messages)
   end
 end


### PR DESCRIPTION
It's expected that some search queries sent to the feed API or tipline bot are repeated. So, let's cache the search results. For now, hard-coded at 2 hours.

Reference: CHECK-2167.