### PR TITLE
Bugfix: Should get Smooch Bot installation ID for self-hosted tiplines.

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -253,7 +253,7 @@ class Bot::Smooch < BotUser
       RequestStore.store[:smooch_bot_provider] = 'TURN' unless smooch_bot_installation&.get_turnio_secret&.to_s.blank?
     end
     settings = smooch_bot_installation&.settings.to_h
-    RequestStore.store[:smooch_bot_settings] = settings.with_indifferent_access.merge({ team_id: smooch_bot_installation&.team_id.to_i })
+    RequestStore.store[:smooch_bot_settings] = settings.with_indifferent_access.merge({ team_id: smooch_bot_installation&.team_id.to_i, installation_id: smooch_bot_installation&.id })
     smooch_bot_installation
   end
 

--- a/app/models/concerns/smooch_menus.rb
+++ b/app/models/concerns/smooch_menus.rb
@@ -8,8 +8,8 @@ module SmoochMenus
       self.config['smooch_version'] == 'v2'
     end
 
-    def send_message_to_user_with_main_menu_appended(uid, text, workflow, language, app_id = nil)
-      self.get_installation(self.installation_setting_id_keys, app_id) if self.config.blank?
+    def send_message_to_user_with_main_menu_appended(uid, text, workflow, language, tbi_id = nil)
+      self.get_installation { |i| i.id == tbi_id } if self.config.blank?
       main = []
       counter = 1
       number_of_options = 0

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -75,7 +75,7 @@ module SmoochMessages
         label = self.get_string('navigation_button', language)
         CheckStateMachine.new(uid).go_to_main
         if interval > 1
-          self.delay_for(interval.seconds, { queue: 'smooch' }).send_message_to_user_with_main_menu_appended(uid, label, nil, language, self.config['smooch_app_id'])
+          self.delay_for(interval.seconds, { queue: 'smooch' }).send_message_to_user_with_main_menu_appended(uid, label, nil, language, self.config['installation_id'])
         else
           sleep(interval)
           response = self.send_message_to_user_with_main_menu_appended(uid, label, workflow, language)


### PR DESCRIPTION
Previously, the installation was retrieved because on `smooch_app_id`, which self-hosted tiplines don't have. Switching to Smooch Bot installation ID, which all have.

Fixes CV2-2782.