### PR TITLE
Change default sort order of suggested similar relationships

### DIFF
--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -189,7 +189,7 @@ class ProjectMedia < ApplicationRecord
   end
 
   def self.get_similar_relationships(project_media, relationship_type)
-    Relationship.where(source_id: project_media.relationship_source(relationship_type).id).where('relationship_type = ?', relationship_type.to_yaml).order('weight DESC')
+    Relationship.where(source_id: project_media.relationship_source(relationship_type).id).where('relationship_type = ?', relationship_type.to_yaml).order('created_at DESC')
   end
 
   def get_default_relationships


### PR DESCRIPTION
Per discussions I had with @caiosba, this seemed like the best way for now since this API call is only used by this one part of the app anyway.