### PR TITLE
Fixing timeout message when tipline is connected to both Smooch and self-hosted WABA

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -963,11 +963,12 @@ class Bot::Smooch < BotUser
     uid = message['authorId']
     time = Time.now.to_f
     Rails.cache.write("smooch:last_message_from_user:#{uid}", time)
-    self.delay_for(15.minutes, { queue: 'smooch' }).timeout_smooch_menu(time, message, app_id)
+    self.delay_for(15.minutes, { queue: 'smooch' }).timeout_smooch_menu(time, message, app_id, RequestStore.store[:smooch_bot_provider])
   end
 
-  def self.timeout_smooch_menu(time, message, app_id)
+  def self.timeout_smooch_menu(time, message, app_id, provider)
     self.get_installation(self.installation_setting_id_keys, app_id) if self.config.blank?
+    RequestStore.store[:smooch_bot_provider] = provider
     return if self.config['smooch_disable_timeout']
     language = self.get_user_language(message)
     uid = message['authorId']

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -536,7 +536,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     assert_equal 'search_result', sm.state.value
 
     message = { 'authorId' => uid, '_id' => random_string }
-    assert_nil Bot::Smooch.timeout_smooch_menu(Time.now + 30.minutes, message, @app_id)
+    assert_nil Bot::Smooch.timeout_smooch_menu(Time.now + 30.minutes, message, @app_id, 'ZENDESK')
   end
 
   test "should send report notification with button after 24 hours window" do


### PR DESCRIPTION
Fixes CHECK-2837.