### PR TITLE
Stop sending Redis information to Honeycomb

### DIFF
--- a/lib/check_open_telemetry_config.rb
+++ b/lib/check_open_telemetry_config.rb
@@ -24,7 +24,6 @@ module Check
         config.use 'OpenTelemetry::Instrumentation::Net::HTTP'
         config.use 'OpenTelemetry::Instrumentation::PG'
         config.use 'OpenTelemetry::Instrumentation::Rails'
-        config.use 'OpenTelemetry::Instrumentation::Redis'
         config.use 'OpenTelemetry::Instrumentation::RestClient'
         config.use 'OpenTelemetry::Instrumentation::Sidekiq'
         config.use 'OpenTelemetry::Instrumentation::Sinatra'


### PR DESCRIPTION
Redis accounts for most of our events in Honeycomb, which we're often going over, but we don't find it very useful. This removes the instrumentation so that we no longer track that information.