### PR TITLE
Fix data deletion in migration task

### DIFF
--- a/db/migrate/20230309200728_remove_legacy_smooch_data_fields_from_tipline_message.rb
+++ b/db/migrate/20230309200728_remove_legacy_smooch_data_fields_from_tipline_message.rb
@@ -2,7 +2,7 @@ class RemoveLegacySmoochDataFieldsFromTiplineMessage < ActiveRecord::Migration[5
   def change
     # Delete all TiplineMessages created by trying to migrate past data. This should not
     # have an effect in deployed environments, but will help keep local clean
-    TiplineMessage.where(imported_from_legacy_smooch_data: false).delete_all
+    TiplineMessage.where(imported_from_legacy_smooch_data: true).delete_all
 
     remove_column :tipline_messages, :imported_from_legacy_smooch_data, :boolean, default: :false
     remove_column :tipline_messages, :legacy_smooch_data, :jsonb, default: {}


### PR DESCRIPTION
I wanted to delete the past data migrated, not the new data created.

This modifies a migration that has already been run on QA, so is mainly intended to prevent future data deletion locally and in other environments.

CV2-2647