### PR TITLE
Save tipline messages when messages sent and received

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ group :test do
   gem 'minitest-retry'
   gem 'rails-controller-testing'
   gem 'pact-consumer-minitest'
-  gem 'rspec-rails', '4.0.1'
   gem 'mocha', '~>1.14.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -727,14 +727,6 @@ GEM
     rspec-mocks (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
-    rspec-rails (4.0.1)
-      actionpack (>= 4.2)
-      activesupport (>= 4.2)
-      railties (>= 4.2)
-      rspec-core (~> 3.9)
-      rspec-expectations (~> 3.9)
-      rspec-mocks (~> 3.9)
-      rspec-support (~> 3.9)
     rspec-support (3.11.0)
     rubocop (0.49.0)
       parallel (~> 1.10)
@@ -1015,7 +1007,6 @@ DEPENDENCIES
   responders
   rest-client
   rqrcode
-  rspec-rails (= 4.0.1)
   rubocop (= 0.49.0)
   ruby-cldr
   ruby-progressbar (~> 1.10, >= 1.10.1)

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -354,7 +354,7 @@ class Bot::Smooch < BotUser
     uid = message['authorId']
     sm = CheckStateMachine.new(uid)
     state = sm.state.value
-    language = self.get_user_language(message, state)
+    language = self.get_user_language(uid, message, state)
     workflow = self.get_workflow(language)
     message['language'] = language
 
@@ -543,7 +543,7 @@ class Bot::Smooch < BotUser
   def self.process_menu_option(message, state, app_id)
     uid = message['authorId']
     sm = CheckStateMachine.new(uid)
-    language = self.get_user_language(message, state)
+    language = self.get_user_language(uid, message, state)
     workflow = self.get_workflow(language)
     typed, new_state = self.get_typed_message(message, sm)
     state = new_state if new_state
@@ -978,8 +978,8 @@ class Bot::Smooch < BotUser
     self.get_installation(self.installation_setting_id_keys, app_id) if self.config.blank?
     RequestStore.store[:smooch_bot_provider] = provider
     return if self.config['smooch_disable_timeout']
-    language = self.get_user_language(message)
     uid = message['authorId']
+    language = self.get_user_language(uid)
     stored_time = Rails.cache.read("smooch:last_message_from_user:#{uid}").to_i
     return if stored_time > time
     sm = CheckStateMachine.new(uid)

--- a/app/models/concerns/smooch_language.rb
+++ b/app/models/concerns/smooch_language.rb
@@ -4,8 +4,7 @@ module SmoochLanguage
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def get_user_language(message, state = nil)
-      uid = message['authorId']
+    def get_user_language(uid, message = {}, state = nil)
       team = Team.find(self.config['team_id'])
       default_language = team.default_language
       supported_languages = self.get_supported_languages

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -144,11 +144,20 @@ module SmoochMessages
       disabled ? 'disabled' : state
     end
 
+    # Used for incoming messages (e.g. message:appUser)
+    # where full message contents available
     def get_platform_from_message(message)
       type = message.dig('source', 'type')
       platform = type ? ::Bot::Smooch::SUPPORTED_INTEGRATION_NAMES[type].to_s : 'Unknown'
       RequestStore.store[:smooch_bot_platform] = platform
       platform
+    end
+
+    # Used for outgoing messages (e.g. message:delivery:channel) where
+    # message contents are truncated
+    def get_platform_from_payload(payload)
+      type = payload.dig('destination', 'type')
+      type ? ::Bot::Smooch::SUPPORTED_INTEGRATION_NAMES[type].to_s : 'Unknown'
     end
 
     def request_platform

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -199,9 +199,10 @@ module SmoochMessages
     end
 
     def process_message(message, app_id, send_message = true, type = 'default_requests')
-      message['language'] = self.get_user_language(message)
+      uid = message['authorId']
+      message['language'] = self.get_user_language(uid)
 
-      return if !Rails.cache.read("smooch:banned:#{message['authorId']}").nil?
+      return if !Rails.cache.read("smooch:banned:#{uid}").nil?
 
       hash = self.message_hash(message)
       pm_id = Rails.cache.read("smooch:message:#{hash}")

--- a/app/models/concerns/smooch_resend.rb
+++ b/app/models/concerns/smooch_resend.rb
@@ -44,11 +44,12 @@ module SmoochResend
 
     def resend_rules_message_after_window(message, original)
       template = original['fallback_template']
-      language = self.get_user_language(message)
+      uid = message['appUser']['_id']
+      language = self.get_user_language(uid)
       query_date = I18n.l(Time.at(original['query_date'].to_i), locale: language, format: :short)
       placeholders = [query_date, original['message']]
       fallback = original['message']
-      self.send_message_to_user(message['appUser']['_id'], self.format_template_message(template, placeholders, nil, fallback, language))
+      self.send_message_to_user(uid, self.format_template_message(template, placeholders, nil, fallback, language))
       true
     end
 
@@ -82,7 +83,7 @@ module SmoochResend
       text = self.get_original_slack_message_text_to_be_resent(message)
       uid = message['appUser']['_id']
       if text
-        language = self.get_user_language({ 'authorId' => uid })
+        language = self.get_user_language(uid)
         date = Rails.cache.read("smooch:last_message_from_user:#{uid}").to_i || Time.now.to_i
         query_date = I18n.l(Time.at(date), locale: language, format: :short)
         params = [query_date, text]
@@ -271,7 +272,7 @@ module SmoochResend
       data = nil
       if report&.get_field_value('state') == 'published'
         data = {}
-        data[:language] = language = self.get_user_language({ 'authorId' => message['appUser']['_id'] })
+        data[:language] = language = self.get_user_language(message['appUser']['_id'])
         data[:query_date] = I18n.l(Time.at(original['query_date'].to_i), locale: language, format: :short)
         data[:query_date_i] = original['query_date'].to_i
         data[:introduction] = report.report_design_field_value('use_introduction') ? report.report_design_introduction({ 'received' => original['query_date'].to_i }, language).to_s : nil

--- a/app/models/concerns/team_associations.rb
+++ b/app/models/concerns/team_associations.rb
@@ -18,6 +18,7 @@ module TeamAssociations
     has_many :feed_teams, dependent: :destroy
     has_many :feeds, through: :feed_teams
     has_many :monthly_team_statistics # No "dependent: :destroy" because we want to retain statistics
+    has_many :tipline_messages
 
     has_annotations
   end

--- a/app/models/tipline_message.rb
+++ b/app/models/tipline_message.rb
@@ -1,0 +1,38 @@
+class TiplineMessage < ApplicationRecord
+  enum direction: { direction_unset: 0, incoming: 1, outgoing: 2 } # default: direction_unset
+
+  belongs_to :team
+
+  validates_uniqueness_of :external_id
+  validates_presence_of :team, :uid, :platform, :language, :direction, :sent_at, :payload
+  validates :sent_at, uniqueness: { scope: [:team, :uid, :platform, :language, :direction] }
+
+  def self.from_smooch_payload(msg, payload)
+    general_attributes = {
+      uid: payload.dig('appUser', '_id'),
+      external_id: msg['_id'],
+      language: Bot::Smooch.get_user_language(msg),
+      team_id: Bot::Smooch.config[:team_id],
+      payload: payload.to_json
+    }
+
+    trigger_attributes = case payload['trigger']
+                          when 'message:appUser'
+                            {
+                              direction: :incoming,
+                              sent_at: Time.at(msg['received']),
+                              platform: Bot::Smooch.get_platform_from_message(msg),
+                            }
+                          when 'message:delivery:channel'
+                            {
+                              direction: :outgoing,
+                              sent_at: Time.at(payload['timestamp']),
+                              platform: Bot::Smooch.get_platform_from_payload(payload),
+                            }
+                          else
+                            {}
+                          end
+
+    new(general_attributes.merge(trigger_attributes))
+  end
+end

--- a/app/models/tipline_message.rb
+++ b/app/models/tipline_message.rb
@@ -8,12 +8,15 @@ class TiplineMessage < ApplicationRecord
   validates :sent_at, uniqueness: { scope: [:team, :uid, :platform, :language, :direction] }
 
   class << self
-    def from_smooch_payload(msg, payload)
+    def from_smooch_payload(msg, payload, event = nil)
+      uid = payload.dig('appUser', '_id')
+      team = Team.find(Bot::Smooch.config['team_id'])
       general_attributes = {
-        uid: payload.dig('appUser', '_id'),
+        uid: uid,
         external_id: msg['_id'],
-        language: Bot::Smooch.get_user_language(msg),
-        team_id: Bot::Smooch.config[:team_id],
+        team: team,
+        event: event,
+        language: Bot::Smooch.get_user_language(uid),
         payload: payload.to_json
       }
 

--- a/app/workers/smooch_tipline_message_worker.rb
+++ b/app/workers/smooch_tipline_message_worker.rb
@@ -1,0 +1,10 @@
+class SmoochTiplineMessageWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: 'smooch', retry: 1
+
+  def perform(message_json, payload_json)
+    tm = TiplineMessage.from_smooch_payload(message_json, payload_json)
+    tm.save!
+  end
+end

--- a/app/workers/smooch_tipline_message_worker.rb
+++ b/app/workers/smooch_tipline_message_worker.rb
@@ -1,10 +1,28 @@
+require 'bot/smooch'
+require 'json'
+
 class SmoochTiplineMessageWorker
   include Sidekiq::Worker
 
-  sidekiq_options queue: 'smooch', retry: 1
+  sidekiq_options queue: 'smooch'
 
   def perform(message_json, payload_json)
-    tm = TiplineMessage.from_smooch_payload(message_json, payload_json)
-    tm.save!
+    app_id = payload_json.dig('app', '_id')
+    User.current = BotUser.smooch_user
+    Bot::Smooch.get_installation(
+      Bot::Smooch.installation_setting_id_keys,
+      app_id
+    )
+
+    event = nil
+    cached_message = Rails.cache.read("smooch:original:#{message_json.dig('_id')}")
+    begin
+      event = JSON.parse(cached_message).dig('fallback_template')
+    rescue TypeError, JSON::ParserError => e; end
+
+    tm = TiplineMessage.from_smooch_payload(message_json, payload_json, event)
+    tm.save
+
+    User.current = nil
   end
 end

--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -46,6 +46,6 @@ class TiplineNewsletterWorker
   private
 
   def log(team_id, language, message)
-    Rails.logger.info "[Smooch Bot] [Newsletter] [Team ##{team_id}] [Language #{language}] [#{Time.now}] #{message}"
+    logger.info "[Smooch Bot] [Newsletter] [Team ##{team_id}] [Language #{language}] [#{Time.now}] #{message}"
   end
 end

--- a/db/migrate/20230207200055_create_tipline_messages.rb
+++ b/db/migrate/20230207200055_create_tipline_messages.rb
@@ -1,6 +1,7 @@
 class CreateTiplineMessages < ActiveRecord::Migration[5.2]
   def change
     create_table :tipline_messages do |t|
+      t.string :event
       t.integer :direction, default: 0
       t.string :language
       t.string :platform

--- a/db/migrate/20230207200055_create_tipline_messages.rb
+++ b/db/migrate/20230207200055_create_tipline_messages.rb
@@ -1,0 +1,21 @@
+class CreateTiplineMessages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :tipline_messages do |t|
+      t.integer :direction, default: 0
+      t.string :language
+      t.string :platform
+      t.datetime :sent_at
+
+      t.string :uid, index: true
+      t.string :external_id
+      t.jsonb :payload, default: {}
+
+      t.references :team, null: false, index: true
+
+      t.timestamps null: false
+
+      t.index [:external_id], unique: true
+      t.index [:team_id, :uid, :platform, :language, :sent_at, :direction], unique: true, name: 'index_tipline_message_uniqueness'
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,7 +26,6 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
 
   create_table "accounts", id: :serial, force: :cascade do |t|
     t.integer "user_id"
-    t.integer "team_id"
     t.string "url"
     t.text "omniauth_info"
     t.string "uid"
@@ -35,6 +34,7 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "team_id"
     t.index ["uid", "provider", "token", "email"], name: "index_accounts_on_uid_and_provider_and_token_and_email"
     t.index ["url"], name: "index_accounts_on_url", unique: true
     t.index ["user_id"], name: "index_accounts_on_user_id"
@@ -49,13 +49,13 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.integer "annotator_id"
     t.text "entities"
     t.text "data"
-    t.string "file"
-    t.integer "lock_version", default: 0, null: false
-    t.boolean "locked", default: false
-    t.text "attribution"
-    t.text "fragment"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "file"
+    t.text "attribution"
+    t.integer "lock_version", default: 0, null: false
+    t.boolean "locked", default: false
+    t.text "fragment"
     t.index "task_fieldset((annotation_type)::text, data)", name: "task_fieldset", where: "((annotation_type)::text = 'task'::text)"
     t.index "task_team_task_id((annotation_type)::text, data)", name: "task_team_task_id", where: "((annotation_type)::text = 'task'::text)"
     t.index ["annotated_type", "annotated_id"], name: "index_annotations_on_annotated_type_and_annotated_id"
@@ -66,20 +66,20 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
   create_table "api_keys", id: :serial, force: :cascade do |t|
     t.string "access_token", default: "", null: false
     t.datetime "expire_at"
-    t.jsonb "rate_limits", default: {}
-    t.string "application"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "application"
+    t.jsonb "rate_limits", default: {}
   end
 
   create_table "assignments", id: :serial, force: :cascade do |t|
     t.integer "assigned_id", null: false
     t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "assigned_type"
     t.integer "assigner_id"
     t.text "message"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["assigned_id", "assigned_type", "user_id"], name: "index_assignments_on_assigned_id_and_assigned_type_and_user_id", unique: true
     t.index ["assigned_id", "assigned_type"], name: "index_assignments_on_assigned_id_and_assigned_type"
     t.index ["assigned_id"], name: "index_assignments_on_assigned_id"
@@ -112,9 +112,9 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.text "description"
     t.bigint "user_id", null: false
     t.bigint "project_media_id", null: false
-    t.text "context"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "context"
     t.index ["project_media_id"], name: "index_claim_descriptions_on_project_media_id", unique: true
     t.index ["user_id"], name: "index_claim_descriptions_on_user_id"
   end
@@ -122,20 +122,20 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
   create_table "clusters", force: :cascade do |t|
     t.integer "project_medias_count", default: 0
     t.integer "project_media_id"
-    t.datetime "first_item_at"
-    t.datetime "last_item_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "first_item_at"
+    t.datetime "last_item_at"
     t.index ["project_media_id"], name: "index_clusters_on_project_media_id", unique: true
   end
 
   create_table "dynamic_annotation_annotation_types", primary_key: "annotation_type", id: :string, force: :cascade do |t|
     t.string "label", null: false
     t.text "description"
-    t.boolean "singleton", default: true
-    t.jsonb "json_schema"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "singleton", default: true
+    t.jsonb "json_schema"
     t.index ["json_schema"], name: "index_dynamic_annotation_annotation_types_on_json_schema", using: :gin
   end
 
@@ -158,7 +158,7 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "dynamic_annotation_fields", id: :serial, force: :cascade do |t|
+  create_table "dynamic_annotation_fields", id: :integer, default: -> { "nextval('new_dynamic_annotation_fields_id_seq'::regclass)" }, force: :cascade do |t|
     t.integer "annotation_id", null: false
     t.string "field_name", null: false
     t.string "annotation_type", null: false
@@ -169,14 +169,11 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.datetime "updated_at", null: false
     t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
-    t.index ["annotation_id"], name: "index_dynamic_annotation_fields_on_annotation_id"
-    t.index ["annotation_type"], name: "index_dynamic_annotation_fields_on_annotation_type"
     t.index ["field_name"], name: "index_dynamic_annotation_fields_on_field_name"
     t.index ["field_type"], name: "index_dynamic_annotation_fields_on_field_type"
     t.index ["value"], name: "fetch_unique_id", unique: true, where: "(((field_name)::text = 'external_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
     t.index ["value"], name: "index_status", where: "((field_name)::text = 'verification_status_status'::text)"
     t.index ["value"], name: "smooch_user_unique_id", unique: true, where: "(((field_name)::text = 'smooch_user_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
-    t.index ["value"], name: "translation_request_id", unique: true, where: "((field_name)::text = 'translation_request_id'::text)"
     t.index ["value_json"], name: "index_dynamic_annotation_fields_on_value_json", using: :gin
   end
 
@@ -186,9 +183,9 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.string "title"
     t.bigint "user_id", null: false
     t.bigint "claim_description_id", null: false
-    t.string "language", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "language", default: "", null: false
     t.index ["claim_description_id"], name: "index_fact_checks_on_claim_description_id", unique: true
     t.index ["language"], name: "index_fact_checks_on_language"
     t.index ["user_id"], name: "index_fact_checks_on_user_id"
@@ -199,9 +196,9 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.bigint "feed_id", null: false
     t.jsonb "filters", default: {}
     t.jsonb "settings", default: {}
-    t.boolean "shared", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "shared", default: false
     t.index ["feed_id"], name: "index_feed_teams_on_feed_id"
     t.index ["team_id", "feed_id"], name: "index_feed_teams_on_team_id_and_feed_id", unique: true
     t.index ["team_id"], name: "index_feed_teams_on_team_id"
@@ -211,9 +208,9 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.string "name", null: false
     t.jsonb "filters", default: {}
     t.jsonb "settings", default: {}
-    t.boolean "published", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "published", default: false
   end
 
   create_table "login_activities", id: :serial, force: :cascade do |t|
@@ -237,11 +234,11 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.integer "user_id"
     t.integer "account_id"
     t.string "url"
-    t.string "file"
-    t.string "quote"
-    t.string "type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "quote"
+    t.string "type"
+    t.string "file"
     t.index ["url"], name: "index_medias_on_url", unique: true
   end
 
@@ -312,21 +309,21 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
   end
 
   create_table "project_medias", id: :serial, force: :cascade do |t|
-    t.integer "project_id"
     t.integer "media_id"
-    t.integer "user_id"
-    t.integer "source_id"
-    t.integer "cluster_id"
-    t.integer "team_id"
-    t.jsonb "channel", default: {"main"=>0}
-    t.boolean "read", default: false, null: false
-    t.integer "sources_count", default: 0, null: false
-    t.integer "archived", default: 0
-    t.integer "cached_annotations_count", default: 0
-    t.integer "targets_count", default: 0, null: false
-    t.integer "last_seen"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.integer "cached_annotations_count", default: 0
+    t.integer "archived", default: 0
+    t.integer "targets_count", default: 0, null: false
+    t.integer "sources_count", default: 0, null: false
+    t.integer "team_id"
+    t.boolean "read", default: false, null: false
+    t.integer "source_id"
+    t.integer "project_id"
+    t.integer "last_seen"
+    t.integer "cluster_id"
+    t.jsonb "channel", default: {"main"=>0}
     t.index ["channel"], name: "index_project_medias_on_channel"
     t.index ["cluster_id"], name: "index_project_medias_on_cluster_id"
     t.index ["last_seen"], name: "index_project_medias_on_last_seen"
@@ -340,18 +337,18 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
   create_table "projects", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "team_id"
-    t.integer "project_group_id"
     t.string "title"
     t.boolean "is_default", default: false
     t.text "description"
     t.string "lead_image"
-    t.string "token"
-    t.integer "assignments_count", default: 0
-    t.integer "privacy", default: 0, null: false
-    t.integer "archived", default: 0
-    t.text "settings"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "archived", default: 0
+    t.text "settings"
+    t.string "token"
+    t.integer "assignments_count", default: 0
+    t.integer "project_group_id"
+    t.integer "privacy", default: 0, null: false
     t.index ["id"], name: "index_projects_on_id"
     t.index ["is_default"], name: "index_projects_on_is_default"
     t.index ["privacy"], name: "index_projects_on_privacy"
@@ -363,24 +360,23 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
   create_table "relationships", id: :serial, force: :cascade do |t|
     t.integer "source_id", null: false
     t.integer "target_id", null: false
-    t.integer "user_id"
     t.string "relationship_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.float "weight", default: 0.0
+    t.integer "confirmed_by"
+    t.datetime "confirmed_at"
+    t.string "source_field"
+    t.string "target_field"
+    t.string "model"
+    t.jsonb "details", default: "{}"
     t.float "original_weight", default: 0.0
-    t.float "float", default: 0.0
     t.jsonb "original_details", default: "{}"
     t.string "original_relationship_type"
     t.string "original_model"
     t.integer "original_source_id"
     t.string "original_source_field"
-    t.integer "confirmed_by"
-    t.datetime "confirmed_at"
-    t.float "weight", default: 0.0
-    t.string "source_field"
-    t.string "target_field"
-    t.string "model"
-    t.jsonb "details", default: "{}"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["relationship_type"], name: "index_relationships_on_relationship_type"
     t.index ["source_id", "target_id", "relationship_type"], name: "relationship_index", unique: true
     t.index ["target_id"], name: "index_relationships_on_target_id", unique: true
@@ -390,18 +386,18 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.bigint "feed_id", null: false
     t.string "request_type", null: false
     t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "request_id"
     t.integer "media_id"
-    t.integer "fact_checked_by_count", default: 0, null: false
-    t.integer "project_medias_count", default: 0, null: false
     t.integer "medias_count", default: 0, null: false
     t.integer "requests_count", default: 0, null: false
     t.datetime "last_submitted_at"
     t.string "webhook_url"
     t.datetime "last_called_webhook_at"
     t.integer "subscriptions_count", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer "fact_checked_by_count", default: 0, null: false
+    t.integer "project_medias_count", default: 0, null: false
     t.index ["feed_id"], name: "index_requests_on_feed_id"
     t.index ["media_id"], name: "index_requests_on_media_id"
     t.index ["request_id"], name: "index_requests_on_request_id"
@@ -434,15 +430,15 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
 
   create_table "sources", id: :serial, force: :cascade do |t|
     t.integer "user_id"
-    t.integer "team_id"
     t.string "name"
     t.string "slogan"
     t.string "avatar"
-    t.integer "archived", default: 0
-    t.string "file"
-    t.integer "lock_version", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "team_id"
+    t.string "file"
+    t.integer "archived", default: 0
+    t.integer "lock_version", default: 0, null: false
   end
 
   create_table "tag_texts", id: :serial, force: :cascade do |t|
@@ -465,12 +461,12 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.integer "team_id", null: false
     t.integer "order", default: 0
     t.string "associated_type", default: "ProjectMedia", null: false
-    t.string "fieldset", default: "", null: false
-    t.boolean "show_in_browser_extension", default: true, null: false
-    t.string "json_schema"
-    t.text "conditional_info"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "json_schema"
+    t.string "fieldset", default: "", null: false
+    t.boolean "show_in_browser_extension", default: true, null: false
+    t.text "conditional_info"
     t.index ["team_id", "fieldset", "associated_type"], name: "index_team_tasks_on_team_id_and_fieldset_and_associated_type"
   end
 
@@ -482,34 +478,53 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.string "invitation_token"
     t.string "raw_invitation_token"
     t.datetime "invitation_accepted_at"
-    t.string "file"
-    t.text "settings"
-    t.string "role"
-    t.string "status", default: "member"
-    t.string "invitation_email"
-    t.integer "lock_version", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "role"
+    t.string "status", default: "member"
+    t.text "settings"
+    t.string "invitation_email"
+    t.string "file"
+    t.integer "lock_version", default: 0, null: false
     t.index ["team_id", "user_id"], name: "index_team_users_on_team_id_and_user_id", unique: true
     t.index ["type"], name: "index_team_users_on_type"
     t.index ["user_id", "team_id", "status"], name: "index_team_users_on_user_id_and_team_id_and_status"
+    t.index ["user_id", "team_id"], name: "index_team_users_on_user_id_and_team_id"
   end
 
   create_table "teams", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "logo"
-    t.boolean "private", default: true, null: false
+    t.boolean "private", default: true
     t.integer "archived", default: 0
-    t.string "country"
-    t.text "description"
-    t.string "slug"
-    t.boolean "inactive", default: false
-    t.text "settings"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "description"
+    t.string "slug"
+    t.text "settings"
+    t.boolean "inactive", default: false
+    t.string "country"
     t.index ["country"], name: "index_teams_on_country"
     t.index ["inactive"], name: "index_teams_on_inactive"
+    t.index ["slug"], name: "index_teams_on_slug"
     t.index ["slug"], name: "unique_team_slugs", unique: true
+  end
+
+  create_table "tipline_messages", force: :cascade do |t|
+    t.integer "direction", default: 0
+    t.string "language"
+    t.string "platform"
+    t.datetime "sent_at"
+    t.string "uid"
+    t.string "external_id"
+    t.jsonb "payload", default: {}
+    t.bigint "team_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["external_id"], name: "index_tipline_messages_on_external_id", unique: true
+    t.index ["team_id", "uid", "platform", "language", "sent_at", "direction"], name: "index_tipline_message_uniqueness", unique: true
+    t.index ["team_id"], name: "index_tipline_messages_on_team_id"
+    t.index ["uid"], name: "index_tipline_messages_on_uid"
   end
 
   create_table "tipline_subscriptions", id: :serial, force: :cascade do |t|
@@ -550,32 +565,31 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.integer "invitation_limit"
     t.integer "invited_by_id"
     t.string "invited_by_type"
-    t.datetime "last_accepted_terms_at"
-    t.string "image"
-    t.string "type"
-    t.integer "source_id"
-    t.boolean "is_active", default: true
-    t.boolean "is_admin", default: false
-    t.integer "current_project_id"
-    t.integer "integer"
-    t.text "settings"
-    t.datetime "last_active_at"
-    t.text "cached_teams"
-    t.integer "current_team_id"
-    t.boolean "completed_signup", default: true
-    t.integer "api_key_id"
-    t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "image"
+    t.integer "current_team_id"
+    t.text "settings"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
+    t.boolean "is_admin", default: false
+    t.text "cached_teams"
+    t.string "type"
+    t.integer "api_key_id"
+    t.integer "source_id"
+    t.string "unconfirmed_email"
+    t.integer "current_project_id"
+    t.boolean "is_active", default: true
+    t.datetime "last_accepted_terms_at"
     t.string "encrypted_otp_secret"
     t.string "encrypted_otp_secret_iv"
     t.string "encrypted_otp_secret_salt"
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.string "otp_backup_codes", array: true
+    t.boolean "completed_signup", default: true
+    t.datetime "last_active_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true, where: "((email IS NOT NULL) AND ((email)::text <> ''::text))"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
@@ -595,11 +609,11 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.text "object_changes"
     t.datetime "created_at"
     t.text "meta"
+    t.string "event_type"
+    t.text "object_after"
     t.integer "associated_id"
     t.string "associated_type"
-    t.string "event_type"
     t.integer "team_id"
-    t.text "object_after"
     t.index ["associated_id"], name: "index_versions_on_associated_id"
     t.index ["event_type"], name: "index_versions_on_event_type"
     t.index ["item_type", "item_id", "whodunnit"], name: "index_versions_on_item_type_and_item_id_and_whodunnit"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -511,6 +511,7 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
   end
 
   create_table "tipline_messages", force: :cascade do |t|
+    t.string "event"
     t.integer "direction", default: 0
     t.string "language"
     t.string "platform"

--- a/lib/check_basic_abilities.rb
+++ b/lib/check_basic_abilities.rb
@@ -99,6 +99,10 @@ module CheckBasicAbilities
       obj.user_id == @user.id
     end
 
+    can [:read, :create], TiplineMessage do |obj|
+      @user.cached_teams.include?(obj.team_id)
+    end
+
     annotation_perms_for_all_users
 
     cannot :manage, ApiKey

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -355,7 +355,7 @@ class CheckSearch
     end
     # Also, adjust projects filter taking projects' privacy settings into account
     if Team.current && !feed_query? && [@options['team_id']].flatten.size == 1
-      t = Team.find(@options['team_id'])
+      t = Team.find([@options['team_id']].flatten.first)
       @options['projects'] = @options['projects'].blank? ? (Project.where(team_id: t.id).allowed(t).map(&:id) + [nil]) : Project.where(id: @options['projects']).allowed(t).map(&:id)
     end
     @options['projects'] += [nil] if @options['none_project']

--- a/test/models/bot/smooch_7_test.rb
+++ b/test/models/bot/smooch_7_test.rb
@@ -65,10 +65,10 @@ class Bot::Smooch7Test < ActiveSupport::TestCase
       assert_equal 'main', sm.state.value
       send_message_to_smooch_bot('1', uid)
       assert_equal 'secondary', sm.state.value
-      assert_equal 'en', Bot::Smooch.get_user_language({ 'authorId' => uid })
+      assert_equal 'en', Bot::Smooch.get_user_language(uid)
       send_message_to_smooch_bot('3', uid)
       assert_equal 'main', sm.state.value
-      assert_equal 'pt', Bot::Smooch.get_user_language({ 'authorId' => uid })
+      assert_equal 'pt', Bot::Smooch.get_user_language(uid)
       send_message_to_smooch_bot('um', uid)
       assert_equal 'query', sm.state.value
     end

--- a/test/models/monthly_team_statistics_test.rb
+++ b/test/models/monthly_team_statistics_test.rb
@@ -18,7 +18,7 @@ class MonthlyTeamStatisticTest < ActiveSupport::TestCase
     assert !stat.valid?
 
     team = create_team(name: "Fake team")
-    stat = MonthlyTeamStatistic.new(team: team, start_date: DateTime.now, end_date: DateTime.now, platform: "Telegram", language: "en")
+    stat = MonthlyTeamStatistic.new(team: team, start_date: DateTime.now, end_date: DateTime.now, platform: "telegram", language: "en")
 
     assert stat.valid?
   end

--- a/test/models/tipline_message_test.rb
+++ b/test/models/tipline_message_test.rb
@@ -18,7 +18,7 @@ class TiplineMessageTest < ActiveSupport::TestCase
                            external_id: 'message-id-12345',
                            uid: 'user-id-12345',
                            sent_at: DateTime.now,
-                           platform: "telegram",
+                           platform: "Telegram",
                            language: "en",
                            payload: {foo: 'bar'}.to_json)
 
@@ -170,5 +170,12 @@ class TiplineMessageTest < ActiveSupport::TestCase
 
   tm = TiplineMessage.from_smooch_payload(msg, payload)
   assert tm.sent_at.present?
+ end
+
+ test "sets event when passed" do
+    setup_smooch_bot
+    
+    tp = TiplineMessage.from_smooch_payload({},{}, 'newsletter_send')
+    assert_equal 'newsletter_send', tp.event
  end
 end

--- a/test/models/tipline_message_test.rb
+++ b/test/models/tipline_message_test.rb
@@ -1,0 +1,141 @@
+require_relative '../test_helper'
+
+class TiplineMessageTest < ActiveSupport::TestCase
+ test "has a direction enum for each of the supported trigger mapping values" do
+  direction_values = TiplineMessage.defined_enums['direction'].keys.map(&:to_sym)
+  supported_trigger_mappings = Bot::Smooch::SUPPORTED_TRIGGER_MAPPING.values.uniq.map(&:to_sym)
+  assert direction_values.sort == (supported_trigger_mappings + [:direction_unset]).sort
+ end
+
+ test "is invalid without required fields" do
+   tm = TiplineMessage.new
+
+   assert !tm.valid?
+
+   team = create_team
+   tm = TiplineMessage.new(direction: :incoming,
+                           team: team,
+                           external_id: 'message-id-12345',
+                           uid: 'user-id-12345',
+                           sent_at: DateTime.now,
+                           platform: "telegram",
+                           language: "en",
+                           payload: {foo: 'bar'}.to_json)
+
+   assert tm.valid?
+ end
+
+ test "is invalid if it seems to be a duplicate created from a race condition, based on info" do
+  team = create_team
+
+  TiplineMessage.create(external_id: 'external-id-1', team: team, uid: 'user-id-12345', direction: :incoming, platform: 'whatsapp', language: 'en', sent_at: DateTime.new(2022,1,2), payload: {foo: 'bar'}.to_json)
+
+  stat = TiplineMessage.new(external_id: 'external-id-2', team: team, uid: 'user-id-12345', direction: :incoming, platform: 'whatsapp', language: 'en', sent_at: DateTime.new(2022,1,2), payload: {foo: 'bar'}.to_json)
+  assert !stat.valid?
+
+  stat.sent_at = Time.now
+  assert stat.valid?
+ end
+
+ test "is invalid if it seems to be a duplicate created from a race condition, based on external_id" do
+  team = create_team
+
+  TiplineMessage.create(external_id: 'external-id-1', team: team, uid: 'user-id-12345', direction: :incoming, platform: 'whatsapp', language: 'en', sent_at: DateTime.new(2022,1,2), payload: {foo: 'bar'}.to_json)
+  stat = TiplineMessage.new(external_id: 'external-id-1', team: team, uid: 'user-id-12345', direction: :incoming, platform: 'whatsapp', language: 'en', sent_at: DateTime.new(2022,1,3), payload: {foo: 'bar'}.to_json)
+  assert !stat.valid?
+ end
+
+ test "parses from smooch json for a message sent to user (message:delivery:channel)" do
+  setup_smooch_bot
+
+  @team.set_languages ['en']
+  @team.save!
+
+  user_id = random_string
+
+  # For full expected response, see docs at
+  # https://docs.smooch.io/rest/v1/#trigger---messagedeliverychannel
+  msg = { "_id": @msg_id }.as_json
+  payload = {
+    "trigger": "message:delivery:channel",
+    "app": {
+        "_id": @app_id
+    },
+    "appUser": {
+        "_id": user_id,
+    },
+    "conversation": {
+        "_id": "105e47578be874292d365ee8"
+    },
+    "destination": {
+        "type": "whatsapp"
+    },
+    "isFinalEvent": false,
+    "externalMessages": [],
+    "message": msg,
+    "timestamp": 1537891147.555,
+    "version": "v1.1"
+  }.as_json
+
+  tm = TiplineMessage.from_smooch_payload(msg, payload)
+
+  assert tm.outgoing?
+  assert_equal tm.team, @team
+  assert_equal tm.uid, user_id
+  assert_equal tm.external_id, @msg_id
+  assert_equal tm.language, 'en'
+  assert_equal tm.platform, 'WhatsApp'
+  assert_equal tm.sent_at, Time.at(1537891147.555)
+  assert_equal JSON.parse(tm.payload), payload
+ end
+
+ test "parses from smooch json for a message sent from user" do
+  setup_smooch_bot
+
+  @team.set_languages ['en']
+  @team.save!
+
+  user_id = random_string
+
+  # For full expected response, see docs at
+  # https://docs.smooch.io/rest/v1/#trigger---messageappuser-text
+  message = {
+    "_id": @msg_id,
+    "type": "text",
+    "role": "appUser",
+    "authorId": user_id,
+    "received": 1444348338.704,
+    "source": {
+        "type": "whatsapp"
+    }
+  }.as_json
+
+  payload = {
+    "trigger": "message:appUser",
+    "app": {
+        "_id": @app_id
+    },
+    "messages": [message],
+    "appUser": {
+        "_id": user_id,
+        "conversationStarted": true,
+    },
+    "client": {},
+    "conversation": {
+        "_id": "105e47578be874292d365ee8"
+    },
+    "version": "v1.1"
+  }.as_json
+
+  tm = TiplineMessage.from_smooch_payload(message, payload)
+
+  assert tm.incoming?
+  assert_equal @team, tm.team
+  assert_equal user_id, tm.uid
+  assert_equal @msg_id, tm.external_id
+  assert_equal 'en', tm.language
+  assert_equal 'WhatsApp', tm.platform
+  assert_equal Time.at(1444348338.704), tm.sent_at
+  assert_equal payload, JSON.parse(tm.payload)
+ end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,7 +30,6 @@ require 'parallel_tests/test/runtime_logger'
 require 'sidekiq/testing'
 require 'minitest/retry'
 require 'pact/consumer/minitest'
-require 'rspec/rails'
 require 'mocha/minitest'
 require "csv"
 Minitest::Retry.use!

--- a/test/workers/smooch_tipline_message_worker_test.rb.rb
+++ b/test/workers/smooch_tipline_message_worker_test.rb.rb
@@ -1,0 +1,56 @@
+require_relative '../test_helper'
+
+class SmoochTiplineMessageWorkerTest < ActiveSupport::TestCase
+  def setup
+    super
+
+    setup_smooch_bot
+  end
+
+  def minimal_message
+    {'_id' => @msg_id}
+  end
+
+  def minimal_payload
+    {
+      'trigger' => 'message:delivery:channel',
+      'app' => { '_id' => @app_id },
+      'appUser' => { '_id' => random_string },
+      'message' => minimal_message
+    }
+  end
+
+  test "should attempt to save a tipline message, without erroring" do
+    assert_nothing_raised do
+      SmoochTiplineMessageWorker.new.perform(minimal_message, minimal_payload)
+    end
+  end
+
+  test "should prepare the smoochbot installation before the model pulls attribtues from it" do
+    Bot::Smooch.expects(:get_installation).with(Bot::Smooch.installation_setting_id_keys, @app_id)
+
+    SmoochTiplineMessageWorker.new.perform(minimal_message, minimal_payload)
+  end
+
+  test "should pass event from the cache fallback template" do
+    Rails.cache.write("smooch:original:#{@msg_id}", {'fallback_template' => 'newsletter_example_event'}.to_json)
+
+    assert_equal 0, TiplineMessage.count
+
+    SmoochTiplineMessageWorker.new.perform(minimal_message, minimal_payload)
+
+    assert_equal 1, TiplineMessage.count
+    assert_equal 'newsletter_example_event', TiplineMessage.last.event
+  end
+
+  test "should pass nil event if parsing from cache fails" do
+    Rails.cache.write("smooch:original:#{@msg_id}", 'fake string')
+
+    assert_equal 0, TiplineMessage.count
+
+    SmoochTiplineMessageWorker.new.perform(minimal_message, minimal_payload)
+
+    assert_equal 1, TiplineMessage.count
+    assert_nil TiplineMessage.last.event
+  end
+end


### PR DESCRIPTION
Specific questions I had noted inline as comments below, but all feedback and other questions welcome!

## To do:
- [x] Test locally with tipline setup for newsletter, report, and user message testcases
    - Tested with a local Telegram tipline and my personal phone
    - Was able to see a TiplineMessage created for each message delivered to my phone, with language ("en"), platform ("Telegram"), sent_at, uid, external_id, and payload all set as expected
    - Event was present for messages associated with a newsletter or report creation / update

## Done:

**Store messages to tipline in database - from user & when newsletter sent**

In order to move away from calculating conversations from the data stored
in annotations, we are beginning to save information in a new model, named
TiplineMessage. These are intended to be saved each time a message is sent
or received, and we are beginning to save them when a user sends a message
to a tipline (incoming) or a partner sends a newsletter to a user (outgoing).

To avoid potential race conditions, we add a validation that looks at uniqueness
both on the external ID from Smooch (which should be unique to the message) and
other indicators, such as the time it was sent, platform, language, uid, and
team.

We were mostly able to use the existing methods to pull data out of the
payload from smooch, but there was one instance where the payload for
outgoing (newsletter) trigger events differs from incoming (user messages)
events - outgoing events have a truncated message body, which requires
us to pull the platform information and timestamp from the payload.

Event is set from the message cache for important message types - report activity and newsletter sending, since we need to track these for statistics generation.

**Remove Rspec from Gemfile dependencies**

We do need Rspec as a dependency of Pact for our contract tests, but we aren't using it directly. Including it in the Gemfile makes running our scaffold generators (eg `rails g model Foo`) add rspec files instead of test unit test files, which are Minitest- compatible.

CV2-2647