### PR TITLE
Save fact-check and claim description user on update as well, not only on create.

### DIFF
--- a/app/models/claim_description.rb
+++ b/app/models/claim_description.rb
@@ -1,11 +1,10 @@
 class ClaimDescription < ApplicationRecord
   include ClaimAndFactCheck
-  has_paper_trail on: [:create, :update], ignore: [:updated_at, :created_at], if: proc { |_x| User.current.present? }, versions: { class_name: 'Version' }
 
   belongs_to :project_media
   has_one :fact_check, dependent: :destroy
 
-  validates_presence_of :user, :project_media
+  validates_presence_of :project_media
 
   # FIXME: Required by GraphQL API
   def fact_checks

--- a/app/models/concerns/claim_and_fact_check.rb
+++ b/app/models/concerns/claim_and_fact_check.rb
@@ -6,9 +6,13 @@ module ClaimAndFactCheck
   included do
     include CheckElasticSearch
 
+    has_paper_trail on: [:create, :update], ignore: [:updated_at, :created_at], if: proc { |_x| User.current.present? }, versions: { class_name: 'Version' }
+
     belongs_to :user
 
-    before_validation :set_user, on: :create
+    before_validation :set_user
+    validates_presence_of :user
+
     after_commit :index_in_elasticsearch, :send_to_alegre, :notify_bots, on: [:create, :update]
   end
 

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -1,6 +1,5 @@
 class FactCheck < ApplicationRecord
   include ClaimAndFactCheck
-  has_paper_trail on: [:create], ignore: [:updated_at, :created_at], if: proc { |_x| User.current.present? }, versions: { class_name: 'Version' }
 
   attr_accessor :skip_report_update
 
@@ -8,7 +7,7 @@ class FactCheck < ApplicationRecord
 
   before_validation :set_language, on: :create, if: proc { |fc| fc.language.blank? }
 
-  validates_presence_of :user, :claim_description
+  validates_presence_of :claim_description
   validates_format_of :url, with: URI.regexp, allow_blank: true, allow_nil: true
   validates :title, length: { maximum: 140 }, allow_blank: true, allow_nil: true
   validates :summary, length: { maximum: 620 }, allow_blank: true, allow_nil: true


### PR DESCRIPTION
Even when another user updates a claim description or fact-check, the attribution remains with the user who created it. This commit changes that... the user saved with the fact-check and claim description is now the user who last saved it. The history is maintained in versions.

Fixes: CHECK-2192.