### PR TITLE
Fix: Send message to tipline user on timeout.

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -983,8 +983,8 @@ class Bot::Smooch < BotUser
         annotated = self.get_saved_search_results_for_user(uid)
         type = 'timeout_search_requests'
       end
-      self.bundle_messages(uid, message['_id'], app_id, type, annotated, true)
       self.send_resource_to_user_on_timeout(uid, workflow, language)
+      self.bundle_messages(uid, message['_id'], app_id, type, annotated, true)
       sm.reset
     end
   end


### PR DESCRIPTION
There is a condition where a message is only sent to the tipline user on timeout if the user has any bundled messages not stored yet. But since bundled messages are stored before the message is sent, that condition will never be met. Fixing by changing the order of things... first, a message is sent on timeout, after that the bundled messages are stored.

Fixes CHECK-2747.