### PR TITLE
Do not sort languages supported by a tipline.

### DIFF
--- a/app/models/concerns/smooch_language.rb
+++ b/app/models/concerns/smooch_language.rb
@@ -37,7 +37,7 @@ module SmoochLanguage
         l = w['smooch_workflow_language']
         languages << l if team_languages.include?(l)
       end
-      languages.sort
+      languages
     end
 
     def should_ask_for_language_confirmation?(uid)


### PR DESCRIPTION
This way it's possible to manually define a particular order for the languages.

Fixes: CHECK-2805.