### PR TITLE
Adding a unique index to `relationships.target_id` column.

### DIFF
--- a/app/graph/types/project_media_type.rb
+++ b/app/graph/types/project_media_type.rb
@@ -154,10 +154,7 @@ ProjectMediaType = GraphqlCrudOperations.define_default_type do
 
   field :source do
     type -> { SourceType }
-
-    resolve -> (project_media, _args, _ctx) {
-      RecordLoader.for(Source).load(project_media.source_id)
-    }
+    resolve -> (project_media, _args, _ctx) { RecordLoader.for(Source).load(project_media.source_id) }
   end
 
   instance_exec :project_media, &GraphqlCrudOperations.field_log

--- a/app/graph/types/source_type.rb
+++ b/app/graph/types/source_type.rb
@@ -28,15 +28,11 @@ SourceType = GraphqlCrudOperations.define_default_type do
   end
 
   connection :medias, -> { ProjectMediaType.connection_type } do
-    resolve ->(source, _args, _ctx) {
-      source.medias
-    }
+    resolve ->(source, _args, _ctx) { source.media }
   end
 
   field :medias_count, types.Int do
-    resolve -> (source, _args, _ctx) {
-      source.medias_count
-    }
+    resolve -> (source, _args, _ctx) { source.medias_count }
   end
 
   connection :collaborators, -> { UserType.connection_type } do

--- a/app/workers/reindex_alegre_workspace.rb
+++ b/app/workers/reindex_alegre_workspace.rb
@@ -9,18 +9,18 @@ class ReindexAlegreWorkspace
 
   sidekiq_options queue: 'alegre', retry: 0
 
-  def perform(team_id, event_id=nil)
+  def perform(team_id, event_id = nil)
     query = get_default_query(team_id)
-    reindex_event_id ||= Digest::MD5.hexdigest(query.to_sql)
-    run_reindex(query, event_id)
+    reindex_event_id = event_id || Digest::MD5.hexdigest(query.to_sql)
+    run_reindex(query, reindex_event_id)
   end
-  
+
   def run_reindex(query, event_id)
     log(event_id, 'Preparing reindex event...')
     reindex_project_medias(query, event_id)
     log(event_id, 'Finished reindex event.')
   end
-  
+
   def cache_key(event_id, team_id)
     "check:migrate:reindex_event__#{event_id}_#{team_id}:pm_id"
   end
@@ -28,15 +28,15 @@ class ReindexAlegreWorkspace
   def get_last_id(event_id, team_id)
     Rails.cache.read(cache_key(event_id, team_id)) || 0
   end
-  
+
   def write_last_id(event_id, team_id, pm_id)
     Rails.cache.write(cache_key(event_id, team_id), pm_id)
   end
-  
+
   def clear_last_id(event_id, team_id)
     Rails.cache.delete(cache_key(event_id, team_id))
   end
-  
+
   def get_default_query(team_id, last_id=nil)
     ProjectMedia.where("project_medias.id > ? ", last_id.to_i).where(team_id: team_id)
   end
@@ -63,9 +63,7 @@ class ReindexAlegreWorkspace
 
   def check_for_write(running_bucket, event_id, team_id, write_remains=false, in_processes=3)
     if running_bucket.length > 500 || write_remains
-      Parallel.map(running_bucket.each_slice(30).to_a, in_processes: in_processes) do |bucket_slice|
-        Bot::Alegre.request_api('post', '/text/bulk_similarity/', { documents: bucket_slice })
-      end
+      Parallel.map(running_bucket.each_slice(30).to_a, in_processes: in_processes) { |bucket_slice| Bot::Alegre.request_api('post', '/text/bulk_similarity/', { documents: bucket_slice }) }
       write_last_id(event_id, team_id, running_bucket.last[:context][:project_media_id])
       running_bucket = []
     end
@@ -80,7 +78,8 @@ class ReindexAlegreWorkspace
   end
 
   def process_team(running_bucket, team_id, query, event_id)
-    last_id = get_last_id(event_id, team_id)
+    # Not using last_id for anything
+    # last_id = get_last_id(event_id, team_id)
     query.where(team_id: team_id).order(:id).find_in_batches(:batch_size => 2500) do |pms|
       pms.each do |pm|
         get_request_docs_for_project_media(pm, models_for_team(team_id)) do |request_doc|
@@ -95,7 +94,6 @@ class ReindexAlegreWorkspace
   end
 
   def reindex_project_medias(query, event_id)
-    started = Time.now.to_i
     running_bucket = []
     query.distinct.pluck(:team_id).each do |team_id|
       running_bucket = process_team(running_bucket, team_id, query, event_id)
@@ -109,4 +107,3 @@ class ReindexAlegreWorkspace
     Rails.logger.info "[Alegre Bot] [Reindex] [Event #{event_id}] [#{Time.now}] #{message}"
   end
 end
-

--- a/db/migrate/20230216030351_add_unique_index_to_relationship_target_id.rb
+++ b/db/migrate/20230216030351_add_unique_index_to_relationship_target_id.rb
@@ -1,0 +1,27 @@
+class AddUniqueIndexToRelationshipTargetId < ActiveRecord::Migration[5.2]
+  def change
+    duplicates = Relationship.group(:target_id).having('COUNT(id) > 1').count
+    n = duplicates.size
+    i = 0
+    duplicates.each do |pm_id, count|
+      i += 1
+      puts "[#{Time.now}] #{i}/#{n}"
+      if count > 1
+        relationships = Relationship.where(target_id: pm_id).to_a
+        # Keep the relationship whose model is image, video or audio... if none, keep the first one
+        keep = relationships.find{ |r| ['image', 'video', 'audio'].include?(r.model) } || relationships.first
+        raise "No relationship to keeo for target_id #{pm_id}!" if keep.nil?
+        relationships.each do |relationship|
+          if relationship.id == keep.id
+            puts "  Keeping relationship ##{r.id}"
+          else
+            puts "  Deleting relationship ##{r.id}"
+            relationship.destroy!
+          end
+        end
+      end
+    end
+
+    add_index :relationships, :target_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_30_074014) do
+ActiveRecord::Schema.define(version: 2023_02_16_030351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -383,6 +383,7 @@ ActiveRecord::Schema.define(version: 2023_01_30_074014) do
     t.datetime "updated_at", null: false
     t.index ["relationship_type"], name: "index_relationships_on_relationship_type"
     t.index ["source_id", "target_id", "relationship_type"], name: "relationship_index", unique: true
+    t.index ["target_id"], name: "index_relationships_on_target_id", unique: true
   end
 
   create_table "requests", force: :cascade do |t|

--- a/lib/tasks/migrate/20230216030351_delete_duplicate_relationships.rake
+++ b/lib/tasks/migrate/20230216030351_delete_duplicate_relationships.rake
@@ -1,0 +1,27 @@
+namespace :check do
+  namespace :migrate do
+    task delete_duplicate_relationships: :environment do
+      duplicates = Relationship.group(:target_id).having('COUNT(id) > 1').count
+      n = duplicates.size
+      i = 0
+      duplicates.each do |pm_id, count|
+        i += 1
+        puts "[#{Time.now}] #{i}/#{n}"
+        if count > 1
+          relationships = Relationship.where(target_id: pm_id).to_a
+          # Keep the relationship whose model is image, video or audio... if none, keep the first one
+          keep = relationships.find{ |r| ['image', 'video', 'audio'].include?(r.model) } || relationships.first
+          raise "No relationship to keeo for target_id #{pm_id}!" if keep.nil?
+          relationships.each do |relationship|
+            if relationship.id == keep.id
+              puts "  Keeping relationship ##{r.id}"
+            else
+              puts "  Deleting relationship ##{r.id}"
+              relationship.destroy!
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/models/relationship_2_test.rb
+++ b/test/models/relationship_2_test.rb
@@ -88,15 +88,6 @@ class Relationship2Test < ActiveSupport::TestCase
         create_relationship source_id: s.id, target_id: t.id, relationship_type: name
       end
     end
-    assert_nothing_raised do
-      create_relationship source_id: s.id, target_id: t2.id, relationship_type: name
-    end
-    assert_nothing_raised do
-      create_relationship source_id: s2.id, target_id: t.id, relationship_type: name
-    end
-    assert_nothing_raised do
-      create_relationship source_id: s.id, target_id: t.id
-    end
   end
 
   test "should start with targets count zero" do
@@ -328,9 +319,9 @@ class Relationship2Test < ActiveSupport::TestCase
     s2 = create_project_media team: t
     t = create_project_media team: t
     create_relationship source_id: s1.id, target_id: t.id, relationship_type: Relationship.confirmed_type
-    create_relationship source_id: s2.id, target_id: t.id, relationship_type: Relationship.confirmed_type
     create_relationship source_id: s2.id, target_id: s1.id, relationship_type: Relationship.confirmed_type
-    assert_equal 2, Relationship.where(source_id: s2).count
+    assert_equal 0, Relationship.where(source_id: s1.id).count
+    assert_equal 2, Relationship.where(source_id: s2.id).count
     assert_nil Relationship.where(source_id: s1, target_id: t).last
     assert_not_nil Relationship.where(source_id: s2, target_id: t).last
     assert_not_nil Relationship.where(source_id: s2, target_id: s1).last

--- a/test/models/relationship_2_test.rb
+++ b/test/models/relationship_2_test.rb
@@ -373,4 +373,17 @@ class Relationship2Test < ActiveSupport::TestCase
     r.destroy!
     assert_queries(0, '=') { assert_nil pm2.confirmed_as_similar_by_name }
   end
-end 
+
+  test "should not save duplicate values for target_id column" do
+    t = create_team
+    pm1 = create_project_media team: t
+    pm2 = create_project_media team: t
+    pm3 = create_project_media team: t
+    assert_nothing_raised do
+      create_relationship source_id: pm1.id, target_id: pm3.id
+    end
+    assert_raises 'ActiveRecord::RecordNotUnique' do
+      create_relationship source_id: pm2.id, target_id: pm3.id
+    end
+  end
+end


### PR DESCRIPTION
We had to have some database-level validation (e.g., a unique index) in order to avoid that an item is related to more than one. In some rare cases, just a model-level validation wouldn't be enough. For example, we've seen some cases where the same item was suggested to two different items. What happened there was a race condition (not likely to happen, but still), for example: looking for related videos happens in a background job and getting transcription happens in another background job. Both executed in parallel and finished at almost the same time and both found a similar item. So that item ended up being suggested to two different items: to one because it’s a similar video and to the other because the transcription matched a text field.

This PR adds a unique index to the `target_id` column of the `relationships` table. This way, an item can't be related to more than one. A unit test was added to validate that.

I also added a rake task to delete current duplications. The same logic is present in the migration. The migration would fail on adding a unique index if there were already duplicate values stored.

I also took the opportunity to fix some Code Climate issues.

Fixes CV2-2728.