### PR TITLE
Add migration to delete unused Annotation Type for Archive.is

### DIFF
--- a/db/migrate/20221122015259_remove_archive_is_annotation_type.rb
+++ b/db/migrate/20221122015259_remove_archive_is_annotation_type.rb
@@ -1,0 +1,9 @@
+class RemoveArchiveIsAnnotationType < ActiveRecord::Migration[5.2]
+  class DynamicAnnotationType < ActiveRecord::Base
+    self.table_name = :dynamic_annotation_annotation_types
+  end
+
+  def change
+    DynamicAnnotationType.where(annotation_type: 'archive_is').delete_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_22_013817) do
+ActiveRecord::Schema.define(version: 2022_11_22_015259) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
The rest of code was deleted in a previous commit.