### PR TITLE
Revert "Raise exception on failed save from Pender link"

### DIFF
--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -85,7 +85,7 @@ module ProjectMediaCreators
     team = self.team || Team.current
     pender_key = team.get_pender_key if team
     url = Link.normalized(self.url, pender_key)
-    Link.find_by(url: url) || Link.create!(url: url, pender_key: pender_key)
+    Link.find_by(url: url) || Link.create(url: url, pender_key: pender_key)
   end
 
   def create_media


### PR DESCRIPTION
This reverts commit 1f7f3803e5cd7b5a28af9e7fc361106fa8443777, since it was
causing the front end to display a confusing error to user and no longer redirecting.