### PR TITLE
Reduce database calls when compiling team data_report

### DIFF
--- a/app/models/monthly_team_statistic.rb
+++ b/app/models/monthly_team_statistic.rb
@@ -9,7 +9,6 @@ class MonthlyTeamStatistic < ApplicationRecord
   # Mapping of attributes to human-readable descriptions
   FIELD_MAPPINGS = {
     id: "ID",
-    org: "Org", # model method
     platform_name: "Platform", # model method
     language: "Language",
     month: "Month", # model method
@@ -40,10 +39,6 @@ class MonthlyTeamStatistic < ApplicationRecord
 
   # Below methods must match a key in FIELD_MAPPINGS to be included in
   # the .formatted_hash output
-  def org
-    team.name
-  end
-
   def month
     start_date&.strftime('%b %Y')
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -558,11 +558,12 @@ class Team < ApplicationRecord
   end
 
   def data_report
-    monthly_statisitcs = MonthlyTeamStatistic.where(team: team).order('start_date ASC')
+    monthly_statisitcs = MonthlyTeamStatistic.where(team_id: self.id).order('start_date ASC')
     if monthly_statisitcs.present?
       index = 1
       monthly_statisitcs.map do |stat|
         hash = stat.formatted_hash
+        hash['Org'] = self.name
         hash['Month'] = "#{index}. #{hash['Month']}"
         index += 1
         hash

--- a/test/models/monthly_team_statistics_test.rb
+++ b/test/models/monthly_team_statistics_test.rb
@@ -63,7 +63,6 @@ class MonthlyTeamStatisticTest < ActiveSupport::TestCase
     hash = stat.formatted_hash
 
     assert_equal hash["ID"], stat.id
-    assert_equal hash["Org"], "Fake team"
     assert_equal hash["Platform"], "WhatsApp"
     assert_equal hash["Language"], "en"
     assert_equal hash["Month"], "Apr 2020"
@@ -100,13 +99,6 @@ class MonthlyTeamStatisticTest < ActiveSupport::TestCase
     stat = MonthlyTeamStatistic.new(start_date: DateTime.new(2020,04,15))
 
     assert_equal "Apr 2020", stat.month
-  end
-
-  test ".org returns the team name" do
-    team = create_team(name: "Fake team")
-    stat = MonthlyTeamStatistic.create(team: team)
-
-    assert_equal "Fake team", stat.org
   end
 
   test "sets default of - if value is not present" do

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -2672,7 +2672,7 @@ class TeamTest < ActiveSupport::TestCase
   end
 
   test "should return data report with chronologically ordered items, preferring the MonthlyTeamStatistics when present" do
-    t = create_team
+    t = create_team(name: 'Test team')
     assert_nil t.data_report
 
     Rails.cache.write("data:report:#{t.id}", [{ 'Month' => 'Jan 2022', 'Conversations' => 200 }])
@@ -2681,10 +2681,12 @@ class TeamTest < ActiveSupport::TestCase
     create_monthly_team_statistic(team: t, start_date: DateTime.new(2022, 1, 1), conversations: 2)
 
     data_report = t.data_report
+    first_stat = data_report.first
 
     assert_equal 2, data_report.length
-    assert_equal '1. Jan 2022', data_report.first['Month']
-    assert_equal 2, data_report.first['Conversations']
+    assert_equal '1. Jan 2022', first_stat['Month']
+    assert_equal 'Test team', first_stat['Org']
+    assert_equal 2, first_stat['Conversations']
   end
 
   test "should have feeds" do


### PR DESCRIPTION
Previously we were retrieving the team name from the database each time we called .org on a MonthlyTeamStatistic, even though this would not change within the scope of a data report (because it's always for the same team). On teams with large datasets, this would significantly slow the GraphQL response.

Instead, this takes the approach of setting the org name at the team level, which we already have, and instead only has the MonthlyTeamStatistic present information it has available in its table, reducing number of queries to the database.

CV2-2565