### PR TITLE
Release database connection while calling Alegre during feed API request

### DIFF
--- a/app/resources/api/v2/feed_resource.rb
+++ b/app/resources/api/v2/feed_resource.rb
@@ -33,6 +33,7 @@ module Api
         feed_id = filters.dig(:feed_id, 0).to_i
         return ProjectMedia.none if team_ids.blank? || query.blank? || !can_read_feed?(feed_id, team_ids)
         query = CGI.unescape(query)
+        RequestStore.store[:pause_database_connection] = true # Release database connection during Bot::Alegre.request_api
         results = Bot::Smooch.search_for_similar_published_fact_checks(type, query, Feed.find(feed_id).team_ids, after, feed_id)
         Feed.delay(retry: 0).save_request(feed_id, type, query, webhook_url, results.to_a.map(&:id)) unless skip_save_request
         results


### PR DESCRIPTION
Some of those calls to Alegre can take a long time. Under concurrency, some requests possibly won't get a database connection if some of them are locked by a request that is waiting for a response from Alegre. Currently using it only for feed requests.