### PR TITLE
Increasing interval between sending newsletter content and sending main menu.

### DIFF
--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -64,11 +64,11 @@ module SmoochMessages
       end
     end
 
-    def send_final_messages_to_user(uid, text, workflow, language)
+    def send_final_messages_to_user(uid, text, workflow, language, interval = 1)
       response = self.send_message_to_user(uid, text)
       if self.is_v2?
         CheckStateMachine.new(uid).go_to_main
-        sleep 1
+        sleep(interval)
         response = self.send_message_to_user_with_main_menu_appended(uid, self.get_string('navigation_button', language), workflow, language)
       end
       response

--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -20,7 +20,7 @@ class TiplineNewsletterWorker
                 introduction = newsletter['smooch_newsletter_introduction'].to_s.gsub('{date}', date).gsub('{channel}', ts.platform)
                 content = Bot::Smooch.build_newsletter_content(newsletter, language, team_id).gsub('{date}', date).gsub('{channel}', ts.platform)
                 Bot::Smooch.get_installation { |i| i.id == tbi.id }
-                response = Bot::Smooch.send_final_messages_to_user(ts.uid, content, workflow, language)
+                response = Bot::Smooch.send_final_messages_to_user(ts.uid, content, workflow, language, 5)
                 Bot::Smooch.save_smooch_response(response, nil, nil, 'newsletter', language, { introduction: introduction })
                 log team_id, language, "Newsletter sent to subscriber ##{ts.id}, response: #{response.inspect}"
                 count += 1


### PR DESCRIPTION
Increasing interval between sending newsletter content and sending message with "main menu".

Just be sure that the user has enough time to read the newsletter content and avoid the chances of the main menu being delivered first.

Fixes CHECK-2563.