### PR TITLE
Do not store a tipline request that is just a reaction to a button not related to any other action

### DIFF
--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -39,8 +39,13 @@ module SmoochMessages
       redis.lrange(key, 0, redis.llen(key)).to_a.uniq
     end
 
+    def bundle_contains_only_a_timeout_button_event(list, type)
+      list.size == 1 && !list[0]['quotedMessage'].blank? && type == 'timeout_requests' && list[0]['payload'].blank?
+    end
+
     def bundle_messages(uid, id, app_id, type = 'default_requests', annotated = nil, force = false, bundle = nil)
       list = bundle || self.list_of_bundled_messages_from_user(uid)
+      return if bundle_contains_only_a_timeout_button_event(list, type) # Don't store a request that is just a reaction to a button
       unless list.empty?
         last = JSON.parse(list.last)
         if last['_id'] == id || ['menu_options_requests'].include?(type) || force


### PR DESCRIPTION
The original issue here was: sometimes a newsletter delivery fails, to a user that hasn't interacted with the tipline in the last 24 hours. Not only a failure, but also a race condition. Anyway, when it happens, there will be no stored ID for the message that was sent with the "Read More" button. This way, when "Read More" is clicked, the application doesn't know that it is connected to a newsletter and thus simply handles it as a regular message. In order to try to avoid storing a request for that situation, ignore the following combination of conditions:

* Only one message
* That message is a reply to another message (so, a button or menu was clicked)
* It's of type "timeout"
* There was no "payload" (so it's not a button or menu from the tipline settings)

Fixes CHECK-2607.