### PR TITLE
Set platform on received TurnIo message

### DIFF
--- a/app/models/concerns/smooch_turnio.rb
+++ b/app/models/concerns/smooch_turnio.rb
@@ -151,6 +151,9 @@ module SmoochTurnio
           app: {
             '_id': self.config['turnio_secret']
           },
+          destination: {
+            type: 'whatsapp'
+          },
           version: 'v1.1',
           message: {
             '_id': status['id'],


### PR DESCRIPTION
We were setting this on unsucessful delivery but not successful delivery, and as a result messages from self-hosted WhatsApp lines were being registered as being from an unknown source.

This also adds some unit tests to reinforce the existing payload input and output expectations of the TurnIo preprocess step to make things more obvious and to support future refactoring, since there's a lot of duplication when we coerce the payload formats. This seems like it could be a good opportunity to break out a separate data model rather than coercing it into the Smooch format.

CV2-2647