### PR TITLE
Support media queries on feed API.

### DIFF
--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -154,7 +154,7 @@ module SmoochSearch
       else
         media_url = Twitter::TwitterText::Extractor.extract_urls(query)[0]
         return [] if media_url.blank?
-        media_url = self.save_locally_and_return_url(media_url, type, feed_id) unless feed_id.nil?
+        media_url = self.save_locally_and_return_url(media_url, type, feed_id)
         threshold = Bot::Alegre.get_threshold_for_query(type, pm)[0][:value]
         alegre_results = Bot::Alegre.get_items_with_similar_media(media_url, [{ value: threshold }], team_ids, "/#{type}/similarity/")
         results = self.parse_search_results_from_alegre(alegre_results, after, feed_id, team_ids)
@@ -164,7 +164,7 @@ module SmoochSearch
     end
 
     def save_locally_and_return_url(media_url, type, feed_id)
-      feed = Feed.find_by_id(feed_id)
+      feed = Feed.find_by_id(feed_id.to_i)
       return media_url if feed.nil?
       headers = feed.get_media_headers.to_h
       return media_url if headers.blank?

--- a/test/models/bot/smooch_5_test.rb
+++ b/test/models/bot/smooch_5_test.rb
@@ -538,4 +538,15 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should store media" do
+    f = create_feed
+    f.set_media_headers = { 'Authorization' => 'App 123456' }
+    f.save!
+    media_url = random_url
+    WebMock.stub_request(:get, media_url).to_return(body: File.read(File.join(Rails.root, 'test', 'data', 'rails.png')))
+    local_media_url = Bot::Smooch.save_locally_and_return_url(media_url, 'image', f.id)
+    assert_match /^http/, local_media_url
+    assert_not_equal media_url, local_media_url
+  end
 end


### PR DESCRIPTION
For media queries, the medias can be stored locally. Additional headers to access the media can be stored in the feed settings.

Reference: CHECK-2423.