### PR TITLE
Update regex for detect last modified date for TOS and privacy policy

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -267,7 +267,7 @@ class User < ApplicationRecord
     return 0 unless mapping.has_key?(page)
     Rails.cache.fetch("last_updated_at:#{page}", expires_in: 24.hours) do
       html = open(CheckConfig.get(mapping[page], nil, :json), read_timeout: 5, open_timeout: 5).read
-      date = ActionController::Base.helpers.strip_tags(html).gsub(/\s\s+/m, '|').match(/Last modified\|([^|]+)/)[1]
+      date = ActionController::Base.helpers.strip_tags(html).match(/Last modified(?<modified_date>(Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:tember)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)\s\d{1,2},\s\d{2,4})/)["modified_date"]
       Time.parse(date).to_i
     end
   end


### PR DESCRIPTION
The HTML structure had changed, which caused our regex to fail to capture the last modified date. This commit changes the regex to capture the current format when stripped of HTML (eg "Last modifiedJanuary 13, 2023") while also building in some hopefully helpful affordances for future - specifically, the ability to detect shortened month names (eg "Last modifiedJan 13, 2023") and two date years (which might be weird - eg "Last modified Jan 13, 23")

CHECK-2898