### PR TITLE
When clearing workspace columns settings, all languages should be included

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -160,7 +160,8 @@ class Team < ApplicationRecord
   end
 
   def clear_list_columns_cache
-    self.get_languages.to_a.each { |l| Rails.cache.delete("list_columns:team:#{l}:#{self.id}") }
+    languages = self.get_languages.to_a + I18n.available_locales.map(&:to_s)
+    languages.uniq.each { |l| Rails.cache.delete("list_columns:team:#{l}:#{self.id}") }
   end
 
   def list_columns=(columns)


### PR DESCRIPTION
Previously, the workspace columns settings cache was cleared only for the languages supported by the workspace. But sometimes a user is browsing in a language that is not supported by the workspace. If that's the case, this user won't be able to save the settings or refresh the cache for the list view. The fix is to include also the languages supported by the application when clearing cache, since users can be browsing in any of those languages.

Fixes CHECK-2197.