### PR TITLE
Pull recipient id from message in payload from Turnio

### DIFF
--- a/app/models/concerns/smooch_turnio.rb
+++ b/app/models/concerns/smooch_turnio.rb
@@ -160,6 +160,7 @@ module SmoochTurnio
             '_id': "#{self.config['turnio_phone']}:#{status['recipient_id'] || status.dig('message', 'recipient_id')}",
             'conversationStarted': true
           },
+          timestamp: status['timestamp'].to_i,
           turnIo: json
         }.with_indifferent_access
 
@@ -188,6 +189,7 @@ module SmoochTurnio
             '_id': "#{self.config['turnio_phone']}:#{status['recipient_id'] || status.dig('message', 'recipient_id')}",
             'conversationStarted': true
           },
+          timestamp: status['timestamp'].to_i,
           turnIo: json
         }.with_indifferent_access
 

--- a/app/models/concerns/smooch_turnio.rb
+++ b/app/models/concerns/smooch_turnio.rb
@@ -157,7 +157,7 @@ module SmoochTurnio
             'type': 'text'
           },
           appUser: {
-            '_id': "#{self.config['turnio_phone']}:#{status['recipient_id']}",
+            '_id': "#{self.config['turnio_phone']}:#{status['recipient_id'] || status.dig('message', 'recipient_id')}",
             'conversationStarted': true
           },
           turnIo: json
@@ -185,7 +185,7 @@ module SmoochTurnio
             'type': 'text'
           },
           appUser: {
-            '_id': "#{self.config['turnio_phone']}:#{status['recipient_id']}",
+            '_id': "#{self.config['turnio_phone']}:#{status['recipient_id'] || status.dig('message', 'recipient_id')}",
             'conversationStarted': true
           },
           turnIo: json

--- a/test/models/concerns/smooch_turnio_test.rb
+++ b/test/models/concerns/smooch_turnio_test.rb
@@ -45,6 +45,7 @@ class SmoochTurnioTest < ActiveSupport::TestCase
     assert_equal 'gBGGFBmZaYRvAglfBtKPeos4sV4', message['message']['_id']
     assert_equal 'secret-12345', message['app']['_id']
     assert_equal 'phone-12345:15551234567', message['appUser']['_id']
+    assert_equal 1676930082, message['timestamp']
     assert message['turnIo']
   end
 
@@ -81,6 +82,7 @@ class SmoochTurnioTest < ActiveSupport::TestCase
     assert_equal 'secret-12345', message['app']['_id']
     assert_equal 'phone-12345:15551234567', message['appUser']['_id']
     assert_equal 470, message.dig('error', 'underlyingError', 'errors', 0, 'code')
+    assert_equal 1676930082, message['timestamp']
     assert message['turnIo']
   end
 end

--- a/test/models/concerns/smooch_turnio_test.rb
+++ b/test/models/concerns/smooch_turnio_test.rb
@@ -1,0 +1,86 @@
+require 'test_helper'
+
+class FakeSmoochTurnio
+  include SmoochTurnio
+
+  class << self
+    # Mock out config, which is normally set in the Smooch class as
+    # RequestStore.store[:smooch_bot_settings]
+    def config
+      {'turnio_secret' => 'secret-12345', 'turnio_phone' => 'phone-12345'}
+    end
+  end
+end
+
+class SmoochTurnioTest < ActiveSupport::TestCase
+  test "#preprocess_turnio_message processes delivered messages, including falling back to message recipient_id when top-level is not available" do
+    payload = {
+      "statuses": [
+        {
+          "conversation": {
+            "id": "fcd809f3194ed089c83d09129d664623",
+            "origin": {
+              "type": "user_initiated"
+            }
+          },
+          "id": "gBGGFBmZaYRvAglfBtKPeos4sV4",
+          "message": {
+            "recipient_id": "15551234567"
+          },
+          "pricing": {
+            "billable": true,
+            "category": "user_initiated",
+            "pricing_model": "CBP"
+          },
+          "status": "delivered",
+          "timestamp": "1676930082",
+          "type": "message"
+        }
+      ]
+    }
+
+    message = FakeSmoochTurnio.preprocess_turnio_message(payload.to_json)
+
+    assert_equal 'message:delivery:channel', message['trigger']
+    assert_equal 'gBGGFBmZaYRvAglfBtKPeos4sV4', message['message']['_id']
+    assert_equal 'secret-12345', message['app']['_id']
+    assert_equal 'phone-12345:15551234567', message['appUser']['_id']
+    assert message['turnIo']
+  end
+
+  test "#preprocess_turnio_message processes delivery failures, including falling back to message recipient_id when top-level is not available" do
+    payload = {
+      "statuses": [
+        {
+          "conversation": {
+            "id": "fcd809f3194ed089c83d09129d664623",
+            "origin": {
+              "type": "user_initiated"
+            }
+          },
+          "id": "gBGGFBmZaYRvAglfBtKPeos4sV4",
+          "message": {
+            "recipient_id": "15551234567"
+          },
+          "pricing": {
+            "billable": true,
+            "category": "user_initiated",
+            "pricing_model": "CBP"
+          },
+          "status": "failed",
+          "timestamp": "1676930082",
+          "type": "message"
+        }
+      ]
+    }
+
+    message = FakeSmoochTurnio.preprocess_turnio_message(payload.to_json)
+
+    assert_equal 'message:delivery:failure', message['trigger']
+    assert_equal 'gBGGFBmZaYRvAglfBtKPeos4sV4', message['message']['_id']
+    assert_equal 'secret-12345', message['app']['_id']
+    assert_equal 'phone-12345:15551234567', message['appUser']['_id']
+    assert_equal 470, message.dig('error', 'underlyingError', 'errors', 0, 'code')
+    assert message['turnIo']
+  end
+end


### PR DESCRIPTION
For the self-hosted WhatsApp API, we were seeing that in some cases the recipient_id is only returned in the message body. When this was the case, we previously were creating an incorrect UID (only the sending number, not the receiving number, which would not be unique for a given user).

This gives us more flexibility w/r/t payload structure. It also adds unit tests around the preprocess method so that we can more easily and directly test the translation of data in the future.

CV2-2647