### PR TITLE
Revert namespace change.

### DIFF
--- a/lib/tasks/data/reclusterize_requests.rake
+++ b/lib/tasks/data/reclusterize_requests.rake
@@ -1,6 +1,6 @@
 # rake check:data:clusterize_requests[feed_id,force]
 namespace :check do
-  namespace :data do
+  namespace :migrate do
     task clusterize_requests: :environment do |_t, params|
       feed_id = params.to_a.first.to_i
       force = (params.to_a.last.to_i == 1)


### PR DESCRIPTION
Given a bisect of deployed images, revert potentially problematic namespace change.