### PR TITLE
Refactoring what happens when a tipline conversation times out.

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -983,7 +983,7 @@ class Bot::Smooch < BotUser
         annotated = self.get_saved_search_results_for_user(uid)
         type = 'timeout_search_requests'
       end
-      self.send_resource_to_user_on_timeout(uid, workflow, language)
+      self.send_message_to_user_on_timeout(uid, workflow, language)
       self.bundle_messages(uid, message['_id'], app_id, type, annotated, true)
       sm.reset
     end

--- a/app/models/concerns/smooch_resources.rb
+++ b/app/models/concerns/smooch_resources.rb
@@ -35,11 +35,11 @@ module SmoochResources
       resource.blank? ? nil : BotResource.find_by_uuid(resource['smooch_custom_resource_id'])
     end
 
-    def send_resource_to_user_on_timeout(uid, workflow, language)
+    def send_message_to_user_on_timeout(uid, workflow, language)
       redis = Redis.new(REDIS_CONFIG)
       user_messages_count = redis.llen("smooch:bundle:#{uid}")
-      resource = workflow['smooch_message_smooch_bot_no_action'] unless workflow.blank?
-      self.send_rss_to_user(uid, resource, workflow, language, true) if !resource.blank? && user_messages_count > 0
+      message = workflow['timeout'] || self.get_string(:timeout, language)
+      self.send_final_messages_to_user(uid, message, workflow, language) if user_messages_count > 0
     end
 
     def render_articles_from_rss_feed(url, count = 3)

--- a/app/models/concerns/smooch_strings.rb
+++ b/app/models/concerns/smooch_strings.rb
@@ -1,7 +1,7 @@
 
 require 'active_support/concern'
 
-TIPLINE_STRINGS = YAML.load(File.read(File.join(Rails.root, 'config', 'tipline_strings.yml')))
+TIPLINE_STRINGS = YAML.load(File.read(File.join(Rails.root, 'config', 'tipline_strings.yml'))).with_indifferent_access
 
 module SmoochStrings
   extend ActiveSupport::Concern

--- a/config/tipline_strings.yml
+++ b/config/tipline_strings.yml
@@ -213,6 +213,7 @@ en:
   main_menu: Main menu
   main_state_button_label: Cancel
   navigation_button: Use the buttons to navigate
+  timeout: Thank you for reaching out to us! Type any key to start a new conversation.
   privacy_and_purpose: |-
     Privacy and Purpose
 


### PR DESCRIPTION
* No more resource or RSS feed: Now just a regular message is sent
* This message can be customized per workflow
* If not customized, a default message is sent

Reference: CHECK-2747.