### PR TITLE
Allow disabling trace sampling via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,10 @@ To enable sampling for Honeycomb, set the following configuration (either in `co
 * `otel_custom_sampling_rate` to an integer value. This will be used to calculate and set OTEL_TRACES_SAMPLER_ARG (1 / `<sample_rate>`) and to append sampler-related value to `OTEL_RESOURCE_ATTRIBUTES` (as `SampleRate=<sample_rate>`).
 
 **Note**: If sampling behavior is changed in Check API, we will also need to update the behavior to match in any other application reporting to Honeycomb. More [here](https://docs.honeycomb.io/getting-data-in/opentelemetry/ruby/#sampling)
+
+#### Environment overrides
+
+Often for rake tasks or background jobs, we will either want none of the data (skip reporting) or all of the data (skip sampling). For these cases we can set specific environment variables:
+
+* To skip reporting to Honeycomb, set `CHECK_SKIP_HONEYCOMB` to `true`
+* To skip sampling data we want to report to Honeycomb, set `CHECK_SKIP_HONEYCOMB_SAMPLING` to `true`

--- a/config/initializers/zz_open_telemetry.rb
+++ b/config/initializers/zz_open_telemetry.rb
@@ -1,7 +1,7 @@
 require 'check_open_telemetry_config'
 require 'check_open_telemetry_test_config'
 
-# Lines immediately below set any environment config that should 
+# Lines immediately below set any environment config that should
 # be applied to all environments
 ENV['OTEL_LOG_LEVEL'] = CheckConfig.get('otel_log_level')
 
@@ -9,7 +9,8 @@ unless Rails.env.test?
   Check::OpenTelemetryConfig.new(
     CheckConfig.get('otel_exporter_otlp_endpoint'),
     CheckConfig.get('otel_exporter_otlp_headers'),
-    ENV['CHECK_SKIP_HONEYCOMB']
+    disable_exporting: ENV['CHECK_SKIP_HONEYCOMB'],
+    disable_sampling: ENV['CHECK_SKIP_HONEYCOMB_SAMPLING']
   ).configure!(
     CheckConfig.get('otel_resource_attributes'),
     sampling_config: {

--- a/lib/check_open_telemetry_config.rb
+++ b/lib/check_open_telemetry_config.rb
@@ -35,10 +35,11 @@ module Check
       end
     end
 
-    def initialize(endpoint, headers, is_disabled = nil)
+    def initialize(endpoint, headers, disable_exporting: false, disable_sampling: false)
       @endpoint = endpoint
       @headers = headers
-      @is_disabled = !!is_disabled
+      @disable_exporting = !!disable_exporting
+      @disable_sampling = !!disable_sampling
     end
 
     def configure!(resource_attributes, sampling_config: nil)
@@ -77,7 +78,7 @@ module Check
 
     def configure_sampling!(sampling_config)
       additional_attributes = {}
-      if sampling_config[:sampler]
+      if sampling_config[:sampler] && !@disable_sampling
         ENV['OTEL_TRACES_SAMPLER'] = sampling_config[:sampler]
 
         begin
@@ -95,7 +96,7 @@ module Check
     end
 
     def exporting_disabled?
-      @endpoint.blank? || @headers.blank? || @is_disabled
+      @endpoint.blank? || @headers.blank? || @disable_exporting
     end
 
     def format_attributes(hash)

--- a/test/lib/check_open_telemetry_config_test.rb
+++ b/test/lib/check_open_telemetry_config_test.rb
@@ -89,6 +89,25 @@ class OpenTelemetryConfigTest < ActiveSupport::TestCase
     env_var_original_state.each{|env_var, original_state| ENV[env_var] = original_state}
   end
 
+  test "does not sample if sampling override given" do
+    env_var_original_state = cache_and_clear_env
+
+    Check::OpenTelemetryConfig.new(
+      'https://fake.com',
+      'foo=bar',
+      disable_sampling: 'true'
+    ).configure!(
+      {'developer.name' => 'piglet' },
+      sampling_config: { sampler: 'traceidratio', rate: 'asdf' }
+    )
+
+    assert_nil ENV['OTEL_TRACES_SAMPLER']
+    assert_nil ENV['OTEL_TRACES_SAMPLER_ARG']
+    assert_equal 'developer.name=piglet', ENV['OTEL_RESOURCE_ATTRIBUTES']
+  ensure
+    env_var_original_state.each{|env_var, original_state| ENV[env_var] = original_state}
+  end
+
   # .tracer
   test "returns a configured tracer" do
     env_var_original_state = cache_and_clear_env
@@ -109,7 +128,7 @@ class OpenTelemetryConfigTest < ActiveSupport::TestCase
   end
 
   test "should disable exporting if override set" do
-    assert Check::OpenTelemetryConfig.new('https://fake.com', 'foo=bar', 'true').send(:exporting_disabled?)
+    assert Check::OpenTelemetryConfig.new('https://fake.com', 'foo=bar', disable_exporting: 'true').send(:exporting_disabled?)
   end
 
   # .format_attributes


### PR DESCRIPTION
Previously we were only able to change the sampling configuration by changing config.yml. This makes forcing a send of data to Honeycomb on a per-job basis, like in a rake task, difficult. To address that, this PR allows for setting an environment variable CHECK_SKIP_HONEYCOMB_SAMPLING, named similarly to the env var we already use for skipping tracing (CHECK_SKIP_HONEYCOMB), to force sending collected traces to Honeycomb. Intended use is when we want specific tasks to be reliably sent to Honeycomb.