### PR TITLE
Escape URLs before verifying if they are valid.

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -689,6 +689,7 @@ class Bot::Smooch < BotUser
       url = urls.reject{ |u| urls_to_ignore.include?(u) }.first
       return nil if url.blank?
       url = 'https://' + url unless url =~ /^https?:\/\//
+      url = URI.escape(url)
       URI.parse(url)
       m = Link.new url: url
       m.validate_pender_result(false, true)
@@ -698,7 +699,8 @@ class Bot::Smooch < BotUser
       else
         m
       end
-    rescue URI::InvalidURIError
+    rescue URI::InvalidURIError => e
+      self.notify_error(e, { bot: 'Smooch', extra: { method: 'extract_url' } }, RequestStore[:request])
       nil
     end
   end

--- a/test/models/bot/smooch_5_test.rb
+++ b/test/models/bot/smooch_5_test.rb
@@ -534,7 +534,7 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
 
     assert_nothing_raised do
       with_current_user_and_team(nil, t) do
-        Bot::Smooch.search_for_similar_published_fact_checks('text', 'https://projetocomprova.com.br/publica%C3%A7%C3%B5es/tuite-engana-ao-dizer-que-o-stf-decidiu-que-voto-impresso-e-inconstitucional/ ', [t.id], nil, f.id)
+        Bot::Smooch.search_for_similar_published_fact_checks('text', 'https://projetocomprova.com.br/publicações/tuite-engana-ao-dizer-que-o-stf-decidiu-que-voto-impresso-e-inconstitucional/ ', [t.id], nil, f.id)
       end
     end
   end

--- a/test/models/bot/smooch_test.rb
+++ b/test/models/bot/smooch_test.rb
@@ -352,6 +352,9 @@ class Bot::SmoochTest < ActiveSupport::TestCase
     assert_nil Bot::Smooch.extract_url('foo https://30th-JUNE-2019.*')
     assert_nil Bot::Smooch.extract_url('foo https://...')
     assert_nil Bot::Smooch.extract_url('foo https://*1.*')
+    URI.stubs(:parse).raises(URI::InvalidURIError)
+    assert_nil Bot::Smooch.extract_url('https://trigger-exception.com')
+    URI.unstub(:parse)
   end
 
   test "should send report to user" do

--- a/test/models/bot/smooch_test.rb
+++ b/test/models/bot/smooch_test.rb
@@ -346,7 +346,7 @@ class Bot::SmoochTest < ActiveSupport::TestCase
   end
 
   test "should not get invalid URL" do
-    assert_nil Bot::Smooch.extract_url('foo http://\foo.bar bar')
+    WebMock.disable_net_connect!
     assert_nil Bot::Smooch.extract_url('foo https://news...')
     assert_nil Bot::Smooch.extract_url('foo https://ha..?')
     assert_nil Bot::Smooch.extract_url('foo https://30th-JUNE-2019.*')


### PR DESCRIPTION
This error was triggered by a URL that contained accents.

Fixes CHECK-2367.