### PR TITLE
Set a report as "published" or not when creating an item with a fact-check through GraphQL API

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -43,7 +43,7 @@ plugins:
     config:
       languages:
         ruby:
-          mass_threshold: 20
+          mass_threshold: 22
   bundler-audit:
     enabled: true
 exclude_patterns:

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -190,6 +190,7 @@ module ProjectMediaCreators
         summary: self.set_fact_check['summary'],
         language: self.set_fact_check['language'],
         url: self.set_fact_check['url'],
+        publish_report: !!self.set_fact_check['publish_report'],
         claim_description: cd,
         skip_check_ability: true
       })
@@ -199,13 +200,5 @@ module ProjectMediaCreators
 
   def create_tags
     self.set_tags.each { |tag| Tag.create!(annotated: self, tag: tag, skip_check_ability: true) } unless self.set_tags.blank?
-  end
-
-  def create_status
-    unless self.set_status.blank?
-      s = self.last_status_obj
-      s.status = self.set_status
-      s.save!
-    end
   end
 end

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -1,7 +1,7 @@
 class FactCheck < ApplicationRecord
   include ClaimAndFactCheck
 
-  attr_accessor :skip_report_update
+  attr_accessor :skip_report_update, :publish_report
 
   belongs_to :claim_description
 
@@ -66,6 +66,7 @@ class FactCheck < ApplicationRecord
     })
     report.merge!({ use_introduction: default_use_introduction, introduction: default_introduction }) if language != report_language && !default_introduction.blank?
     data[:options] = report
+    data[:state] = (self.publish_report ? 'published' : 'paused')
     reports.annotator = self.user || User.current
     reports.set_fields = data.to_json
     reports.save!

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -64,7 +64,7 @@ class FactCheck < ApplicationRecord
       published_article_url: self.url,
       language: self.language
     })
-    report.merge!({ use_introduction: default_use_introduction, introduction: default_introduction }) if language != report_language && !default_introduction.blank?
+    report.merge!({ use_introduction: default_use_introduction, introduction: default_introduction }) if language != report_language
     data[:options] = report
     data[:state] = (self.publish_report ? 'published' : 'paused')
     reports.annotator = self.user || User.current

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -29,7 +29,6 @@ class ProjectMedia < ApplicationRecord
   after_create :add_source_creation_log, unless: proc { |pm| pm.source_id.blank? }
   after_commit :apply_rules_and_actions_on_create, :set_quote_metadata, :notify_team_bots_create, on: [:create]
   after_commit :create_relationship, on: [:update]
-  after_commit :create_status, on: [:create], prepend: false
   after_update :archive_or_restore_related_medias_if_needed, :notify_team_bots_update, :move_similar_item, :send_move_to_slack_notification
   after_update :apply_rules_and_actions_on_update, if: proc { |pm| pm.saved_changes.keys.include?('read') }
   after_update :apply_delete_for_ever, if: proc { |pm| pm.saved_change_to_archived? && pm.archived == CheckArchivedFlags::FlagCodes::TRASHED }

--- a/app/models/workflow/concerns/target_concern.rb
+++ b/app/models/workflow/concerns/target_concern.rb
@@ -55,7 +55,7 @@ module Workflow
             unless type.nil? || workflow_id == 'task_status'
               fields = {}
               type.schema.each do |fi|
-                fields[fi.name.to_sym] = fi.name == "#{workflow_id}_status" ? ::Workflow::Workflow.options(self, workflow_id)[:default] : fi.default_value
+                fields[fi.name.to_sym] = fi.name == "#{workflow_id}_status" ? (self.set_status || ::Workflow::Workflow.options(self, workflow_id)[:default]) : fi.default_value
               end
 
               next if self.team.is_being_copied


### PR DESCRIPTION
Also, better way to set status for items created through the GraphQL API (for example, if status is invalid, the item won't be created... and it's also possible to set the status and then publish a report).

Fixes: CV2-2807.