### PR TITLE
Support text in feed API media search

### DIFF
--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -152,8 +152,10 @@ module SmoochSearch
           Rails.logger.info "[Smooch Bot] Text similarity search got #{results.count} results while looking for '#{text}' after date #{after.inspect} for teams #{team_ids}"
         end
       else
+        media_url = Twitter::TwitterText::Extractor.extract_urls(query)[0]
+        return [] if media_url.blank?
         threshold = Bot::Alegre.get_threshold_for_query(type, pm)[:value]
-        alegre_results = Bot::Alegre.get_items_with_similar_media(query, { value: threshold }, team_ids, "/#{type}/similarity/")
+        alegre_results = Bot::Alegre.get_items_with_similar_media(media_url, { value: threshold }, team_ids, "/#{type}/similarity/")
         results = self.parse_search_results_from_alegre(alegre_results, after, feed_id, team_ids)
         Rails.logger.info "[Smooch Bot] Media similarity search got #{results.count} results while looking for '#{query}' after date #{after.inspect} for teams #{team_ids}"
       end


### PR DESCRIPTION
The Feed API currently expects that when the type of the request is image, audio or video, the query is exactly a media URL. This is not very flexible because this way we miss some important context information from a user. These cases should be refactored to allow any text in the query parameter, but extract the first URL found in the query and perform the media similarity search against that.

Reference: CHECK-2301.