### PR TITLE
Disable PaperTrail from tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -53,4 +53,10 @@ Rails.application.configure do
 
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
+
+  # Disable PaperTrail by default on tests
+  # https://github.com/paper-trail-gem/paper_trail#7-testing
+  config.after_initialize do
+    PaperTrail.enabled = false
+  end
 end

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -604,12 +604,15 @@ module SampleData
   end
 
   def create_version(options = {})
-    t = create_team
-    claim = create_claim_media skip_check_ability: true
-    User.current = options[:user] || create_user
-    pm = create_project_media team: t, media: claim, skip_check_ability: true
-    v = pm.versions.from_partition(t.id).where(item_type: 'ProjectMedia').last
-    User.current = nil
+    v = nil
+    with_versioning do
+      t = create_team
+      claim = create_claim_media skip_check_ability: true
+      User.current = options[:user] || create_user
+      pm = create_project_media team: t, media: claim, skip_check_ability: true
+      v = pm.versions.from_partition(t.id).where(item_type: 'ProjectMedia').last
+      User.current = nil
+    end
     v
   end
 

--- a/test/controllers/elastic_search_5_test.rb
+++ b/test/controllers/elastic_search_5_test.rb
@@ -124,15 +124,17 @@ class ElasticSearch5Test < ActionController::TestCase
     id = p.id
     p.title = 'Change title'; p.save!
     Sidekiq::Testing.inline! do
-      pm = create_project_media project: p, disable_es_callbacks: false
-      c = create_comment annotated: pm, disable_es_callbacks: false
-      sleep 1
-      result = $repository.find(get_es_id(pm))
-      p.destroy
-      assert_equal 0, ProjectMedia.where(project_id: id).count
-      assert_equal 1, ProjectMedia.where(id: pm.id).count
-      assert_equal 2, Annotation.where(annotated_id: pm.id, annotated_type: 'ProjectMedia').count
-      assert_equal 0, PaperTrail::Version.where(item_id: id, item_type: 'Project').count
+      with_versioning do
+        pm = create_project_media project: p, disable_es_callbacks: false
+        c = create_comment annotated: pm, disable_es_callbacks: false
+        sleep 1
+        result = $repository.find(get_es_id(pm))
+        p.destroy
+        assert_equal 0, ProjectMedia.where(project_id: id).count
+        assert_equal 1, ProjectMedia.where(id: pm.id).count
+        assert_equal 2, Annotation.where(annotated_id: pm.id, annotated_type: 'ProjectMedia').count
+        assert_equal 0, PaperTrail::Version.where(item_id: id, item_type: 'Project').count
+      end
     end
   end
 

--- a/test/controllers/graphql_controller_5_test.rb
+++ b/test/controllers/graphql_controller_5_test.rb
@@ -380,25 +380,27 @@ class GraphqlController5Test < ActionController::TestCase
   end
 
   test "should get version related to status change" do
-    create_verification_status_stuff
-    u = create_user
-    t = create_team
-    create_team_user user: u, team: t, role: 'admin'
-    p = create_project team: t
-    pm = nil
-    with_current_user_and_team(u, t) do
-      pm = create_project_media project: p
-      s = pm.last_status_obj
-      s.status = 'in_progress'
-      s.save!
+    with_versioning do
+      create_verification_status_stuff
+      u = create_user
+      t = create_team
+      create_team_user user: u, team: t, role: 'admin'
+      p = create_project team: t
+      pm = nil
+      with_current_user_and_team(u, t) do
+        pm = create_project_media project: p
+        s = pm.last_status_obj
+        s.status = 'in_progress'
+        s.save!
+      end
+      authenticate_with_user(u)
+      query = 'query { project_media(ids: "' + [pm.id, p.id, t.id].join(',') + '") {  log(annotation_types: ["verification_status"]) { edges { node { annotation { annotation_type } } } } } }'
+      post :create, params: { query: query, team: t.slug }
+      assert_response :success
+      log = JSON.parse(@response.body)['data']['project_media']['log']['edges'].collect{ |e| e['node'] }
+      assert_equal 1, log.size
+      assert_equal 'verification_status', log[0]['annotation']['annotation_type']
     end
-    authenticate_with_user(u)
-    query = 'query { project_media(ids: "' + [pm.id, p.id, t.id].join(',') + '") {  log(annotation_types: ["verification_status"]) { edges { node { annotation { annotation_type } } } } } }'
-    post :create, params: { query: query, team: t.slug }
-    assert_response :success
-    log = JSON.parse(@response.body)['data']['project_media']['log']['edges'].collect{ |e| e['node'] }
-    assert_equal 1, log.size
-    assert_equal 'verification_status', log[0]['annotation']['annotation_type']
   end
 
   test "should get cluster information" do

--- a/test/models/claim_description_test.rb
+++ b/test/models/claim_description_test.rb
@@ -13,16 +13,18 @@ class ClaimDescriptionTest < ActiveSupport::TestCase
   end
 
   test "should have versions" do
-    u = create_user
-    t = create_team
-    create_team_user team: t, user: u, role: 'admin'
-    pm = create_project_media team: t
-    with_current_user_and_team(u, t) do
-      cd = nil
-      assert_difference 'PaperTrail::Version.count', 1 do
-        cd = create_claim_description project_media: pm, user: u
+    with_versioning do
+      u = create_user
+      t = create_team
+      create_team_user team: t, user: u, role: 'admin'
+      pm = create_project_media team: t
+      with_current_user_and_team(u, t) do
+        cd = nil
+        assert_difference 'PaperTrail::Version.count', 1 do
+          cd = create_claim_description project_media: pm, user: u
+        end
+        assert_equal 1, cd.versions.count
       end
-      assert_equal 1, cd.versions.count
     end
   end
 

--- a/test/models/fact_check_test.rb
+++ b/test/models/fact_check_test.rb
@@ -13,17 +13,19 @@ class FactCheckTest < ActiveSupport::TestCase
   end
 
   test "should have versions" do
-    u = create_user
-    t = create_team
-    create_team_user team: t, user: u, role: 'admin'
-    pm = create_project_media team: t
-    cd = create_claim_description project_media: pm, user: u
-    with_current_user_and_team(u, t) do
-      fc = nil
-      assert_difference 'PaperTrail::Version.count', 1 do
-        fc = create_fact_check claim_description: cd, user: u
+    with_versioning do
+      u = create_user
+      t = create_team
+      create_team_user team: t, user: u, role: 'admin'
+      pm = create_project_media team: t
+      cd = create_claim_description project_media: pm, user: u
+      with_current_user_and_team(u, t) do
+        fc = nil
+        assert_difference 'PaperTrail::Version.count', 1 do
+          fc = create_fact_check claim_description: cd, user: u
+        end
+        assert_equal 1, fc.versions.count
       end
-      assert_equal 1, fc.versions.count
     end
   end
 

--- a/test/models/project_media_test.rb
+++ b/test/models/project_media_test.rb
@@ -532,51 +532,55 @@ class ProjectMediaTest < ActiveSupport::TestCase
   end
 
   test "should have versions" do
-    t = create_team
-    m = create_valid_media team: t
-    u = create_user
-    create_team_user user: u, team: t, role: 'admin'
-    pm = nil
-    User.current = u
-    assert_difference 'PaperTrail::Version.count', 2 do
-      pm = create_project_media team: t, media: m, user: u, skip_autocreate_source: false
+    with_versioning do
+      t = create_team
+      m = create_valid_media team: t
+      u = create_user
+      create_team_user user: u, team: t, role: 'admin'
+      pm = nil
+      User.current = u
+      assert_difference 'PaperTrail::Version.count', 2 do
+        pm = create_project_media team: t, media: m, user: u, skip_autocreate_source: false
+      end
+      assert_equal 2, pm.versions.count
+      pm.destroy!
+      v = Version.from_partition(t.id).where(item_type: 'ProjectMedia', item_id: pm.id, event: 'destroy').last
+      assert_not_nil v
+      User.current = nil
     end
-    assert_equal 2, pm.versions.count
-    pm.destroy!
-    v = Version.from_partition(t.id).where(item_type: 'ProjectMedia', item_id: pm.id, event: 'destroy').last
-    assert_not_nil v
-    User.current = nil
   end
 
   test "should get log" do
-    m = create_valid_media
-    u = create_user
-    t = create_team
-    p = create_project team: t
-    p2 = create_project team: t
-    create_team_user user: u, team: t, role: 'admin'
+    with_versioning do
+      m = create_valid_media
+      u = create_user
+      t = create_team
+      p = create_project team: t
+      p2 = create_project team: t
+      create_team_user user: u, team: t, role: 'admin'
 
-    with_current_user_and_team(u, t) do
-      pm = create_project_media project: p, media: m, user: u
-      c = create_comment annotated: pm
-      tg = create_tag annotated: pm
-      f = create_flag annotated: pm
-      s = pm.annotations.where(annotation_type: 'verification_status').last.load
-      s.status = 'In Progress'; s.save!
-      info = { title: 'Foo' }; pm.analysis = info; pm.save!
-      info = { title: 'Bar' }; pm.analysis = info; pm.save!
+      with_current_user_and_team(u, t) do
+        pm = create_project_media project: p, media: m, user: u
+        c = create_comment annotated: pm
+        tg = create_tag annotated: pm
+        f = create_flag annotated: pm
+        s = pm.annotations.where(annotation_type: 'verification_status').last.load
+        s.status = 'In Progress'; s.save!
+        info = { title: 'Foo' }; pm.analysis = info; pm.save!
+        info = { title: 'Bar' }; pm.analysis = info; pm.save!
 
-      assert_equal [
-        "create_dynamic", "create_dynamicannotationfield", "create_projectmedia",
-        "create_projectmedia", "create_tag", "update_dynamicannotationfield"
-      ].sort, pm.get_versions_log.map(&:event_type).sort
-      assert_equal 5, pm.get_versions_log_count
-      c.destroy
-      assert_equal 5, pm.get_versions_log_count
-      tg.destroy
-      assert_equal 6, pm.get_versions_log_count
-      f.destroy
-      assert_equal 6, pm.get_versions_log_count
+        assert_equal [
+          "create_dynamic", "create_dynamicannotationfield", "create_projectmedia",
+          "create_projectmedia", "create_tag", "update_dynamicannotationfield"
+        ].sort, pm.get_versions_log.map(&:event_type).sort
+        assert_equal 5, pm.get_versions_log_count
+        c.destroy
+        assert_equal 5, pm.get_versions_log_count
+        tg.destroy
+        assert_equal 6, pm.get_versions_log_count
+        f.destroy
+        assert_equal 6, pm.get_versions_log_count
+      end
     end
   end
 
@@ -1465,23 +1469,25 @@ class ProjectMediaTest < ActiveSupport::TestCase
   end
 
   test "should destroy project media when associated_id on version is not valid" do
-    m = create_valid_media
-    t = create_team
-    p = create_project team: t
-    u = create_user
-    create_team_user user: u, team: t, role: 'admin'
-    pm = nil
-    with_current_user_and_team(u, t) do
-      pm = create_project_media project: p, media: m, user: u
-      pm.source_id = create_source(team_id: t.id).id
-      pm.save
-      assert_equal 3, pm.versions.count
-    end
-    version = pm.versions.last
-    version.update_attribute('associated_id', 100)
+    with_versioning do
+      m = create_valid_media
+      t = create_team
+      p = create_project team: t
+      u = create_user
+      create_team_user user: u, team: t, role: 'admin'
+      pm = nil
+      with_current_user_and_team(u, t) do
+        pm = create_project_media project: p, media: m, user: u
+        pm.source_id = create_source(team_id: t.id).id
+        pm.save
+        assert_equal 3, pm.versions.count
+      end
+      version = pm.versions.last
+      version.update_attribute('associated_id', 100)
 
-    assert_nothing_raised do
-      pm.destroy
+      assert_nothing_raised do
+        pm.destroy
+      end
     end
   end
 

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -214,33 +214,35 @@ class RelationshipTest < ActiveSupport::TestCase
   end
 
   test "should have versions" do
-    u = create_user is_admin: true
-    t = create_team
-    p = create_project team: t
-    r = create_relationship relationship_type: Relationship.confirmed_type
-    assert_empty r.versions
-    so = create_project_media project: p
-    n = so.cached_annotations_count
-    ta = create_project_media project: p
-    
-    with_current_user_and_team(u, t) do
-      r = create_relationship source_id: so.id, target_id: ta.id, relationship_type: Relationship.confirmed_type
-    end
-    assert_not_empty r.versions
-    v = r.versions.last
-    assert_equal ta.id, v.associated_id
-    assert_equal 'ProjectMedia', v.associated_type
-    ta = ProjectMedia.find(ta.id)
-    assert ta.get_versions_log.map(&:event_type).include?('create_relationship')
+    with_versioning do
+      u = create_user is_admin: true
+      t = create_team
+      p = create_project team: t
+      r = create_relationship relationship_type: Relationship.confirmed_type
+      assert_empty r.versions
+      so = create_project_media project: p
+      n = so.cached_annotations_count
+      ta = create_project_media project: p
+      
+      with_current_user_and_team(u, t) do
+        r = create_relationship source_id: so.id, target_id: ta.id, relationship_type: Relationship.confirmed_type
+      end
+      assert_not_empty r.versions
+      v = r.versions.last
+      assert_equal ta.id, v.associated_id
+      assert_equal 'ProjectMedia', v.associated_type
+      ta = ProjectMedia.find(ta.id)
+      assert ta.get_versions_log.map(&:event_type).include?('create_relationship')
 
-    with_current_user_and_team(u, t) do
-      ta.destroy
+      with_current_user_and_team(u, t) do
+        ta.destroy
+      end
+      
+      v2 = Version.where(item_type: 'Relationship', item_id: r.id.to_s, event_type: 'destroy_relationship').last
+      assert_not_equal v, v2
+      assert_equal ta.id, v2.associated_id
+      assert_equal 'ProjectMedia', v2.associated_type
     end
-    
-    v2 = Version.where(item_type: 'Relationship', item_id: r.id.to_s, event_type: 'destroy_relationship').last
-    assert_not_equal v, v2
-    assert_equal ta.id, v2.associated_id
-    assert_equal 'ProjectMedia', v2.associated_type
   end
 
   test "should not crash if can't delete from ElasticSearch" do
@@ -478,60 +480,64 @@ class RelationshipTest < ActiveSupport::TestCase
   end
 
   test "should verify versions and ES for bulk-update" do
-    setup_elasticsearch
-    t = create_team
-    u = create_user
-    create_team_user team: t, user: u, role: 'admin'
-    with_current_user_and_team(u, t) do
-      pm_s = create_project_media team: t
-      pm_t1 = create_project_media team: t
-      pm_t2 = create_project_media team: t
-      pm_t3 = create_project_media team: t
-      r1 = create_relationship source_id: pm_s.id, target_id: pm_t1.id, relationship_type: Relationship.suggested_type
-      r2 = create_relationship source_id: pm_s.id, target_id: pm_t2.id, relationship_type: Relationship.suggested_type
-      r3 = create_relationship source_id: pm_s.id, target_id: pm_t3.id, relationship_type: Relationship.suggested_type
-      relations = [r1, r2]
-      ids = relations.map(&:id)
-      updates = { action: "accept", source_id: pm_s.id }
-      assert_difference 'Version.count', 2 do
-        Relationship.bulk_update(ids, updates, t)
+    with_versioning do
+      setup_elasticsearch
+      t = create_team
+      u = create_user
+      create_team_user team: t, user: u, role: 'admin'
+      with_current_user_and_team(u, t) do
+        pm_s = create_project_media team: t
+        pm_t1 = create_project_media team: t
+        pm_t2 = create_project_media team: t
+        pm_t3 = create_project_media team: t
+        r1 = create_relationship source_id: pm_s.id, target_id: pm_t1.id, relationship_type: Relationship.suggested_type
+        r2 = create_relationship source_id: pm_s.id, target_id: pm_t2.id, relationship_type: Relationship.suggested_type
+        r3 = create_relationship source_id: pm_s.id, target_id: pm_t3.id, relationship_type: Relationship.suggested_type
+        relations = [r1, r2]
+        ids = relations.map(&:id)
+        updates = { action: "accept", source_id: pm_s.id }
+        assert_difference 'Version.count', 2 do
+          Relationship.bulk_update(ids, updates, t)
+        end
+        assert_equal Relationship.suggested_type, r3.reload.relationship_type
+        # Verify confirmed_by
+        assert_equal [u.id], Relationship.where(id: ids).map(&:confirmed_by).uniq
+        sleep 2
+        # Verify ES
+        es_t = $repository.find(get_es_id(pm_t1))
+        assert_equal r1.source_id, es_t['parent_id']
+        assert_equal pm_t1.reload.sources_count, es_t['sources_count']
+        assert_equal 1, pm_t1.reload.sources_count
       end
-      assert_equal Relationship.suggested_type, r3.reload.relationship_type
-      # Verify confirmed_by
-      assert_equal [u.id], Relationship.where(id: ids).map(&:confirmed_by).uniq
-      sleep 2
-      # Verify ES
-      es_t = $repository.find(get_es_id(pm_t1))
-      assert_equal r1.source_id, es_t['parent_id']
-      assert_equal pm_t1.reload.sources_count, es_t['sources_count']
-      assert_equal 1, pm_t1.reload.sources_count
     end
   end
 
   test "should bulk-reject similar items" do
-    setup_elasticsearch
-    t = create_team
-    u = create_user
-    p = create_project team: t
-    p2 = create_project team: t
-    create_team_user team: t, user: u, role: 'admin'
-    with_current_user_and_team(u, t) do
-      pm_s = create_project_media team: t, project: p
-      pm_t1 = create_project_media team: t, project: p
-      pm_t2 = create_project_media team: t, project: p
-      pm_t3 = create_project_media team: t, project: p
-      r1 = create_relationship source_id: pm_s.id, target_id: pm_t1.id, relationship_type: Relationship.suggested_type
-      r2 = create_relationship source_id: pm_s.id, target_id: pm_t2.id, relationship_type: Relationship.suggested_type
-      r3 = create_relationship source_id: pm_s.id, target_id: pm_t3.id, relationship_type: Relationship.suggested_type
-      relations = [r1, r2]
-      ids = relations.map(&:id)
-      updates = { source_id: pm_s.id, add_to_project_id: p2.id }
-      assert_difference 'Version.count', 2 do
-        Relationship.bulk_destroy(ids, updates, t)
+    with_versioning do
+      setup_elasticsearch
+      t = create_team
+      u = create_user
+      p = create_project team: t
+      p2 = create_project team: t
+      create_team_user team: t, user: u, role: 'admin'
+      with_current_user_and_team(u, t) do
+        pm_s = create_project_media team: t, project: p
+        pm_t1 = create_project_media team: t, project: p
+        pm_t2 = create_project_media team: t, project: p
+        pm_t3 = create_project_media team: t, project: p
+        r1 = create_relationship source_id: pm_s.id, target_id: pm_t1.id, relationship_type: Relationship.suggested_type
+        r2 = create_relationship source_id: pm_s.id, target_id: pm_t2.id, relationship_type: Relationship.suggested_type
+        r3 = create_relationship source_id: pm_s.id, target_id: pm_t3.id, relationship_type: Relationship.suggested_type
+        relations = [r1, r2]
+        ids = relations.map(&:id)
+        updates = { source_id: pm_s.id, add_to_project_id: p2.id }
+        assert_difference 'Version.count', 2 do
+          Relationship.bulk_destroy(ids, updates, t)
+        end
+        assert_equal p2.id, pm_t1.reload.project_id
+        assert_equal p2.id, pm_t2.reload.project_id
+        assert_equal p.id, pm_t3.reload.project_id
       end
-      assert_equal p2.id, pm_t1.reload.project_id
-      assert_equal p2.id, pm_t2.reload.project_id
-      assert_equal p.id, pm_t3.reload.project_id
     end
   end
 

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -67,16 +67,18 @@ class TagTest < ActiveSupport::TestCase
   end
 
   test "should create version when tag is created" do
-    u = create_user
-    t = create_team
-    create_team_user user: u, team: t, role: 'admin'
-    p = create_project team: t
-    pm = create_project_media project: p
-    with_current_user_and_team(u, t) do
-      tag = create_tag(tag: 'test', annotated: pm)
-      assert_equal 1, tag.versions.count
-      v = tag.versions.last
-      assert_equal 'create', v.event
+    with_versioning do
+      u = create_user
+      t = create_team
+      create_team_user user: u, team: t, role: 'admin'
+      p = create_project team: t
+      pm = create_project_media project: p
+      with_current_user_and_team(u, t) do
+        tag = create_tag(tag: 'test', annotated: pm)
+        assert_equal 1, tag.versions.count
+        v = tag.versions.last
+        assert_equal 'create', v.event
+      end
     end
   end
 

--- a/test/models/tipline_subscription_test.rb
+++ b/test/models/tipline_subscription_test.rb
@@ -6,13 +6,15 @@ class TiplineSubscriptionTest < ActiveSupport::TestCase
   end
 
   test "should keep versions after tipline subscription is deleted" do
-    ts = nil
-    assert_difference 'Version.count', 1 do
-      ts = create_tipline_subscription
-    end
-    ts = TiplineSubscription.find(ts.id)
-    assert_difference 'Version.count', 1 do
-      ts.destroy!
+    with_versioning do
+      ts = nil
+      assert_difference 'Version.count', 1 do
+        ts = create_tipline_subscription
+      end
+      ts = TiplineSubscription.find(ts.id)
+      assert_difference 'Version.count', 1 do
+        ts.destroy!
+      end
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -194,6 +194,19 @@ class ActiveSupport::TestCase
     CONFIG.unstub(:[])
   end
 
+  def with_versioning
+    was_enabled = PaperTrail.enabled?
+    was_enabled_for_request = PaperTrail.request.enabled?
+    PaperTrail.enabled = true
+    PaperTrail.request.enabled = true
+    begin
+      yield
+    ensure
+      PaperTrail.enabled = was_enabled
+      PaperTrail.request.enabled = was_enabled_for_request
+    end
+  end
+
   def valid_flags_data(random = true)
     keys = ['adult', 'spoof', 'medical', 'violence', 'racy', 'spam']
     flags = {}


### PR DESCRIPTION
Disable `PaperTrail` on tests, and enable it only for tests that really need it. The idea here is to try to make tests run faster. Reference: https://github.com/paper-trail-gem/paper_trail#7-testing.