### PR TITLE
Send "main menu" as a separate message on final messages

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -885,7 +885,7 @@ class Bot::Smooch < BotUser
       end
       if report.report_design_field_value('use_text_message')
         workflow = self.get_workflow(lang)
-        last_smooch_response = self.send_final_message_to_user(uid, report.report_design_text(lang), workflow, lang)
+        last_smooch_response = self.send_final_messages_to_user(uid, report.report_design_text(lang), workflow, lang)
         Rails.logger.info "[Smooch Bot] Sent text report to user #{uid} for item with ID #{pm.id}, response was: #{last_smooch_response.to_json}"
       elsif report.report_design_field_value('use_visual_card')
         last_smooch_response = self.send_message_to_user(uid, '', { 'type' => 'image', 'mediaUrl' => report.report_design_image_url })

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -64,6 +64,16 @@ module SmoochMessages
       end
     end
 
+    def send_final_messages_to_user(uid, text, workflow, language)
+      response = self.send_message_to_user(uid, text)
+      if self.is_v2?
+        CheckStateMachine.new(uid).go_to_main
+        sleep 1
+        response = self.send_message_to_user_with_main_menu_appended(uid, self.get_string('navigation_button', language), workflow, language)
+      end
+      response
+    end
+
     def send_message_for_state(uid, workflow, state, language, pretext = '')
       message = self.utmize_urls(self.get_message_for_state(workflow, state, language, uid).to_s, 'resource')
       text = [pretext, message].reject{ |part| part.blank? }.join("\n\n")

--- a/app/models/concerns/smooch_newsletter.rb
+++ b/app/models/concerns/smooch_newsletter.rb
@@ -108,7 +108,7 @@ module SmoochNewsletter
       newsletter_workflow = self.get_workflow(newsletter_language)
       date = I18n.l(Time.now.to_date, locale: newsletter_language.to_s.tr('_', '-'), format: :long)
       newsletter = Bot::Smooch.build_newsletter_content(newsletter_workflow['smooch_newsletter'], newsletter_language, self.config['team_id'], false).gsub('{date}', date).gsub('{channel}', self.get_platform_from_message(message))
-      Bot::Smooch.send_final_message_to_user(uid, newsletter, newsletter_workflow, newsletter_language)
+      Bot::Smooch.send_final_messages_to_user(uid, newsletter, newsletter_workflow, newsletter_language)
     end
   end
 end

--- a/app/models/concerns/smooch_resend.rb
+++ b/app/models/concerns/smooch_resend.rb
@@ -123,7 +123,7 @@ module SmoochResend
     end
 
     def send_message_on_template_button_click(_message, uid, language, info)
-      self.send_final_message_to_user(uid, info[1], self.get_workflow(language), language)
+      self.send_final_messages_to_user(uid, info[1], self.get_workflow(language), language)
     end
 
     def clicked_on_template_button?(message)

--- a/app/models/concerns/smooch_resources.rb
+++ b/app/models/concerns/smooch_resources.rb
@@ -26,7 +26,7 @@ module SmoochResources
         end
       end
       message = self.utmize_urls(message.join("\n\n"), 'resource')
-      self.send_final_message_to_user(uid, message, workflow, language) unless message.blank?
+      self.send_final_messages_to_user(uid, message, workflow, language) unless message.blank?
     end
 
     def send_resource_to_user(uid, workflow, option, language)

--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -20,7 +20,7 @@ class TiplineNewsletterWorker
                 introduction = newsletter['smooch_newsletter_introduction'].to_s.gsub('{date}', date).gsub('{channel}', ts.platform)
                 content = Bot::Smooch.build_newsletter_content(newsletter, language, team_id).gsub('{date}', date).gsub('{channel}', ts.platform)
                 Bot::Smooch.get_installation { |i| i.id == tbi.id }
-                response = Bot::Smooch.send_final_message_to_user(ts.uid, content, workflow, language)
+                response = Bot::Smooch.send_final_messages_to_user(ts.uid, content, workflow, language)
                 Bot::Smooch.save_smooch_response(response, nil, nil, 'newsletter', language, { introduction: introduction })
                 log team_id, language, "Newsletter sent to subscriber ##{ts.id}, response: #{response.inspect}"
                 count += 1

--- a/test/workers/tipline_newsletter_worker_test.rb
+++ b/test/workers/tipline_newsletter_worker_test.rb
@@ -18,11 +18,11 @@ class TiplineNewsletterWorkerTest < ActiveSupport::TestCase
   end
 
   test "should not crash if error happens when sending newsletter to some subscriber" do
-    Bot::Smooch.stubs(:send_final_message_to_user).raises(StandardError)
+    Bot::Smooch.stubs(:send_final_messages_to_user).raises(StandardError)
     assert_nothing_raised do
       TiplineNewsletterWorker.perform_async(@team.id, 'en')
     end
-    Bot::Smooch.unstub(:send_final_message_to_user)
+    Bot::Smooch.unstub(:send_final_messages_to_user)
   end
 
   test "should skip sending newsletter if content hasn't changed" do


### PR DESCRIPTION
When the "main menu" is appended to a message, there is no preview for the URLs in that message. So, in order to have a preview rendered for URLs in final messages, the "main menu" is sent as a separate message. This applies for the following cases: resources, newsletters and reports.

Implementation-wise, that is pretty simple: in addition to the existing `send_final_message_to_user` there is now a new `send_final_messages_to_user`.

Reference: CHECK-2721.