### PR TITLE
Cache media file path

### DIFF
--- a/app/models/concerns/has_file.rb
+++ b/app/models/concerns/has_file.rb
@@ -12,7 +12,10 @@ module HasFile
   end
 
   def image_path(version = nil)
-    self.file_url(version).to_s
+    # This never changes, so let's cache it
+    Rails.cache.fetch("media:image:path:#{self.id}:#{version}") do
+      self.file_url(version).to_s
+    end
   end
 
   def file_path


### PR DESCRIPTION
This is an easy win in terms of performance... it avoids N + 1 performance issues on various GraphQL queries and it's a value that never changes, so we can keep it cached forever essencially.

Hopefully fixes CHECK-2491.