### PR TITLE
Fixing imported report language

### DIFF
--- a/app/models/bot/fetch.rb
+++ b/app/models/bot/fetch.rb
@@ -291,7 +291,7 @@ class Bot::Fetch < BotUser
         end
       end
       date = claim_review['datePublished'].blank? ? Time.now : Time.parse(claim_review['datePublished'])
-      language = claim_review.dig('raw', 'language') || team.default_language
+      language = team.default_language
       title = self.get_title(claim_review).truncate(140)
       summary = self.parse_text(claim_review['text']).truncate(620)
       fields = {


### PR DESCRIPTION
When Fetch imports a report, it shouldn't set the report language to be the one of the claim review, because maybe the workspace doesn't support that language. Also, we're soon getting rid of the report language, and just keeping it for fact-checks. The fix here is to revert to how it was before, which is to use the workspace default language as the report language.

Fixes CHECK-2328.