### PR TITLE
If required configurations for QA or Live are missing, fail with error

### DIFF
--- a/production/bin/create_configs.sh
+++ b/production/bin/create_configs.sh
@@ -26,13 +26,20 @@ echo "Starting application configuration. Processing ENV settings."
     cp sidekiq.yml.example sidekiq.yml
   fi
 
+  # If we are missing required configuration settings for QA and Live
+  # environments, emit an error message explaining the omissions.
+  #
+  missing_configs=""
+
   # For production environments we use a secret token initializer from SSM:
   WORKTMP=$(mktemp)
   if [[ -z ${initializers_secret_token+x} ]]; then
+    missing_configs="$missing_configs initializers_secret_token,"
     echo "Error: missing initializers_secret_token ENV setting. Using defaults."
   else
     echo ${initializers_secret_token} | base64 -d > $WORKTMP
     if (( $? != 0 )); then
+      missing_configs="$missing_configs initializers_secret_token,"
       echo "Error: could not decode ENV var: ${initializers_secret_token} . Using defaults."
       rm $WORKTMP
     else
@@ -45,10 +52,12 @@ echo "Starting application configuration. Processing ENV settings."
   # For sidekiq use config from SSM:
   WORKTMP=$(mktemp)
   if [[ -z ${sidekiq_config+x} ]]; then
+    missing_configs="$missing_configs sidekiq_config,"
     echo "Error: missing sidekiq_config ENV setting. Using defaults."
   else
     echo ${sidekiq_config} | base64 -d > $WORKTMP
     if (( $? != 0 )); then
+      missing_configs="$missing_configs sidekiq_config,"
       echo "Error: could not decode ENV var: ${sidekiq_config} . Using defaults."
       rm $WORKTMP
     else
@@ -61,10 +70,12 @@ echo "Starting application configuration. Processing ENV settings."
   # For database configuration use SSM:
   WORKTMP=$(mktemp)
   if [[ -z ${database_config+x} ]]; then
+    missing_configs="$missing_configs database_config,"
     echo "Error: missing database_config ENV setting. Using defaults."
   else
     echo ${database_config} | base64 -d > $WORKTMP
     if (( $? != 0 )); then
+      missing_configs="$missing_configs database_config,"
       echo "Error: could not decode ENV var: ${database_config} . Using defaults."
       rm $WORKTMP
     else
@@ -77,10 +88,12 @@ echo "Starting application configuration. Processing ENV settings."
   # Populate production environment config from SSM:
   WORKTMP=$(mktemp)
   if [[ -z ${environments_production+x} ]]; then
+    missing_configs="$missing_configs environments_production,"
     echo "Error: missing environments_production ENV setting. Using defaults."
   else
     echo ${environments_production} | base64 -d > $WORKTMP
     if (( $? != 0 )); then
+      missing_configs="$missing_configs environments_production,"
       echo "Error: could not decode ENV var: ${environments_production} . Using defaults."
       rm $WORKTMP
     else
@@ -93,16 +106,29 @@ echo "Starting application configuration. Processing ENV settings."
   # Populate credentials from SSM:
   WORKTMP=$(mktemp)
   if [[ -z ${credentials_config+x} ]]; then
+    missing_configs="$missing_configs credentials_config,"
     echo "Error: missing credentials_config ENV setting. Using defaults."
   else
     echo ${credentials_config} | base64 -d > $WORKTMP
     if (( $? != 0 )); then
+      missing_configs="$missing_configs credentials_config,"
       echo "Error: could not decode ENV var: ${credentials_config} . Using defaults."
       rm $WORKTMP
     else
       echo "Using decoded credentials config from ENV var: ${credentials_config} ."
       mv $WORKTMP credentials.json
       sha1sum credentials.json
+    fi
+  fi
+
+  # If we are missing required configs in QA or Live environemnts emit an error
+  # detailing the omitted configurations and exit.  This will promptly fail an
+  # attempted deployment, rather than deferring to application failures.
+  #
+  if [[ "$DEPLOY_ENV" == "qa" || "$DEPLOY_ENV" == "live" ]]; then
+    if [[ "$missing_configs" != "" ]]; then
+      echo "Error: missing required configurations: $missing_configs exiting."
+      kill 0
     fi
   fi
 )


### PR DESCRIPTION
This change checks for required configuration settings during QA and Live deployments, and exit with error if any are missing. This will halt deployment with an explanation of missing configurations, rather than continue with application errors.