### PR TITLE
Sort keyword search results by score on tipline search and feed API.

### DIFF
--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -164,6 +164,7 @@ module SmoochSearch
 
     def search_by_keywords_for_similar_published_fact_checks(words, after, team_ids, feed_id = nil)
       filters = { keyword: words.join('+'), eslimit: 3 }
+      filters.merge!({ sort: 'score' }) if words.size > 1 # We still want to be able to return the latest fact-checks if a meaninful query is not passed
       feed_id.blank? ? filters.merge!({ report_status: ['published'] }) : filters.merge!({ feed_id: feed_id })
       filters.merge!({ range: { updated_at: { start_time: after.strftime('%Y-%m-%dT%H:%M:%S.%LZ') } } }) unless after.blank?
       results = CheckSearch.new(filters.to_json, nil, team_ids).medias

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -53,7 +53,7 @@ class CheckSearch
     'type_of_media' => 'type_of_media', 'title' => 'title_index', 'creator_name' => 'creator_name',
     'cluster_size' => 'cluster_size', 'cluster_first_item_at' => 'cluster_first_item_at',
     'cluster_last_item_at' => 'cluster_last_item_at', 'cluster_requests_count' => 'cluster_requests_count',
-    'cluster_published_reports_count' => 'cluster_published_reports_count'
+    'cluster_published_reports_count' => 'cluster_published_reports_count', 'score' => '_score'
   }
 
   def team_condition(team_id = nil)


### PR DESCRIPTION
When searching by keyword on a tipline or from a feed API request, the search results should be sorted by score.

Fixes CHECK-2357.