### PR TITLE
Fallback to Rails cache for statistics

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -559,14 +559,22 @@ class Team < ApplicationRecord
 
   def data_report
     monthly_statisitcs = MonthlyTeamStatistic.where(team: team).order('start_date ASC')
-    return nil if monthly_statisitcs.blank?
+    if monthly_statisitcs.present?
+      index = 1
+      monthly_statisitcs.map do |stat|
+        hash = stat.formatted_hash
+        hash['Month'] = "#{index}. #{hash['Month']}"
+        index += 1
+        hash
+      end
+    else
+      data = Rails.cache.read("data:report:#{self.id}")
+      return nil if data.blank?
 
-    index = 1
-    monthly_statisitcs.map do |stat|
-      hash = stat.formatted_hash
-      hash['Month'] = "#{index}. #{hash['Month']}"
-      index += 1
-      hash
+      data.map.with_index do |row, i|
+        row['Month'] = "#{i + 1}. #{row['Month']}"
+        row.reject { |key, _value| key =~ /[sS]earch/ || ['Average number of conversations per day', 'Number of messages sent'].include?(key) }
+      end
     end
   end
 

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -2663,9 +2663,19 @@ class TeamTest < ActiveSupport::TestCase
     assert_equal 3, t.reload.medias_count
   end
 
-  test "should return data report with chronologically ordered items" do
+  test "should default to Rails cache for data report if monthly team statistics not present" do
     t = create_team
     assert_nil t.data_report
+
+    Rails.cache.write("data:report:#{t.id}", [{ 'Month' => 'Jan 2022', 'Search' => 1, 'Foo' => 2 }])
+    assert_equal([{ 'Month' => '1. Jan 2022', 'Foo' => 2 }], t.data_report)
+  end
+
+  test "should return data report with chronologically ordered items, preferring the MonthlyTeamStatistics when present" do
+    t = create_team
+    assert_nil t.data_report
+
+    Rails.cache.write("data:report:#{t.id}", [{ 'Month' => 'Jan 2022', 'Conversations' => 200 }])
 
     create_monthly_team_statistic(team: t, start_date: DateTime.new(2022, 2, 1), conversations: 3)
     create_monthly_team_statistic(team: t, start_date: DateTime.new(2022, 1, 1), conversations: 2)


### PR DESCRIPTION
We may have a period of time between when we deploy the application and when we deploy the new batch statistics job that uses the Postgres database instead of the Rails cache. To make sure the data report pages still show some statistics, this commit introduces a fallback for the data report - if the Postgres data has been populated, use it. If not, look to the Rails cache and present the data how it was presented before the format update.

We can merge this safely even if we expect to update the batch job before the next deploy, which I think we should do to decouple the deploy processes.

If merged, this commit can be reverted after we have run the updated statistics batch job for the first time.

CV2-2565