### PR TITLE
CHECK-2331: Add random argument to team graphql type

### DIFF
--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -53,6 +53,9 @@ QueryType = GraphQL::ObjectType.define do
     description 'Information about the context team or the team from given id'
     argument :id, types.ID
     argument :slug, types.String
+    # random argument is for bypassing Relay cache. This is a temporary fix
+    # while we don't have our Relay code 100% up to date, which we expect will
+    # make this unnecessary. Fixes issue reported in CHECK-2331
     argument :random, types.String
     resolve -> (_obj, args, ctx) do
       tid = args['id'].to_i

--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -53,6 +53,7 @@ QueryType = GraphQL::ObjectType.define do
     description 'Information about the context team or the team from given id'
     argument :id, types.ID
     argument :slug, types.String
+    argument :random, types.String
     resolve -> (_obj, args, ctx) do
       tid = args['id'].to_i
       if !args['slug'].blank?


### PR DESCRIPTION
This commit adds a random argument to team graphql type to cheat weird relay caching. Some queries in SearchFieldXxx components were not trigerred, probably because of having a similar root to both QueryRenderers.

Type of change
☑︎ Bug fix (non-breaking change which fixes an issue)

How has this been tested?
I created a filter with fields "Assigned to" and "Folder is" and applied it to "All items" and verified that the page loads correctly without crashing.  
I haven't implemented any automated tests.

Fixes: CHECK-2331