### PR TITLE
Avoid circular dependency in feed request.

### DIFF
--- a/lib/tasks/data/reclusterize_requests.rake
+++ b/lib/tasks/data/reclusterize_requests.rake
@@ -46,9 +46,8 @@ namespace :check do
         i += 1
         failed = false
         begin
-          Request.send_to_alegre(r.id)
-          r = Request.find(r.id)
           r.attach_to_similar_request!
+          Request.send_to_alegre(r.id)
         rescue Exception => e
           failed = e.message
         end

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -330,4 +330,12 @@ class RequestTest < ActiveSupport::TestCase
     assert_equal 'UploadedImage', r.media_type(true)
     Bot::Alegre.unstub(:request_api)
   end
+
+  test "should not have a circular dependency" do
+    r = create_request
+    assert_raises ActiveRecord::RecordInvalid do
+      r.similar_to_request = r
+      r.save!
+    end
+  end
 end


### PR DESCRIPTION
When looking for a feed request that is similar to another feed request, be sure that a circular relation doesn't happen: a feed request can't be similar to itself.

Fixes CHECK-2773.