### PR TITLE
Inherit report when pinning a new item

### DIFF
--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -534,4 +534,21 @@ class RelationshipTest < ActiveSupport::TestCase
       assert_equal p.id, pm_t3.reload.project_id
     end
   end
+
+  test "should inherit report when pinning new main item" do
+    t = create_team
+    pm1 = create_project_media team: t
+    pm2 = create_project_media team: t
+    r = create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
+    publish_report(pm1)
+    assert_not_nil pm1.get_dynamic_annotation('report_design')
+    assert_nil pm2.get_dynamic_annotation('report_design')
+
+    r = Relationship.find(r.id)
+    r.source_id = pm2.id
+    r.target_id = pm1.id
+    r.save!
+    assert_nil pm1.get_dynamic_annotation('report_design')
+    assert_not_nil pm2.get_dynamic_annotation('report_design')
+  end
 end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -538,6 +538,7 @@ class RelationshipTest < ActiveSupport::TestCase
   test "should inherit report when pinning new main item" do
     t = create_team
     pm1 = create_project_media team: t
+    create_claim_description project_media: pm1
     pm2 = create_project_media team: t
     r = create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
     publish_report(pm1)


### PR DESCRIPTION
There is a similarity relationship between items A and B. A is the main. A has report, claim and fact-check. If B is pinned (so, the relationship between A and B is inverted and B becomes the new main item), then B should inherit the report, claim and fact-check from A.

Fixes CHECK-2753.