### PR TITLE
Changes to requests/feeds and related GraphQL APIs.

### DIFF
--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -179,7 +179,7 @@ QueryType = GraphQL::ObjectType.define do
 
   # Getters by ID
 
-  [:source, :user, :task, :tag_text, :bot_user, :project_group, :saved_search, :cluster, :feed].each do |type|
+  [:source, :user, :task, :tag_text, :bot_user, :project_group, :saved_search, :cluster, :feed, :request].each do |type|
     field type do
       type "#{type.to_s.camelize}Type".constantize
       description "Information about the #{type} with given id"

--- a/app/graph/types/request_type.rb
+++ b/app/graph/types/request_type.rb
@@ -12,7 +12,17 @@ RequestType = GraphqlCrudOperations.define_default_type do
   field :requests_count, types.Int
   field :similar_to_request, RequestType
   field :media, MediaType
+  field :feed, FeedType
 
   connection :medias, MediaType.connection_type
-  connection :similar_requests, RequestType.connection_type
+
+  connection :similar_requests, -> { RequestType.connection_type } do
+    argument :media_id, types.Int
+
+    resolve ->(request, args, _ctx) {
+      requests = request.similar_requests
+      requests = requests.where(media_id: args['media_id'].to_i) unless args['media_id'].blank?
+      requests
+    }
+  end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -26,6 +26,8 @@ class Request < ApplicationRecord
     elsif ['UploadedImage', 'UploadedAudio', 'UploadedVideo'].include?(media.type)
       type = media.type.gsub(/^Uploaded/, '').downcase
       similar_request_id = ::Bot::Alegre.request_api('get', "/#{type}/similarity/", { url: media.file.file.public_url, threshold: threshold, context: context }).dig('result', 0, 'context', 0, 'request_id')
+    elsif media.type == 'Link'
+      similar_request_id = Request.where(media_id: media.id, feed_id: self.feed_id).order('id ASC').first
     end
     unless similar_request_id.blank?
       similar_request = Request.where(id: similar_request_id, feed_id: self.feed_id).last

--- a/lib/check_basic_abilities.rb
+++ b/lib/check_basic_abilities.rb
@@ -116,6 +116,10 @@ module CheckBasicAbilities
     can :read, FeedTeam do |obj|
       @user.cached_teams.include?(obj.team_id)
     end
+
+    can :read, Request do |obj|
+      !(@user.cached_teams & obj.feed.team_ids).empty?
+    end
   end
 
   def annotation_perms_for_all_users

--- a/test/controllers/graphql_controller_5_test.rb
+++ b/test/controllers/graphql_controller_5_test.rb
@@ -510,6 +510,83 @@ class GraphqlController5Test < ActionController::TestCase
     assert_equal 2, response.size
   end
 
+  test "should get feed directly by id" do
+    t = create_team
+    u = create_user
+    create_team_user user: u, team: t
+    authenticate_with_user(u)
+
+    f1 = create_feed
+    f1.teams << t
+    f2 = create_feed
+    FeedTeam.update_all(shared: true)
+
+    query = "query { feed(id: \"#{f1.id}\") { dbid } }"
+    post :create, params: { query: query, team: t.slug }
+    assert_response :success
+    assert_equal f1.id, JSON.parse(@response.body).dig('data', 'feed', 'dbid')
+
+    query = "query { feed(id: \"#{f2.id}\") { dbid } }"
+    post :create, params: { query: query, team: t.slug }
+    assert_response :success
+    assert_nil JSON.parse(@response.body).dig('data', 'feed', 'dbid')
+  end
+
+  test "should get request directly by id" do
+    t = create_team
+    u = create_user
+    create_team_user user: u, team: t
+    authenticate_with_user(u)
+
+    f1 = create_feed
+    f1.teams << t
+    f2 = create_feed
+    FeedTeam.update_all(shared: true)
+
+    r1 = create_request feed: f1
+    r2 = create_request feed: f2
+
+    query = "query { request(id: \"#{r1.id}\") { dbid } }"
+    post :create, params: { query: query, team: t.slug }
+    assert_response :success
+    assert_equal r1.id, JSON.parse(@response.body).dig('data', 'request', 'dbid')
+
+    query = "query { request(id: \"#{r2.id}\") { dbid } }"
+    post :create, params: { query: query, team: t.slug }
+    assert_response :success
+    assert_nil JSON.parse(@response.body).dig('data', 'request', 'dbid')
+  end
+
+  test "should filter similar requests by media" do
+    t = create_team
+    u = create_user
+    create_team_user user: u, team: t
+    authenticate_with_user(u)
+
+    f = create_feed
+    f.teams << t
+    FeedTeam.update_all(shared: true)
+
+    r1 = create_request feed: f
+    r2 = create_request feed: f
+    r2.similar_to_request = r1
+    r2.save!
+    m = create_uploaded_image
+    r3 = create_request feed: f, media: m
+    r3.similar_to_request = r1
+    r3.save!
+
+    query = "query { request(id: \"#{r1.id}\") { similar_requests(first: 10) { edges { node { dbid } } } } }"
+    post :create, params: { query: query, team: t.slug }
+    assert_response :success
+    assert_equal 2, JSON.parse(@response.body).dig('data', 'request', 'similar_requests', 'edges').size
+
+    query = "query { request(id: \"#{r1.id}\") { similar_requests(first: 10, media_id: #{m.id}) { edges { node { dbid } } } } }"
+    post :create, params: { query: query, team: t.slug }
+    assert_response :success
+    assert_equal 1, JSON.parse(@response.body).dig('data', 'request', 'similar_requests', 'edges').size
+  end
+
   protected
 
   def assert_error_message(expected)

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -161,6 +161,19 @@ class RequestTest < ActiveSupport::TestCase
     Bot::Alegre.unstub(:request_api)
   end
 
+  test "should attach to similar link" do
+    Bot::Alegre.stubs(:request_api).returns(true)
+    f = create_feed
+    m = create_valid_media
+    create_request request_type: 'text', media: m
+    create_request request_type: 'text', feed: f
+    r1 = create_request request_type: 'text', media: m, feed: f
+    r2 = create_request request_type: 'text', media: m, feed: f
+    r2.attach_to_similar_request!
+    assert_equal r1, r2.reload.similar_to_request
+    assert_equal [r2], r1.reload.similar_requests
+  end
+
   test "should set fields" do
     r = create_request
     assert_not_nil r.reload.last_submitted_at


### PR DESCRIPTION
* Add a field `request` to `QueryType`, to be sure that we can get a request by its ID (permissions set accordingly)
* Add a `media_id` argument to `RequestType` connection `similar_requests`
* Group (clusterize) requests that mention the same URL
* Add a field `feed` to `RequestType`

Reference: CHECK-2253.