### PR TITLE
Add rake task to migrate smooch_data from annotations to TiplineMessage

### DIFF
--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -151,10 +151,10 @@ module SmoochMessages
 
     # Used for incoming messages (e.g. message:appUser)
     # where full message contents available
-    def get_platform_from_message(message)
+    def get_platform_from_message(message, skip_store: false)
       type = message.dig('source', 'type')
       platform = type ? ::Bot::Smooch::SUPPORTED_INTEGRATION_NAMES[type].to_s : 'Unknown'
-      RequestStore.store[:smooch_bot_platform] = platform
+      RequestStore.store[:smooch_bot_platform] = platform if skip_store
       platform
     end
 

--- a/app/models/tipline_message.rb
+++ b/app/models/tipline_message.rb
@@ -3,9 +3,14 @@ class TiplineMessage < ApplicationRecord
 
   belongs_to :team
 
-  validates_uniqueness_of :external_id
-  validates_presence_of :team, :uid, :platform, :language, :direction, :sent_at, :payload
-  validates :sent_at, uniqueness: { scope: [:team, :uid, :platform, :language, :direction] }
+  validates :external_id, uniqueness: true, presence: true
+  validates_presence_of :team, :uid, :platform, :language, :direction, :sent_at
+
+  # The following behaviors are only for importing historic annotation data
+  with_options unless: :imported_from_legacy_smooch_data? do |new_data|
+    new_data.validates :sent_at, uniqueness: { scope: [:team, :uid, :platform, :language, :direction] }
+    new_data.validates_presence_of :payload
+  end
 
   class << self
     def from_smooch_payload(msg, payload, event = nil)
@@ -17,7 +22,8 @@ class TiplineMessage < ApplicationRecord
         team: team,
         event: event,
         language: Bot::Smooch.get_user_language(uid),
-        payload: payload.to_json
+        payload: payload,
+        imported_from_legacy_smooch_data: false,
       }
 
       trigger_attributes = case payload['trigger']

--- a/db/migrate/20230224205948_add_legacy_smooch_data_to_tipline_message.rb
+++ b/db/migrate/20230224205948_add_legacy_smooch_data_to_tipline_message.rb
@@ -1,0 +1,9 @@
+class AddLegacySmoochDataToTiplineMessage < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tipline_messages, :imported_from_legacy_smooch_data, :boolean, default: :false
+    add_column :tipline_messages, :legacy_smooch_data, :jsonb, default: {}
+    add_column :tipline_messages, :legacy_smooch_message_text, :string
+
+    remove_index :tipline_messages, name: "index_tipline_message_uniqueness", column: [:team_id, :uid, :platform, :language, :sent_at, :direction]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_16_030351) do
+ActiveRecord::Schema.define(version: 2023_02_24_205948) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -522,8 +522,10 @@ ActiveRecord::Schema.define(version: 2023_02_16_030351) do
     t.bigint "team_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "imported_from_legacy_smooch_data", default: false
+    t.jsonb "legacy_smooch_data", default: {}
+    t.string "legacy_smooch_message_text"
     t.index ["external_id"], name: "index_tipline_messages_on_external_id", unique: true
-    t.index ["team_id", "uid", "platform", "language", "sent_at", "direction"], name: "index_tipline_message_uniqueness", unique: true
     t.index ["team_id"], name: "index_tipline_messages_on_team_id"
     t.index ["uid"], name: "index_tipline_messages_on_uid"
   end

--- a/lib/tasks/migrate/20230224205948_add_legacy_smooch_data_to_tipline_message.rake
+++ b/lib/tasks/migrate/20230224205948_add_legacy_smooch_data_to_tipline_message.rake
@@ -1,0 +1,213 @@
+
+# A helper class for migrating smooch_data from existing tiplines
+# into the new TiplineMessage format
+class MigratedTiplineMessageHelper
+  class << self
+    def requests(team_id, cutoff_time)
+      relation = Annotation.where(annotation_type: 'smooch').joins("INNER JOIN dynamic_annotation_fields fs ON fs.annotation_id = annotations.id AND fs.field_name = 'smooch_data'")
+        .where('t.id' => team_id)
+        .where("annotations.created_at < ?", cutoff_time)
+    end
+
+    def project_media_requests(team_id, cutoff_time)
+      base = requests(team_id, cutoff_time)
+      base.joins("INNER JOIN project_medias pm ON pm.id = annotations.annotated_id AND annotations.annotated_type = 'ProjectMedia' INNER JOIN teams t ON t.id = pm.team_id")
+    end
+
+    def team_requests(team_id, cutoff_time)
+      base = requests(team_id, cutoff_time)
+      base.joins("INNER JOIN teams t ON annotations.annotated_type = 'Team' AND t.id = annotations.annotated_id")
+    end
+
+    def reports_received(team_id, cutoff_time)
+      DynamicAnnotation::Field
+        .where(field_name: 'smooch_report_received')
+        .joins("INNER JOIN annotations a ON a.id = dynamic_annotation_fields.annotation_id INNER JOIN project_medias pm ON pm.id = a.annotated_id AND a.annotated_type = 'ProjectMedia' INNER JOIN teams t ON t.id = pm.team_id INNER JOIN dynamic_annotation_fields fs ON fs.annotation_id = a.id AND fs.field_name = 'smooch_data'")
+        .where('t.id' => team_id)
+        .where("a.created_at < ?", cutoff_time)
+    end
+
+    def split_into_individual_messages(smooch_data)
+      smooch_data['text'].to_s.split(Bot::Smooch::MESSAGE_BOUNDARY)
+    end
+
+    def approximate_conversations(team_id, req)
+      tipline_messages = []
+      smooch_data = begin JSON.parse(req.load.get_field_value('smooch_data')) rescue return tipline_messages end
+
+      split_into_individual_messages(smooch_data).each_with_index do |message_text, index|
+        external_id = index.zero? ? smooch_data['_id'] : "#{smooch_data['_id']}-#{index}"
+
+        tm1 = MigratedTiplineMessage.from_smooch_annotation_data(
+          smooch_data,
+          team_id: team_id,
+          direction: :incoming,
+          legacy_smooch_message_text: message_text,
+          external_id: external_id
+        )
+        tipline_messages << tm1
+
+        tm2 = MigratedTiplineMessage.from_smooch_annotation_data(smooch_data, team_id: team_id, direction: :outgoing, external_id: "#{external_id}_sent")
+        tipline_messages << tm2
+      end
+
+      tipline_messages
+    end
+
+    def append_to_cache(team_id)
+      completed_ids = self.read_cache || []
+      completed_ids << team_id
+      Rails.cache.write("smooch_data_migration:completed_team_ids", completed_ids)
+    end
+
+    def read_cache
+      Rails.cache.read("smooch_data_migration:completed_team_ids")
+    end
+  end
+end
+
+namespace :check do
+  namespace :migrate do
+    desc "Generate historic TiplineMessages from annotation data"
+    task generate_tipline_messages: :environment do
+
+      # A temporary constructor for loading in data from annotations,
+      # used only for this import task
+      #
+      # Needs to be defined within the rake task in order to access TiplineMessage,
+      # which requires the TiplineMessage class to be available in the environment
+      # upon class definition
+      class MigratedTiplineMessage < TiplineMessage
+        class << self
+          def from_smooch_annotation_data(msg, **attrs)
+            msg = msg.with_indifferent_access
+
+            attributes = {
+              uid: msg['authorId'],
+              external_id: msg['_id'],
+              language: msg['language'],
+              platform: Bot::Smooch.get_platform_from_message(msg, skip_store: true),
+              sent_at: parse_timestamp(msg['received']),
+              legacy_smooch_data: msg,
+              imported_from_legacy_smooch_data: true,
+            }.merge(attrs)
+
+            new(attributes)
+          end
+
+          def from_tipline_subscription(tipline_subscription, sent_at, **attrs)
+            language = attrs[:language] || tipline_subscription.language
+            attributes = {
+              external_id: "#{tipline_subscription.id}_#{language}_#{sent_at.to_i}_newsletter",
+              team_id: tipline_subscription.team_id,
+              event: 'newsletter',
+              direction: :outgoing,
+              language: language,
+              platform: tipline_subscription.platform,
+              sent_at: sent_at,
+              uid: tipline_subscription.uid,
+              legacy_smooch_data: {},
+              imported_from_legacy_smooch_data: true
+            }.merge(attrs)
+
+            new(attributes)
+          end
+        end
+      end
+
+      task_started_at = Time.now
+      # Time when we first began storing TiplineMessages, at which point we will have duplicated new
+      # TiplineMessage data and old-version Annotation data
+      tipline_message_cutover = MigratedTiplineMessage.where(imported_from_legacy_smooch_data: false).order(:created_at).first&.created_at
+      cutoff_time = tipline_message_cutover || task_started_at
+      puts "[#{Time.now}] Considering records created before #{cutoff_time}"
+
+      # For any team that has Smooch tipline data
+      tipline_team_ids = Team.
+              joins(:project_medias).
+              where(project_medias: { user: BotUser.smooch_user }).
+              distinct.pluck(:id)
+
+      completed_team_ids = MigratedTiplineMessageHelper.read_cache
+      puts "[#{Time.now}] #{tipline_team_ids.length} teams found with data for active tiplines: #{tipline_team_ids}"
+      if completed_team_ids
+        remaining_team_ids = tipline_team_ids - completed_team_ids
+        puts "[#{Time.now}] #{completed_team_ids} detected as completed. Starting at team_id: #{remaining_team_ids.first}"
+      else
+        remaining_team_ids = tipline_team_ids
+      end
+
+      remaining_team_ids.each_with_index do |team_id, index|
+        puts "[#{Time.now}] Creating historic tipline messages for team with ID #{team_id}. (#{index + 1} / #{remaining_team_ids.length})"
+
+        team = Team.find(team_id)
+
+        # Messages sent to tipline from users, and estimated responses from tiplines
+        MigratedTiplineMessageHelper.project_media_requests(team_id, cutoff_time).in_batches do |batch|
+          tipline_messages = batch.map { |req| MigratedTiplineMessageHelper.approximate_conversations(team_id, req) }.flatten
+          result = MigratedTiplineMessage.import(tipline_messages, on_duplicate_key_ignore: true)
+          puts "[#{Time.now}] Saved #{result.ids.count} of #{tipline_messages.size} in this batch of project media requests"
+        end
+        MigratedTiplineMessageHelper.team_requests(team_id, cutoff_time).in_batches do |batch|
+          tipline_messages = batch.map { |req| MigratedTiplineMessageHelper.approximate_conversations(team_id, req) }.flatten
+          result = MigratedTiplineMessage.import(tipline_messages, on_duplicate_key_ignore: true)
+          puts "[#{Time.now}] Saved #{result.ids.count} of #{tipline_messages.size} in this batch of team requests"
+        end
+
+        # Reports sent to users
+        MigratedTiplineMessageHelper.reports_received(team_id, cutoff_time).in_batches do |batch|
+          reports = batch.map do |f|
+            annotation = f.is_a?(Annotation) ? f : f.annotation
+            smooch_data = begin JSON.parse(annotation.load.get_field_value('smooch_data')) rescue next end
+            MigratedTiplineMessage.from_smooch_annotation_data(smooch_data, external_id: "#{smooch_data["_id"]}_report", direction: :outgoing, event: 'fact_check_report_annotation', team_id: team_id)
+          end.compact
+          result = MigratedTiplineMessage.import(reports, on_duplicate_key_ignore: true)
+          puts "[#{Time.now}] Saved #{result.ids.count} of #{reports.size} in this batch of reports sent"
+        end
+
+        # Newsletters sent to users
+        tbi = TeamBotInstallation.where(team: team, user: BotUser.smooch_user).last
+        if tbi
+          sent_newsletters_by_language = {}
+          # Gather all sent newsletters, grouped by language
+          Version.from_partition(team_id).
+            where(whodunnit: BotUser.smooch_user.id.to_s, item_id: tbi.id.to_s, item_type: ['TeamUser', 'TeamBotInstallation']).
+            where("created_at < ?", cutoff_time).each do |newsletter_version|
+              begin
+                YAML.load(JSON.parse(newsletter_version.object_after)['settings'])['smooch_workflows'].each do |smooch_workflow|
+                  language = smooch_workflow['smooch_workflow_language']
+                  sent_time = smooch_workflow['smooch_newsletter']['smooch_newsletter_last_sent_at']
+
+                  sent_newsletters_by_language[language] ||= []
+                  sent_newsletters_by_language[language] << sent_time.to_s
+                end
+              rescue StandardError => e
+                next
+              end
+          end
+
+          # For each subscriber at the time a newsletter was sent to a given language,
+          # create a record of an outgoing message
+          newsletter_messages = []
+          sent_newsletters_by_language.each do |language, sent_times|
+            sent_times.uniq.each do |sent_time_string|
+              sent_time = Time.parse(sent_time_string)
+              subscriptions = TiplineSubscription.where(created_at: 100.years.ago..sent_time, language: language, team_id: team_id)
+
+              newsletter_messages << subscriptions.map do |ts|
+                tm = MigratedTiplineMessage.from_tipline_subscription(ts, sent_time)
+              end
+            end
+          end
+          newsletter_messages.flatten!
+
+          result = MigratedTiplineMessage.import(newsletter_messages, on_duplicate_key_ignore: true)
+          puts "[#{Time.now}] Saved #{result.ids.count} of #{newsletter_messages.size} in this batch of newsletters sent."
+        end
+        MigratedTiplineMessageHelper.append_to_cache(team_id)
+      end
+
+      puts "[#{Time.now}] Done in #{Time.now.to_i - task_started_at.to_i} seconds."
+    end
+  end
+end

--- a/lib/tasks/migrate/20230224205948_add_legacy_smooch_data_to_tipline_message.rake
+++ b/lib/tasks/migrate/20230224205948_add_legacy_smooch_data_to_tipline_message.rake
@@ -178,6 +178,9 @@ namespace :check do
                   language = smooch_workflow['smooch_workflow_language']
                   sent_time = smooch_workflow['smooch_newsletter']['smooch_newsletter_last_sent_at']
 
+                  # Attempt to parse the timestamp - if not valid then will hit rescue and continue
+                  Time.parse(sent_time) unless sent_time.acts_like?(:time)
+
                   sent_newsletters_by_language[language] ||= []
                   sent_newsletters_by_language[language] << sent_time.to_s
                 end

--- a/test/models/tipline_message_test.rb
+++ b/test/models/tipline_message_test.rb
@@ -174,7 +174,7 @@ class TiplineMessageTest < ActiveSupport::TestCase
 
  test "sets event when passed" do
     setup_smooch_bot
-    
+
     tp = TiplineMessage.from_smooch_payload({},{}, 'newsletter_send')
     assert_equal 'newsletter_send', tp.event
  end

--- a/test/models/tipline_message_test.rb
+++ b/test/models/tipline_message_test.rb
@@ -1,181 +1,225 @@
-require_relative '../test_helper'
+require_relative "../test_helper"
 
 class TiplineMessageTest < ActiveSupport::TestCase
- test "has a direction enum for each of the supported trigger mapping values" do
-  direction_values = TiplineMessage.defined_enums['direction'].keys.map(&:to_sym)
-  supported_trigger_mappings = Bot::Smooch::SUPPORTED_TRIGGER_MAPPING.values.uniq.map(&:to_sym)
-  assert direction_values.sort == (supported_trigger_mappings + [:direction_unset]).sort
- end
+  test "has a direction enum for each of the supported trigger mapping values" do
+    direction_values =
+      TiplineMessage.defined_enums["direction"].keys.map(&:to_sym)
+    supported_trigger_mappings =
+      Bot::Smooch::SUPPORTED_TRIGGER_MAPPING.values.uniq.map(&:to_sym)
+    assert direction_values.sort ==
+             (supported_trigger_mappings + [:direction_unset]).sort
+  end
 
- test "is invalid without required fields" do
-   tm = TiplineMessage.new
+  test "is invalid without required fields" do
+    tm = TiplineMessage.new
 
-   assert !tm.valid?
+    assert !tm.valid?
 
-   team = create_team
-   tm = TiplineMessage.new(direction: :incoming,
-                           team: team,
-                           external_id: 'message-id-12345',
-                           uid: 'user-id-12345',
-                           sent_at: DateTime.now,
-                           platform: "Telegram",
-                           language: "en",
-                           payload: {foo: 'bar'}.to_json)
+    team = create_team
+    tm =
+      TiplineMessage.new(
+        direction: :incoming,
+        team: team,
+        external_id: "message-id-12345",
+        uid: "user-id-12345",
+        sent_at: DateTime.now,
+        platform: "Telegram",
+        language: "en",
+        payload: { foo: "bar" }.to_json
+      )
 
-   assert tm.valid?
- end
+    assert tm.valid?
+  end
 
- test "is invalid if it seems to be a duplicate created from a race condition, based on info" do
-  team = create_team
+  test "is invalid if it seems to be a duplicate created from a race condition, based on info" do
+    team = create_team
 
-  TiplineMessage.create(external_id: 'external-id-1', team: team, uid: 'user-id-12345', direction: :incoming, platform: 'whatsapp', language: 'en', sent_at: DateTime.new(2022,1,2), payload: {foo: 'bar'}.to_json)
+    TiplineMessage.create(
+      external_id: "external-id-1",
+      team: team,
+      uid: "user-id-12345",
+      direction: :incoming,
+      platform: "whatsapp",
+      language: "en",
+      sent_at: DateTime.new(2022, 1, 2),
+      payload: { foo: "bar" }.to_json
+    )
 
-  stat = TiplineMessage.new(external_id: 'external-id-2', team: team, uid: 'user-id-12345', direction: :incoming, platform: 'whatsapp', language: 'en', sent_at: DateTime.new(2022,1,2), payload: {foo: 'bar'}.to_json)
-  assert !stat.valid?
+    stat = TiplineMessage.new(
+        external_id: "external-id-2",
+        team: team,
+        uid: "user-id-12345",
+        direction: :incoming,
+        platform: "whatsapp",
+        language: "en",
+        sent_at: DateTime.new(2022, 1, 2),
+        payload: { foo: "bar" }.to_json
+      )
+    assert !stat.valid?
 
-  stat.sent_at = Time.now
-  assert stat.valid?
- end
+    stat.sent_at = Time.now
+    assert stat.valid?
+  end
 
- test "is invalid if it seems to be a duplicate created from a race condition, based on external_id" do
-  team = create_team
+  test "is invalid if it seems to be a duplicate created from a race condition, based on external_id" do
+    team = create_team
 
-  TiplineMessage.create(external_id: 'external-id-1', team: team, uid: 'user-id-12345', direction: :incoming, platform: 'whatsapp', language: 'en', sent_at: DateTime.new(2022,1,2), payload: {foo: 'bar'}.to_json)
-  stat = TiplineMessage.new(external_id: 'external-id-1', team: team, uid: 'user-id-12345', direction: :incoming, platform: 'whatsapp', language: 'en', sent_at: DateTime.new(2022,1,3), payload: {foo: 'bar'}.to_json)
-  assert !stat.valid?
- end
+    TiplineMessage.create(
+      external_id: "external-id-1",
+      team: team,
+      uid: "user-id-12345",
+      direction: :incoming,
+      platform: "whatsapp",
+      language: "en",
+      sent_at: DateTime.new(2022, 1, 2),
+      payload: { foo: "bar" }.to_json
+    )
+    stat =
+      TiplineMessage.new(
+        external_id: "external-id-1",
+        team: team,
+        uid: "user-id-12345",
+        direction: :incoming,
+        platform: "whatsapp",
+        language: "en",
+        sent_at: DateTime.new(2022, 1, 3),
+        payload: { foo: "bar" }.to_json
+      )
+    assert !stat.valid?
+  end
 
- test "parses from smooch json for a message sent to user (message:delivery:channel)" do
-  setup_smooch_bot
-
-  @team.set_languages ['en']
-  @team.save!
-
-  user_id = random_string
-
-  # For full expected response, see docs at
-  # https://docs.smooch.io/rest/v1/#trigger---messagedeliverychannel
-  msg = { "_id": @msg_id }.as_json
-  payload = {
-    "trigger": "message:delivery:channel",
-    "app": {
-        "_id": @app_id
-    },
-    "appUser": {
-        "_id": user_id,
-    },
-    "conversation": {
-        "_id": "105e47578be874292d365ee8"
-    },
-    "destination": {
-        "type": "whatsapp"
-    },
-    "isFinalEvent": false,
-    "externalMessages": [],
-    "message": msg,
-    "timestamp": 1537891147.555,
-    "version": "v1.1"
-  }.as_json
-
-  tm = TiplineMessage.from_smooch_payload(msg, payload)
-
-  assert tm.outgoing?
-  assert_equal tm.team, @team
-  assert_equal tm.uid, user_id
-  assert_equal tm.external_id, @msg_id
-  assert_equal tm.language, 'en'
-  assert_equal tm.platform, 'WhatsApp'
-  assert_equal tm.sent_at, Time.at(1537891147.555)
-  assert_equal JSON.parse(tm.payload), payload
- end
-
- test "parses from smooch json for a message sent from user" do
-  setup_smooch_bot
-
-  @team.set_languages ['en']
-  @team.save!
-
-  user_id = random_string
-
-  # For full expected response, see docs at
-  # https://docs.smooch.io/rest/v1/#trigger---messageappuser-text
-  message = {
-    "_id": @msg_id,
-    "type": "text",
-    "role": "appUser",
-    "authorId": user_id,
-    "received": 1444348338.704,
-    "source": {
-        "type": "whatsapp"
-    }
-  }.as_json
-
-  payload = {
-    "trigger": "message:appUser",
-    "app": {
-        "_id": @app_id
-    },
-    "messages": [message],
-    "appUser": {
-        "_id": user_id,
-        "conversationStarted": true,
-    },
-    "client": {},
-    "conversation": {
-        "_id": "105e47578be874292d365ee8"
-    },
-    "version": "v1.1"
-  }.as_json
-
-  tm = TiplineMessage.from_smooch_payload(message, payload)
-
-  assert tm.incoming?
-  assert_equal @team, tm.team
-  assert_equal user_id, tm.uid
-  assert_equal @msg_id, tm.external_id
-  assert_equal 'en', tm.language
-  assert_equal 'WhatsApp', tm.platform
-  assert_equal Time.at(1444348338.704), tm.sent_at
-  assert_equal payload, JSON.parse(tm.payload)
- end
-
- # This is to protect against any failures to parse time data - if it's missing,
- # or if the format cannot be parsed. So far we have only seen this in test,
- # but it seems possible in production. If we fall back, we do use our uniqueness
- # protection that is intended to prevent duplicates on race conditions
- test "defaults to current time for sent_at if parsing fails" do
-  setup_smooch_bot
-
-  msg = { "_id": @msg_id }.as_json
-  # payload is missing the timestamp key
-  payload = {
-    "trigger": "message:delivery:channel",
-    "app": {
-        "_id": @app_id
-    },
-    "appUser": {
-        "_id": random_string,
-    },
-    "conversation": {
-        "_id": "105e47578be874292d365ee8"
-    },
-    "destination": {
-        "type": "whatsapp"
-    },
-    "isFinalEvent": false,
-    "externalMessages": [],
-    "message": msg,
-    "version": "v1.1"
-  }.as_json
-
-  tm = TiplineMessage.from_smooch_payload(msg, payload)
-  assert tm.sent_at.present?
- end
-
- test "sets event when passed" do
+  test "parses from smooch json for a message sent to user (message:delivery:channel)" do
     setup_smooch_bot
 
-    tp = TiplineMessage.from_smooch_payload({},{}, 'newsletter_send')
-    assert_equal 'newsletter_send', tp.event
- end
+    @team.set_languages ["en"]
+    @team.save!
+
+    user_id = random_string
+
+    # For full expected response, see docs at
+    # https://docs.smooch.io/rest/v1/#trigger---messagedeliverychannel
+    payload = {
+      trigger: "message:delivery:channel",
+      app: {
+        _id: @app_id
+      },
+      appUser: {
+        _id: user_id
+      },
+      conversation: {
+        _id: "105e47578be874292d365ee8"
+      },
+      destination: {
+        type: "whatsapp"
+      },
+      isFinalEvent: false,
+      externalMessages: [],
+      message: {
+        _id: @msg_id
+      },
+      timestamp: 1537891147.555,
+      version: "v1.1"
+    }.with_indifferent_access
+
+    tm = TiplineMessage.from_smooch_payload(payload[:message], payload)
+
+    assert tm.outgoing?
+    assert_equal tm.team, @team
+    assert_equal tm.uid, user_id
+    assert_equal tm.external_id, @msg_id
+    assert_equal tm.language, "en"
+    assert_equal tm.platform, "WhatsApp"
+    assert_equal tm.sent_at, Time.at(1537891147.555)
+    assert_equal tm.payload, payload
+  end
+
+  test "parses from smooch json for a message sent from user" do
+    setup_smooch_bot
+
+    @team.set_languages ["en"]
+    @team.save!
+
+    user_id = random_string
+
+    # For full expected response, see docs at
+    # https://docs.smooch.io/rest/v1/#trigger---messageappuser-text
+    payload = {
+      'trigger' => "message:appUser",
+      'app' => {
+        '_id' => @app_id
+      },
+      'messages' => [
+        {
+          '_id' => @msg_id,
+          'type' => "text",
+          'role' => "appUser",
+          'authorId' => user_id,
+          'received' => 1444348338.704,
+          'source' => {
+            'type' => "whatsapp"
+          }
+        }
+      ],
+      'appUser' => {
+        '_id' => user_id,
+        'conversationStarted' => true
+      },
+      'client' => {
+      },
+      'conversation' => {
+        '_id' => "105e47578be874292d365ee8"
+      },
+      'version' => "v1.1"
+    }
+
+    tm = TiplineMessage.from_smooch_payload(payload['messages'].first, payload)
+
+    assert tm.incoming?
+    assert_equal @team, tm.team
+    assert_equal user_id, tm.uid
+    assert_equal @msg_id, tm.external_id
+    assert_equal "en", tm.language
+    assert_equal "WhatsApp", tm.platform
+    assert_equal Time.at(1444348338.704), tm.sent_at
+    assert_equal tm.payload, payload
+  end
+
+  # This is to protect against any failures to parse time data - if it's missing,
+  # or if the format cannot be parsed. So far we have only seen this in test,
+  # but it seems possible in production. If we fall back, we do use our uniqueness
+  # protection that is intended to prevent duplicates on race conditions
+  test "defaults to current time for sent_at if parsing fails" do
+    setup_smooch_bot
+
+    # payload is missing the timestamp key
+    payload = {
+      'trigger' => "message:delivery:channel",
+      'app' => {
+        '_id' => @app_id
+      },
+      'appUser' => {
+        '_id' => random_string
+      },
+      'conversation' => {
+        '_id' => "105e47578be874292d365ee8"
+      },
+      'destination' => {
+        'type' => "whatsapp"
+      },
+      'isFinalEvent' => false,
+      'externalMessages' => [],
+      'message' => { '_id' => @msg_id },
+      'version' => "v1.1"
+    }
+
+    tm = TiplineMessage.from_smooch_payload(payload['message'], payload)
+    assert tm.sent_at.present?
+  end
+
+  test "sets event when passed" do
+    setup_smooch_bot
+
+    tp = TiplineMessage.from_smooch_payload({}, {}, "newsletter_send")
+    assert_equal "newsletter_send", tp.event
+  end
 end


### PR DESCRIPTION
This rake task intends to take the smooch data we have stored for annotations and translate them into the new TiplineMessage format, so that we can more easily calculate historic statistics data.

We iterate through a few types of saved data:
* Messages sent to users (via project media and team requests)

In this case, we are previously only storing one annotation for an entire lifecycle of a message, from receipt of initial message to submission of claim. This means that multiple of what we now consider TiplineMessages are represented by one Annotation and have been collapsed into one external_id, which in the new world will be unique. To get around this, we make the following modifications: 1) split up the message text by the text separator (a newline), 2) create two TiplineMessages for each text in that cycle - one outgoing, and one incoming, 3) create unique external_ids that can be related back to the original annotation (by using the original message ID for first, then appending an index to subsquent, and appending "_sent" to the outgoing messages).

* Reports sent to users

For this, we take a similar approach to above without mimicing conversations. Since we now look to the "event" key on TiplineMessage to understand meaningful events, usually represented by template we sent, we hardcode this to "fact_check_report_annotation".

* Newsletters sent

This one is different than the other approaches. For this, we see every newsletter sent by an organization for each language. We then go through and calculate the number of newsletters sent by looking at the number of TiplineSubscriptions for the newsletter in that language at that time, and create one TiplineMessage for each subscription (representing a user and platform). To do this, we must again create a synthetic external_id.

--

Additional notes:
* For each of these approaches, we drop any records with duplicate external_ids at import, since we assume they are duplicates of what we already have. We have seen this in the reports and conversations data, since it seems like we just get multiple webhook events for the same messages.
* For all of these approaches, we specify some legacy data flags that attempt to give us ways of tracking taht this is historic (and differently formatted than the new) data, and of checking the original data it was made from (eg by storing smooch_data)
* Because this rake task will take awhile to run, I have added a cache that will help us skip completed teams on subsequent runs. Beacuse of compelxity within the individual calculations, I didn't attempt to cache on a more granular level
* To avoid duplicating TiplineMessages in the time between we've deployed the code that creates TipelineMessages when the webhook is called, and when this task is first run, the rake task looks at when the first non-legacy TiplineMessage was created and only imports data before that mark.
* I wanted to add automated tests to actually address the rake functionality, but setup was really difficult because our data model is hard! This should make it easier going forward!

CV2-2647