### PR TITLE
Prevent error when team has no languages configured

### DIFF
--- a/lib/tasks/data/statistics.rake
+++ b/lib/tasks/data/statistics.rake
@@ -23,7 +23,7 @@ namespace :check do
 
           puts "[#{Time.now}] Generating month tipline statistics for team with ID #{team_id} (#{month_start}). (#{index + 1} / #{team_ids.length})"
           TeamBotInstallation.where(team_id: team_id, user: BotUser.smooch_user).last.smooch_enabled_integrations.keys.each do |platform|
-            team.get_languages.each do |language|
+            team.get_languages.to_a.each do |language|
               # Complete month - skip
               next unless MonthlyTeamStatistic.where(team_id: team_id, platform: platform, language: language, start_date: month_start, end_date: month_end).blank?
 

--- a/test/lib/tasks/statistics_test.rb
+++ b/test/lib/tasks/statistics_test.rb
@@ -176,4 +176,20 @@ class StatisticsTest < ActiveSupport::TestCase
     assert_equal current_statistics.end_date, @current_date
     assert_equal 2, current_statistics.conversations
   end
+
+  test "skips generating statistics for teams without languages configured" do
+    @tipline_team.set_languages(nil)
+    @tipline_team.save!
+
+    CheckStatistics.expects(:get_statistics).never
+
+    travel_to @current_date
+
+    assert_equal 0, MonthlyTeamStatistic.where(team: @tipline_team).count
+
+    Rake::Task['check:data:statistics'].invoke
+    Rake::Task['check:data:statistics'].reenable
+
+    assert_equal 0, MonthlyTeamStatistic.where(team: @tipline_team).count
+  end
 end


### PR DESCRIPTION
In production data, some teams with inactive tiplines do not have languages configured. In these cases, we can safetly skip over them for statistics generation.

CHECK-2892