### PR TITLE
Fixing permission check for update mutations

### DIFF
--- a/app/graph/mutations/graphql_crud_operations.rb
+++ b/app/graph/mutations/graphql_crud_operations.rb
@@ -15,7 +15,7 @@ class GraphqlCrudOperations
   end
 
   def self.safe_save(obj, attrs, parents = [], inputs = {})
-    raise "This operation must be done by a signed-in user" if User.current.nil?
+    raise "This operation must be done by a signed-in user" if User.current.nil? && ApiKey.current.nil?
     attrs.each do |key, value|
       method = key == 'clientMutationId' ? 'client_mutation_id=' : "#{key}="
       obj.send(method, value) if obj.respond_to?(method)


### PR DESCRIPTION
Exception should not be raised if the mutation was made using a valid API key.

Fixes CHECK-2762.