### PR TITLE
Fixing request clustering and validation.

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -706,7 +706,7 @@ class Bot::Smooch < BotUser
   def self.extract_claim(text)
     claim = ''
     text.split(MESSAGE_BOUNDARY).each do |part|
-      claim = part.chomp if part.size > claim.size
+      claim = part.chomp.strip if part.size > claim.size
     end
     claim
   end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -20,7 +20,6 @@ class Request < ApplicationRecord
 
   def attach_to_similar_request!
     media = self.media
-    similar_request_id = nil
     context = { feed_id: self.feed_id }
     threshold = self.similarity_threshold
     # First try to find an identical media

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -70,7 +70,7 @@ class Request < ApplicationRecord
     else
       if url.blank?
         text = ::Bot::Smooch.extract_claim(query)
-        media = Media.where(type: 'Claim', quote: text).last || Media.create!(type: 'Claim', quote: text)
+        media = Media.where(type: 'Claim').where('quote ILIKE ?', text).last || Media.create!(type: 'Claim', quote: text)
       else
         link = ::Bot::Smooch.extract_url(url) # Parse URL to get a normalized/canonical one
         url = (link ? link.url : url)
@@ -90,9 +90,11 @@ class Request < ApplicationRecord
       request_id: request.id
     }
     if media.type == 'Claim'
+      text = media.quote
+      return if text.length < 2
       params = {
         doc_id: doc_id,
-        text: media.quote,
+        text: text,
         model: request.similarity_model,
         context: context
       }

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -8,6 +8,8 @@ class Request < ApplicationRecord
   after_commit :send_to_alegre, on: :create
   after_commit :update_fields, on: :update
 
+  validates_inclusion_of :request_type, in: ['audio', 'video', 'image', 'text']
+
   def similarity_threshold
     0.85 # FIXME: Adjust this value for text and image (eventually it can be a feed setting)
   end
@@ -21,15 +23,17 @@ class Request < ApplicationRecord
     similar_request_id = nil
     context = { feed_id: self.feed_id }
     threshold = self.similarity_threshold
-    if media.type == 'Claim' && ::Bot::Alegre.get_number_of_words(media.quote) > 3
-      params = { text: media.quote, threshold: threshold, context: context }
-      similar_request_id = ::Bot::Alegre.request_api('get', '/text/similarity/', params).dig('result').to_a.collect{ |result| result.dig('_source', 'context', 'request_id').to_i }.find{ |id| id != 0 && id != self.id }
-    elsif ['UploadedImage', 'UploadedAudio', 'UploadedVideo'].include?(media.type)
-      type = media.type.gsub(/^Uploaded/, '').downcase
-      params = { url: media.file.file.public_url, threshold: threshold, context: context }
-      similar_request_id = ::Bot::Alegre.request_api('get', "/#{type}/similarity/", params).dig('result').to_a.collect{ |result| result.dig('context').to_a.collect{ |c| c['request_id'].to_i } }.flatten.find{ |id| id != 0 && id != self.id }
-    elsif media.type == 'Link'
-      similar_request_id = Request.where(media_id: media.id, feed_id: self.feed_id).where.not(id: self.id).order('id ASC').first
+    # First try to find an identical media
+    similar_request_id = Request.where(media_id: media.id, feed_id: self.feed_id).where.not(id: self.id).order('id ASC').first
+    if similar_request_id.nil?
+      if media.type == 'Claim' && ::Bot::Alegre.get_number_of_words(media.quote) > 3
+        params = { text: media.quote, threshold: threshold, context: context }
+        similar_request_id = ::Bot::Alegre.request_api('get', '/text/similarity/', params).dig('result').to_a.collect{ |result| result.dig('_source', 'context', 'request_id').to_i }.find{ |id| id != 0 && id != self.id }
+      elsif ['UploadedImage', 'UploadedAudio', 'UploadedVideo'].include?(media.type)
+        type = media.type.gsub(/^Uploaded/, '').downcase
+        params = { url: media.file.file.public_url, threshold: threshold, context: context }
+        similar_request_id = ::Bot::Alegre.request_api('get', "/#{type}/similarity/", params).dig('result').to_a.collect{ |result| result.dig('context').to_a.collect{ |c| c['request_id'].to_i } }.flatten.find{ |id| id != 0 && id != self.id }
+      end
     end
     unless similar_request_id.blank?
       similar_request = Request.where(id: similar_request_id, feed_id: self.feed_id).last

--- a/lib/tasks/migrate/20220828210303_request_fields.rake
+++ b/lib/tasks/migrate/20220828210303_request_fields.rake
@@ -1,0 +1,27 @@
+namespace :check do
+  namespace :migrate do
+    task request_fields: :environment do
+      started = Time.now.to_i
+      query = Request.where(media_id: nil).order('id ASC')
+      count = query.count
+      counter = 0
+      query.find_each do |r|
+        counter += 1
+        failed = false
+        begin
+          media = Request.get_media_from_query(r.request_type, r.content)
+          r.update_columns({ media_id: media.id, last_submitted_at: r.created_at, medias_count: 1, requests_count: 1 })
+          Request.send_to_alegre(r.id)
+          sleep 1
+          r = Request.find(r.id)
+          r.attach_to_similar_request!
+        rescue Exception => e
+          failed = e.message
+        end
+        puts "[#{Time.now}] Processed item #{counter}/#{count}: ##{r.id} (#{failed ? 'failed with ' + e.message : 'success'})"
+      end
+      minutes = ((Time.now.to_i - started) / 60).to_i
+      puts "[#{Time.now}] Done in #{minutes} minutes."
+    end
+  end
+end

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -58,6 +58,8 @@ class FeedsControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal 'Bar', json_response['data'][0]['attributes']['organization']
     assert_equal 'Foo', json_response['data'][1]['attributes']['organization']
+
+    Bot::Smooch.unstub(:search_for_similar_published_fact_checks)
   end
 
   test "should return empty set if feed is not published" do


### PR DESCRIPTION
* Cluster requests related to the same media
* Validate that the `request_type` is valid
* Better way to look for existing text media, by ignoring case and removing trailing and leading spaces
* Added rake task to extract media for existing requests and to clusterize existing requests

Fixes CHECK-2253.