### PR TITLE
Refactoring "fact_checked_by" for feed requests.

### DIFF
--- a/app/graph/types/feed_type.rb
+++ b/app/graph/types/feed_type.rb
@@ -26,7 +26,8 @@ FeedType = GraphqlCrudOperations.define_default_type do
         'medias' => 'medias_count',
         'last_submitted' => 'last_submitted_at',
         'subscriptions' => 'subscriptions_count',
-        'media_type' => 'request_type'
+        'media_type' => 'request_type',
+        'fact_checked_by' => 'fact_checked_by_count'
       }[args['sort'].to_s] || 'last_submitted_at'
       sort_type = args['sort_type'].to_s.downcase == 'asc' ? 'ASC' : 'DESC'
       query = Request.where(request_id: request_id, feed_id: feed.id)

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -42,8 +42,10 @@ class Feed < ApplicationRecord
   end
 
   def project_media_ids(team_id)
+    team = Team.find_by_id(team_id.to_i)
+    return [] if team.nil?
     current_team = Team.current
-    Team.current = Team.find(team_id)
+    Team.current = team
     ids = CheckSearch.new({ feed_id: self.id, eslimit: 10000 }.to_json, nil, team_id).medias.map(&:id) # FIXME: Limited at 10000
     Team.current = current_team
     ids

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -41,11 +41,16 @@ class Feed < ApplicationRecord
     self.requests.where(request_id: nil).count
   end
 
-  def item_belongs_to_feed?(pm)
+  def project_media_ids(team_id)
     current_team = Team.current
-    Team.current = Team.find(pm.team_id)
-    items = CheckSearch.new({ feed_id: self.id, eslimit: 10000 }.to_json, nil, pm.team_id).medias.map(&:id)
+    Team.current = Team.find(team_id)
+    ids = CheckSearch.new({ feed_id: self.id, eslimit: 10000 }.to_json, nil, team_id).medias.map(&:id) # FIXME: Limited at 10000
     Team.current = current_team
+    ids
+  end
+
+  def item_belongs_to_feed?(pm)
+    items = self.project_media_ids(pm.team_id)
     items.include?(pm.id)
   end
 
@@ -58,10 +63,10 @@ class Feed < ApplicationRecord
   def self.save_request(feed_id, type, query, webhook_url, result_ids)
     media = Request.get_media_from_query(type, query, feed_id)
     request = Request.create!(feed_id: feed_id, request_type: type, content: query, webhook_url: webhook_url, media: media, skip_check_ability: true)
+    request.attach_to_similar_request!
     unless result_ids.blank?
       result_ids.each { |id| ProjectMediaRequest.create!(project_media_id: id, request_id: request.id, skip_check_ability: true) }
     end
-    request.attach_to_similar_request!
     request
   end
 

--- a/app/models/project_media_request.rb
+++ b/app/models/project_media_request.rb
@@ -1,4 +1,12 @@
 class ProjectMediaRequest < ApplicationRecord
   belongs_to :project_media
   belongs_to :request
+
+  after_create :update_request_fact_checked_by
+
+  private
+
+  def update_request_fact_checked_by
+    self.request.fact_checked_by(true)
+  end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -106,7 +106,7 @@ class Request < ApplicationRecord
       end
 
       # Workspaces that returned results for any request in this cluster
-      team_names.concat(ProjectMediaRequest.joins(:project_media).where(request_id: r.similar_requests.map(&:id).concat([r.id])).group('project_medias.team_id').count.keys.uniq.collect{ |id| Team.find(id).name })
+      team_names.concat(ProjectMediaRequest.joins(:project_media).where(request_id: r.similar_requests.map(&:id).concat([r.id])).group('project_medias.team_id').count.keys.uniq.collect{ |tid| Team.find(tid).name })
 
       team_names = team_names.uniq.sort
       r.update_column(:fact_checked_by_count, team_names.size)

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -118,7 +118,7 @@ class Request < ApplicationRecord
   def self.update_fact_checked_by(pm)
     request = Request.where(media_id: pm.media_id).first
     request = request&.similar_to_request || request
-    request.fact_checked_by(true)
+    request.fact_checked_by(true) unless request.nil?
   end
 
   def self.get_media_from_query(type, query, fid = nil)

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -106,7 +106,7 @@ class Request < ApplicationRecord
       end
 
       # Workspaces that returned results for any request in this cluster
-      team_names.concat(ProjectMediaRequest.joins(:project_media).where(request_id: r.similar_requests.map(&:id)).group('project_medias.team_id').count.keys.uniq.collect{ |id| Team.find(id).name })
+      team_names.concat(ProjectMediaRequest.joins(:project_media).where(request_id: r.similar_requests.map(&:id).concat([r.id])).group('project_medias.team_id').count.keys.uniq.collect{ |id| Team.find(id).name })
 
       team_names = team_names.uniq.sort
       r.update_column(:fact_checked_by_count, team_names.size)

--- a/config/initializers/report_designer.rb
+++ b/config/initializers/report_designer.rb
@@ -39,7 +39,9 @@ Dynamic.class_eval do
       end
     end
     if self.annotation_type == 'report_design' && self.action =~ /publish/
-      Feed.delay_for(1.minute, retry: 0).notify_subscribers(pm, title, summary, url) # Need to be sure that the item is indexed in the feed before notifying
+      # Wait for 1 minute to be sure that the item is indexed in the feed
+      Feed.delay_for(1.minute, retry: 0).notify_subscribers(pm, title, summary, url)
+      Request.delay_for(1.minute, retry: 0).update_fact_checked_by(pm)
     end
   end
 

--- a/db/migrate/20221014033716_add_fact_checked_by_count_to_requests.rb
+++ b/db/migrate/20221014033716_add_fact_checked_by_count_to_requests.rb
@@ -1,0 +1,5 @@
+class AddFactCheckedByCountToRequests < ActiveRecord::Migration[5.2]
+  def change
+    add_column :requests, :fact_checked_by_count, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_19_011554) do
+ActiveRecord::Schema.define(version: 2022_10_14_033716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -366,6 +366,7 @@ ActiveRecord::Schema.define(version: 2022_09_19_011554) do
     t.string "webhook_url"
     t.datetime "last_called_webhook_at"
     t.integer "subscriptions_count", default: 0, null: false
+    t.integer "fact_checked_by_count", default: 0, null: false
     t.index ["feed_id"], name: "index_requests_on_feed_id"
     t.index ["media_id"], name: "index_requests_on_media_id"
     t.index ["request_id"], name: "index_requests_on_request_id"


### PR DESCRIPTION
* Store in a new `requests.fact_checked_by_count` database column the number of organizations that have a fact-check for that request
* Instead of considering all workspaces that are part of the feed, it now considers only the ones that have sharing enabled
* Only fact-checks that are actually part of the feed are included
* Sort requests by number of organizations that fact-checked them
* Also consider workspaces that returned fact-checks for keyword queries

Reference: CHECK-2500.