### PR TITLE
Adding "listed" attribute to bots

### DIFF
--- a/app/graph/types/root_level_type.rb
+++ b/app/graph/types/root_level_type.rb
@@ -18,9 +18,9 @@ RootLevelType = GraphQL::ObjectType.define do
     }
   end
 
-  connection :team_bots_approved, BotUserType.connection_type do
+  connection :team_bots_listed, BotUserType.connection_type do
     resolve -> (_object, _args, _ctx) {
-      BotUser.all.select{ |b| b.get_approved }
+      BotUser.listed
     }
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -500,7 +500,7 @@ en:
     to create a bot
   bot_not_approved_for_installation: Sorry, this bot was not approved so it can't
     be installed
-  only_admins_can_approve_bots: Sorry, only system administrators can approve bots
+  only_admins_can_approve_or_list_bots: Sorry, only system administrators can approve or list bots
   could_not_save_related_bot_data: Sorry, could not add the bot to this workspace
   bot_cant_add_response_to_task: Sorry, a bot can't answer a task directly - please
     send an answer suggestion instead

--- a/db/migrate/20230116233317_set_listed_bots.rb
+++ b/db/migrate/20230116233317_set_listed_bots.rb
@@ -1,0 +1,9 @@
+class SetListedBots < ActiveRecord::Migration[5.2]
+  def change
+    # These bots should be marked as "listed", so they appear on the UI
+    BotUser.where(login: ['fetch', 'keep', 'slack']).each do |bot|
+      bot.set_listed = true
+      bot.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_06_220307) do
+ActiveRecord::Schema.define(version: 2023_01_16_233317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/public/relay.json
+++ b/public/relay.json
@@ -56984,7 +56984,7 @@
               "deprecationReason": null
             },
             {
-              "name": "team_bots_approved",
+              "name": "team_bots_listed",
               "description": null,
               "args": [
                 {

--- a/test/controllers/graphql_controller_2_test.rb
+++ b/test/controllers/graphql_controller_2_test.rb
@@ -310,14 +310,14 @@ class GraphqlController2Test < ActionController::TestCase
     User.current = nil
   end
 
-  test "should get approved bots, current user and current team" do
+  test "should get listed bots, current user and current team" do
     BotUser.delete_all
     authenticate_with_user
-    tb1 = create_team_bot set_approved: true
-    tb2 = create_team_bot set_approved: false
-    query = "query read { root { current_user { id }, current_team { id }, team_bots_approved { edges { node { dbid } } } } }"
+    tb1 = create_team_bot set_listed: true
+    tb2 = create_team_bot set_listed: false
+    query = "query read { root { current_user { id }, current_team { id }, team_bots_listed { edges { node { dbid } } } } }"
     post :create, params: { query: query }
-    edges = JSON.parse(@response.body)['data']['root']['team_bots_approved']['edges']
+    edges = JSON.parse(@response.body)['data']['root']['team_bots_listed']['edges']
     assert_equal [tb1.id], edges.collect{ |e| e['node']['dbid'] }
   end
 


### PR DESCRIPTION
This is a new boolean attribute. "Listed" bots are the ones that are displayed to users so they can install in their workspaces.

Reference: CHECK-2902.