### PR TITLE
Configure mocha to automatically teardown stubs after test run

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ group :test do
   gem 'rails-controller-testing'
   gem 'pact-consumer-minitest'
   gem 'rspec-rails', '4.0.1'
+  gem 'mocha', '~>1.14.0'
 end
 
 group :doc do
@@ -33,7 +34,6 @@ group :development do
 end
 
 gem 'webmock'
-gem 'mocha', '1.2.1'
 gem 'pender_client', git: 'https://github.com/meedan/pender-client.git', ref: '89c9072'
 gem 'sqlite3', '1.3.13', require: false
 gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,7 +414,6 @@ GEM
     memoist (0.16.2)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
-    metaclass (0.0.4)
     method_source (1.0.0)
     mime-types (3.4.1)
       mime-types-data (~> 3.2015)
@@ -427,8 +426,7 @@ GEM
       minitest (> 5.3)
     minitest-retry (0.2.2)
       minitest (>= 5.0)
-    mocha (1.2.1)
-      metaclass (~> 0.0.1)
+    mocha (1.14.0)
     msgpack (1.4.5)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -861,7 +859,7 @@ DEPENDENCIES
   minitest (= 5.14.4)
   minitest-hooks
   minitest-retry
-  mocha (= 1.2.1)
+  mocha (~> 1.14.0)
   multi_json (= 1.15.0)
   nokogiri (= 1.13.6)
   omniauth-facebook

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -143,12 +143,7 @@ class ActiveSupport::TestCase
   def before_all
     super
 
-    mocha_setup
     create_metadata_stuff
-    ApolloTracing.stubs(:start_proxy)
-    Pusher::Client.any_instance.stubs(:trigger)
-    Pusher::Client.any_instance.stubs(:post)
-    ProjectMedia.any_instance.stubs(:clear_caches).returns(nil)
     # URL mocked by pender-client
     @url = 'https://www.youtube.com/user/MeedanTube'
   end
@@ -175,6 +170,13 @@ class ActiveSupport::TestCase
     WebMock.stub_request(:get, /#{CheckConfig.get('narcissus_url')}/).to_return(body: '{"url":"http://screenshot/test/test.png"}')
     WebMock.stub_request(:get, /api\.smooch\.io/)
     RequestStore.store[:skip_cached_field_update] = true
+
+    # Set up stubs on per-test basis so that we don't accidentally
+    # create a shared state for stubbing and unstubbing
+    ApolloTracing.stubs(:start_proxy)
+    Pusher::Client.any_instance.stubs(:trigger)
+    Pusher::Client.any_instance.stubs(:post)
+    ProjectMedia.any_instance.stubs(:clear_caches).returns(nil)
   end
 
   # This will run after any test

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -21,13 +21,13 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'webmock/minitest'
-require 'mocha/test_unit'
 require 'sample_data'
 require 'parallel_tests/test/runtime_logger'
 require 'sidekiq/testing'
 require 'minitest/retry'
 require 'pact/consumer/minitest'
 require 'rspec/rails'
+require 'mocha/minitest'
 Minitest::Retry.use!
 
 class ActionController::TestCase
@@ -142,6 +142,8 @@ class ActiveSupport::TestCase
 
   def before_all
     super
+
+    mocha_setup
     create_metadata_stuff
     ApolloTracing.stubs(:start_proxy)
     Pusher::Client.any_instance.stubs(:trigger)


### PR DESCRIPTION
In order to get mocha to tear down stubs, it has to be loaded last. I think that previously we were importing it before some of our minitest libraries, and also weren't using the minitest-specific version of the gem, which meant that we lost the auto-teardown functionality.

Changing the version of mocha and the load order means we no longer need to manually tear down mocks as part of test setup and teardown. (See https://github.com/freerange/mocha#installation)

See related Pender commit: https://github.com/meedan/pender/pull/281/commits/eac701330e9259731a36b9f15337da3e3e383eb6