### PR TITLE
Adding some missing default tipline strings

### DIFF
--- a/app/models/concerns/smooch_menus.rb
+++ b/app/models/concerns/smooch_menus.rb
@@ -140,9 +140,12 @@ module SmoochMenus
       # - Button label: 20 characters
       # - Body: 1024 characters
       workflow = self.get_workflow(language) || {}
-      custom_label = workflow.with_indifferent_access[key.to_s]
+      custom_label = workflow.with_indifferent_access.dig(*key)
+      key = key.join('_') if key.is_a?(Array)
       default_label = {
         # Default values for customizable strings
+        smooch_message_smooch_bot_greetings: 'Welcome to our fact-checking bot. Use the main menu to navigate.',
+        smooch_state_query_smooch_menu_message: 'Please enter the question, link, picture, or video that you want to be fact-checked.',
         ask_if_ready_state: 'Are you ready to submit?',
         add_more_details_state: 'Please add more content.',
         search_state: 'Thank you! Looking for fact-checks, it may take a minute.',
@@ -150,10 +153,12 @@ module SmoochMenus
         search_result_state: 'Are these fact-checks answering your question?',
         search_submit: 'Thank you for your feedback. Journalists on our team have been notified and you will receive an update in this thread if a new fact-check is published.',
         search_result_is_relevant: 'Thank you! Spread the word about this tipline to help us fight misinformation! *insert_entry_point_link*',
-        newsletter_optin_optout: '{subscription_status}',
-        option_not_available: 'Option not available.',
-        timeout: 'Thank you for reaching out to us! Type any key to start a new conversation.'
-      }[key.to_sym] || key
+        newsletter_optin_optout: 'Subscribe now to get the most important facts delivered directly on WhatsApp, every week. {subscription_status}',
+        smooch_state_subscription_smooch_menu_message: '', # FIXME: Backwards compatibility with v1, should be removed in the future.
+        option_not_available: "I'm sorry, I didn't understand your message.",
+        timeout: 'Thank you for reaching out to us! Type any key to start a new conversation.',
+        smooch_message_smooch_bot_disabled: 'Our bot is currently inactive. Please visit *insert URL* to read the latest fact-checks.'
+      }[key.to_sym] || ''
       label = custom_label.blank? ? default_label : custom_label
       label.to_s.truncate(truncate_at)
     end
@@ -285,7 +290,7 @@ module SmoochMenus
 
     def send_greeting(uid, workflow)
       if self.is_v2?
-        text = workflow['smooch_message_smooch_bot_greetings'] || ''
+        text = self.get_custom_string('smooch_message_smooch_bot_greetings', workflow['smooch_workflow_language'])
         image = workflow['smooch_greeting_image']
         image.blank? || image == 'none' ? self.send_message_to_user(uid, text) : self.send_message_to_user(uid, text, { 'type' => 'image', 'mediaUrl' => image })
         sleep 2 # Give it some time, so the main menu message is sent after the greetings

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -126,7 +126,7 @@ module SmoochMessages
         message << self.tos_message(workflow, language) unless is_v2
       end
       message << self.subscription_message(uid, language) if state.to_s == 'subscription'
-      message << workflow&.dig("smooch_state_#{state}", 'smooch_menu_message') if state != 'main' || !is_v2
+      message << self.get_custom_string(["smooch_state_#{state}", 'smooch_menu_message'], language) if state != 'main' || !is_v2
       message << self.get_custom_string("#{state}_state", language) if ['search', 'search_result', 'add_more_details', 'ask_if_ready'].include?(state.to_s)
       message.reject{ |m| m.blank? }.join("\n\n")
     end
@@ -140,7 +140,7 @@ module SmoochMessages
 
     def send_message_if_disabled_and_return_state(uid, workflow, state)
       disabled = self.config['smooch_disabled']
-      self.send_message_to_user(uid, workflow['smooch_message_smooch_bot_disabled'], {}, true) if disabled
+      self.send_message_to_user(uid, self.get_custom_string('smooch_message_smooch_bot_disabled', workflow['smooch_workflow_language']), {}, true) if disabled
       disabled ? 'disabled' : state
     end
 


### PR DESCRIPTION
Some customizable tipline strings were missing default values. Adding them here so it's aligned with the default strings that the frontend shows.

Fixes CV2-2689.