### PR TITLE
When importing an article from Fetch, set the fact-check summary to be blank if it's equal to the title.

### DIFF
--- a/app/models/bot/fetch.rb
+++ b/app/models/bot/fetch.rb
@@ -227,6 +227,15 @@ class Bot::Fetch < BotUser
       self.parse_text(title.to_s)
     end
 
+    def self.get_summary(claim_review)
+      url = claim_review['url'].to_s
+      title = self.get_title(claim_review).to_s
+      text = claim_review['text'].to_s.blank? ? claim_review['headline'] : claim_review['text']
+      return '' if text.to_s == title.to_s || text.blank?
+      summary = self.parse_text(text)
+      summary.to_s.truncate(900 - title.size - url.size)
+    end
+
     def self.set_claim_and_fact_check(claim_review, pm, user)
       current_user = User.current
       User.current = user
@@ -243,8 +252,7 @@ class Bot::Fetch < BotUser
       fc.claim_description = cd
       fc.title = self.get_title(claim_review).to_s
       fc.url = claim_review['url'].to_s
-      summary = self.parse_text(claim_review['text'].to_s.blank? ? claim_review['headline'] : claim_review['text'])
-      fc.summary = summary.to_s.truncate(900 - fc.title.size - fc.url.size)
+      fc.summary = self.get_summary(claim_review).to_s
       fc.user = user
       fc.skip_report_update = true
       fc.language = claim_review['inLanguage']

--- a/test/models/bot/fetch_test.rb
+++ b/test/models/bot/fetch_test.rb
@@ -261,4 +261,18 @@ class Bot::FetchTest < ActiveSupport::TestCase
 
     assert_equal 'verified', pm.reload.last_status
   end
+
+  test "should return empty summary if it is equal to the title" do
+    claim_review = {
+      'text' => 'Foo',
+      'headline' => 'Foo'
+    }
+    assert_equal '', Bot::Fetch::Import.get_summary(claim_review)
+
+    claim_review = {
+      'text' => 'Foo',
+      'headline' => 'Bar'
+    }
+    assert_equal 'Foo', Bot::Fetch::Import.get_summary(claim_review)
+  end
 end


### PR DESCRIPTION
Fixes CHECK-2686.