### PR TITLE
A couple of tipline fixes: corrupted greeting image & WhatsApp token update

### DIFF
--- a/app/models/concerns/smooch_menus.rb
+++ b/app/models/concerns/smooch_menus.rb
@@ -291,7 +291,7 @@ module SmoochMenus
     def send_greeting(uid, workflow)
       if self.is_v2?
         text = self.get_custom_string('smooch_message_smooch_bot_greetings', workflow['smooch_workflow_language'])
-        image = workflow['smooch_greeting_image']
+        image = workflow['smooch_greeting_image'] if workflow['smooch_greeting_image'] =~ /^https?:\/\//
         image.blank? || image == 'none' ? self.send_message_to_user(uid, text) : self.send_message_to_user(uid, text, { 'type' => 'image', 'mediaUrl' => image })
         sleep 2 # Give it some time, so the main menu message is sent after the greetings
       end

--- a/app/models/concerns/smooch_team_bot_installation.rb
+++ b/app/models/concerns/smooch_team_bot_installation.rb
@@ -9,7 +9,7 @@ module SmoochTeamBotInstallation
 
       # Only super-admins can change WhatsApp token
       before_validation do
-        if self.bot_user.identifier == 'smooch'
+        if self.bot_user&.identifier == 'smooch'
           if User.current && !User.current.is_admin? && self.settings.to_h.with_indifferent_access['turnio_token'].to_s != self.settings_was.to_h.with_indifferent_access['turnio_token'].to_s
             self.set_turnio_token = self.settings_was.to_h.with_indifferent_access['turnio_token']
           end
@@ -18,7 +18,7 @@ module SmoochTeamBotInstallation
 
       # Save Twitter/Facebook token and authorization URL
       after_create do
-        if self.bot_user.identifier == 'smooch'
+        if self.bot_user&.identifier == 'smooch'
           self.reset_smooch_authorization_token
           self.save!
         end
@@ -26,7 +26,7 @@ module SmoochTeamBotInstallation
 
       # Save greeting images
       after_save do
-        if self.bot_user.identifier == 'smooch' && !self.skip_save_images && self.respond_to?(:saved_change_to_file?) && self.saved_change_to_file?
+        if self.bot_user&.identifier == 'smooch' && !self.skip_save_images && self.respond_to?(:saved_change_to_file?) && self.saved_change_to_file?
           workflows = self.get_smooch_workflows
           images_updated = false
           self.file.each_with_index do |image, i|

--- a/app/models/concerns/smooch_team_bot_installation.rb
+++ b/app/models/concerns/smooch_team_bot_installation.rb
@@ -7,6 +7,15 @@ module SmoochTeamBotInstallation
     TeamBotInstallation.class_eval do
       attr_accessor :skip_save_images
 
+      # Only super-admins can change WhatsApp token
+      before_validation do
+        if self.bot_user.identifier == 'smooch'
+          if User.current && !User.current.is_admin? && self.settings.to_h.with_indifferent_access['turnio_token'].to_s != self.settings_was.to_h.with_indifferent_access['turnio_token'].to_s
+            self.set_turnio_token = self.settings_was.to_h.with_indifferent_access['turnio_token']
+          end
+        end
+      end
+
       # Save Twitter/Facebook token and authorization URL
       after_create do
         if self.bot_user.identifier == 'smooch'

--- a/app/models/tipline_message.rb
+++ b/app/models/tipline_message.rb
@@ -21,21 +21,21 @@ class TiplineMessage < ApplicationRecord
       }
 
       trigger_attributes = case payload['trigger']
-                            when 'message:appUser'
-                              {
-                                direction: :incoming,
-                                sent_at: parse_timestamp(msg['received']),
-                                platform: Bot::Smooch.get_platform_from_message(msg),
-                              }
-                            when 'message:delivery:channel'
-                              {
-                                direction: :outgoing,
-                                sent_at: parse_timestamp(payload['timestamp']),
-                                platform: Bot::Smooch.get_platform_from_payload(payload),
-                              }
-                            else
-                              {}
-                            end
+                           when 'message:appUser'
+                             {
+                               direction: :incoming,
+                               sent_at: parse_timestamp(msg['received']),
+                               platform: Bot::Smooch.get_platform_from_message(msg),
+                             }
+                           when 'message:delivery:channel'
+                             {
+                               direction: :outgoing,
+                               sent_at: parse_timestamp(payload['timestamp']),
+                               platform: Bot::Smooch.get_platform_from_payload(payload),
+                             }
+                           else
+                             {}
+                           end
 
       new(general_attributes.merge(trigger_attributes))
     end
@@ -45,7 +45,7 @@ class TiplineMessage < ApplicationRecord
     def parse_timestamp(epoch_time)
       begin
         Time.at(epoch_time)
-      rescue TypeError => e
+      rescue TypeError
         Time.now
       end
     end

--- a/app/workers/smooch_tipline_message_worker.rb
+++ b/app/workers/smooch_tipline_message_worker.rb
@@ -18,7 +18,9 @@ class SmoochTiplineMessageWorker
     cached_message = Rails.cache.read("smooch:original:#{message_json.dig('_id')}")
     begin
       event = JSON.parse(cached_message).dig('fallback_template')
-    rescue TypeError, JSON::ParserError => e; end
+    rescue TypeError, JSON::ParserError
+      event = nil
+    end
 
     tm = TiplineMessage.from_smooch_payload(message_json, payload_json, event)
     tm.save

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
 
   create_table "accounts", id: :serial, force: :cascade do |t|
     t.integer "user_id"
+    t.integer "team_id"
     t.string "url"
     t.text "omniauth_info"
     t.string "uid"
@@ -34,7 +35,6 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "team_id"
     t.index ["uid", "provider", "token", "email"], name: "index_accounts_on_uid_and_provider_and_token_and_email"
     t.index ["url"], name: "index_accounts_on_url", unique: true
     t.index ["user_id"], name: "index_accounts_on_user_id"
@@ -49,13 +49,13 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.integer "annotator_id"
     t.text "entities"
     t.text "data"
-    t.datetime "created_at"
-    t.datetime "updated_at"
     t.string "file"
-    t.text "attribution"
     t.integer "lock_version", default: 0, null: false
     t.boolean "locked", default: false
+    t.text "attribution"
     t.text "fragment"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index "task_fieldset((annotation_type)::text, data)", name: "task_fieldset", where: "((annotation_type)::text = 'task'::text)"
     t.index "task_team_task_id((annotation_type)::text, data)", name: "task_team_task_id", where: "((annotation_type)::text = 'task'::text)"
     t.index ["annotated_type", "annotated_id"], name: "index_annotations_on_annotated_type_and_annotated_id"
@@ -66,20 +66,20 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
   create_table "api_keys", id: :serial, force: :cascade do |t|
     t.string "access_token", default: "", null: false
     t.datetime "expire_at"
+    t.jsonb "rate_limits", default: {}
+    t.string "application"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "application"
-    t.jsonb "rate_limits", default: {}
   end
 
   create_table "assignments", id: :serial, force: :cascade do |t|
     t.integer "assigned_id", null: false
     t.integer "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "assigned_type"
     t.integer "assigner_id"
     t.text "message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["assigned_id", "assigned_type", "user_id"], name: "index_assignments_on_assigned_id_and_assigned_type_and_user_id", unique: true
     t.index ["assigned_id", "assigned_type"], name: "index_assignments_on_assigned_id_and_assigned_type"
     t.index ["assigned_id"], name: "index_assignments_on_assigned_id"
@@ -112,9 +112,9 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.text "description"
     t.bigint "user_id", null: false
     t.bigint "project_media_id", null: false
+    t.text "context"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "context"
     t.index ["project_media_id"], name: "index_claim_descriptions_on_project_media_id", unique: true
     t.index ["user_id"], name: "index_claim_descriptions_on_user_id"
   end
@@ -122,20 +122,20 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
   create_table "clusters", force: :cascade do |t|
     t.integer "project_medias_count", default: 0
     t.integer "project_media_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.datetime "first_item_at"
     t.datetime "last_item_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["project_media_id"], name: "index_clusters_on_project_media_id", unique: true
   end
 
   create_table "dynamic_annotation_annotation_types", primary_key: "annotation_type", id: :string, force: :cascade do |t|
     t.string "label", null: false
     t.text "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.boolean "singleton", default: true
     t.jsonb "json_schema"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["json_schema"], name: "index_dynamic_annotation_annotation_types_on_json_schema", using: :gin
   end
 
@@ -158,7 +158,7 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "dynamic_annotation_fields", id: :integer, default: -> { "nextval('new_dynamic_annotation_fields_id_seq'::regclass)" }, force: :cascade do |t|
+  create_table "dynamic_annotation_fields", id: :serial, force: :cascade do |t|
     t.integer "annotation_id", null: false
     t.string "field_name", null: false
     t.string "annotation_type", null: false
@@ -169,11 +169,14 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.datetime "updated_at", null: false
     t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
+    t.index ["annotation_id"], name: "index_dynamic_annotation_fields_on_annotation_id"
+    t.index ["annotation_type"], name: "index_dynamic_annotation_fields_on_annotation_type"
     t.index ["field_name"], name: "index_dynamic_annotation_fields_on_field_name"
     t.index ["field_type"], name: "index_dynamic_annotation_fields_on_field_type"
     t.index ["value"], name: "fetch_unique_id", unique: true, where: "(((field_name)::text = 'external_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
     t.index ["value"], name: "index_status", where: "((field_name)::text = 'verification_status_status'::text)"
     t.index ["value"], name: "smooch_user_unique_id", unique: true, where: "(((field_name)::text = 'smooch_user_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
+    t.index ["value"], name: "translation_request_id", unique: true, where: "((field_name)::text = 'translation_request_id'::text)"
     t.index ["value_json"], name: "index_dynamic_annotation_fields_on_value_json", using: :gin
   end
 
@@ -183,9 +186,9 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.string "title"
     t.bigint "user_id", null: false
     t.bigint "claim_description_id", null: false
+    t.string "language", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "language", default: "", null: false
     t.index ["claim_description_id"], name: "index_fact_checks_on_claim_description_id", unique: true
     t.index ["language"], name: "index_fact_checks_on_language"
     t.index ["user_id"], name: "index_fact_checks_on_user_id"
@@ -196,9 +199,9 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.bigint "feed_id", null: false
     t.jsonb "filters", default: {}
     t.jsonb "settings", default: {}
+    t.boolean "shared", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "shared", default: false
     t.index ["feed_id"], name: "index_feed_teams_on_feed_id"
     t.index ["team_id", "feed_id"], name: "index_feed_teams_on_team_id_and_feed_id", unique: true
     t.index ["team_id"], name: "index_feed_teams_on_team_id"
@@ -208,9 +211,9 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.string "name", null: false
     t.jsonb "filters", default: {}
     t.jsonb "settings", default: {}
+    t.boolean "published", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "published", default: false
   end
 
   create_table "login_activities", id: :serial, force: :cascade do |t|
@@ -234,11 +237,11 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.integer "user_id"
     t.integer "account_id"
     t.string "url"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "file"
     t.string "quote"
     t.string "type"
-    t.string "file"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["url"], name: "index_medias_on_url", unique: true
   end
 
@@ -309,21 +312,21 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
   end
 
   create_table "project_medias", id: :serial, force: :cascade do |t|
+    t.integer "project_id"
     t.integer "media_id"
+    t.integer "user_id"
+    t.integer "source_id"
+    t.integer "cluster_id"
+    t.integer "team_id"
+    t.jsonb "channel", default: {"main"=>0}
+    t.boolean "read", default: false, null: false
+    t.integer "sources_count", default: 0, null: false
+    t.integer "archived", default: 0
+    t.integer "cached_annotations_count", default: 0
+    t.integer "targets_count", default: 0, null: false
+    t.integer "last_seen"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "user_id"
-    t.integer "cached_annotations_count", default: 0
-    t.integer "archived", default: 0
-    t.integer "targets_count", default: 0, null: false
-    t.integer "sources_count", default: 0, null: false
-    t.integer "team_id"
-    t.boolean "read", default: false, null: false
-    t.integer "source_id"
-    t.integer "project_id"
-    t.integer "last_seen"
-    t.integer "cluster_id"
-    t.jsonb "channel", default: {"main"=>0}
     t.index ["channel"], name: "index_project_medias_on_channel"
     t.index ["cluster_id"], name: "index_project_medias_on_cluster_id"
     t.index ["last_seen"], name: "index_project_medias_on_last_seen"
@@ -337,18 +340,18 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
   create_table "projects", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "team_id"
+    t.integer "project_group_id"
     t.string "title"
     t.boolean "is_default", default: false
     t.text "description"
     t.string "lead_image"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "archived", default: 0
-    t.text "settings"
     t.string "token"
     t.integer "assignments_count", default: 0
-    t.integer "project_group_id"
     t.integer "privacy", default: 0, null: false
+    t.integer "archived", default: 0
+    t.text "settings"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["id"], name: "index_projects_on_id"
     t.index ["is_default"], name: "index_projects_on_is_default"
     t.index ["privacy"], name: "index_projects_on_privacy"
@@ -360,23 +363,24 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
   create_table "relationships", id: :serial, force: :cascade do |t|
     t.integer "source_id", null: false
     t.integer "target_id", null: false
-    t.string "relationship_type", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.integer "user_id"
-    t.float "weight", default: 0.0
-    t.integer "confirmed_by"
-    t.datetime "confirmed_at"
-    t.string "source_field"
-    t.string "target_field"
-    t.string "model"
-    t.jsonb "details", default: "{}"
+    t.string "relationship_type", null: false
     t.float "original_weight", default: 0.0
+    t.float "float", default: 0.0
     t.jsonb "original_details", default: "{}"
     t.string "original_relationship_type"
     t.string "original_model"
     t.integer "original_source_id"
     t.string "original_source_field"
+    t.integer "confirmed_by"
+    t.datetime "confirmed_at"
+    t.float "weight", default: 0.0
+    t.string "source_field"
+    t.string "target_field"
+    t.string "model"
+    t.jsonb "details", default: "{}"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["relationship_type"], name: "index_relationships_on_relationship_type"
     t.index ["source_id", "target_id", "relationship_type"], name: "relationship_index", unique: true
     t.index ["target_id"], name: "index_relationships_on_target_id", unique: true
@@ -386,18 +390,18 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.bigint "feed_id", null: false
     t.string "request_type", null: false
     t.text "content", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.integer "request_id"
     t.integer "media_id"
+    t.integer "fact_checked_by_count", default: 0, null: false
+    t.integer "project_medias_count", default: 0, null: false
     t.integer "medias_count", default: 0, null: false
     t.integer "requests_count", default: 0, null: false
     t.datetime "last_submitted_at"
     t.string "webhook_url"
     t.datetime "last_called_webhook_at"
     t.integer "subscriptions_count", default: 0, null: false
-    t.integer "fact_checked_by_count", default: 0, null: false
-    t.integer "project_medias_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["feed_id"], name: "index_requests_on_feed_id"
     t.index ["media_id"], name: "index_requests_on_media_id"
     t.index ["request_id"], name: "index_requests_on_request_id"
@@ -430,15 +434,15 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
 
   create_table "sources", id: :serial, force: :cascade do |t|
     t.integer "user_id"
+    t.integer "team_id"
     t.string "name"
     t.string "slogan"
     t.string "avatar"
+    t.integer "archived", default: 0
+    t.string "file"
+    t.integer "lock_version", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "team_id"
-    t.string "file"
-    t.integer "archived", default: 0
-    t.integer "lock_version", default: 0, null: false
   end
 
   create_table "tag_texts", id: :serial, force: :cascade do |t|
@@ -461,12 +465,12 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.integer "team_id", null: false
     t.integer "order", default: 0
     t.string "associated_type", default: "ProjectMedia", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "json_schema"
     t.string "fieldset", default: "", null: false
     t.boolean "show_in_browser_extension", default: true, null: false
+    t.string "json_schema"
     t.text "conditional_info"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["team_id", "fieldset", "associated_type"], name: "index_team_tasks_on_team_id_and_fieldset_and_associated_type"
   end
 
@@ -478,35 +482,33 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.string "invitation_token"
     t.string "raw_invitation_token"
     t.datetime "invitation_accepted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "file"
+    t.text "settings"
     t.string "role"
     t.string "status", default: "member"
-    t.text "settings"
     t.string "invitation_email"
-    t.string "file"
     t.integer "lock_version", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["team_id", "user_id"], name: "index_team_users_on_team_id_and_user_id", unique: true
     t.index ["type"], name: "index_team_users_on_type"
     t.index ["user_id", "team_id", "status"], name: "index_team_users_on_user_id_and_team_id_and_status"
-    t.index ["user_id", "team_id"], name: "index_team_users_on_user_id_and_team_id"
   end
 
   create_table "teams", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "logo"
-    t.boolean "private", default: true
+    t.boolean "private", default: true, null: false
     t.integer "archived", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "country"
     t.text "description"
     t.string "slug"
-    t.text "settings"
     t.boolean "inactive", default: false
-    t.string "country"
+    t.text "settings"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["country"], name: "index_teams_on_country"
     t.index ["inactive"], name: "index_teams_on_inactive"
-    t.index ["slug"], name: "index_teams_on_slug"
     t.index ["slug"], name: "unique_team_slugs", unique: true
   end
 
@@ -566,31 +568,32 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.integer "invitation_limit"
     t.integer "invited_by_id"
     t.string "invited_by_type"
+    t.datetime "last_accepted_terms_at"
+    t.string "image"
+    t.string "type"
+    t.integer "source_id"
+    t.boolean "is_active", default: true
+    t.boolean "is_admin", default: false
+    t.integer "current_project_id"
+    t.integer "integer"
+    t.text "settings"
+    t.datetime "last_active_at"
+    t.text "cached_teams"
+    t.integer "current_team_id"
+    t.boolean "completed_signup", default: true
+    t.integer "api_key_id"
+    t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "image"
-    t.integer "current_team_id"
-    t.text "settings"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.boolean "is_admin", default: false
-    t.text "cached_teams"
-    t.string "type"
-    t.integer "api_key_id"
-    t.integer "source_id"
-    t.string "unconfirmed_email"
-    t.integer "current_project_id"
-    t.boolean "is_active", default: true
-    t.datetime "last_accepted_terms_at"
     t.string "encrypted_otp_secret"
     t.string "encrypted_otp_secret_iv"
     t.string "encrypted_otp_secret_salt"
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.string "otp_backup_codes", array: true
-    t.boolean "completed_signup", default: true
-    t.datetime "last_active_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true, where: "((email IS NOT NULL) AND ((email)::text <> ''::text))"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
@@ -610,11 +613,11 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.text "object_changes"
     t.datetime "created_at"
     t.text "meta"
-    t.string "event_type"
-    t.text "object_after"
     t.integer "associated_id"
     t.string "associated_type"
+    t.string "event_type"
     t.integer "team_id"
+    t.text "object_after"
     t.index ["associated_id"], name: "index_versions_on_associated_id"
     t.index ["event_type"], name: "index_versions_on_event_type"
     t.index ["item_type", "item_id", "whodunnit"], name: "index_versions_on_item_type_and_item_id_and_whodunnit"


### PR DESCRIPTION
**(1) Ensure that WhatsApp token can't be overwritten in tipline settings**

We had an issue with WhatsApp tokens in the past: since they are in the tipline settings page, users that had the tipline settings page already opened while the token was refreshed could overwrite the token with their settings by hitting “publish”. We worked around that on https://meedan.atlassian.net/browse/CV2-2482 : users would get an error when trying to save tipline settings if other changes were saved since they loaded the settings page. This is a way to avoid conflicts.

But it still happened with a workspace twice this week. I strongly suspect that some of their users still have the old Check version loaded in the browser and didn’t reload the page.

On our side, let’s be even safer and not even allow the token to be rewritten from the UI side if the user is not a super-admin.

**(2) Handle corrupted greeting images**

Sometimes users upload images that are not valid as greeting images. We need to at least be sure that the main menu and greeting text are delivered for those cases.

Both are fixes for CV2-2773.

Also, fixing some Code Climate issues.