### PR TITLE
Refactoring/normalizing how strings are localized on the tipline.

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -970,7 +970,6 @@ class Bot::Smooch < BotUser
     self.get_installation(self.installation_setting_id_keys, app_id) if self.config.blank?
     return if self.config['smooch_disable_timeout']
     language = self.get_user_language(message)
-    workflow = self.get_workflow(language)
     uid = message['authorId']
     stored_time = Rails.cache.read("smooch:last_message_from_user:#{uid}").to_i
     return if stored_time > time
@@ -983,7 +982,7 @@ class Bot::Smooch < BotUser
         annotated = self.get_saved_search_results_for_user(uid)
         type = 'timeout_search_requests'
       end
-      self.send_message_to_user_on_timeout(uid, workflow, language)
+      self.send_message_to_user_on_timeout(uid, language)
       self.bundle_messages(uid, message['_id'], app_id, type, annotated, true)
       sm.reset
     end

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -372,7 +372,7 @@ class Bot::Smooch < BotUser
       end
     when 'main', 'secondary', 'subscription', 'search_result'
       unless self.process_menu_option(message, state, app_id)
-        self.send_message_for_state(uid, workflow, state, language, workflow['smooch_message_smooch_bot_option_not_available'] || self.get_string(:option_not_available, language))
+        self.send_message_for_state(uid, workflow, state, language, self.get_custom_string(:option_not_available, language))
       end
     when 'search'
       self.send_message_to_user(uid, self.get_message_for_state(workflow, state, language, uid))
@@ -472,7 +472,7 @@ class Bot::Smooch < BotUser
     sm.send("go_to_#{new_state}")
     self.delay_for(1.seconds, { queue: 'smooch_priority', retry: false }).search(app_id, uid, language, message, self.config['team_id'].to_i, workflow) if new_state == 'search'
     self.clear_user_bundled_messages(uid) if new_state == 'main'
-    new_state == 'main' && self.is_v2? ? self.send_message_to_user_with_main_menu_appended(uid, self.get_menu_string('cancelled', language), workflow, language) : self.send_message_for_state(uid, workflow, new_state, language)
+    new_state == 'main' && self.is_v2? ? self.send_message_to_user_with_main_menu_appended(uid, self.get_string('cancelled', language), workflow, language) : self.send_message_for_state(uid, workflow, new_state, language)
   end
 
   def self.process_menu_option_value(value, option, message, language, workflow, app_id)
@@ -502,7 +502,7 @@ class Bot::Smooch < BotUser
       self.bundle_message(message)
       results = self.get_saved_search_results_for_user(uid)
       self.delay_for(1.seconds, { queue: 'smooch', retry: false }).bundle_messages(uid, message['_id'], app_id, 'relevant_search_result_requests', results, true, self.bundle_search_query(uid))
-      self.send_final_message_to_user(uid, self.get_menu_string('search_result_is_relevant', language), workflow, language)
+      self.send_final_message_to_user(uid, self.get_custom_string('search_result_is_relevant', language), workflow, language)
     elsif value =~ CheckCldr::LANGUAGE_FORMAT_REGEXP
       Rails.cache.write("smooch:user_language:#{uid}", value)
       Rails.cache.write("smooch:user_language:#{self.config['team_id']}:#{uid}:confirmed", value)

--- a/app/models/concerns/smooch_menus.rb
+++ b/app/models/concerns/smooch_menus.rb
@@ -42,9 +42,9 @@ module SmoochMenus
       # Languages and privacy
       rows = []
       languages = self.get_supported_languages
-      title = self.get_menu_string('privacy_title', language, 24)
+      title = self.get_string('privacy_title', language, 24)
       if languages.size > 1
-        title = self.get_menu_string('languages_and_privacy_title', language, 24)
+        title = self.get_string('languages_and_privacy_title', language, 24)
         languages.reject{ |l| l == language }.each do |l|
           rows << {
             id: { state: 'main', keyword: counter.to_s }.to_json,
@@ -57,7 +57,7 @@ module SmoochMenus
       end
       rows << {
         id: { state: 'main', keyword: '9' }.to_json,
-        title: self.get_menu_string('privacy_statement', language, 24)
+        title: self.get_string('privacy_statement', language, 24)
       }
       number_of_options += 1
       main << {
@@ -77,7 +77,7 @@ module SmoochMenus
                   text: text.truncate(1024)
                 },
                 action: {
-                  button: self.get_menu_string('main_menu', language, 20),
+                  button: self.get_string('main_menu', language, 20),
                   sections: main.reject{ |m| m[:rows].empty? }
                 }
               }
@@ -120,7 +120,7 @@ module SmoochMenus
       new_rows = rows.dup
       new_rows = [{
         id: { state: 'main', keyword: JSON.parse(rows.first[:id])['keyword'] }.to_json,
-        title: '🌐 ' + self.get_menu_string('languages', language, 24)
+        title: '🌐 ' + self.get_string('languages', language, 24)
       }] if number_of_options >= 10
       new_rows
     end
@@ -132,7 +132,7 @@ module SmoochMenus
       counter
     end
 
-    def get_menu_string(key, language, truncate_at = 1024)
+    def get_custom_string(key, language, truncate_at = 1024)
       # Truncation happens because WhatsApp has limitations:
       # - Section title: 24 characters
       # - Menu item title: 24 characters
@@ -140,9 +140,8 @@ module SmoochMenus
       # - Button label: 20 characters
       # - Body: 1024 characters
       workflow = self.get_workflow(language) || {}
-      label = workflow[key.to_s] || self.get_string(key, language) || {
+      label = workflow[key.to_s] || {
         # Default values for customizable strings
-        cancelled: 'OK! Your submission is canceled.',
         ask_if_ready_state: 'Are you ready to submit?',
         add_more_details_state: 'Please add more content.',
         search_state: 'Thank you! Looking for fact-checks, it may take a minute.',
@@ -152,7 +151,7 @@ module SmoochMenus
         search_result_is_relevant: 'Thank you! Spread the word about this tipline to help us fight misinformation! *insert_entry_point_link*',
         newsletter_optin_optout: '{subscription_status}',
         option_not_available: 'Option not available.',
-        languages: 'Languages'
+        timeout: 'Thank you for reaching out to us! Type any key to start a new conversation.'
       }[key.to_sym] || key
       label.truncate(truncate_at)
     end
@@ -262,7 +261,7 @@ module SmoochMenus
       options = []
       i = 0
       self.get_supported_languages.each do |l|
-        text << self.get_menu_string('confirm_preferred_language', l)
+        text << self.get_string('confirm_preferred_language', l)
         i = self.get_next_menu_item_number(i)
         options << {
           value: { state: 'main', keyword: i.to_s }.to_json,
@@ -272,7 +271,7 @@ module SmoochMenus
       text = text.join("\n\n")
       if ['Telegram', 'Viber', 'Facebook Messenger'].include?(self.request_platform)
         text = '🌐​' unless with_text
-        self.send_message_to_user_with_single_section_menu(uid, text, options, self.get_menu_string('languages', language))
+        self.send_message_to_user_with_single_section_menu(uid, text, options, self.get_string('languages', language))
       else
         self.send_message_to_user(uid, text) if with_text
         options.each_slice(3).to_a.each do |sub_options|

--- a/app/models/concerns/smooch_menus.rb
+++ b/app/models/concerns/smooch_menus.rb
@@ -140,7 +140,8 @@ module SmoochMenus
       # - Button label: 20 characters
       # - Body: 1024 characters
       workflow = self.get_workflow(language) || {}
-      label = workflow[key.to_s] || {
+      custom_label = workflow.with_indifferent_access[key.to_s]
+      default_label = {
         # Default values for customizable strings
         ask_if_ready_state: 'Are you ready to submit?',
         add_more_details_state: 'Please add more content.',
@@ -153,7 +154,8 @@ module SmoochMenus
         option_not_available: 'Option not available.',
         timeout: 'Thank you for reaching out to us! Type any key to start a new conversation.'
       }[key.to_sym] || key
-      label.truncate(truncate_at)
+      label = custom_label.blank? ? default_label : custom_label
+      label.to_s.truncate(truncate_at)
     end
 
     def send_message_to_user_with_buttons(uid, text, options)

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -107,7 +107,7 @@ module SmoochMessages
         end
         options << {
           value: { keyword: keyword }.to_json,
-          label: self.get_menu_string("#{key}_button_label", language, 20)
+          label: self.get_string("#{key}_button_label", language, 20)
         }
       end
       options.size > 0 ? self.send_message_to_user_with_buttons(uid, text, options) : self.send_message_to_user(uid, text)
@@ -122,15 +122,15 @@ module SmoochMessages
       end
       message << self.subscription_message(uid, language) if state.to_s == 'subscription'
       message << workflow.dig("smooch_state_#{state}", 'smooch_menu_message') if state != 'main' || !is_v2
-      message << self.get_menu_string("#{state}_state", language) if ['search', 'search_result', 'add_more_details', 'ask_if_ready'].include?(state.to_s)
+      message << self.get_custom_string("#{state}_state", language) if ['search', 'search_result', 'add_more_details', 'ask_if_ready'].include?(state.to_s)
       message.reject{ |m| m.blank? }.join("\n\n")
     end
 
     def subscription_message(uid, language, subscribed = nil, full_message = true)
       subscribed = subscribed.nil? ? !TiplineSubscription.where(team_id: self.config['team_id'], uid: uid, language: language).last.nil? : subscribed
-      status = subscribed ? self.get_menu_string('subscribed', language.gsub(/[-_].*$/, '')) : self.get_menu_string('unsubscribed', language.gsub(/[-_].*$/, ''))
+      status = subscribed ? self.get_string('subscribed', language.gsub(/[-_].*$/, '')) : self.get_string('unsubscribed', language.gsub(/[-_].*$/, ''))
       status = "*#{status}*"
-      full_message ? self.get_menu_string('newsletter_optin_optout', language).gsub('{subscription_status}', status) : status
+      full_message ? self.get_custom_string('newsletter_optin_optout', language).gsub('{subscription_status}', status) : status
     end
 
     def send_message_if_disabled_and_return_state(uid, workflow, state)

--- a/app/models/concerns/smooch_resources.rb
+++ b/app/models/concerns/smooch_resources.rb
@@ -35,12 +35,11 @@ module SmoochResources
       resource.blank? ? nil : BotResource.find_by_uuid(resource['smooch_custom_resource_id'])
     end
 
-    def send_message_to_user_on_timeout(uid, workflow, language)
+    def send_message_to_user_on_timeout(uid, language)
       sm = CheckStateMachine.new(uid)
       redis = Redis.new(REDIS_CONFIG)
       user_messages_count = redis.llen("smooch:bundle:#{uid}")
-      message = workflow['timeout']
-      message = self.get_string(:timeout, language) if message.blank?
+      message = self.get_custom_string(:timeout, language)
       self.send_message_to_user(uid, message) if user_messages_count > 0 && sm.state.value != 'main'
       sm.reset
     end

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -13,7 +13,7 @@ module SmoochSearch
         results = self.get_search_results(uid, message, team_id, language)
         if results.empty?
           self.bundle_messages(uid, '', app_id, 'default_requests', nil, true)
-          self.send_final_message_to_user(uid, self.get_menu_string('search_no_results', language), workflow, language)
+          self.send_final_message_to_user(uid, self.get_custom_string('search_no_results', language), workflow, language)
         else
           self.send_search_results_to_user(uid, results)
           sm.go_to_search_result
@@ -48,7 +48,7 @@ module SmoochSearch
 
     def submit_search_query_for_verification(uid, app_id, workflow, language)
       self.delay_for(1.seconds, { queue: 'smooch', retry: false }).bundle_messages(uid, '', app_id, 'irrelevant_search_result_requests', nil, true, self.bundle_search_query(uid))
-      self.send_final_message_to_user(uid, self.get_menu_string('search_submit', language), workflow, language)
+      self.send_final_message_to_user(uid, self.get_custom_string('search_submit', language), workflow, language)
     end
 
     def ask_if_ready_to_submit(uid, workflow, state, language)

--- a/app/models/concerns/smooch_strings.rb
+++ b/app/models/concerns/smooch_strings.rb
@@ -7,9 +7,16 @@ module SmoochStrings
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def get_string(key, language)
+    def get_string(key, language, truncate_at = 1024)
+      # Truncation happens because WhatsApp has limitations:
+      # - Section title: 24 characters
+      # - Menu item title: 24 characters
+      # - Menu item description: 72 characters
+      # - Button label: 20 characters
+      # - Body: 1024 characters
       strings = TIPLINE_STRINGS[language] || TIPLINE_STRINGS[language.gsub(/[-_].*$/, '')] || TIPLINE_STRINGS['en']
-      strings[key] || key
+      string = strings[key] || key
+      string.truncate(truncate_at)
     end
   end
 end

--- a/config/tipline_strings.yml
+++ b/config/tipline_strings.yml
@@ -213,7 +213,6 @@ en:
   main_menu: Main menu
   main_state_button_label: Cancel
   navigation_button: Use the buttons to navigate
-  timeout: Thank you for reaching out to us! Type any key to start a new conversation.
   privacy_and_purpose: |-
     Privacy and Purpose
 


### PR DESCRIPTION
* The method `get_string` is only for hard-coded tipline strings, downloaded from Transifex into a YML file
* The method `get_menu_string` was renamed to `get_custom_string` and returns either a custom string/translation stored in a tipline workflow (so, in the database, in the Smooch Bot installation settings) or a default string in English

Reference: CHECK-2747.