### PR TITLE
Avoid duplicate user messages when bundling

### DIFF
--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -36,7 +36,7 @@ module SmoochMessages
     def list_of_bundled_messages_from_user(uid)
       redis = Redis.new(REDIS_CONFIG)
       key = "smooch:bundle:#{uid}"
-      redis.lrange(key, 0, redis.llen(key))
+      redis.lrange(key, 0, redis.llen(key)).to_a.uniq
     end
 
     def bundle_messages(uid, id, app_id, type = 'default_requests', annotated = nil, force = false, bundle = nil)

--- a/test/models/bot/smooch_5_test.rb
+++ b/test/models/bot/smooch_5_test.rb
@@ -134,8 +134,8 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
       a = Dynamic.where(conditions).last
       f = a.get_field_value('smooch_data')
       text  = JSON.parse(f)['text'].split("\n#{Bot::Smooch::MESSAGE_BOUNDARY}")
-      # verify that all messages stored
-      assert_equal 4, text.size
+      # Verify that all messages were stored
+      assert_equal 3, text.size
       assert_equal '1', text.last
       send_message_to_smooch_bot(random_string, uid)
       assert_equal 'main', sm.state.value
@@ -151,7 +151,7 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
       f = a.get_field_value('smooch_data')
       text  = JSON.parse(f)['text'].split("\n#{Bot::Smooch::MESSAGE_BOUNDARY}")
       # verify that all messages stored
-      assert_equal 6, text.size
+      assert_equal 5, text.size
       assert_equal '1', text.last
       send_message_to_smooch_bot(random_string, uid)
       assert_equal 'main', sm.state.value


### PR DESCRIPTION
When a user finishes interacting with the tipline bot, all messages that were sent by the user during the interaction are bundled into a single one. In some cases, some messages can be duplicated, either by a race condition, duplicate bundling or just because the user sends twice. So, be sure to de-duplicate messages before bundling.

Fixes CHECK-2846.