### PR TITLE
A couple fixes for reports

### DIFF
--- a/app/models/bot/fetch.rb
+++ b/app/models/bot/fetch.rb
@@ -309,7 +309,7 @@ class Bot::Fetch < BotUser
         state: auto_publish_reports ? 'published' : 'paused',
         options: [{
           language: language,
-          status_label: pm.status_i18n(pm.reload.last_verification_status),
+          status_label: pm.status_i18n(pm.reload.last_verification_status, { locale: language }),
           description: summary,
           title: title,
           published_article_url: claim_review['url'],

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -201,8 +201,8 @@ module SmoochSearch
       results.each do |result|
         report = result.get_dynamic_annotation('report_design')
         response = nil
-        response = self.send_message_to_user(uid, '', { 'type' => 'image', 'mediaUrl' => report&.report_design_image_url }) if report && report.report_design_field_value('use_visual_card')
-        response = self.send_message_to_user(uid, report.report_design_text) if report && !report.report_design_field_value('use_visual_card') && report.report_design_field_value('use_text_message')
+        response = self.send_message_to_user(uid, report.report_design_text) if report && report.report_design_field_value('use_text_message')
+        response = self.send_message_to_user(uid, '', { 'type' => 'image', 'mediaUrl' => report&.report_design_image_url }) if report && !report.report_design_field_value('use_text_message') && report.report_design_field_value('use_visual_card')
         id = self.get_id_from_send_response(response)
         redis.rpush("smooch:search:#{uid}", id) unless id.blank?
       end


### PR DESCRIPTION
* For imported reports, the status on visual cards should be localized to the workspace's default language (CHECK-2466)
* Prioritize text reports on search results (CHECK-2459)