### PR TITLE
More robust feedback prompt on tipline search

### DIFF
--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -237,11 +237,13 @@ module SmoochSearch
     def ask_for_feedback_when_all_search_results_are_received(app_id, language, workflow, uid, platform, attempts)
       RequestStore.store[:smooch_bot_platform] = platform
       redis = Redis.new(REDIS_CONFIG)
+      max = 20
       if redis.llen("smooch:search:#{uid}") == 0 && CheckStateMachine.new(uid).state.value == 'search_result'
         self.get_installation(self.installation_setting_id_keys, app_id) if self.config.blank?
         self.send_message_for_state(uid, workflow, 'search_result', language)
       else
-        self.delay_for(1.second, { queue: 'smooch_priority' }).ask_for_feedback_when_all_search_results_are_received(app_id, language, workflow, uid, platform, attempts + 1) if attempts < 30 # Try for 30 seconds
+        redis.del("smooch:search:#{uid}") if (attempts + 1) == max # Give up and just ask for feedback on the last iteration
+        self.delay_for(1.second, { queue: 'smooch_priority' }).ask_for_feedback_when_all_search_results_are_received(app_id, language, workflow, uid, platform, attempts + 1) if attempts < max # Try for 20 seconds
       end
     end
   end

--- a/config/initializers/02_sidekiq.rb
+++ b/config/initializers/02_sidekiq.rb
@@ -44,5 +44,6 @@ if File.exist?(file)
 
   Sidekiq.configure_client do |config|
     config.redis = redis_config
+    config.logger.level = Logger::WARN if Rails.env.test?
   end
 end

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -692,4 +692,17 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
       Sidekiq::Worker.drain_all
     end
   end
+
+  test "should ask for feedback even when confirmation is not received" do
+    uid = random_string
+    CheckStateMachine.new(uid).go_to_search_result
+    id = random_string
+    redis = Redis.new(REDIS_CONFIG)
+    redis.rpush("smooch:search:#{uid}", id)
+    assert_equal 1, redis.llen("smooch:search:#{uid}")
+    Sidekiq::Testing.inline! do
+      Bot::Smooch.ask_for_feedback_when_all_search_results_are_received(@app_id, 'en', {}, uid, 'WhatsApp', 1)
+    end
+    assert_equal 0, redis.llen("smooch:search:#{uid}")
+  end
 end


### PR DESCRIPTION
In some cases, tipline users were not receiving the feedback prompt after a search ("Are these fact-checks answering your question?"). This can happen for various reasons, including some we can't control. So, it's better to be more robust on our side. This commit adds the following change: the feedback prompt is delivered after 20 seconds waiting for the confirmation that the user has received the search results.

Bonus: Disable Sidekiq INFO-level log messages on tests output.

Fixes CV2-2692.