### PR TITLE
Should be able to revert relationship when both items have a claim.

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -205,7 +205,7 @@ class Relationship < ApplicationRecord
       claim = ClaimDescription.where(project_media_id: self.source_id_before_last_save).last
       unless claim.nil?
         claim.project_media_id = self.source_id
-        claim.save!
+        claim.save
       end
       Relationship.where(source_id: self.target_id).update_all({ source_id: self.source_id })
       self.source&.clear_cached_fields

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -561,4 +561,20 @@ class RelationshipTest < ActiveSupport::TestCase
     assert_nil pm1.get_dynamic_annotation('report_design')
     assert_not_nil pm2.get_dynamic_annotation('report_design')
   end
+
+  test "should pin item when both have claims" do
+    t = create_team
+    pm1 = create_project_media team: t
+    create_claim_description project_media: pm1
+    pm2 = create_project_media team: t
+    create_claim_description project_media: pm2
+    r = create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
+
+    assert_nothing_raised do
+      r = Relationship.find(r.id)
+      r.source_id = pm2.id
+      r.target_id = pm1.id
+      r.save!
+    end
+  end
 end


### PR DESCRIPTION
This is a bug fix. There was an error "ProjectMedia has already been taken" when pinning an item as main when both the item being pinned and the current main item have a claim. It failed when trying to point the claim to the new main item, which already has a claim. The fix for now is to just not switch claims if both have claims.

Fixes CHECK-2882.