### PR TITLE
Do not try to send "blank" items to Alegre media similarity index.

### DIFF
--- a/app/models/concerns/alegre_similarity.rb
+++ b/app/models/concerns/alegre_similarity.rb
@@ -174,7 +174,7 @@ module AlegreSimilarity
 
     def send_to_media_similarity_index(pm)
       type = self.get_pm_type(pm)
-      unless type == "text"
+      if ['audio', 'video', 'image'].include?(type)
         params = {
           doc_id: self.item_doc_id(pm, type),
           url: self.media_file_url(pm),


### PR DESCRIPTION
The previous condition, 'type != text', was not enough because it didn't discard blank items.

Fixes CHECK-2271.