### PR TITLE
Bugfix: Generate monthly statistics for current month

### DIFF
--- a/lib/tasks/data/statistics.rake
+++ b/lib/tasks/data/statistics.rake
@@ -52,7 +52,8 @@ namespace :check do
             end
           end
           date += 1.month
-        end while date <= current_time
+        # Protect against generating stats for the future, by bailing if start of the start of first day of month is later than time rake task was run
+        end while date.beginning_of_month <= current_time
 
         puts "[#{Time.now}] Stats summary for team with ID #{team_id}: #{team_stats.map{|k,v| "#{k} - #{v}" }.join("; ") }. Platforms: #{platforms.join(',')}. Languages: #{languages.join(', ')}"
       end

--- a/test/lib/tasks/statistics_test.rb
+++ b/test/lib/tasks/statistics_test.rb
@@ -104,7 +104,7 @@ class StatisticsTest < ActiveSupport::TestCase
   end
 
   test "generates statistics data for each month in tipline history when absent" do
-    create_project_media(user: BotUser.smooch_user, claim: "Claim: previous month", team: @tipline_team, created_at: @current_date - 1.month)
+    create_project_media(user: BotUser.smooch_user, claim: "Claim: previous month", team: @tipline_team, created_at: @current_date - (1.month - 2.weeks))
 
     # Full month - past
     start_of_previous_month = (@current_date - 1.month).beginning_of_month


### PR DESCRIPTION
Previously we were bailing out of statistics generation when the month index was less than the current date, which meant that, for example, if the first project media for a team was mid-month and we were at the beginning of the month then we wouldn't generate a new MonthlyTeamStatistic for that month. The user- facing impact of this is that some teams weren't having new stats generated for them despite it being a new month.

This changes the approach to determine when to stop generating statistics by comparing the current time to the start of the month being generated. This should protect us from generating future stats without accidentally skipping the current month.

CV2-2729