### PR TITLE
Feed API: Similar requests and media requests.

### DIFF
--- a/app/graph/types/feed_type.rb
+++ b/app/graph/types/feed_type.rb
@@ -10,4 +10,13 @@ FeedType = GraphqlCrudOperations.define_default_type do
   field :filters, JsonStringType
   field :current_feed_team, FeedTeamType
   field :teams_count, types.Int
+
+  connection :requests, -> { RequestType.connection_type } do
+    argument :request_id, types.Int
+
+    resolve ->(feed, args, _ctx) {
+      request_id = (args['request_id'].to_i == 0 ? nil : args['request_id'].to_i)
+      Request.where(request_id: request_id).or(Request.where(id: request_id)).order('requests_count DESC')
+    }
+  end
 end

--- a/app/graph/types/feed_type.rb
+++ b/app/graph/types/feed_type.rb
@@ -16,7 +16,7 @@ FeedType = GraphqlCrudOperations.define_default_type do
 
     resolve ->(feed, args, _ctx) {
       request_id = (args['request_id'].to_i == 0 ? nil : args['request_id'].to_i)
-      Request.where(request_id: request_id).or(Request.where(id: request_id)).order('requests_count DESC')
+      Request.where(request_id: request_id, feed_id: feed.id).or(Request.where(id: request_id, feed_id: feed.id)).order('requests_count DESC')
     }
   end
 end

--- a/app/graph/types/request_type.rb
+++ b/app/graph/types/request_type.rb
@@ -1,0 +1,18 @@
+RequestType = GraphqlCrudOperations.define_default_type do
+  name 'Request'
+  description 'Request type'
+
+  interfaces [NodeIdentification.interface]
+
+  field :dbid, types.Int
+  field :last_submitted, types.String
+  field :request_type, types.String
+  field :content, types.String
+  field :medias_count, types.Int
+  field :requests_count, types.Int
+  field :similar_to_request, RequestType
+  field :media, MediaType
+
+  connection :medias, MediaType.connection_type
+  connection :similar_requests, RequestType.connection_type
+end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -33,7 +33,14 @@ class Feed < ApplicationRecord
     self.teams.count
   end
 
+  # This takes some time to run because it involves external HTTP requests:
+  # 1) If the query contains a media URL, it will be downloaded... if it contains some other URL, it will be sent to Pender
+  # 2) Requests will be made to Alegre in order to index the request media and to look for similar requests
+  # So please consider always calling this method in background.
   def self.save_request(feed_id, type, query)
-    Request.create!(feed_id: feed_id, request_type: type, content: query, skip_check_ability: true)
+    media = Request.get_media_from_query(type, query)
+    request = Request.create!(feed_id: feed_id, request_type: type, content: query, media: media, skip_check_ability: true)
+    request.attach_to_similar_request!
+    request
   end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,3 +1,105 @@
 class Request < ApplicationRecord
   belongs_to :feed
+  belongs_to :media
+  belongs_to :similar_to_request, foreign_key: :request_id, class_name: 'Request', optional: true
+  has_many :similar_requests, foreign_key: :request_id, class_name: 'Request'
+
+  after_commit :send_to_alegre
+
+  def similarity_threshold
+    0.85 # FIXME: Adjust this value for text and image (eventually it can be a feed setting)
+  end
+
+  def similarity_model
+    ::Bot::Alegre::ELASTICSEARCH_MODEL # FIXME: Use vector models too (eventually it can be a feed setting)
+  end
+
+  def attach_to_similar_request!
+    media = self.media
+    similar_request_id = nil
+    context = { feed_id: self.feed_id }
+    threshold = self.similarity_threshold
+    if media.type == 'Claim' && ::Bot::Alegre.get_number_of_words(media.quote) > 3
+      similar_request_id = ::Bot::Alegre.request_api('get', '/text/similarity/', { text: media.quote, threshold: threshold, context: context }).dig('result', 0, '_source', 'context', 'request_id')
+    elsif ['UploadedImage', 'UploadedAudio', 'UploadedVideo'].include?(media.type)
+      type = media.type.gsub(/^Uploaded/, '').downcase
+      similar_request_id = ::Bot::Alegre.request_api('get', "/#{type}/similarity/", { url: media.file.file.public_url, threshold: threshold, context: context }).dig('result', 0, 'context', 0, 'request_id')
+    end
+    unless similar_request_id.blank?
+      similar_request = Request.where(id: similar_request_id, feed_id: self.feed_id).last
+      self.similar_to_request = similar_request&.similar_to_request || similar_request
+      self.save!
+    end
+  end
+
+  def self.get_media_from_query(type, query)
+    media = nil
+    url = Twitter::TwitterText::Extractor.extract_urls(query)[0]
+    if ['audio', 'image', 'video'].include?(type.to_s) && !url.blank?
+      open(url) do |f|
+        data = f.read
+        hash = Digest::MD5.hexdigest(data)
+        extension = { audio: 'mp3', image: 'jpeg', video: 'mp4' }[type.to_sym]
+        filename = "#{hash}.#{extension}"
+        filepath = File.join(Rails.root, 'tmp', filename)
+        media_type = "Uploaded#{type.camelize}"
+        File.atomic_write(filepath) { |file| file.write(data) }
+        media = Media.where(type: media_type, file: filename).last
+        if media.nil?
+          media = Media.new(type: media_type)
+          File.open(filepath) do |f2|
+            media.file = f2
+            media.save!
+          end
+        end
+        FileUtils.rm_f filepath
+      end
+    else
+      if url.blank?
+        text = ::Bot::Smooch.extract_claim(query)
+        media = Media.where(type: 'Claim', quote: text).last || Media.create!(type: 'Claim', quote: text)
+      else
+        link = ::Bot::Smooch.extract_url(url) # Parse URL to get a normalized/canonical one
+        url = (link ? link.url : url)
+        media = Media.where(type: 'Link', url: url).last || Media.create!(type: 'Link', url: url)
+      end
+    end
+    media
+  end
+
+  def self.send_to_alegre(id)
+    request = self.find_by_id(id)
+    media = request.media
+    doc_id = Base64.encode64(['check', 'request', request.id, 'media'].join('-')).strip.delete("\n").delete('=')
+    context = {
+      has_custom_id: true,
+      feed_id: request.feed_id,
+      request_id: request.id
+    }
+    if media.type == 'Claim'
+      params = {
+        doc_id: doc_id,
+        text: media.quote,
+        model: request.similarity_model,
+        context: context
+      }
+      ::Bot::Alegre.request_api('post', '/text/similarity/', params)
+    elsif ['UploadedImage', 'UploadedAudio', 'UploadedVideo'].include?(media.type)
+      type = media.type.gsub(/^Uploaded/, '').downcase
+      url = media.file&.file&.public_url
+      params = {
+        doc_id: doc_id,
+        url: url,
+        context: context,
+        match_across_content_types: true,
+      }
+      ::Bot::Alegre.request_api('post', "/#{type}/similarity/", params)
+    end
+  end
+
+  private
+
+  def send_to_alegre
+    self.class.delay_for(1.second).send_to_alegre(self.id)
+  end
 end

--- a/db/migrate/20220825223906_add_request_id_and_media_id_to_requests.rb
+++ b/db/migrate/20220825223906_add_request_id_and_media_id_to_requests.rb
@@ -1,0 +1,8 @@
+class AddRequestIdAndMediaIdToRequests < ActiveRecord::Migration[5.2]
+  def change
+    add_column :requests, :request_id, :integer, foreign_key: true
+    add_index :requests, :request_id
+    add_column :requests, :media_id, :integer, foreign_key: true
+    add_index :requests, :media_id
+  end
+end

--- a/db/migrate/20220828210303_add_fields_to_requests.rb
+++ b/db/migrate/20220828210303_add_fields_to_requests.rb
@@ -1,0 +1,7 @@
+class AddFieldsToRequests < ActiveRecord::Migration[5.2]
+  def change
+    add_column :requests, :medias_count, :integer, null: false, default: 0
+    add_column :requests, :requests_count, :integer, null: false, default: 0
+    add_column :requests, :last_submitted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_16_170718) do
+ActiveRecord::Schema.define(version: 2022_08_25_223906) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -348,7 +348,11 @@ ActiveRecord::Schema.define(version: 2022_08_16_170718) do
     t.text "content", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "request_id"
+    t.integer "media_id"
     t.index ["feed_id"], name: "index_requests_on_feed_id"
+    t.index ["media_id"], name: "index_requests_on_media_id"
+    t.index ["request_id"], name: "index_requests_on_request_id"
   end
 
   create_table "saved_searches", id: :serial, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_25_223906) do
+ActiveRecord::Schema.define(version: 2022_08_28_210303) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -350,6 +350,9 @@ ActiveRecord::Schema.define(version: 2022_08_25_223906) do
     t.datetime "updated_at", null: false
     t.integer "request_id"
     t.integer "media_id"
+    t.integer "medias_count", default: 0, null: false
+    t.integer "requests_count", default: 0, null: false
+    t.datetime "last_submitted_at"
     t.index ["feed_id"], name: "index_requests_on_feed_id"
     t.index ["media_id"], name: "index_requests_on_media_id"
     t.index ["request_id"], name: "index_requests_on_request_id"

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -981,4 +981,8 @@ module SampleData
       team: create_team
     }.merge(options))
   end
+
+  def create_request(options = {})
+    Request.create!({ content: random_string, request_type: 'text', feed: create_feed, media: create_valid_media }.merge(options))
+  end
 end

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -85,13 +85,17 @@ class FeedsControllerTest < ActionController::TestCase
   end
 
   test "should save request query" do
+    Bot::Alegre.stubs(:request_api).returns({})
     Sidekiq::Testing.inline!
     authenticate_with_token @a
     assert_difference 'Request.count' do
-      get :index, params: { filter: { type: 'text', query: 'Foo', feed_id: @f.id } }
+      assert_difference 'Media.count' do
+        get :index, params: { filter: { type: 'text', query: 'Foo', feed_id: @f.id } }
+      end
     end
     assert_response :success
     assert_equal 2, json_response['data'].size
     assert_equal 2, json_response['meta']['record-count']
+    Bot::Alegre.unstub(:request_api)
   end
 end

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -160,4 +160,28 @@ class RequestTest < ActiveSupport::TestCase
     assert_equal [r2], r1.reload.similar_requests
     Bot::Alegre.unstub(:request_api)
   end
+
+  test "should set fields" do
+    r = create_request
+    assert_not_nil r.reload.last_submitted_at
+    assert_equal 1, r.reload.requests_count
+    assert_equal 1, r.reload.medias_count
+  end
+
+  test "should update fields" do
+    Bot::Alegre.stubs(:request_api).returns({})
+    m1 = create_uploaded_image
+    m2 = create_uploaded_image
+    r1 = create_request media: m1
+    r2 = create_request media: m1
+    r3 = create_request media: m2
+    r4 = create_request media: m2
+    r2.similar_to_request = r1 ; r2.save!
+    r3.similar_to_request = r1 ; r3.save!
+    r4.similar_to_request = r1 ; r4.save!
+    assert_equal r4.created_at.to_s, r1.reload.last_submitted_at.to_s
+    assert_equal 2, r1.reload.medias_count
+    assert_equal 4, r1.reload.requests_count
+    Bot::Alegre.unstub(:request_api)
+  end
 end

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -1,0 +1,160 @@
+require_relative '../test_helper'
+
+class RequestTest < ActiveSupport::TestCase
+  def setup
+    super
+    Sidekiq::Testing.inline!
+    Request.delete_all
+  end
+
+  test "should create request" do
+    assert_difference 'Request.count' do
+      create_request
+    end
+  end
+
+  test "should belong to media" do
+    m = create_valid_media
+    r = create_request media: m
+    assert_equal m, r.media
+  end
+
+  test "should belong to similar request" do
+    r1 = create_request
+    r2 = create_request
+    r1.similar_to_request = r2
+    r1.save!
+    assert_equal r2, r1.reload.similar_to_request
+    assert_equal [r1], r2.reload.similar_requests
+  end
+
+  test "should get media for image" do
+    image_url_1 = random_url
+    image_url_2 = random_url
+    m1 = nil
+    m2 = nil
+    WebMock.stub_request(:get, image_url_1).to_return(body: File.read(File.join(Rails.root, 'test', 'data', 'rails.png')))
+    WebMock.stub_request(:get, image_url_2).to_return(body: File.read(File.join(Rails.root, 'test', 'data', 'rails.png')))
+    assert_difference 'UploadedImage.count' do
+      m1 = Request.get_media_from_query('image', "Foo #{image_url_1} bar #{random_url} test")
+    end
+    assert_kind_of UploadedImage, m1
+    assert_no_difference 'UploadedImage.count' do
+      m2 = Request.get_media_from_query('image', "Test #{image_url_2} foo #{random_url} bar")
+    end
+    assert_kind_of UploadedImage, m2
+    assert_equal m1, m2
+  end
+
+  test "should get media for audio" do
+    audio_url_1 = random_url
+    audio_url_2 = random_url
+    m1 = nil
+    m2 = nil
+    WebMock.stub_request(:get, audio_url_1).to_return(body: File.read(File.join(Rails.root, 'test', 'data', 'rails.mp3')))
+    WebMock.stub_request(:get, audio_url_2).to_return(body: File.read(File.join(Rails.root, 'test', 'data', 'rails.mp3')))
+    assert_difference 'UploadedAudio.count' do
+      m1 = Request.get_media_from_query('audio', "Foo #{audio_url_1} bar #{random_url} test")
+    end
+    assert_kind_of UploadedAudio, m1
+    assert_no_difference 'UploadedAudio.count' do
+      m2 = Request.get_media_from_query('audio', "Test #{audio_url_2} foo #{random_url} bar")
+    end
+    assert_kind_of UploadedAudio, m2
+    assert_equal m1, m2
+  end
+
+  test "should get media for video" do
+    video_url_1 = random_url
+    video_url_2 = random_url
+    m1 = nil
+    m2 = nil
+    WebMock.stub_request(:get, video_url_1).to_return(body: File.read(File.join(Rails.root, 'test', 'data', 'rails.mp4')))
+    WebMock.stub_request(:get, video_url_2).to_return(body: File.read(File.join(Rails.root, 'test', 'data', 'rails.mp4')))
+    assert_difference 'UploadedVideo.count' do
+      m1 = Request.get_media_from_query('video', "Foo #{video_url_1} bar #{random_url} test")
+    end
+    assert_kind_of UploadedVideo, m1
+    assert_no_difference 'UploadedVideo.count' do
+      m2 = Request.get_media_from_query('video', "Test #{video_url_2} foo #{random_url} bar")
+    end
+    assert_kind_of UploadedVideo, m2
+    assert_equal m1, m2
+  end
+
+  test "should get media for link" do
+    url = @url
+    m1 = nil
+    m2 = nil
+    assert_difference 'Link.count' do
+      m1 = Request.get_media_from_query('text', "Foo #{url} bar")
+    end
+    assert_kind_of Link, m1
+    assert_no_difference 'Link.count' do
+      m2 = Request.get_media_from_query('text', "Bar #{url} foo")
+    end
+    assert_kind_of Link, m2
+    assert_equal m1, m2
+  end
+
+  test "should get media for text" do
+    text = random_string
+    m1 = nil
+    m2 = nil
+    assert_difference 'Claim.count' do
+      m1 = Request.get_media_from_query('text', text)
+    end
+    assert_kind_of Claim, m1
+    assert_no_difference 'Claim.count' do
+      m2 = Request.get_media_from_query('text', text)
+    end
+    assert_kind_of Claim, m2
+    assert_equal m1, m2
+  end
+
+  test "should send text request to Alegre" do
+    Bot::Alegre.stubs(:request_api).returns(true)
+    assert_nothing_raised do
+      create_request(media: create_claim_media)
+    end
+    Bot::Alegre.unstub(:request_api)
+  end
+
+  test "should send media request to Alegre" do
+    Bot::Alegre.stubs(:request_api).returns(true)
+    assert_nothing_raised do
+      create_request(media: create_uploaded_image)
+    end
+    Bot::Alegre.unstub(:request_api)
+  end
+
+  test "should attach to similar text" do
+    Bot::Alegre.stubs(:request_api).returns(true)
+    f = create_feed
+    m1 = Media.create! type: 'Claim', quote: 'Foo bar foo bar'
+    r1 = create_request media: m1, feed: f
+    m2 = Media.create! type: 'Claim', quote: 'Foo bar foo bar 2'
+    r2 = create_request media: m2, feed: f
+    response = { 'result' => [{ '_source' => { 'context' => { 'request_id' => r1.id } } }] }
+    Bot::Alegre.stubs(:request_api).with('get', '/text/similarity/', { text: 'Foo bar foo bar 2', threshold: 0.85, context: { feed_id: f.id } }).returns(response)
+    r2.attach_to_similar_request!
+    assert_equal r1, r2.reload.similar_to_request
+    assert_equal [r2], r1.reload.similar_requests
+    Bot::Alegre.unstub(:request_api)
+  end
+
+  test "should attach to similar media" do
+    Bot::Alegre.stubs(:request_api).returns(true)
+    f = create_feed
+    m1 = create_uploaded_image
+    r1 = create_request request_type: 'image', media: m1, feed: f
+    m2 = create_uploaded_image
+    r2 = create_request request_type: 'image', media: m2, feed: f
+    response = { 'result' => [{ 'context' => [{ 'request_id' => r1.id }] }] }
+    Bot::Alegre.stubs(:request_api).with('get', '/image/similarity/', { url: m2.file.file.public_url, threshold: 0.85, context: { feed_id: f.id } }).returns(response)
+    r2.attach_to_similar_request!
+    assert_equal r1, r2.reload.similar_to_request
+    assert_equal [r2], r1.reload.similar_requests
+    Bot::Alegre.unstub(:request_api)
+  end
+end

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -5,6 +5,7 @@ class RequestTest < ActiveSupport::TestCase
     super
     Sidekiq::Testing.inline!
     Request.delete_all
+    WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
   end
 
   test "should create request" do
@@ -83,7 +84,9 @@ class RequestTest < ActiveSupport::TestCase
   end
 
   test "should get media for link" do
-    url = @url
+    url = random_url
+    pender_url = CheckConfig.get('pender_url_private') + '/api/medias'
+    WebMock.stub_request(:get, pender_url).with({ query: { url: url } }).to_return(body: '{"type":"media","data":{"url":"' + url + '","type":"item","foo":"1"}}')
     m1 = nil
     m2 = nil
     assert_difference 'Link.count' do


### PR DESCRIPTION
* Request has media: For each request to the Feed API, a Request object should be created and its media should be automatically extracted
* Request has a similar request: When a Request is created, if its media is similar to another media of a Request of the same Feed, they should be related (one level only)

Reference: CHECK-2253.