### PR TITLE
CHECK-2748 - no fuzzy search for emoji only query

### DIFF
--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -191,7 +191,7 @@ module SmoochSearch
       results = CheckSearch.new(filters.to_json, nil, team_ids).medias
       Rails.logger.info "[Smooch Bot] Keyword search got #{results.count} results (only main items) while looking for '#{words}' after date #{after.inspect} for teams #{team_ids}"
       if results.empty? and not words.join().gsub(/\P{L}/u, ' ').strip().blank?
-        results = CheckSearch.new(filters.merge({ keyword: words.collect{ |w| "+#{w}~1" }.join(' '), show_similar: true }).to_json, nil, team_ids).medias
+        results = CheckSearch.new(filters.merge({ keyword: words.collect{ |w| w =~ /^\P{L}$/u ? "+#{w}" : "+#{w}~1" }.join(' '), show_similar: true }).to_json, nil, team_ids).medias
         Rails.logger.info "[Smooch Bot] Keyword search got #{results.count} results (including secondary items and using fuzzy matching) while looking for '#{words}' after date #{after.inspect} for teams #{team_ids}"
       end
       results

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -190,7 +190,7 @@ module SmoochSearch
       filters.merge!({ range: { updated_at: { start_time: after.strftime('%Y-%m-%dT%H:%M:%S.%LZ') } } }) unless after.blank?
       results = CheckSearch.new(filters.to_json, nil, team_ids).medias
       Rails.logger.info "[Smooch Bot] Keyword search got #{results.count} results (only main items) while looking for '#{words}' after date #{after.inspect} for teams #{team_ids}"
-      if results.empty?
+      if results.empty? and not words.join().gsub(/\P{L}/u, ' ').strip().blank?
         results = CheckSearch.new(filters.merge({ keyword: words.collect{ |w| "+#{w}~1" }.join(' '), show_similar: true }).to_json, nil, team_ids).medias
         Rails.logger.info "[Smooch Bot] Keyword search got #{results.count} results (including secondary items and using fuzzy matching) while looking for '#{words}' after date #{after.inspect} for teams #{team_ids}"
       end

--- a/test/models/bot/smooch_5_test.rb
+++ b/test/models/bot/smooch_5_test.rb
@@ -571,7 +571,6 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
 
     assert_equal [], Bot::Smooch.search_for_similar_published_fact_checks('text', 'Segurando', [t.id]).to_a.map(&:id)
   end
-end
 
   test "should *not* perform fuzzy matching on keyword search when query is emoji only" do
     RequestStore.store[:skip_cached_field_update] = false


### PR DESCRIPTION
When a query is only emoji, we should not run a fuzzy search