### PR TITLE
CHECK-2773: Recluster shared feed

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -44,13 +44,13 @@ class Request < ApplicationRecord
         words = ::Bot::Alegre.get_number_of_words(media.quote)
         models_thresholds = self.text_similarity_settings.reject{ |_k, v| v['min_words'] > words }
         if models_thresholds.count > 0
-          params = { text: media.quote, models: models_thresholds.keys, per_model_threshold: models_thresholds.transform_values{ |v| v['threshold'] }, context: context }
+          params = { text: media.quote, models: models_thresholds.keys, per_model_threshold: models_thresholds.transform_values{ |v| v['threshold'] }, limit: 10000, context: context }
           similar_request_id = ::Bot::Alegre.request_api('get', '/text/similarity/', params)&.dig('result').to_a.collect{ |result| result&.dig('_source', 'context', 'request_id').to_i }.find{ |id| id != 0 && id < self.id }
         end
       elsif ['UploadedImage', 'UploadedAudio', 'UploadedVideo'].include?(media.type)
         threshold = 0.85 #FIXME: Should be feed setting
         type = media.type.gsub(/^Uploaded/, '').downcase
-        params = { url: media.file.file.public_url, threshold: threshold, context: context }
+        params = { url: media.file.file.public_url, threshold: threshold, limit: 10000, context: context }
         similar_request_id = ::Bot::Alegre.request_api('get', "/#{type}/similarity/", params)&.dig('result').to_a.collect{ |result| result&.dig('context').to_a.collect{ |c| c['request_id'].to_i } }.flatten.find{ |id| id != 0 && id < self.id }
       end
     end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -38,20 +38,20 @@ class Request < ApplicationRecord
     media = self.media
     context = { feed_id: self.feed_id }
     # First try to find an identical media
-    similar_request_id = Request.where(media_id: media.id, feed_id: self.feed_id).where.not(id: self.id).order('id ASC').first
+    similar_request_id = Request.where(media_id: media.id, feed_id: self.feed_id).where('id < ?', self.id).order('id ASC').first
     if similar_request_id.nil?
       if media.type == 'Claim'
         words = ::Bot::Alegre.get_number_of_words(media.quote)
         models_thresholds = self.text_similarity_settings.reject{ |_k, v| v['min_words'] > words }
         if models_thresholds.count > 0
           params = { text: media.quote, models: models_thresholds.keys, per_model_threshold: models_thresholds.transform_values{ |v| v['threshold'] }, context: context }
-          similar_request_id = ::Bot::Alegre.request_api('get', '/text/similarity/', params)&.dig('result').to_a.collect{ |result| result&.dig('_source', 'context', 'request_id').to_i }.find{ |id| id != 0 && id != self.id }
+          similar_request_id = ::Bot::Alegre.request_api('get', '/text/similarity/', params)&.dig('result').to_a.collect{ |result| result&.dig('_source', 'context', 'request_id').to_i }.find{ |id| id != 0 && id < self.id }
         end
       elsif ['UploadedImage', 'UploadedAudio', 'UploadedVideo'].include?(media.type)
         threshold = 0.85 #FIXME: Should be feed setting
         type = media.type.gsub(/^Uploaded/, '').downcase
         params = { url: media.file.file.public_url, threshold: threshold, context: context }
-        similar_request_id = ::Bot::Alegre.request_api('get', "/#{type}/similarity/", params)&.dig('result').to_a.collect{ |result| result&.dig('context').to_a.collect{ |c| c['request_id'].to_i } }.flatten.find{ |id| id != 0 && id != self.id }
+        similar_request_id = ::Bot::Alegre.request_api('get', "/#{type}/similarity/", params)&.dig('result').to_a.collect{ |result| result&.dig('context').to_a.collect{ |c| c['request_id'].to_i } }.flatten.find{ |id| id != 0 && id < self.id }
       end
     end
     unless similar_request_id.blank?

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -34,7 +34,7 @@ class Request < ApplicationRecord
     }
   end
 
-  def attach_to_similar_request!
+  def attach_to_similar_request!(alegre_limit = 20)
     media = self.media
     context = { feed_id: self.feed_id }
     # First try to find an identical media
@@ -44,13 +44,13 @@ class Request < ApplicationRecord
         words = ::Bot::Alegre.get_number_of_words(media.quote)
         models_thresholds = self.text_similarity_settings.reject{ |_k, v| v['min_words'] > words }
         if models_thresholds.count > 0
-          params = { text: media.quote, models: models_thresholds.keys, per_model_threshold: models_thresholds.transform_values{ |v| v['threshold'] }, limit: 10000, context: context }
+          params = { text: media.quote, models: models_thresholds.keys, per_model_threshold: models_thresholds.transform_values{ |v| v['threshold'] }, limit: alegre_limit, context: context }
           similar_request_id = ::Bot::Alegre.request_api('get', '/text/similarity/', params)&.dig('result').to_a.collect{ |result| result&.dig('_source', 'context', 'request_id').to_i }.find{ |id| id != 0 && id < self.id }
         end
       elsif ['UploadedImage', 'UploadedAudio', 'UploadedVideo'].include?(media.type)
         threshold = 0.85 #FIXME: Should be feed setting
         type = media.type.gsub(/^Uploaded/, '').downcase
-        params = { url: media.file.file.public_url, threshold: threshold, limit: 10000, context: context }
+        params = { url: media.file.file.public_url, threshold: threshold, limit: alegre_limit, context: context }
         similar_request_id = ::Bot::Alegre.request_api('get', "/#{type}/similarity/", params)&.dig('result').to_a.collect{ |result| result&.dig('context').to_a.collect{ |c| c['request_id'].to_i } }.flatten.find{ |id| id != 0 && id < self.id }
       end
     end

--- a/lib/tasks/data/reclusterize_requests.rake
+++ b/lib/tasks/data/reclusterize_requests.rake
@@ -39,14 +39,14 @@ namespace :check do
       end
 
       # Clusterize
-      query = Request.where(request_id: nil, feed_id: feed_id).order('id ASC')
+      query = Request.where(request_id: nil, feed_id: feed_id).order('id ASC') #Add request_type:'text' to only recluster text items
       n = query.count
       i = 0
       query.find_each do |r|
         i += 1
         failed = false
         begin
-          r.attach_to_similar_request!
+          r.attach_to_similar_request!(alegre_limit = 10000)
           Request.send_to_alegre(r.id)
         rescue Exception => e
           failed = e.message

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -139,7 +139,7 @@ class RequestTest < ActiveSupport::TestCase
     m2 = Media.create! type: 'Claim', quote: 'Foo bar foo bar 2'
     r2 = create_request media: m2, feed: f
     response = { 'result' => [{ '_source' => { 'context' => { 'request_id' => r1.id } } }] }
-    Bot::Alegre.stubs(:request_api).with('get', '/text/similarity/', { text: 'Foo bar foo bar 2', models: [::Bot::Alegre::ELASTICSEARCH_MODEL, ::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::ELASTICSEARCH_MODEL => 0.85, ::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, context: { feed_id: f.id } }).returns(response)
+    Bot::Alegre.stubs(:request_api).with('get', '/text/similarity/', { text: 'Foo bar foo bar 2', models: [::Bot::Alegre::ELASTICSEARCH_MODEL, ::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::ELASTICSEARCH_MODEL => 0.85, ::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
     r2.attach_to_similar_request!
     #Alegre should be called with ES and vector model for request with 4 or more words
     assert_equal r1, r2.reload.similar_to_request
@@ -155,7 +155,7 @@ class RequestTest < ActiveSupport::TestCase
     m2 = Media.create! type: 'Claim', quote: 'Foo bar 2'
     r2 = create_request media: m2, feed: f
     response = { 'result' => [{ '_source' => { 'context' => { 'request_id' => r1.id } } }] }
-    Bot::Alegre.stubs(:request_api).with('get', '/text/similarity/', { text: 'Foo bar 2', models: [::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, context: { feed_id: f.id } }).returns(response)
+    Bot::Alegre.stubs(:request_api).with('get', '/text/similarity/', { text: 'Foo bar 2', models: [::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
     r2.attach_to_similar_request!
     #Alegre should only be called with vector models for 2 or 3 word request
     assert_equal r1, r2.reload.similar_to_request
@@ -185,7 +185,7 @@ class RequestTest < ActiveSupport::TestCase
     m2 = create_uploaded_image
     r2 = create_request request_type: 'image', media: m2, feed: f
     response = { 'result' => [{ 'context' => [{ 'request_id' => r1.id }] }] }
-    Bot::Alegre.stubs(:request_api).with('get', '/image/similarity/', { url: m2.file.file.public_url, threshold: 0.85, context: { feed_id: f.id } }).returns(response)
+    Bot::Alegre.stubs(:request_api).with('get', '/image/similarity/', { url: m2.file.file.public_url, threshold: 0.85, limit: 20, context: { feed_id: f.id } }).returns(response)
     r2.attach_to_similar_request!
     assert_equal r1, r2.reload.similar_to_request
     assert_equal [r2], r1.reload.similar_requests


### PR DESCRIPTION
Update Request model to require parent (request_id) to have a lower id than the child. This shouldn't have any effect on on-going /realtime clustering. It is, however, necessary when reclustering a feed.