### PR TITLE
Send the same URL to Pender when looking up or creating Link

### DIFF
--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -84,8 +84,8 @@ module ProjectMediaCreators
   def create_link
     team = self.team || Team.current
     pender_key = team.get_pender_key if team
-    url = Link.normalized(self.url, pender_key)
-    Link.find_by(url: url) || Link.create(url: url, pender_key: pender_key)
+    url_from_pender = Link.normalized(self.url, pender_key)
+    Link.find_by(url: url_from_pender) || Link.create(url: self.url, pender_key: pender_key)
   end
 
   def create_media

--- a/test/models/concerns/project_media_creators_test.rb
+++ b/test/models/concerns/project_media_creators_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class FakeProjectMediaCreators
+  include ProjectMediaCreators
+
+  def initialize(url)
+    @url = url
+  end
+
+  def url
+    @url
+  end
+
+  def team
+    nil
+  end
+end
+
+class ProjectMediaCreatorsTest < ActiveSupport::TestCase
+  test "#create_link calls find with normalized URL" do
+    Team.current = nil
+
+    Link.stubs(:normalized).returns('https://example.com/new')
+    Link.expects(:find_by).with(url: 'https://example.com/new').returns('fake link')
+
+    fpc = FakeProjectMediaCreators.new('https://example.com/original')
+    assert_equal 'fake link', fpc.send(:create_link)
+
+    Link.unstub(:normalized)
+    Link.unstub(:find_by)
+  end
+
+  test "#create_link calls create with original URL, to let Pender normalize it" do
+    Team.current = nil
+    create_url = nil
+
+    Link.stubs(:find_by).returns(nil)
+    Link.stubs(:normalized).returns('https://example.com/new')
+    Link.expects(:create).with(url: 'https://example.com/original', pender_key: nil).returns('fake link')
+
+    fpc = FakeProjectMediaCreators.new('https://example.com/original')
+    assert_equal 'fake link', fpc.send(:create_link)
+
+    Link.unstub(:find_by)
+    Link.unstub(:normalized)
+    Link.unstub(:create)
+  end
+end


### PR DESCRIPTION
Previously we were looking up by the normalized URL from Pender, and then re-sending that normalized URL to Pender if the lookup failed. This means that even though Pender could be (and was) returning deterministic reference URLs when given the same URL that we were actually asking it for different URLs in some cases. This was causing a bug where the Media could not be created successfully on our side sometimes, because there was already Media in the database that we didn't retrieve on the lookup before because of the URL changes.