### PR TITLE
Allow skipping test coverage report when running tests with bin/rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ Often for rake tasks or background jobs, we will either want none of the data (s
 
 * To skip reporting to Honeycomb, set `CHECK_SKIP_HONEYCOMB` to `true`
 * To skip sampling data we want to report to Honeycomb, set `CHECK_SKIP_HONEYCOMB_SAMPLING` to `true`
+
+## Testing
+
+Running tests with argument `-n` (used for running an individual test via `ruby`) or environment variable `MINIMAL_TEST_RUN` set to true (i.e. `MINIMAL_TEST_RUN=true bin/rails test test/models/tipline_message_test.rb`) will force tests not to retry and skip generating a coverage report. This is intended to speed up individual runs of tests locally.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,22 @@
 require 'minitest/hooks/test'
 
-# Avoid coverage report when running a single test
-unless ARGV.include?('-n')
+ENV['RAILS_ENV'] ||= 'test'
+
+require File.expand_path('../../config/environment', __FILE__)
+require 'rails/test_help'
+require 'webmock/minitest'
+require 'sample_data'
+require 'parallel_tests/test/runtime_logger'
+require 'sidekiq/testing'
+require 'minitest/retry'
+require 'pact/consumer/minitest'
+require 'mocha/minitest'
+require "csv"
+
+# Avoid coverage report and test re-running when running a single test
+unless ENV['MINIMAL_TEST_RUN'] || ARGV.include?('-n')
+  Minitest::Retry.use!
+
   require 'simplecov'
   puts 'Starting coverage...'
   SimpleCov.start 'rails' do
@@ -20,19 +35,6 @@ unless ARGV.include?('-n')
     coverage_dir 'coverage'
   end
 end
-
-ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
-require 'rails/test_help'
-require 'webmock/minitest'
-require 'sample_data'
-require 'parallel_tests/test/runtime_logger'
-require 'sidekiq/testing'
-require 'minitest/retry'
-require 'pact/consumer/minitest'
-require 'mocha/minitest'
-require "csv"
-Minitest::Retry.use!
 
 class ActionController::TestCase
   include Devise::Test::ControllerHelpers


### PR DESCRIPTION
This adds a more explicit way to skip generating test coverage and re-trying tests when running them locally, intended to be for running individual tests repeatedly. We previously were keying off of only the -n flag, which is used when running an individual test with ruby, but is a little awkward when using to run with `bin/rails`, which we're moving toward since it doesn't require manually specifying the environment.

To skip that output for individual tests, we can now run e.g.:
```
MINIMAL_TEST_RUN=true bin/rails test test/models/tipline_message_test.rb

or

bundle exec ruby -I"lib:test" test/path/to/specific_test.rb -n /.*KEYWORD.*/
```