### PR TITLE
Feeds API: Fixes and improvements

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -192,8 +192,7 @@ class Bot::Alegre < BotUser
     return {} if text.blank? || self.get_number_of_words(text) < 3
     field ||= ALL_TEXT_SIMILARITY_FIELDS
     threshold ||= self.get_threshold_for_query('text', nil, true)
-    pm = team_ids.size == 1 ? ProjectMedia.new(team_id: team_ids[0]) : nil
-    models ||= [self.matching_model_to_use(pm)]
+    models ||= [self.matching_model_to_use(team_ids)].flatten
     Hash[self.get_similar_items_from_api(
       '/text/similarity/',
       self.similar_texts_from_api_conditions(text, models, fuzzy, team_ids, field, threshold),
@@ -251,7 +250,7 @@ class Bot::Alegre < BotUser
     similarity_level = automatic ? 'matching' : 'suggestion'
     setting_type = 'threshold'
     if media_type == 'text' && !pm.nil?
-      model = self.matching_model_to_use(pm)
+      model = self.matching_model_to_use(pm.team_id)
       similarity_method = 'vector' if model != Bot::Alegre::ELASTICSEARCH_MODEL
     end
     key = "#{media_type}_#{similarity_method}_#{similarity_level}_#{setting_type}"
@@ -385,9 +384,14 @@ class Bot::Alegre < BotUser
     tbi.nil? ? self.default_model : tbi.get_alegre_model_in_use || self.default_model
   end
 
-  def self.matching_model_to_use(pm)
-    tbi = self.get_alegre_tbi(pm&.team_id)
-    tbi.nil? ? self.default_matching_model : tbi.get_text_similarity_model || self.default_matching_model
+  def self.matching_model_to_use(team_ids)
+    models = []
+    [team_ids].flatten.each do |team_id|
+      tbi = self.get_alegre_tbi(team_id)
+      model = (tbi.nil? ? self.default_matching_model : tbi.get_text_similarity_model || self.default_matching_model)
+      models << model unless models.include?(model)
+    end
+    models.size == 1 ? models[0] : models
   end
 
   def self.get_alegre_tbi(team_id)

--- a/app/models/concerns/alegre_similarity.rb
+++ b/app/models/concerns/alegre_similarity.rb
@@ -175,7 +175,7 @@ module AlegreSimilarity
     def get_merged_similar_items(pm, threshold, fields, value, team_ids = [pm&.team_id])
       output = {}
       fields.each do |field|
-        response = self.get_items_with_similar_text(pm, field, threshold, value, [self.default_matching_model, self.matching_model_to_use(pm)].flatten.uniq, team_ids)
+        response = self.get_items_with_similar_text(pm, field, threshold, value, [self.default_matching_model, self.matching_model_to_use(team_ids)].flatten.uniq, team_ids)
         output[field] = response unless response.blank?
       end
       es_matches = output.values.reduce({}, :merge)
@@ -206,14 +206,14 @@ module AlegreSimilarity
     end
 
     def get_items_with_similar_text(pm, field, threshold, text, models = nil, team_ids = [pm&.team_id])
-      models ||= [self.matching_model_to_use(pm)]
+      models ||= [self.matching_model_to_use(team_ids)].flatten
       self.get_items_from_similar_text(team_ids, text, field, threshold, models).reject{ |id, _score_with_context| pm&.id == id }
     end
 
     def similar_texts_from_api_conditions(text, models, fuzzy, team_id, field, threshold, match_across_content_types=true)
       {
         text: text,
-        models: [models].flatten.empty? ? nil : [models].flatten,
+        models: [models].flatten.empty? ? nil : [models].flatten.uniq,
         fuzzy: fuzzy == 'true' || fuzzy.to_i == 1,
         context: self.build_context(team_id, field),
         threshold: threshold[:value],

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -124,7 +124,7 @@ module SmoochSearch
           Rails.logger.info "[Smooch Bot] Search query (URL): #{link.url}"
           result = ProjectMedia.joins(:media).where('medias.url' => link.url, 'project_medias.team_id' => team_ids).last
           return [result] if result&.report_status == 'published'
-          text = link.pender_data['description'].to_s
+          text = [link.pender_data['description'].to_s, text].max_by(&:length)
         end
         return [] if text.blank?
         words = text.split(/\s+/)

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -98,38 +98,45 @@ module SmoochSearch
       results
     end
 
+    def normalized_query_hash(type, query, team_ids, after)
+      normalized_query = query.downcase.chomp.strip
+      Digest::MD5.hexdigest([type.to_s, normalized_query, [team_ids].flatten.join(','), after.to_s].join(':'))
+    end
+
     # "type" is text, video, audio or image
     # "query" is either a piece of text of a media URL
     def search_for_similar_published_fact_checks(type, query, team_ids, after = nil)
-      results = []
-      pm = nil
-      pm = ProjectMedia.new(team_id: team_ids[0]) if team_ids.size == 1 # We'll use the settings of a team instead of global settings when there is only one team
-      if type == 'text'
-        link = self.extract_url(query)
-        text = ::Bot::Smooch.extract_claim(query)
-        unless link.nil?
-          Rails.logger.info "[Smooch Bot] Search query (URL): #{link.url}"
-          result = ProjectMedia.joins(:media).where('medias.url' => link.url, 'project_medias.team_id' => team_ids).last
-          return [result] if result&.report_status == 'published'
-          text = link.pender_data['description'].to_s
-        end
-        return [] if text.blank?
-        words = text.split(/\s+/)
-        Rails.logger.info "[Smooch Bot] Search query (text): #{text}"
-        if words.size <= self.max_number_of_words_for_keyword_search
-          results = self.search_by_keywords_for_similar_published_fact_checks(words, after, team_ids)
+      Rails.cache.fetch("smooch:search_results:#{self.normalized_query_hash(type, query, team_ids, after)}", expires_in: 2.hours) do
+        results = []
+        pm = nil
+        pm = ProjectMedia.new(team_id: team_ids[0]) if team_ids.size == 1 # We'll use the settings of a team instead of global settings when there is only one team
+        if type == 'text'
+          link = self.extract_url(query)
+          text = ::Bot::Smooch.extract_claim(query)
+          unless link.nil?
+            Rails.logger.info "[Smooch Bot] Search query (URL): #{link.url}"
+            result = ProjectMedia.joins(:media).where('medias.url' => link.url, 'project_medias.team_id' => team_ids).last
+            return [result] if result&.report_status == 'published'
+            text = link.pender_data['description'].to_s
+          end
+          return [] if text.blank?
+          words = text.split(/\s+/)
+          Rails.logger.info "[Smooch Bot] Search query (text): #{text}"
+          if words.size <= self.max_number_of_words_for_keyword_search
+            results = self.search_by_keywords_for_similar_published_fact_checks(words, after, team_ids)
+          else
+            alegre_results = Bot::Alegre.get_merged_similar_items(pm, { value: self.get_text_similarity_threshold }, Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS, text, team_ids)
+            results = self.parse_search_results_from_alegre(alegre_results, after)
+            Rails.logger.info "[Smooch Bot] Text similarity search got #{results.count} results while looking for '#{text}' after date #{after.inspect} for teams #{team_ids}"
+          end
         else
-          alegre_results = Bot::Alegre.get_merged_similar_items(pm, { value: self.get_text_similarity_threshold }, Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS, text, team_ids)
+          threshold = Bot::Alegre.get_threshold_for_query(type, pm)[:value]
+          alegre_results = Bot::Alegre.get_items_with_similar_media(query, { value: threshold }, team_ids, "/#{type}/similarity/")
           results = self.parse_search_results_from_alegre(alegre_results, after)
-          Rails.logger.info "[Smooch Bot] Text similarity search got #{results.count} results while looking for '#{text}' after date #{after.inspect} for teams #{team_ids}"
+          Rails.logger.info "[Smooch Bot] Media similarity search got #{results.count} results while looking for '#{query}' after date #{after.inspect} for teams #{team_ids}"
         end
-      else
-        threshold = Bot::Alegre.get_threshold_for_query(type, pm)[:value]
-        alegre_results = Bot::Alegre.get_items_with_similar_media(query, { value: threshold }, team_ids, "/#{type}/similarity/")
-        results = self.parse_search_results_from_alegre(alegre_results, after)
-        Rails.logger.info "[Smooch Bot] Media similarity search got #{results.count} results while looking for '#{query}' after date #{after.inspect} for teams #{team_ids}"
+        results
       end
-      results
     end
 
     def search_by_keywords_for_similar_published_fact_checks(words, after, team_ids)

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -124,7 +124,7 @@ module SmoochSearch
           Rails.logger.info "[Smooch Bot] Search query (URL): #{link.url}"
           result = ProjectMedia.joins(:media).where('medias.url' => link.url, 'project_medias.team_id' => team_ids).last
           return [result] if result&.report_status == 'published'
-          text = [link.pender_data['description'].to_s, text].max_by(&:length)
+          text = [link.pender_data['description'].to_s, text.to_s.gsub(link.url, '').strip].max_by(&:length)
         end
         return [] if text.blank?
         words = text.split(/\s+/)

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -4,23 +4,24 @@ class FeedsControllerTest < ActionController::TestCase
   def setup
     @controller = Api::V2::FeedsController.new
     super
+    RequestStore.store[:skip_cached_field_update] = false
     create_verification_status_stuff
     @a = create_api_key
     @b = create_bot_user
     @b.api_key = @a
     @b.save!
-    t1 = create_team
-    t2 = create_team
-    t3 = create_team
+    @t1 = create_team name: 'Foo'
+    @t2 = create_team name: 'Bar'
+    @t3 = create_team
     TeamUser.destroy_all
-    create_team_user team: t1, user: @b
-    create_team_user team: t2, user: @b
-    pm1 = create_project_media quote: 'Foo 1', media: nil, team: t1
-    pm2 = create_project_media quote: 'Foo 2', media: nil, team: t2
-    create_project_media quote: 'Bar 1', media: nil, team: t1
-    create_project_media quote: 'Bar 2', media: nil, team: t2
-    create_project_media quote: 'Foo Bar', media: nil, team: t3
-    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [t1.id, t2.id], nil).returns([pm1, pm2])
+    create_team_user team: @t1, user: @b
+    create_team_user team: @t2, user: @b
+    @pm1 = create_project_media quote: 'Foo 1', media: nil, team: @t1
+    @pm2 = create_project_media quote: 'Foo 2', media: nil, team: @t2
+    create_project_media quote: 'Bar 1', media: nil, team: @t1
+    create_project_media quote: 'Bar 2', media: nil, team: @t2
+    create_project_media quote: 'Foo Bar', media: nil, team: @t3
+    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], nil).returns([@pm1, @pm2])
   end
 
   def teardown
@@ -38,5 +39,21 @@ class FeedsControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal 2, json_response['data'].size
     assert_equal 2, json_response['meta']['record-count']
+  end
+
+  test "should keep order" do
+    authenticate_with_token @a
+
+    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).returns([@pm1, @pm2])
+    get :index, params: { filter: { type: 'text', query: 'Foo' } }
+    assert_response :success
+    assert_equal 'Foo', json_response['data'][0]['attributes']['organization']
+    assert_equal 'Bar', json_response['data'][1]['attributes']['organization']
+
+    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).returns([@pm2, @pm1])
+    get :index, params: { filter: { type: 'text', query: 'Foo' } }
+    assert_response :success
+    assert_equal 'Bar', json_response['data'][0]['attributes']['organization']
+    assert_equal 'Foo', json_response['data'][1]['attributes']['organization']
   end
 end

--- a/test/models/bot/alegre_test.rb
+++ b/test/models/bot/alegre_test.rb
@@ -428,7 +428,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   test "should get similar items" do
     p = create_project
     pm1 = create_project_media project: p
-    Bot::Alegre.stubs(:matching_model_to_use).with(pm1).returns(Bot::Alegre::ELASTICSEARCH_MODEL)
+    Bot::Alegre.stubs(:matching_model_to_use).with(pm1.team_id).returns(Bot::Alegre::ELASTICSEARCH_MODEL)
     response = Bot::Alegre.get_similar_items(pm1)
     assert_equal response.class, Hash
     Bot::Alegre.unstub(:matching_model_to_use)
@@ -489,8 +489,8 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     pm2 = create_project_media quote: "Blah2", team: @team
     pm2.analysis = { title: 'This is also a long enough Title so as to allow an actual check of other titles' }
     pm2.save!
-    Bot::Alegre.stubs(:matching_model_to_use).with(pm).returns(Bot::Alegre::ELASTICSEARCH_MODEL)
-    Bot::Alegre.stubs(:matching_model_to_use).with(pm2).returns(Bot::Alegre::ELASTICSEARCH_MODEL)
+    Bot::Alegre.stubs(:matching_model_to_use).with(pm.team_id).returns(Bot::Alegre::ELASTICSEARCH_MODEL)
+    Bot::Alegre.stubs(:matching_model_to_use).with(pm2.team_id).returns(Bot::Alegre::ELASTICSEARCH_MODEL)
     Bot::Alegre.stubs(:request_api).returns({"result" => [{
         "_index" => "alegre_similarity",
         "_type" => "_doc",
@@ -680,7 +680,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
       }
       ]
     })
-    Bot::Alegre.stubs(:matching_model_to_use).with(pm).returns(Bot::Alegre::MEAN_TOKENS_MODEL)
+    Bot::Alegre.stubs(:matching_model_to_use).with(pm.team_id).returns(Bot::Alegre::MEAN_TOKENS_MODEL)
     response = Bot::Alegre.get_items_with_similar_title(pm, {key: 'text_elasticsearch_suggestion_threshold', value: 0.1, automatic: false})
     assert_equal response.class, Hash
     Bot::Alegre.unstub(:request_api)
@@ -718,7 +718,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         Bot::Alegre.stubs(:request_api).with("get", "/text/similarity/", {:text=>"Blah foo bar", :models=>["elasticsearch", Bot::Alegre::MEAN_TOKENS_MODEL], :fuzzy=>false, :context=>{:has_custom_id=>true, :field=>field, :team_id=>[pm.team_id]}, :threshold=>threshold, :match_across_content_types=>true}, "body").returns(response)
       end
     end
-    Bot::Alegre.stubs(:matching_model_to_use).with(pm).returns(Bot::Alegre::MEAN_TOKENS_MODEL)
+    Bot::Alegre.stubs(:matching_model_to_use).with(pm.team_id).returns(Bot::Alegre::MEAN_TOKENS_MODEL)
     response = Bot::Alegre.relate_project_media_to_similar_items(pm)
     assert_equal response.model, Bot::Alegre::MEAN_TOKENS_MODEL
     assert_equal response.weight, 0.9
@@ -784,7 +784,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     pm.save!
     BotUser.stubs(:alegre_user).returns(User.new)
     TeamBotInstallation.stubs(:find_by_team_id_and_user_id).returns(TeamBotInstallation.new)
-    assert_equal Bot::Alegre.matching_model_to_use(pm), Bot::Alegre.default_matching_model
+    assert_equal Bot::Alegre.matching_model_to_use(pm.team_id), Bot::Alegre.default_matching_model
     BotUser.unstub(:alegre_user)
     TeamBotInstallation.unstub(:find_by_team_id_and_user_id)
   end

--- a/test/models/bot/alegre_test.rb
+++ b/test/models/bot/alegre_test.rb
@@ -680,8 +680,8 @@ class Bot::AlegreTest < ActiveSupport::TestCase
       }
       ]
     })
-    Bot::Alegre.stubs(:matching_model_to_use).with(pm.team_id).returns(Bot::Alegre::MEAN_TOKENS_MODEL)
-    response = Bot::Alegre.get_items_with_similar_title(pm, {key: 'text_elasticsearch_suggestion_threshold', value: 0.1, automatic: false})
+    Bot::Alegre.stubs(:matching_model_to_use).with([pm.team_id]).returns(Bot::Alegre::MEAN_TOKENS_MODEL)
+    response = Bot::Alegre.get_items_with_similar_title(pm, { key: 'text_elasticsearch_suggestion_threshold', value: 0.1, automatic: false })
     assert_equal response.class, Hash
     Bot::Alegre.unstub(:request_api)
     Bot::Alegre.unstub(:matching_model_to_use)

--- a/test/models/bot/alegre_test.rb
+++ b/test/models/bot/alegre_test.rb
@@ -489,7 +489,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     pm2 = create_project_media quote: "Blah2", team: @team
     pm2.analysis = { title: 'This is also a long enough Title so as to allow an actual check of other titles' }
     pm2.save!
-    Bot::Alegre.stubs(:matching_model_to_use).with(pm.team_id).returns(Bot::Alegre::ELASTICSEARCH_MODEL)
+    Bot::Alegre.stubs(:matching_model_to_use).with([pm.team_id]).returns(Bot::Alegre::ELASTICSEARCH_MODEL)
     Bot::Alegre.stubs(:matching_model_to_use).with(pm2.team_id).returns(Bot::Alegre::ELASTICSEARCH_MODEL)
     Bot::Alegre.stubs(:request_api).returns({"result" => [{
         "_index" => "alegre_similarity",
@@ -718,6 +718,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         Bot::Alegre.stubs(:request_api).with("get", "/text/similarity/", {:text=>"Blah foo bar", :models=>["elasticsearch", Bot::Alegre::MEAN_TOKENS_MODEL], :fuzzy=>false, :context=>{:has_custom_id=>true, :field=>field, :team_id=>[pm.team_id]}, :threshold=>threshold, :match_across_content_types=>true}, "body").returns(response)
       end
     end
+    Bot::Alegre.stubs(:matching_model_to_use).with([pm.team_id]).returns(Bot::Alegre::MEAN_TOKENS_MODEL)
     Bot::Alegre.stubs(:matching_model_to_use).with(pm.team_id).returns(Bot::Alegre::MEAN_TOKENS_MODEL)
     response = Bot::Alegre.relate_project_media_to_similar_items(pm)
     assert_equal response.model, Bot::Alegre::MEAN_TOKENS_MODEL

--- a/test/models/bot/smooch_5_test.rb
+++ b/test/models/bot/smooch_5_test.rb
@@ -428,12 +428,12 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
     pender_url = CheckConfig.get('pender_url_private') + '/api/medias'
     response = '{"type":"media","data":{"url":"' + url + '","type":"item","description":"Foo bar"}}'
     WebMock.stub_request(:get, pender_url).with({ query: { url: url } }).to_return(body: response)
-    Bot::Smooch.stubs(:bundle_list_of_messages).returns({ 'type' => 'text', 'text' => "Foo bar test #{url}" })
+    Bot::Smooch.stubs(:bundle_list_of_messages).returns({ 'type' => 'text', 'text' => "Foo bar foo bar #{url}" })
     CheckSearch.any_instance.stubs(:medias).returns([pm1])
     Bot::Alegre.stubs(:get_merged_similar_items).returns({ pm2.id => { score: 0.9, model: 'elasticsearch' } })
 
     assert_equal [pm2], Bot::Smooch.get_search_results(random_string, {}, t.id, 'en')
-    Bot::Smooch.stubs(:bundle_list_of_messages).returns({ 'type' => 'text', 'text' => url })
+    Bot::Smooch.stubs(:bundle_list_of_messages).returns({ 'type' => 'text', 'text' => "Test #{url}" })
     assert_equal [pm1], Bot::Smooch.get_search_results(random_string, {}, t.id, 'en')
 
     ProjectMedia.any_instance.unstub(:report_status)

--- a/test/models/bot/smooch_5_test.rb
+++ b/test/models/bot/smooch_5_test.rb
@@ -397,4 +397,25 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
     CheckSearch.any_instance.unstub(:medias)
     Bot::Smooch.unstub(:bundle_list_of_messages)
   end
+
+  test "should cache search results" do
+    ProjectMedia.any_instance.stubs(:report_status).returns('published')
+
+    t = create_team
+    pm = create_project_media team: t
+    CheckSearch.any_instance.stubs(:medias).returns([pm])
+    query = 'foo bar'
+
+    assert_queries '>', 1 do
+      assert_equal [pm], Bot::Smooch.search_for_similar_published_fact_checks('text', query, [t.id], nil)
+    end
+
+    assert_queries '=', 0 do
+      assert_equal [pm], Bot::Smooch.search_for_similar_published_fact_checks('text', query, [t.id], nil)
+    end
+
+    ProjectMedia.any_instance.unstub(:report_status)
+    CheckSearch.any_instance.unstub(:medias)
+    Bot::Smooch.unstub(:bundle_list_of_messages)
+  end
 end

--- a/test/models/bot/smooch_5_test.rb
+++ b/test/models/bot/smooch_5_test.rb
@@ -416,6 +416,5 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
 
     ProjectMedia.any_instance.unstub(:report_status)
     CheckSearch.any_instance.unstub(:medias)
-    Bot::Smooch.unstub(:bundle_list_of_messages)
   end
 end

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -88,7 +88,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
   end
 
   test "should submit query without details on tipline bot v2" do
-    WebMock.stub_request(:get, 'http://alegre:3100/text/similarity/').to_return(body: {}.to_json)
+    WebMock.stub_request(:get, /\/text\/similarity\//).to_return(body: {}.to_json)
     claim = 'This is a test claim'
     send_message 'hello', '1', '1', random_string, random_string, claim, random_string, random_string, '1'
     assert_saved_query_type 'default_requests'
@@ -157,7 +157,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
   end
 
   test "should submit query with details on tipline bot v2" do
-    WebMock.stub_request(:get, 'http://alegre:3100/text/similarity/').to_return(body: {}.to_json)
+    WebMock.stub_request(:get, /\/text\/similarity\//).to_return(body: {}.to_json)
     claim = 'This is a test claim'
     send_message 'hello', '1', '1', random_string, '2', random_string, claim, '1'
     assert_saved_query_type 'default_requests'


### PR DESCRIPTION
A set of fixes and improvements to the feeds API and tipline bot search. Details below:

**Cache search results**

It's expected that some search queries sent to the feed API or tipline bot are repeated. So, let's cache the search results. For now, hard-coded at 2 hours. Reference: CHECK-2167.

**Use vector models when searching across multiple workspaces**

Previously, when searching for items under a single workspace, vector models could be used if the workspace was configured to use them. But when searching for items under multiple workspaces, it just fell back to the default model. This change is to use all models configured for each workspace when searching across multiple workspaces. Reference: CHECK-2170.

**When there is no published fact-check for a submitted query URL, fallback to text**

Currently, when a query is submitted to the tipline bot, if it contains a URL, the procedure is:

* Look for a published fact-check for the exact URL, if there is one, return it
* If not, try to match against the parsed description for that URL

The change here is for the second step: instead of always picking the parsed description, get the longest one between the parsed description and the user query. Reference: CHECK-2119.

**Keep the right order of results in Feeds API**

The Feeds API v2 uses JSON API Resource, which expects an `ActiveRecord::Relation` to be returned. We were doing that, but then the order of results (which is relevant) returned by the similarity matching algorithms was lost. The fix is to add a custom `order` statement that makes the Feeds API v2 return results in the same order returned by the similarity matching algorithms. Reference: CHECK-2171.