### PR TITLE
Shared Feeds v1: Changes to GraphQL `RequestType`

### DIFF
--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -179,7 +179,7 @@ QueryType = GraphQL::ObjectType.define do
 
   # Getters by ID
 
-  [:source, :user, :task, :tag_text, :bot_user, :project_group, :saved_search, :cluster].each do |type|
+  [:source, :user, :task, :tag_text, :bot_user, :project_group, :saved_search, :cluster, :feed].each do |type|
     field type do
       type "#{type.to_s.camelize}Type".constantize
       description "Information about the #{type} with given id"

--- a/app/graph/types/request_type.rb
+++ b/app/graph/types/request_type.rb
@@ -5,7 +5,7 @@ RequestType = GraphqlCrudOperations.define_default_type do
   interfaces [NodeIdentification.interface]
 
   field :dbid, types.Int
-  field :last_submitted, types.String
+  field :last_submitted_at, types.String
   field :request_type, types.String
   field :content, types.String
   field :medias_count, types.Int

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -8,6 +8,7 @@ class Media < ApplicationRecord
   belongs_to :account, optional: true
   belongs_to :user, optional: true
   has_many :project_medias, dependent: :destroy
+  has_many :requests, dependent: :destroy
   has_annotations
 
   before_validation :set_type, :set_url_nil_if_empty, :set_user, on: :create

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -34,6 +34,10 @@ class Request < ApplicationRecord
     end
   end
 
+  def medias
+    Media.distinct.joins(:requests).where('requests.request_id = ? OR medias.id = ?', self.id, self.media_id)
+  end
+
   def self.get_media_from_query(type, query)
     media = nil
     url = Twitter::TwitterText::Extractor.extract_urls(query)[0]

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -184,4 +184,19 @@ class RequestTest < ActiveSupport::TestCase
     assert_equal 4, r1.reload.requests_count
     Bot::Alegre.unstub(:request_api)
   end
+
+  test "should return medias" do
+    Bot::Alegre.stubs(:request_api).returns({})
+    create_request
+    create_uploaded_image
+    m1 = create_uploaded_image
+    r1 = create_request media: m1
+    m2 = create_uploaded_image
+    r2 = create_request media: m2
+    r2.similar_to_request = r1 ; r2.save!
+    r3 = create_request media: m2
+    r3.similar_to_request = r1 ; r3.save!
+    assert_equal [m1, m2].map(&:id).sort, r1.reload.medias.map(&:id).sort
+    Bot::Alegre.unstub(:request_api)
+  end
 end


### PR DESCRIPTION
* Fixing typo in field `last_submitted_at`
* Implementing a `medias` method for the `Request` model (already exposed in `RequestType` as a `connection`)

Reference: CHECK-2253.