### PR TITLE
No more limits for fact-check title and URL.

### DIFF
--- a/app/models/bot/fetch.rb
+++ b/app/models/bot/fetch.rb
@@ -227,10 +227,10 @@ class Bot::Fetch < BotUser
       fc = FactCheck.new
       fc.skip_check_ability = true
       fc.claim_description = cd
-      fc.title = self.get_title(claim_review).truncate(140)
-      summary = self.parse_text(claim_review['text'].to_s.blank? ? claim_review['headline'] : claim_review['text'])
-      fc.summary = summary.to_s.truncate(620)
+      fc.title = self.get_title(claim_review).to_s
       fc.url = claim_review['url'].to_s
+      summary = self.parse_text(claim_review['text'].to_s.blank? ? claim_review['headline'] : claim_review['text'])
+      fc.summary = summary.to_s.truncate(900 - fc.title.size - fc.url.size)
       fc.user = user
       fc.skip_report_update = true
       fc.language = claim_review.dig('raw', 'language')

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -10,8 +10,6 @@ class FactCheck < ApplicationRecord
   validates_presence_of :claim_description
   validates_uniqueness_of :claim_description_id
   validates_format_of :url, with: URI.regexp, allow_blank: true, allow_nil: true
-  validates :title, length: { maximum: 140 }, allow_blank: true, allow_nil: true
-  validates :summary, length: { maximum: 620 }, allow_blank: true, allow_nil: true
 
   after_save :update_report
 


### PR DESCRIPTION
Now only fact-check summary has a limit. The summary is truncated (when importing from Fetch) but title and URL never are.

Reference: CHECK-2468.