### PR TITLE
Avoid name collision for media items titles.

### DIFF
--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -38,10 +38,8 @@ module ProjectMediaCreators
     if self.set_title
       title = self.set_title
     elsif self.user&.login == 'smooch' && ['UploadedVideo', 'UploadedImage', 'UploadedAudio'].include?(self.media.type)
-      type_count = Media.where(type: self.media.type).joins("INNER JOIN project_medias pm ON medias.id = pm.media_id")
-      .where("pm.team_id = ?", self.team&.id).count
       type = self.media.type.sub('Uploaded', '').downcase
-      title = "#{type}-#{self.team&.slug}-#{type_count}"
+      title = "#{type}-#{self.team&.slug}-#{self.id}"
     else
       # Get original file name first
       title = File.basename(self.file.original_filename, '.*') if !self.file.blank? && self.file.respond_to?(:original_filename)

--- a/test/models/project_media_test.rb
+++ b/test/models/project_media_test.rb
@@ -474,17 +474,11 @@ class ProjectMediaTest < ActiveSupport::TestCase
     # test with smooch user
     with_current_user_and_team(bot, team) do
       pm = create_project_media team: team, media: m
-      count = Media.where(type: 'UploadedImage').joins("INNER JOIN project_medias pm ON medias.id = pm.media_id")
-      .where("pm.team_id = ?", team&.id).count
-      assert_equal "image-#{team.slug}-#{count}", pm.title
+      assert_equal "image-#{team.slug}-#{pm.id}", pm.title
       pm2 = create_project_media team: team, media: v
-      count = Media.where(type: 'UploadedVideo').joins("INNER JOIN project_medias pm ON medias.id = pm.media_id")
-      .where("pm.team_id = ?", team&.id).count
-      assert_equal "video-#{team.slug}-#{count}", pm2.title
+      assert_equal "video-#{team.slug}-#{pm2.id}", pm2.title
       pm3 = create_project_media team: team, media: a
-      count = Media.where(type: 'UploadedAudio').joins("INNER JOIN project_medias pm ON medias.id = pm.media_id")
-      .where("pm.team_id = ?", team&.id).count
-      assert_equal pm3.title, "audio-#{team.slug}-#{count}"
+      assert_equal "audio-#{team.slug}-#{pm3.id}", pm3.title
       pm.destroy; pm2.destroy; pm3.destroy
     end
     # test with non smooch user


### PR DESCRIPTION
Currently, the pattern for media items titles is `<media type>-<team slug>-<number of items of that type>`. The problem is that a collision can happen when items are deleted, because the number of items of that type can be repeated. This commit tries to avoid a name collision by replacing that count by the ID of the item.

Fixes CV2-2695.