### PR TITLE
Do not use v1 workflow messages

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -663,8 +663,7 @@ class Bot::Smooch < BotUser
   def self.send_error_message(message, is_supported)
     m_type = is_supported[:m_type] || 'file'
     max_size = "Uploaded#{m_type.camelize}".constantize.max_size_readable
-    workflow = self.get_workflow(message['language'])
-    error_message = is_supported[:type] == false ? (workflow['smooch_message_smooch_bot_message_type_unsupported'] || self.get_string(:invalid_format, message['language'])) : I18n.t(:smooch_bot_message_size_unsupported, { max_size: max_size, locale: message['language'].gsub(/[-_].*$/, '') })
+    error_message = is_supported[:type] == false ? self.get_string(:invalid_format, message['language']) : I18n.t(:smooch_bot_message_size_unsupported, { max_size: max_size, locale: message['language'].gsub(/[-_].*$/, '') })
     self.send_message_to_user(message['authorId'], error_message)
   end
 
@@ -865,9 +864,7 @@ class Bot::Smooch < BotUser
     # User received a report before
     if subscribed_at.to_i < last_published_at.to_i && published_count > 0
       if ['publish', 'republish_and_resend'].include?(action)
-        workflow = self.get_workflow(lang)
-        pre_message = workflow['smooch_message_smooch_bot_result_changed'] || self.get_string(:report_updated, lang)
-        self.send_report_to_user(uid, data, pm, lang, 'fact_check_report_updated', pre_message)
+        self.send_report_to_user(uid, data, pm, lang, 'fact_check_report_updated', self.get_string(:report_updated, lang))
       end
     # First report
     else

--- a/data/zh/languages.yml
+++ b/data/zh/languages.yml
@@ -1,5 +1,5 @@
-zh: 
-  languages: 
+zh:
+  languages:
     aa: 阿法文
     ab: 阿布哈西亚文
     ace: 亚齐文
@@ -571,6 +571,7 @@ zh:
     zen: 泽纳加文
     zgh: 标准摩洛哥塔马塞特文
     zh: 中文
+    zh-CN: 中文
     zh-Hans: 简体中文
     zh-Hant: 繁体中文
     znd: 赞德文

--- a/lib/check_cldr.rb
+++ b/lib/check_cldr.rb
@@ -13,7 +13,7 @@ class CheckCldr
   end
 
   def self.language_code_to_name(code, locale = I18n.locale)
-    code = code.to_s.tr('_', '-')
+    code = code.to_s.tr('_', '-') # match locale format in check-api/data directory
     short_code = code.to_s.gsub(/[_-].*$/, '')
     short_locale = locale.to_s.gsub(/[_-].*$/, '')
     locale ||= :en


### PR DESCRIPTION
This commit drops the usage of older smooch bot v1 messages that are saved in the workflow data in favor of the current way of getting localized strings for tiplines: either get_string or get_custom_string

References CV2-2602