### PR TITLE
Fetch Sidekiq job refactoring.

### DIFF
--- a/app/models/bot/fetch.rb
+++ b/app/models/bot/fetch.rb
@@ -53,7 +53,7 @@ class Bot::Fetch < BotUser
       User.current = installation.user
       Team.current = installation.team
       status_mapping = installation.get_status_mapping.blank? ? nil : JSON.parse(installation.get_status_mapping, { quirks_mode: true })
-      Bot::Fetch::Import.delay_for(1.second, { queue: 'fetch', retry: 3 }).import_claim_review(claim_review, installation.team_id, installation.user_id, installation.get_status_fallback, status_mapping, installation.get_auto_publish_reports)
+      FetchWorker.perform_in(1.second, claim_review, installation.team_id, installation.user_id, installation.get_status_fallback, status_mapping, installation.get_auto_publish_reports)
       true
     rescue StandardError => e
       Rails.logger.error("[Fetch Bot] Exception: #{e.message}")

--- a/app/workers/fetch_worker.rb
+++ b/app/workers/fetch_worker.rb
@@ -1,0 +1,11 @@
+class FetchWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'fetch', retry: 3
+
+  sidekiq_retry_in { |_count, _exception| 300 } # Retry 5 minutes later in order to avoid database conflicts like ActiveRecord::PreparedStatementCacheExpired
+
+  def perform(claim_review, team_id, user_id, status_fallback, status_mapping, auto_publish_reports)
+    Bot::Fetch::Import.import_claim_review(claim_review, team_id, user_id, status_fallback, status_mapping, auto_publish_reports)
+  end
+end


### PR DESCRIPTION
Use a regular `FetchWorker` instead of executing a delayed class method. This way we can customize the interval between retries and thus avoid some database errors.

Fixes CHECK-2619.