### PR TITLE
Save generated statistics to Postgres instead of Rails cache

### DIFF
--- a/app/models/concerns/team_associations.rb
+++ b/app/models/concerns/team_associations.rb
@@ -17,6 +17,7 @@ module TeamAssociations
     has_many :project_groups, dependent: :destroy
     has_many :feed_teams, dependent: :destroy
     has_many :feeds, through: :feed_teams
+    has_many :monthly_team_statistics # No "dependent: :destroy" because we want to retain statistics
 
     has_annotations
   end

--- a/app/models/monthly_team_statistic.rb
+++ b/app/models/monthly_team_statistic.rb
@@ -1,0 +1,53 @@
+class MonthlyTeamStatistic < ApplicationRecord
+  belongs_to :team
+
+  validates_presence_of :start_date, :end_date, :team, :platform, :language
+
+  include ActionView::Helpers::DateHelper
+
+  # Mapping of attributes to human-readable descriptions
+  FIELD_MAPPINGS = {
+    id: "ID",
+    org: "Org", # model method
+    platform: "Platform",
+    language: "Language",
+    month: "Month", # model method
+    conversations: 'Conversations',
+    average_messages_per_day: 'Average messages per day',
+    unique_users: 'Unique users',
+    returning_users: 'Returning users',
+    valid_new_requests: 'Valid new requests',
+    published_native_reports: 'Published native reports',
+    published_imported_reports: 'Published imported reports',
+    requests_answered_with_report: 'Requests answered with a report',
+    reports_sent_to_users: 'Reports sent to users',
+    unique_users_who_received_report: 'Unique users who received a report',
+    formatted_median_response_time: 'Average (median) response time', # model method
+    unique_newsletters_sent: 'Unique newsletters sent',
+    new_newsletter_subscriptions: 'New newsletter subscriptions',
+    newsletter_cancellations: 'Newsletter cancellations',
+    current_subscribers: 'Current subscribers',
+  }.freeze
+
+  def formatted_hash
+    {}.tap do |formatted_hash|
+      FIELD_MAPPINGS.each do |attribute_name, human_readable_label|
+        formatted_hash[human_readable_label] = public_send(attribute_name.to_sym) || '-'
+      end
+    end
+  end
+
+  # Below methods must match a key in FIELD_MAPPINGS to be included in
+  # the .formatted_hash output
+  def org
+    team.name
+  end
+
+  def month
+    start_date&.strftime('%b %Y')
+  end
+
+  def formatted_median_response_time
+    distance_of_time_in_words(median_response_time) if median_response_time
+  end
+end

--- a/app/models/monthly_team_statistic.rb
+++ b/app/models/monthly_team_statistic.rb
@@ -2,6 +2,7 @@ class MonthlyTeamStatistic < ApplicationRecord
   belongs_to :team
 
   validates_presence_of :start_date, :end_date, :team, :platform, :language
+  validates :start_date, uniqueness: { scope: [:platform, :language, :team] }
 
   include ActionView::Helpers::DateHelper
 
@@ -9,7 +10,7 @@ class MonthlyTeamStatistic < ApplicationRecord
   FIELD_MAPPINGS = {
     id: "ID",
     org: "Org", # model method
-    platform: "Platform",
+    platform_name: "Platform", # model method
     language: "Language",
     month: "Month", # model method
     conversations: 'Conversations',
@@ -49,5 +50,9 @@ class MonthlyTeamStatistic < ApplicationRecord
 
   def formatted_median_response_time
     distance_of_time_in_words(median_response_time) if median_response_time
+  end
+
+  def platform_name
+    Bot::Smooch::SUPPORTED_INTEGRATION_NAMES[platform]
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -517,11 +517,15 @@ class Team < ApplicationRecord
   end
 
   def data_report
-    data = Rails.cache.read("data:report:#{self.id}")
-    return nil if data.blank?
-    data.map.with_index do |row, i|
-      row['Month'] = "#{i + 1}. #{row['Month']}"
-      row.reject { |key, _value| key =~ /[sS]earch/ || ['Average number of conversations per day', 'Number of messages sent'].include?(key) }
+    monthly_statisitcs = MonthlyTeamStatistic.where(team: team).order('start_date ASC')
+    return nil if monthly_statisitcs.blank?
+
+    index = 1
+    monthly_statisitcs.map do |stat|
+      hash = stat.formatted_hash
+      hash['Month'] = "#{index}. #{hash['Month']}"
+      index += 1
+      hash
     end
   end
 

--- a/config/initializers/zz_open_telemetry.rb
+++ b/config/initializers/zz_open_telemetry.rb
@@ -1,7 +1,7 @@
 require 'check_open_telemetry_config'
 require 'check_open_telemetry_test_config'
 
-# Lines immediately below set any environment config that should 
+# Lines immediately below set any environment config that should
 # be applied to all environments
 ENV['OTEL_LOG_LEVEL'] = CheckConfig.get('otel_log_level')
 

--- a/db/migrate/20230106220307_create_monthly_team_statistics.rb
+++ b/db/migrate/20230106220307_create_monthly_team_statistics.rb
@@ -1,0 +1,28 @@
+class CreateMonthlyTeamStatistics < ActiveRecord::Migration[5.2]
+  def change
+    create_table :monthly_team_statistics do |t|
+      t.integer :conversations
+      t.integer :average_messages_per_day
+      t.integer :unique_users
+      t.integer :returning_users
+      t.integer :valid_new_requests
+      t.integer :published_native_reports
+      t.integer :published_imported_reports
+      t.integer :requests_answered_with_report
+      t.integer :reports_sent_to_users
+      t.integer :unique_users_who_received_report
+      t.integer :median_response_time
+      t.integer :unique_newsletters_sent
+      t.integer :new_newsletter_subscriptions
+      t.integer :newsletter_cancellations
+      t.integer :current_subscribers
+
+      t.datetime :start_date
+      t.datetime :end_date
+      t.string :platform
+      t.string :language
+      t.references :team, null: false, foreign_key: true, index: true
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/migrate/20230106220307_create_monthly_team_statistics.rb
+++ b/db/migrate/20230106220307_create_monthly_team_statistics.rb
@@ -21,8 +21,9 @@ class CreateMonthlyTeamStatistics < ActiveRecord::Migration[5.2]
       t.datetime :end_date
       t.string :platform
       t.string :language
-      t.references :team, null: false, foreign_key: true, index: true
+      t.references :team, null: false, index: true
       t.timestamps null: false
+      t.index [:team_id, :platform, :language, :start_date], unique: true, name: 'index_monthly_stats_team_platform_language_start'
     end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_03_125636) do
+ActiveRecord::Schema.define(version: 2023_01_06_220307) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -239,6 +239,32 @@ ActiveRecord::Schema.define(version: 2023_01_03_125636) do
     t.string "type"
     t.string "file"
     t.index ["url"], name: "index_medias_on_url", unique: true
+  end
+
+  create_table "monthly_team_statistics", force: :cascade do |t|
+    t.integer "conversations"
+    t.integer "average_messages_per_day"
+    t.integer "unique_users"
+    t.integer "returning_users"
+    t.integer "valid_new_requests"
+    t.integer "published_native_reports"
+    t.integer "published_imported_reports"
+    t.integer "requests_answered_with_report"
+    t.integer "reports_sent_to_users"
+    t.integer "unique_users_who_received_report"
+    t.integer "median_response_time"
+    t.integer "unique_newsletters_sent"
+    t.integer "new_newsletter_subscriptions"
+    t.integer "newsletter_cancellations"
+    t.integer "current_subscribers"
+    t.datetime "start_date"
+    t.datetime "end_date"
+    t.string "platform"
+    t.string "language"
+    t.bigint "team_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["team_id"], name: "index_monthly_team_statistics_on_team_id"
   end
 
   create_table "pghero_query_stats", id: :serial, force: :cascade do |t|
@@ -579,6 +605,7 @@ ActiveRecord::Schema.define(version: 2023_01_03_125636) do
   add_foreign_key "fact_checks", "users"
   add_foreign_key "feed_teams", "feeds"
   add_foreign_key "feed_teams", "teams"
+  add_foreign_key "monthly_team_statistics", "teams"
   add_foreign_key "project_media_requests", "project_medias"
   add_foreign_key "project_media_requests", "requests"
   add_foreign_key "requests", "feeds"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -264,6 +264,7 @@ ActiveRecord::Schema.define(version: 2023_01_06_220307) do
     t.bigint "team_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["team_id", "platform", "language", "start_date"], name: "index_monthly_stats_team_platform_language_start", unique: true
     t.index ["team_id"], name: "index_monthly_team_statistics_on_team_id"
   end
 
@@ -605,7 +606,6 @@ ActiveRecord::Schema.define(version: 2023_01_06_220307) do
   add_foreign_key "fact_checks", "users"
   add_foreign_key "feed_teams", "feeds"
   add_foreign_key "feed_teams", "teams"
-  add_foreign_key "monthly_team_statistics", "teams"
   add_foreign_key "project_media_requests", "project_medias"
   add_foreign_key "project_media_requests", "requests"
   add_foreign_key "requests", "feeds"

--- a/lib/check_statistics.rb
+++ b/lib/check_statistics.rb
@@ -41,31 +41,32 @@ module CheckStatistics
     end
 
     def get_statistics(start_date, end_date, team_id, platform, language)
+      # attributes in statistics hash must correspond to database fields on MonthlyTeamStatistic
+      statistics = {}
       tracing_attributes = { "app.team.id" => team_id, "app.attr.platform" => platform, "app.attr.language" => language}
       CheckTracer.in_span('CheckStatistics.get_statistics', attributes: tracing_attributes) do
         team = Team.find(team_id)
 
         platform_name = Bot::Smooch::SUPPORTED_INTEGRATION_NAMES[platform]
-        id = [team.slug, platform_name, language, start_date.strftime('%Y-%m-%d'), end_date.strftime('%Y-%m-%d')].join('-').downcase.gsub(/[_ ]+/, '-')
-        data = [id, team.name, platform_name, language, start_date.strftime('%Y-%m-%d')]
+        statistics = {
+          platform: platform_name,
+          language: language,
+          start_date: start_date,
+          end_date: end_date,
+        }
 
         conversations = nil
-        CheckTracer.in_span('CheckStatistics#number_of_conversations', attributes: tracing_attributes) do
+        CheckTracer.in_span('CheckStatistics#conversations', attributes: tracing_attributes) do
           # Number of conversations
           # FIXME: Should be a new conversation only after 15 minutes of inactivity
           value1 = unique_requests_count(project_media_requests(team_id, platform, start_date, end_date, language))
           value2 = team_requests(team_id, platform, start_date, end_date, language).count
           conversations = value1 + value2
-          data << conversations
-        end
-
-        CheckTracer.in_span('CheckStatistics#conversations_per_day', attributes: tracing_attributes) do
-          # Average number of conversations per day
-          data << (conversations / (start_date.to_date..end_date.to_date).count).to_i
+          statistics[:conversations] = conversations
         end
 
         number_of_newsletters = 0
-        CheckTracer.in_span('CheckStatistics#number_of_newsletters_sent', attributes: tracing_attributes) do
+        CheckTracer.in_span('CheckStatistics#unique_newsletters_sent', attributes: tracing_attributes) do
           # Number of newsletters sent
           # NOTE: For all platforms
           # NOTE: Only starting from June 1, 2022
@@ -79,42 +80,40 @@ module CheckStatistics
                 nil
               end
             end.reject{ |t| t.blank? }.collect{ |t| Time.parse(t.to_s).to_s }.uniq.size
+            statistics[:unique_newsletters_sent] = end_date
           end
         end
 
-        CheckTracer.in_span('CheckStatistics#number_of_messages_sent', attributes: tracing_attributes) do
-          # Number of newsletter subscribers
-          number_of_subscribers = TiplineSubscription.where(created_at: start_date.ago(100.years)..end_date, platform: platform_name, language: language).where('teams.id' => team_id).joins(:team).count
+        current_newsletter_subscribers = nil
+        CheckTracer.in_span('CheckStatistics#current_subscribers', attributes: tracing_attributes) do
+          # Current number of newsletter subscribers
+          current_newsletter_subscribers = TiplineSubscription.where(created_at: start_date.ago(100.years)..end_date, platform: platform_name, language: language).where('teams.id' => team_id).joins(:team).count
+          statistics[:current_subscribers] = current_newsletter_subscribers
+        end
 
+        CheckTracer.in_span('CheckStatistics#average_messages_per_day', attributes: tracing_attributes) do
           numbers_of_messages = []
-          numbers_of_messages_sent = []
           project_media_requests(team_id, platform, start_date, end_date, language).find_each do |a|
             n = JSON.parse(a.load.get_field_value('smooch_data'))['text'].to_s.split(Bot::Smooch::MESSAGE_BOUNDARY).size
-            numbers_of_messages_sent << n
             numbers_of_messages << n * 2
           end
           team_requests(team_id, platform, start_date, end_date, language).find_each do |a|
             n = JSON.parse(a.load.get_field_value('smooch_data'))['text'].to_s.split(Bot::Smooch::MESSAGE_BOUNDARY).size
-            numbers_of_messages_sent << n
             numbers_of_messages << n * 2
           end
           search_results = project_media_requests(team_id, platform, start_date, end_date, language, 'relevant_search_result_requests').count + project_media_requests(team_id, platform, start_date, end_date, language, 'irrelevant_search_result_requests').count + project_media_requests(team_id, platform, start_date, end_date, language, 'timeout_search_requests').count
-          number_of_messages_sent = numbers_of_messages_sent.sum + search_results + (number_of_newsletters * number_of_subscribers)
-
-          # Number of messages sent
-          data << number_of_messages_sent
 
           # Average number of messages per day
-          number_of_messages = numbers_of_messages.sum + search_results + (number_of_newsletters * number_of_subscribers)
+          number_of_messages = numbers_of_messages.sum + search_results + (number_of_newsletters * current_newsletter_subscribers)
           if number_of_messages == 0
-            data << 0
+            statistics[:average_messages_per_day] = 0
           else
-            data << (number_of_messages / (start_date.to_date..end_date.to_date).count).to_i
+            statistics[:average_messages_per_day] = (number_of_messages / (start_date.to_date..end_date.to_date).count).to_i
           end
         end
 
         uids = []
-        CheckTracer.in_span('CheckStatistics#number_of_unique_users', attributes: tracing_attributes) do
+        CheckTracer.in_span('CheckStatistics#unique_users', attributes: tracing_attributes) do
           # Number of unique users
           project_media_requests(team_id, platform, start_date, end_date, language).find_each do |a|
             uid = begin JSON.parse(a.load.get_field_value('smooch_data'))['authorId'] rescue nil end
@@ -124,123 +123,75 @@ module CheckStatistics
             uid = begin JSON.parse(a.load.get_field_value('smooch_data'))['authorId'] rescue nil end
             uids << uid if !uid.nil? && !uids.include?(uid)
           end
-          data << uids.size
+          statistics[:unique_users] = uids.size
         end
 
-        CheckTracer.in_span('CheckStatistics#number_of_returning_users', attributes: tracing_attributes) do
+        CheckTracer.in_span('CheckStatistics#returning_users', attributes: tracing_attributes) do
           # Number of returning users (at least one session in the current month, and at least one session in the last previous 2 months)
-          data << DynamicAnnotation::Field.where(field_name: 'smooch_data', created_at: start_date.ago(2.months)..start_date).where("value_json->>'authorId' IN (?) AND value_json->>'language' = ?", uids, language).collect{ |f| f.value_json['authorId'] }.uniq.size
+          statistics[:returning_users] = DynamicAnnotation::Field.where(field_name: 'smooch_data', created_at: start_date.ago(2.months)..start_date).where("value_json->>'authorId' IN (?) AND value_json->>'language' = ?", uids, language).collect{ |f| f.value_json['authorId'] }.uniq.size
         end
 
-        CheckTracer.in_span('CheckStatistics#search', attributes: tracing_attributes) do
-          # SEARCH
-          # 1. All searches (2 + 3)
-          # 2. Positive search results (4 + 5 + 6)
-          # 3. Negative search results
-          # 4. Relevant feedback
-          # 5. Irrelevant feedback
-          # 6. No feedback
-          search4 = unique_requests_count(project_media_requests(team_id, platform, start_date, end_date, language, 'relevant_search_result_requests'))
-          search5 = project_media_requests(team_id, platform, start_date, end_date, language, 'irrelevant_search_result_requests').count
-          search6 = unique_requests_count(project_media_requests(team_id, platform, start_date, end_date, language, 'timeout_search_requests'))
-          search2 = search4 + search5 + search6
-          search3 = project_media_requests(team_id, platform, start_date, end_date, language, 'default_requests').count
-          search1 = search2 + search3
-          data << search1
-          data << search2
-          data << search3
-          data << search4
-          data << search5
-          data << search6
-        end
-
-        CheckTracer.in_span('CheckStatistics#number_of_valid_queries', attributes: tracing_attributes) do
+        CheckTracer.in_span('CheckStatistics#valid_new_requests', attributes: tracing_attributes) do
           # Number of valid queries
-          data << unique_requests_count(project_media_requests(team_id, platform, start_date, end_date, language).where('pm.archived' => 0))
+          statistics[:valid_new_requests] = unique_requests_count(project_media_requests(team_id, platform, start_date, end_date, language).where('pm.archived' => 0))
         end
 
-        CheckTracer.in_span('CheckStatistics#number_of_new_published_reports', attributes: tracing_attributes) do
+        CheckTracer.in_span('CheckStatistics#published_native_reports', attributes: tracing_attributes) do
           # Number of new published reports created in Check (e.g., native, not imported)
           # NOTE: For all platforms
-          data << Annotation.where(annotation_type: 'report_design').joins("INNER JOIN project_medias pm ON pm.id = annotations.annotated_id AND annotations.annotated_type = 'ProjectMedia' INNER JOIN teams t ON t.id = pm.team_id").where('t.id' => team_id).where('annotations.created_at' => start_date..end_date).where("data LIKE '%language: #{language}%'").where("data LIKE '%state: published%'").where('annotations.annotator_id NOT IN (?)', [BotUser.fetch_user.id, BotUser.alegre_user.id]).count
+          statistics[:published_native_reports] = Annotation.where(annotation_type: 'report_design').joins("INNER JOIN project_medias pm ON pm.id = annotations.annotated_id AND annotations.annotated_type = 'ProjectMedia' INNER JOIN teams t ON t.id = pm.team_id").where('t.id' => team_id).where('annotations.created_at' => start_date..end_date).where("data LIKE '%language: #{language}%'").where("data LIKE '%state: published%'").where('annotations.annotator_id NOT IN (?)', [BotUser.fetch_user.id, BotUser.alegre_user.id]).count
         end
 
-        CheckTracer.in_span('CheckStatistics#number_of_published_imported_reports', attributes: tracing_attributes) do
+        CheckTracer.in_span('CheckStatistics#published_imported_reports', attributes: tracing_attributes) do
           # Number of published imported reports
           # NOTE: For all languages and platforms
-          data << Annotation.where(annotation_type: 'report_design').joins("INNER JOIN project_medias pm ON pm.id = annotations.annotated_id AND annotations.annotated_type = 'ProjectMedia' INNER JOIN teams t ON t.id = pm.team_id").where('t.id' => team_id).where('annotations.created_at' => start_date..end_date, 'annotations.annotator_id' => [BotUser.fetch_user.id, BotUser.alegre_user.id]).where("data LIKE '%state: published%'").count
+          statistics[:published_imported_reports] = Annotation.where(annotation_type: 'report_design').joins("INNER JOIN project_medias pm ON pm.id = annotations.annotated_id AND annotations.annotated_type = 'ProjectMedia' INNER JOIN teams t ON t.id = pm.team_id").where('t.id' => team_id).where('annotations.created_at' => start_date..end_date, 'annotations.annotator_id' => [BotUser.fetch_user.id, BotUser.alegre_user.id]).where("data LIKE '%state: published%'").count
         end
 
-        CheckTracer.in_span('CheckStatistics#number_of_queries_answered_with_report', attributes: tracing_attributes) do
+        CheckTracer.in_span('CheckStatistics#requests_answerwed_with_report', attributes: tracing_attributes) do
           # Number of queries answered with a report
-          data << reports_received(team_id, platform, start_date, end_date, language).group('pm.id').count.size + project_media_requests(team_id, platform, start_date, end_date, language, 'relevant_search_result_requests').group('pm.id').count.size
+          statistics[:requests_answered_with_report] = reports_received(team_id, platform, start_date, end_date, language).group('pm.id').count.size + project_media_requests(team_id, platform, start_date, end_date, language, 'relevant_search_result_requests').group('pm.id').count.size
         end
 
-        CheckTracer.in_span('CheckStatistics#number_of_reports_sent_to_users', attributes: tracing_attributes) do
+        CheckTracer.in_span('CheckStatistics#reports_sent_to_users', attributes: tracing_attributes) do
           # Number of reports sent to users
-          data << reports_received(team_id, platform, start_date, end_date, language).count + project_media_requests(team_id, platform, start_date, end_date, language, 'relevant_search_result_requests').count
+          statistics[:reports_sent_to_users] = reports_received(team_id, platform, start_date, end_date, language).count + project_media_requests(team_id, platform, start_date, end_date, language, 'relevant_search_result_requests').count
         end
 
-        CheckTracer.in_span('CheckStatistics#number_of_unique_users_who_received_report', attributes: tracing_attributes) do
+        CheckTracer.in_span('CheckStatistics#unique_users_who_received_report', attributes: tracing_attributes) do
           # Number of unique users who received a report
-          data << [reports_received(team_id, platform, start_date, end_date, language) + project_media_requests(team_id, platform, start_date, end_date, language, 'relevant_search_result_requests')].flatten.collect do |f|
+          statistics[:unique_users_who_received_report] = [reports_received(team_id, platform, start_date, end_date, language) + project_media_requests(team_id, platform, start_date, end_date, language, 'relevant_search_result_requests')].flatten.collect do |f|
             annotation = f.is_a?(Annotation) ? f : f.annotation
             JSON.parse(annotation.load.get_field_value('smooch_data'))['authorId']
           end.uniq.size
         end
 
-        CheckTracer.in_span('CheckStatistics#average_time_to_publishing', attributes: tracing_attributes) do
+        CheckTracer.in_span('CheckStatistics#median_response_time', attributes: tracing_attributes) do
           # Average time to publishing
           times = []
           reports_received(team_id, platform, start_date, end_date, language).find_each do |f|
             times << (f.created_at - f.annotation.created_at)
           end
-          if times.size == 0
-            data << '-'
-          else
-            avg = times.sum.to_f / times.size
-            data << distance_of_time_in_words(avg)
-          end
+          median_response_time_in_seconds = times.size == 0 ? nil : times.sum.to_f / times.size
+          statistics[:median_response_time] = median_response_time_in_seconds
         end
 
-        CheckTracer.in_span('CheckStatistics#number_of_newsletters_sent', attributes: tracing_attributes) do
-          # Number of newsletters sent
-          # NOTE: For all platforms
-          # NOTE: Only starting from June 1, 2022
-          if end_date < Time.parse('2022-06-01')
-            data << '-'
-          else
-            data << number_of_newsletters
-          end
-        end
-
-        CheckTracer.in_span('CheckStatistics#number_of_new_newsletter_subscriptions', attributes: tracing_attributes) do
+        CheckTracer.in_span('CheckStatistics#new_newsletter_subscriptions', attributes: tracing_attributes) do
           # Number of new newsletter subscriptions
           # We were not storing versions for created TiplineSubscription after they got deleted
           if end_date < Time.parse('2023-01-01')
-            data << TiplineSubscription.where(created_at: start_date..end_date, platform: platform_name, language: language).where('teams.id' => team_id).joins(:team).count
+            statistics[:new_newsletter_subscriptions] = TiplineSubscription.where(created_at: start_date..end_date, platform: platform_name, language: language).where('teams.id' => team_id).joins(:team).count
           else
-            data << Version.from_partition(team_id).where(created_at: start_date..end_date, team_id: team_id, item_type: 'TiplineSubscription', event_type: 'create_tiplinesubscription').where('object_after LIKE ?', "%#{platform_name}%").where('object_after LIKE ?', '%"language":"' + language + '"%').count
+            statistics[:new_newsletter_subscriptions] = Version.from_partition(team_id).where(created_at: start_date..end_date, team_id: team_id, item_type: 'TiplineSubscription', event_type: 'create_tiplinesubscription').where('object_after LIKE ?', "%#{platform_name}%").where('object_after LIKE ?', '%"language":"' + language + '"%').count
           end
         end
 
-        CheckTracer.in_span('CheckStatistics#number_of_newsletter_subscription_cancellations', attributes: tracing_attributes) do
+        CheckTracer.in_span('CheckStatistics#newsletter_cancellations', attributes: tracing_attributes) do
           # Number of newsletter subscription cancellations
-          data << Version.from_partition(team_id).where(created_at: start_date..end_date, team_id: team_id, item_type: 'TiplineSubscription', event_type: 'destroy_tiplinesubscription').where('object LIKE ?', "%#{platform_name}%").where('object LIKE ?', '%"language":"' + language + '"%').count
+          statistics[:newsletter_cancellations] = Version.from_partition(team_id).where(created_at: start_date..end_date, team_id: team_id, item_type: 'TiplineSubscription', event_type: 'destroy_tiplinesubscription').where('object LIKE ?', "%#{platform_name}%").where('object LIKE ?', '%"language":"' + language + '"%').count
         end
-
-        CheckTracer.in_span('CheckStatistics#number_of_current_newsletter_subscribers', attributes: tracing_attributes) do
-          # Current number of newsletter subscribers
-          data << TiplineSubscription.where(created_at: start_date.ago(100.years)..end_date, platform: platform_name, language: language).where('teams.id' => team_id).joins(:team).count
-        end
-
-        # CheckTracer.in_span('CheckStatistics#number_of_imported_reports', attributes: tracing_attributes) do
-          # Total number of imported reports
-          # NOTE: For all languages and platforms
-          # data << ProjectMedia.joins(:team).where('teams.id' => team_id, 'created_at' => start_date..end_date, 'user_id' => BotUser.fetch_user.id).count
-        # end
-        data
       end
+      statistics
     end
 
     def cache_team_data(team_id, header, rows)

--- a/lib/check_statistics.rb
+++ b/lib/check_statistics.rb
@@ -47,13 +47,13 @@ module CheckStatistics
       CheckTracer.in_span('CheckStatistics.get_statistics', attributes: tracing_attributes) do
         team = Team.find(team_id)
 
-        platform_name = Bot::Smooch::SUPPORTED_INTEGRATION_NAMES[platform]
         statistics = {
-          platform: platform_name,
+          platform: platform,
           language: language,
           start_date: start_date,
           end_date: end_date,
         }
+        platform_name = Bot::Smooch::SUPPORTED_INTEGRATION_NAMES[platform]
 
         conversations = nil
         CheckTracer.in_span('CheckStatistics#conversations', attributes: tracing_attributes) do
@@ -80,7 +80,7 @@ module CheckStatistics
                 nil
               end
             end.reject{ |t| t.blank? }.collect{ |t| Time.parse(t.to_s).to_s }.uniq.size
-            statistics[:unique_newsletters_sent] = end_date
+            statistics[:unique_newsletters_sent] = number_of_newsletters
           end
         end
 

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -1002,4 +1002,16 @@ module SampleData
     pmr.save!
     pmr
   end
+
+  def create_monthly_team_statistic(options = {})
+    attributes = {
+      team: options[:team] || create_team,
+      platform: 'WhatsApp',
+      language: 'en',
+      start_date: DateTime.new(2022,1,1),
+      end_date: DateTime.new(2022,1,31)
+    }.merge(options)
+
+    MonthlyTeamStatistic.create!(attributes)
+  end
 end

--- a/test/lib/tasks/lapis_error_codes_test.rb
+++ b/test/lib/tasks/lapis_error_codes_test.rb
@@ -1,14 +1,16 @@
 require_relative '../../test_helper'
+require 'rake'
 
 class LapisErrorCodeTest < ActiveSupport::TestCase
   # Basic smoke test
   def setup
-    Check::Application.load_tasks
+    Rake.application.rake_require("tasks/error_codes")
+    Rake::Task.define_task(:environment)
   end
 
   test "lapis:error_codes doesn't error when run, and outputs list to stdout" do
     out, err = capture_io do
-      Rake::Task['lapis:error_codes'].invoke
+      Rake::Task['lapis:error_codes'].execute
     end
 
     assert_match /UNAUTHORIZED: 1/, out

--- a/test/lib/tasks/statistics_test.rb
+++ b/test/lib/tasks/statistics_test.rb
@@ -1,4 +1,5 @@
 require_relative '../../test_helper'
+require 'rake'
 
 class StatisticsTest < ActiveSupport::TestCase
   # override default test setup
@@ -6,39 +7,44 @@ class StatisticsTest < ActiveSupport::TestCase
   def after_all; end
 
   def setup
-    Check::Application.load_tasks
+    Rake.application.rake_require("tasks/data/statistics")
+    Rake::Task.define_task(:environment)
 
+    MonthlyTeamStatistic.delete_all
     Team.delete_all
     TeamBotInstallation.delete_all
     ProjectMedia.delete_all
-    MonthlyTeamStatistic.delete_all
-  end
 
-  def teardown; end
+    @current_date = DateTime.new(2022,5,15,5,30,00)
+    @start_of_month =  DateTime.new(2022,5,1,0,0,0).beginning_of_month
+    @end_of_month = DateTime.new(2022,5,31,23,59,59).end_of_month
 
-  test "check:data:statistics saves historic statistics data for any workspaces with tipline data" do
-    fake_current_date = DateTime.new(2022,5,15)
-
-    other_team = create_team(slug: 'other-team')
-    other_team_user = create_user(team: other_team)
-    3.times{|i| create_project_media(user: other_team_user, claim: "Claim: other team #{i}", team: other_team, created_at: fake_current_date) }
-
-    tipline_team = create_team(slug: 'test-team')
-    tipline_team.set_languages(['en', 'es'])
-    tipline_team.save!
-    create_team_bot_installation(team_id: tipline_team.id, user_id: BotUser.smooch_user.id)
-    3.times{|i| create_project_media(user: BotUser.smooch_user, claim: "Claim: correct team #{i}", team: tipline_team, created_at: fake_current_date) }
-
-    start_of_month = DateTime.new(2022,5,1,0,0,0).beginning_of_month
-    end_of_month = DateTime.new(2022,5,31,23,59,59).end_of_month
+    # Create data for tipline team
+    @tipline_team = create_team(slug: 'test-team')
+    create_team_bot_installation(team_id: @tipline_team.id, user_id: BotUser.smooch_user.id)
+    3.times{|i| create_project_media(user: BotUser.smooch_user, claim: "Claim: correct team #{i}", team: @tipline_team, created_at: @current_date) }
 
     TeamBotInstallation.any_instance.stubs(:smooch_enabled_integrations).returns({whatsapp: 'foo'})
-    CheckStatistics.expects(:get_statistics).with(start_of_month, end_of_month, tipline_team.id, :whatsapp, 'en').returns(
+  end
+
+  def teardown
+    travel_back
+  end
+
+  test "generates statistics data for every platform and language of tipline teams" do
+    @tipline_team.set_languages(['en', 'es'])
+    @tipline_team.save!
+
+    non_tipline_team = create_team(slug: 'other-team')
+    non_tipline_team_user = create_user(team: non_tipline_team)
+    3.times{|i| create_project_media(user: non_tipline_team_user, claim: "Claim: other team #{i}", team: non_tipline_team, created_at: @current_date) }
+
+    CheckStatistics.expects(:get_statistics).with(@start_of_month, @current_date, @tipline_team.id, :whatsapp, 'en').returns(
       {
-        platform: 'WhatsApp',
+        platform: 'whatsapp',
         language: 'en',
-        start_date: start_of_month,
-        end_date: end_of_month,
+        start_date: @start_of_month,
+        end_date: @current_date,
         conversations: 1,
         average_messages_per_day: 2,
         unique_users: 3,
@@ -56,31 +62,28 @@ class StatisticsTest < ActiveSupport::TestCase
         current_subscribers: 15,
       }
     )
-    CheckStatistics.expects(:get_statistics).with(start_of_month, end_of_month, tipline_team.id, :whatsapp, 'es').returns({
-      platform: 'WhatsApp',
+    CheckStatistics.expects(:get_statistics).with(@start_of_month, @current_date, @tipline_team.id, :whatsapp, 'es').returns({
+      platform: 'whatsapp',
       language: 'es',
-      start_date: start_of_month,
-      end_date: end_of_month,
+      start_date: @start_of_month,
+      end_date: @current_date,
       conversations: 200,
     })
+    travel_to @current_date
 
-    assert_nil Rails.cache.read("data:report:#{tipline_team.id}")
-
-    travel_to fake_current_date
-
-    assert_equal 0, MonthlyTeamStatistic.where(team: tipline_team).count
+    assert_equal 0, MonthlyTeamStatistic.where(team: @tipline_team).count
 
     Rake::Task['check:data:statistics'].invoke
+    Rake::Task['check:data:statistics'].reenable
 
-    assert_equal 2, MonthlyTeamStatistic.where(team: tipline_team).count
+    # One for each language
+    assert_equal 2, MonthlyTeamStatistic.where(team: @tipline_team).count
 
     stats = MonthlyTeamStatistic.first
-    # Check every attribute, since we're doing an insert_all,
-    # which bypasses ActiveRecord's usual callbacks and validations
-    assert_equal start_of_month.to_i, stats.start_date.to_i
-    assert_equal end_of_month.to_i, stats.end_date.to_i
+    assert_equal @start_of_month.to_i, stats.start_date.to_i
+    assert_equal @current_date.to_i, stats.end_date.to_i
     assert_equal 'en', stats.language
-    assert_equal 'WhatsApp', stats.platform
+    assert_equal 'whatsapp', stats.platform
     assert_equal 4, stats.returning_users
     assert_equal 5, stats.valid_new_requests
     assert_equal 6, stats.published_native_reports
@@ -95,7 +98,82 @@ class StatisticsTest < ActiveSupport::TestCase
     assert_equal 15, stats.current_subscribers
 
     assert_equal MonthlyTeamStatistic.last.conversations, 200
-  ensure
-    travel_back
+  end
+
+  test "generates statistics data for each month in tipline history when absent" do
+    create_project_media(user: BotUser.smooch_user, claim: "Claim: previous month", team: @tipline_team, created_at: @current_date - 1.month)
+
+    # Full month - past
+    start_of_previous_month = (@current_date - 1.month).beginning_of_month
+    end_of_previous_month = (@current_date - 1.month).end_of_month
+    CheckStatistics.expects(:get_statistics).with(start_of_previous_month, end_of_previous_month, @tipline_team.id, :whatsapp, 'en').returns(
+      {
+        platform: :whatsapp,
+        language: 'en',
+        start_date: start_of_previous_month,
+        end_date: end_of_previous_month,
+      }
+    )
+
+    # Partial month - current
+    CheckStatistics.expects(:get_statistics).with(@start_of_month, @current_date, @tipline_team.id, :whatsapp, 'en').returns(
+      {
+        platform: :whatsapp,
+        language: 'en',
+        start_date: @start_of_month,
+        end_date: @current_date,
+      }
+    )
+
+    travel_to @current_date
+
+    assert_equal 0, MonthlyTeamStatistic.where(team: @tipline_team).count
+
+    Rake::Task['check:data:statistics'].invoke
+    Rake::Task['check:data:statistics'].reenable
+
+    assert_equal 2, MonthlyTeamStatistic.where(team: @tipline_team).count
+  end
+
+  test "only regenerates the current month's statistics when past data is present and complete, and updates end_date" do
+    # Create data for previous months
+    create_project_media(user: BotUser.smooch_user, claim: "Claim: previous month", team: @tipline_team, created_at: @current_date - 1.month)
+    create_monthly_team_statistic(team: @tipline_team,
+                                  start_date: (@current_date - 1.month).beginning_of_month,
+                                  end_date: (@current_date - 1.month).end_of_month,
+                                  platform: 'whatsapp',
+                                  language: 'en')
+
+    # Create data for current month, to be updated  by task
+    current_statistics = create_monthly_team_statistic(team: @tipline_team,
+                                                       start_date: @current_date.beginning_of_month,
+                                                       end_date: @current_date - 1.day,
+                                                       platform: 'whatsapp',
+                                                       language: 'en',
+                                                       conversations: 1)
+
+    CheckStatistics.expects(:get_statistics).with(@start_of_month, @current_date, @tipline_team.id, :whatsapp, 'en').returns(
+      {
+        platform: :whatsapp,
+        language: 'en',
+        start_date: @start_of_month,
+        end_date: @current_date,
+        conversations: 2,
+      }
+    )
+
+    travel_to @current_date
+
+    assert_equal 2, MonthlyTeamStatistic.where(team: @tipline_team).count
+    assert_equal current_statistics.end_date, @current_date - 1.day
+    assert_equal 1, current_statistics.conversations
+
+    Rake::Task['check:data:statistics'].invoke
+    Rake::Task['check:data:statistics'].reenable
+
+    current_statistics.reload
+    assert_equal 2, MonthlyTeamStatistic.where(team: @tipline_team).count
+    assert_equal current_statistics.end_date, @current_date
+    assert_equal 2, current_statistics.conversations
   end
 end

--- a/test/lib/tasks/statistics_test.rb
+++ b/test/lib/tasks/statistics_test.rb
@@ -4,17 +4,19 @@ class StatisticsTest < ActiveSupport::TestCase
   # override default test setup
   def before_all; end
   def after_all; end
+
   def setup
     Check::Application.load_tasks
 
     Team.delete_all
     TeamBotInstallation.delete_all
     ProjectMedia.delete_all
+    MonthlyTeamStatistic.delete_all
   end
 
   def teardown; end
 
-  test "check:data:statistics caches statistics data for any workspaces with tipline data" do
+  test "check:data:statistics saves historic statistics data for any workspaces with tipline data" do
     fake_current_date = DateTime.new(2022,5,15)
 
     other_team = create_team(slug: 'other-team')
@@ -31,17 +33,68 @@ class StatisticsTest < ActiveSupport::TestCase
     end_of_month = DateTime.new(2022,5,31,23,59,59).end_of_month
 
     TeamBotInstallation.any_instance.stubs(:smooch_enabled_integrations).returns({whatsapp: 'foo'})
-    CheckStatistics.expects(:get_statistics).with(start_of_month, end_of_month, tipline_team.id, :whatsapp, 'en').returns(['id-1234'])
-    CheckStatistics.expects(:get_statistics).with(start_of_month, end_of_month, tipline_team.id, :whatsapp, 'es').returns(['id-1234'])
+    CheckStatistics.expects(:get_statistics).with(start_of_month, end_of_month, tipline_team.id, :whatsapp, 'en').returns(
+      {
+        platform: 'WhatsApp',
+        language: 'en',
+        start_date: start_of_month,
+        end_date: end_of_month,
+        conversations: 1,
+        average_messages_per_day: 2,
+        unique_users: 3,
+        returning_users: 4,
+        valid_new_requests: 5,
+        published_native_reports: 6,
+        published_imported_reports: 7,
+        requests_answered_with_report: 8,
+        reports_sent_to_users: 9,
+        unique_users_who_received_report: 10,
+        median_response_time: 11,
+        unique_newsletters_sent: 12,
+        new_newsletter_subscriptions: 13,
+        newsletter_cancellations: 14,
+        current_subscribers: 15,
+      }
+    )
+    CheckStatistics.expects(:get_statistics).with(start_of_month, end_of_month, tipline_team.id, :whatsapp, 'es').returns({
+      platform: 'WhatsApp',
+      language: 'es',
+      start_date: start_of_month,
+      end_date: end_of_month,
+      conversations: 200,
+    })
 
     assert_nil Rails.cache.read("data:report:#{tipline_team.id}")
 
     travel_to fake_current_date
 
+    assert_equal 0, MonthlyTeamStatistic.where(team: tipline_team).count
+
     Rake::Task['check:data:statistics'].invoke
 
-    assert_nil Rails.cache.read("data:report:#{other_team.id}")
-    assert_not_nil Rails.cache.read("data:report:#{tipline_team.id}")
+    assert_equal 2, MonthlyTeamStatistic.where(team: tipline_team).count
+
+    stats = MonthlyTeamStatistic.first
+    # Check every attribute, since we're doing an insert_all,
+    # which bypasses ActiveRecord's usual callbacks and validations
+    assert_equal start_of_month.to_i, stats.start_date.to_i
+    assert_equal end_of_month.to_i, stats.end_date.to_i
+    assert_equal 'en', stats.language
+    assert_equal 'WhatsApp', stats.platform
+    assert_equal 4, stats.returning_users
+    assert_equal 5, stats.valid_new_requests
+    assert_equal 6, stats.published_native_reports
+    assert_equal 7, stats.published_imported_reports
+    assert_equal 8, stats.requests_answered_with_report
+    assert_equal 9, stats.reports_sent_to_users
+    assert_equal 10, stats.unique_users_who_received_report
+    assert_equal 11, stats.median_response_time
+    assert_equal 12, stats.unique_newsletters_sent
+    assert_equal 13, stats.new_newsletter_subscriptions
+    assert_equal 14, stats.newsletter_cancellations
+    assert_equal 15, stats.current_subscribers
+
+    assert_equal MonthlyTeamStatistic.last.conversations, 200
   ensure
     travel_back
   end

--- a/test/models/monthly_team_statistics_test.rb
+++ b/test/models/monthly_team_statistics_test.rb
@@ -1,0 +1,107 @@
+require_relative '../test_helper'
+
+class MonthlyTeamStatisticTest < ActiveSupport::TestCase
+  # override default test setup
+  def before_all; end
+  def after_all; end
+
+  def setup
+    MonthlyTeamStatistic.delete_all
+    Team.delete_all
+  end
+
+  def teardown; end
+
+  test "is invalid without required fields" do
+    stat = MonthlyTeamStatistic.new
+
+    assert !stat.valid?
+
+    team = create_team(name: "Fake team")
+    stat = MonthlyTeamStatistic.new(team: team, start_date: DateTime.now, end_date: DateTime.now, platform: "Telegram", language: "en")
+
+    assert stat.valid?
+  end
+
+  test ".formatted_hash presents data with human-readable keys" do
+    team = create_team(name: "Fake team")
+
+    stat = MonthlyTeamStatistic.create(
+      team: team,
+      platform: "whatsapp",
+      language: "en",
+      start_date: DateTime.new(2020,4,1),
+      end_date: DateTime.new(2020,4,15),
+      conversations: 1,
+      average_messages_per_day: 2,
+      unique_users: 3,
+      returning_users: 4,
+      valid_new_requests: 5,
+      published_native_reports: 6,
+      published_imported_reports: 7,
+      requests_answered_with_report: 8,
+      reports_sent_to_users: 9,
+      unique_users_who_received_report: 10,
+      median_response_time: 11,
+      unique_newsletters_sent: 12,
+      new_newsletter_subscriptions: 13,
+      newsletter_cancellations: 14,
+      current_subscribers: 15,
+    )
+
+    hash = stat.formatted_hash
+
+    assert_equal hash["ID"], stat.id
+    assert_equal hash["Org"], "Fake team"
+    assert_equal hash["Platform"], "whatsapp"
+    assert_equal hash["Language"], "en"
+    assert_equal hash["Month"], "Apr 2020"
+    assert_equal hash["Conversations"], 1
+    assert_equal hash["Average messages per day"], 2
+    assert_equal hash["Unique users"], 3
+    assert_equal hash["Returning users"], 4
+    assert_equal hash["Valid new requests"], 5
+    assert_equal hash["Published native reports"], 6
+    assert_equal hash["Published imported reports"], 7
+    assert_equal hash["Requests answered with a report"], 8
+    assert_equal hash["Reports sent to users"], 9
+    assert_equal hash["Unique users who received a report"], 10
+    assert_equal hash["Average (median) response time"], "less than a minute"
+    assert_equal hash["Unique newsletters sent"], 12
+    assert_equal hash["New newsletter subscriptions"], 13
+    assert_equal hash["Newsletter cancellations"], 14
+    assert_equal hash["Current subscribers"], 15
+  end
+
+  test ".formatted_median_response_time formats integer value" do
+    stat = MonthlyTeamStatistic.new(median_response_time: 11)
+
+    assert_equal "less than a minute", stat.formatted_median_response_time
+  end
+
+  test ".formatted_median_response_time does not choke when nil" do
+    stat = MonthlyTeamStatistic.new(median_response_time: nil)
+
+    assert_nil stat.formatted_median_response_time
+  end
+
+  test ".month formats the start date to MonthName Year" do
+    stat = MonthlyTeamStatistic.new(start_date: DateTime.new(2020,04,15))
+
+    assert_equal "Apr 2020", stat.month
+  end
+
+  test ".org returns the team name" do
+    team = create_team(name: "Fake team")
+    stat = MonthlyTeamStatistic.create(team: team)
+
+    assert_equal "Fake team", stat.org
+  end
+
+  test "sets default of - if value is not present" do
+    team = create_team(name: "Fake team")
+    stat = MonthlyTeamStatistic.create(team: team, unique_newsletters_sent: nil)
+
+    assert_equal '-', stat.formatted_hash["Unique newsletters sent"]
+  end
+end

--- a/test/models/monthly_team_statistics_test.rb
+++ b/test/models/monthly_team_statistics_test.rb
@@ -23,6 +23,17 @@ class MonthlyTeamStatisticTest < ActiveSupport::TestCase
     assert stat.valid?
   end
 
+  test "is invalid if not unique for team, platform, language, and start_date" do
+    team = create_team
+    create_monthly_team_statistic(team: team, platform: 'whatsapp', language: 'en', start_date: DateTime.new(2022,1,2))
+
+    stat = MonthlyTeamStatistic.new(team: team, platform: 'whatsapp', language: 'en', start_date: DateTime.new(2022,1,2), end_date: DateTime.new(2022,2,3))
+    assert !stat.valid?
+
+    stat.start_date = DateTime.new(2022,2,3)
+    assert stat.valid?
+  end
+
   test ".formatted_hash presents data with human-readable keys" do
     team = create_team(name: "Fake team")
 
@@ -53,7 +64,7 @@ class MonthlyTeamStatisticTest < ActiveSupport::TestCase
 
     assert_equal hash["ID"], stat.id
     assert_equal hash["Org"], "Fake team"
-    assert_equal hash["Platform"], "whatsapp"
+    assert_equal hash["Platform"], "WhatsApp"
     assert_equal hash["Language"], "en"
     assert_equal hash["Month"], "Apr 2020"
     assert_equal hash["Conversations"], 1
@@ -103,5 +114,11 @@ class MonthlyTeamStatisticTest < ActiveSupport::TestCase
     stat = MonthlyTeamStatistic.create(team: team, unique_newsletters_sent: nil)
 
     assert_equal '-', stat.formatted_hash["Unique newsletters sent"]
+  end
+
+  test ".platform_name sets human-readable name for platform" do
+    stat = MonthlyTeamStatistic.new(platform: 'whatsapp')
+
+    assert_equal "WhatsApp", stat.platform_name
   end
 end

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -2663,11 +2663,18 @@ class TeamTest < ActiveSupport::TestCase
     assert_equal 3, t.reload.medias_count
   end
 
-  test "should return data report" do
+  test "should return data report with chronologically ordered items" do
     t = create_team
     assert_nil t.data_report
-    Rails.cache.write("data:report:#{t.id}", [{ 'Month' => 'Jan 2022', 'Search' => 1, 'Foo' => 2 }])
-    assert_equal([{ 'Month' => '1. Jan 2022', 'Foo' => 2 }], t.data_report)
+
+    create_monthly_team_statistic(team: t, start_date: DateTime.new(2022, 2, 1), conversations: 3)
+    create_monthly_team_statistic(team: t, start_date: DateTime.new(2022, 1, 1), conversations: 2)
+
+    data_report = t.data_report
+
+    assert_equal 2, data_report.length
+    assert_equal '1. Jan 2022', data_report.first['Month']
+    assert_equal 2, data_report.first['Conversations']
   end
 
   test "should have feeds" do


### PR DESCRIPTION
Previously we were generating statistics and storing them to the Rails cache. The entries could be very large - one row per language, platform, and month since a tipline was enabled, for each workspace. We were also generating statistics for each month each time we ran it, which took a long time.

This PR moves toward saving the data more incrementally as a single-purpose ActiveRecord model, and determines which months to generate based on what months have missing or partial data.

From the frontend's perspective, this change should not change any behavior except for two small things:
* The ID returned with each row of the report is different (numeric ID from database instead of generated ID with date, platform, etc)
* Month is in format of `1. Jun 2020` instead of `1. 2020-06-01` (most recent change) or `1. June 2020` (currently deployed behavior)

Some details:

**MonthlyTeamStatistic**
The intention of the MonthlyTeamStatistic model is to only be used for monthly statistic generation. We could change this in the future if we wanted—bounding to a month allowed me to set a validation on the time period. As written currently, we only have one MonthlyTeamStatistic per team, language, platform, and start date (assuming that we would want to only have say one object for Test Team on WhatsApp in English for July, but that the end date might change if we're midmonth and regenerating so isn't worth validating).

The model has the ability for us to specific methods for formatting, which we can then configure in the `FIELD_MAPPINGS` hash so that they are used in the `.formatted_hash` method, which is used for preparing the response to client.

**Approach to generating data**
I kept to the same approach we were using before, which looks at the first ProjectMedia for a tipline for a given team and then iterates through each month of data for each platform and language the team has enabled.

* If full data is present for the month (ie there is a MonthlyTeamStatistic with a start and end date matching start and end date of that month), it continues to next month
* If partial data is present for the month (ie there is a MonthlyTeamStatistic with a start date matching month start but end date not matching the end - representing partially calculated data, like when the task was run on a month boundary), it regenerates and updates the model
* If no data is present for the month (ie there is no MonthlyTeamStatistic - representing a new month), it generates and creates a model

**Note**: I'm a little worried about the performance of this since we are still iterating over a lot of data and touching the database once per iteration (vs assembling the array and saving the whole thing once to cache like before). Want to see if we can try and monitor in an environment with more data than I have locally. We could do a bulk insert, but would miss the ActiveRecord validations so wanted to avoid if we can.

**Changes to get_statistics**
* Returns a hash from CheckStatistics.get_statistics, so that we can more easily keep track of what values are being set instead of relying on positional data
* Removes generation of statistics that we were filtering out of the response to the front end (search, some message related fields)
* Changes the ID format for the returned data structure. It's still unique because it's a database index, but is no longer human readable in the same way

## How I checked locally

I ran the rake task on develop on a workspace with tipline enabled and some minimal data - `bundle exec rake check:data:statistics`. Entered rails console and checked report `Team.find(team_id).data_report` and checked Rails cache `Rails.cache.read("data:report:#{team_id}"). Then switched branches, rebuilt container and reran rake task, then in rails console checked return `Team.find(team_id).data_report` and then the cached values `MonthlyTeamStatistic.where(team_id: team_id)`.

* UI looks the same
* Output from team.data_report looks the same
* Confirmed that database is caching values (saves past months, and then doesn't update the non-current months)

**this branch result for team.data_report**
```
[
  {
    "ID"=> 1,
    "Org"=> "test",
    "Platform"=> "Telegram",
    "Language"=> "en",
    "Month"=> "1. Dec 2022",
    "Conversations"=> 1,
    "Average messages per day"=> 0,
    "Unique users"=> 1,
    "Returning users"=> 0,
    "Valid new requests"=> 0,
    "Published native reports"=> 0,
    "Published imported reports"=> 0,
    "Requests answered with a report"=> 0,
    "Reports sent to users"=> 0,
    "Unique users who received a report"=> 0,
    "Average (median) response time"=> "-",
    "Unique newsletters sent"=> 0,
    "New newsletter subscriptions"=> 0,
    "Newsletter cancellations"=> 0,
    "Current subscribers"=> 0
  },
  {
    "ID"=> 2
    "Org"=> "test",
    "Platform"=> "Telegram",
    "Language"=> "en",
    "Month"=> "2. Jan 2023",
    "Conversations"=> 0,
    "Average messages per day"=> 0,
    "Unique users"=> 0,
    "Returning users"=> 0,
    "Valid new requests"=> 0,
    "Published native reports"=> 0,
    "Published imported reports"=> 0,
    "Requests answered with a report"=> 0,
    "Reports sent to users"=> 0,
    "Unique users who received a report"=> 0,
    "Average (median) response time"=> "-",
    "Unique newsletters sent"=> 0,
    "New newsletter subscriptions"=> 0,
    "Newsletter cancellations"=> 0,
    "Current subscribers"=> 0
  }
]
```

**develop result**
```
[
  {
    "ID"=>"test-telegram-en-2022-12-01-2022-12-31",
    "Org"=>"test",
    "Platform"=>"Telegram",
    "Language"=>"en",
    "Month"=>"1. 2022-12-01",
    "Conversations"=>1,
    "Average messages per day"=>0,
    "Unique users"=>1,
    "Returning users"=>0,
    "Valid new requests"=>0,
    "Published native reports"=>0,
    "Published imported reports"=>0,
    "Requests answered with a report"=>0,
    "Reports sent to users"=>0,
    "Unique users who received a report"=>0,
    "Average (median) response time"=>"-",
    "Unique newsletters sent"=>0,
    "New newsletter subscriptions"=>0,
    "Newsletter cancellations"=>0,
    "Current subscribers"=>0
  },
  {
    "ID"=>"test-telegram-en-2023-01-01-2023-01-31",
    "Org"=>"test",
    "Platform"=>"Telegram",
    "Language"=>"en",
    "Month"=>"2. 2023-01-01",
    "Conversations"=>0,
    "Average messages per day"=>0,
    "Unique users"=>0,
    "Returning users"=>0,
    "Valid new requests"=>0,
    "Published native reports"=>0,
    "Published imported reports"=>0,
    "Requests answered with a report"=>0,
    "Reports sent to users"=>0,
    "Unique users who received a report"=>0,
    "Average (median) response time"=>"-",
    "Unique newsletters sent"=>0,
    "New newsletter subscriptions"=>0,
    "Newsletter cancellations"=>0,
    "Current subscribers"=>0
  }
]
```

**Times to run:**
* current branch: 1st run: real 23s, user 3.2s, sys 1.10s; 2nd run: real 23s, user 3.1s, sys 1.8s
* develop: 1st run: real 23.4s, user 3.6s, sys 1.2s; 2nd run: real 28.6s, user 3.3s, sys 1.3s

Honeycomb trace of running the current branch and then develop: https://ui.honeycomb.io/meedan/environments/dev/datasets/check-api/result/CuANxUVZErU
* [Example trace of task on this branch](https://ui.honeycomb.io/meedan/environments/dev/datasets/check-api/result/CuANxUVZErU/trace/ym4PEgb8JBT?fields[]=c_name&fields[]=c_service.name&fields[]=c_library.name&span=350b056433a981ee) - duration 1.1s with 130 spans
* [Example trace of task on develop](https://ui.honeycomb.io/meedan/environments/dev/datasets/check-api/result/CuANxUVZErU/trace/CVvq35DtVxP?fields[]=c_name&fields[]=c_service.name&fields[]=c_library.name&span=ac46f12b58137070) - duration 7.9s with 318 spans

Hopefully will see more improvement with larger dataset, but we'll see!

CHECK-2892