### PR TITLE
Bulk-import medias from shared feed.

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -608,6 +608,9 @@ class Bot::Alegre < BotUser
   def self.can_create_relationship?(source, target, relationship_type)
     return false if source.nil? || target.nil?
     return false if self.is_suggested_to_trash(source, target, relationship_type)
+    # Make sure that items imported from shared feed are not related automatically to anything,
+    # since multiple medias can be imported at the same time, so the imported medias should form a cluster themselves
+    return false if target.is_imported_from_shared_feed?
     return true
   end
 

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -147,7 +147,7 @@ module ProjectMediaCreators
     ]
   end
 
-  def create_relationship(type = Relationship.default_type)
+  def create_relationship(type = Relationship.confirmed_type)
     unless self.related_to_id.nil?
       related = ProjectMedia.where(id: self.related_to_id).last
       unless related.nil?

--- a/app/models/concerns/project_media_getters.rb
+++ b/app/models/concerns/project_media_getters.rb
@@ -39,6 +39,10 @@ module ProjectMediaGetters
     self.is_image? || self.is_audio? || self.is_video?
   end
 
+  def is_imported_from_shared_feed?
+    self.channel.to_h['main'] == ::CheckChannels::ChannelCodes::SHARED_DATABASE
+  end
+
   def report_type
     self.media.class.name.downcase
   end


### PR DESCRIPTION
* Disable automatic similarity matching for items imported from shared feeds (because the cluster should be manually-formed by the items imported)
* When creating a new item related to another one, set the relationship type as "confirmed" instead of "default", which was deprecated a while ago

Reference: CHECK-2508.