### PR TITLE
Raise exception on failed save from Pender link

### DIFF
--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -85,7 +85,7 @@ module ProjectMediaCreators
     team = self.team || Team.current
     pender_key = team.get_pender_key if team
     url = Link.normalized(self.url, pender_key)
-    Link.find_by(url: url) || Link.create(url: url, pender_key: pender_key)
+    Link.find_by(url: url) || Link.create!(url: url, pender_key: pender_key)
   end
 
   def create_media


### PR DESCRIPTION
Previously this was save was failing silently, which caused us to receive a blank media ID without having visibility into why.