### PR TITLE
[CV2-2675] Do not suggest to suggestions

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -545,12 +545,12 @@ class Bot::Alegre < BotUser
       # 1. A is confirmed to B and C is suggested to B: type of the relationship between A and C is: suggested to A
       # 2. A is confirmed to B and C is confirmed to B: type of the relationship between A and C is: confirmed to A
       # 3. A is suggested to B and C is suggested to B: type of the relationship between A and C is: IGNORE (don't suggest to suggest)
-      # 4. A is suggested to B and C is confirmed to B: type of the relationship between A and C is: FORM NEW RELATIONSHIP, break old
+      # 4. A is suggested to B and C is confirmed to B: type of the relationship between A and C is: form new relationship to B, break old relation to A
       parent_relationship = parent_relationships.first
       proposed_relationship_is_confirmed = pm_id_scores[proposed_id][:relationship_type] == Relationship.confirmed_type
       new_type = Relationship.suggested_type
 
-      # if relationship to parent was suggested, and new relationship is also suggested
+      # (3) if relationship to parent was suggested, and new relationship is also suggested
       # we don't want to record this any more https://meedan.atlassian.net/browse/CV2-2675
       if !parent_relationship.is_confirmed? & !proposed_relationship_is_confirmed
         Rails.logger.info "[Alegre Bot] [ProjectMedia ##{pm.id}] [Relationships 3/6] [Relationships WARNING] ignoring suggested relationship pm_id, pm_id_scores, parent_id #{
@@ -558,7 +558,7 @@ class Bot::Alegre < BotUser
         return
       end
 
-      # relationships look great, but the proposed match should be replaced by a match to its parent
+      # (1,2) relationships look great, but the proposed match should be replaced by a match to its parent
       if parent_relationship.is_confirmed? 
         if proposed_relationship_is_confirmed
           new_type = Relationship.confirmed_type
@@ -570,7 +570,7 @@ class Bot::Alegre < BotUser
         pm_id_scores[parent_id][:relationship_type] = new_type if pm_id_scores[parent_id]
       end
 
-      # if the relationship to parent was only suggested, but new relationship is confirmed
+      # (4) if the relationship to parent was only suggested, but new relationship is confirmed
       if !parent_relationship.is_confirmed? & proposed_relationship_is_confirmed
         new_type = Relationship.confirmed_type
         # break the old parent relationship involving proposed_id, make the proposed_id into a new parent
@@ -580,7 +580,6 @@ class Bot::Alegre < BotUser
         parent_id = proposed_id
       end
 
-      
     else
       # the proposed match has no previous relationships, so we accept it as a parent
       parent_id = proposed_id

--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -555,7 +555,7 @@ class Bot::Alegre < BotUser
       if !parent_relationship.is_confirmed? & !proposed_relationship_is_confirmed
         Rails.logger.info "[Alegre Bot] [ProjectMedia ##{pm.id}] [Relationships 3/6] [Relationships WARNING] ignoring suggested relationship pm_id, pm_id_scores, parent_id #{
           [pm.id, pm_id_scores, proposed_id].inspect}"
-        return
+        return nil
       end
 
       # (1,2) relationships look great, but the proposed match should be replaced by a match to its parent
@@ -590,10 +590,10 @@ class Bot::Alegre < BotUser
 
   def self.add_relationship(pm, pm_id_scores, parent_id, original_parent_id=nil, original_relationship=nil)
     # Better be safe than sorry.
-    return false if parent_id == pm.id
+    return nil if parent_id == pm.id
     parent = ProjectMedia.find_by_id(parent_id)
     original_parent = ProjectMedia.find_by_id(original_parent_id)
-    return false if parent.nil?
+    return nil if parent.nil?
     if parent.is_blank?
       Rails.logger.info "[Alegre Bot] [ProjectMedia ##{pm.id}] [Relationships 4/6] Parent is blank, creating suggested relationship"
       self.create_relationship(parent, pm, pm_id_scores, Relationship.suggested_type, original_parent, original_relationship)
@@ -613,7 +613,7 @@ class Bot::Alegre < BotUser
   end
 
   def self.create_relationship(source, target, pm_id_scores, relationship_type, original_source=nil, original_relationship_type=nil)
-    return if !self.can_create_relationship?(source, target, relationship_type)
+    return nil if !self.can_create_relationship?(source, target, relationship_type)
     r = Relationship.where(source_id: source.id, target_id: target.id)
     .where('relationship_type = ? OR relationship_type = ?', Relationship.confirmed_type.to_yaml, Relationship.suggested_type.to_yaml).last
     if r.nil?

--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -576,7 +576,7 @@ class Bot::Alegre < BotUser
         # break the old parent relationship involving proposed_id, make the proposed_id into a new parent
         Rails.logger.info "[Alegre Bot] [ProjectMedia ##{pm.id}] [Relationships 3/6] [Relationships NOTE] removing suggested relationship pm_id, parent_id #{
           [parent_relationship.source_id, parent_relationship.target_id].inspect}"
-        parent_relationship.destroy
+        parent_relationship.destroy!
         parent_id = proposed_id
       end
 

--- a/test/models/bot/alegre_3_test.rb
+++ b/test/models/bot/alegre_3_test.rb
@@ -330,28 +330,6 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
     assert_equal r.weight, 1
   end
 
-  test "should fail to add relationships" do
-    p = create_project
-    pm1 = create_project_media project: p, is_image: true
-    pm2 = create_project_media project: p, is_image: true
-    pm3 = create_project_media project: p, is_image: true
-    Relationship.all.class.any_instance.stubs(:all).returns([Relationship.new(source_id: 1), Relationship.new(source_id: 2)])
-    response = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.confirmed_type}})
-    assert_equal response, false
-    Relationship.all.class.any_instance.unstub(:all)
-  end
-
-  test "resets relationship transitively" do
-    p = create_project
-    pm1 = create_project_media project: p, is_image: true
-    pm2 = create_project_media project: p, is_image: true
-    pm3 = create_project_media project: p, is_image: true
-    Relationship.all.class.any_instance.stubs(:all).returns([Relationship.new(source_id: 1), Relationship.new(source_id: 2)])
-    response = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.confirmed_type}})
-    assert_equal response, false
-    Relationship.all.class.any_instance.unstub(:all)
-  end
-
   test "should get similar items" do
     p = create_project
     pm1 = create_project_media project: p

--- a/test/models/bot/alegre_relationship_test.rb
+++ b/test/models/bot/alegre_relationship_test.rb
@@ -114,7 +114,7 @@ class Bot::AlegreRelationshipTest < ActiveSupport::TestCase
         pm3 = create_project_media project: p # the new item to be suggested
         test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.suggested_type}})
         # check that it was created
-        assert_equal( test_relationship nil)
+        assert_equal( test_relationship, nil)
  
     end
 

--- a/test/models/bot/alegre_relationship_test.rb
+++ b/test/models/bot/alegre_relationship_test.rb
@@ -21,172 +21,156 @@ class Bot::AlegreRelationshipTest < ActiveSupport::TestCase
     Sidekiq::Testing.inline!
   end
 
-    """    
-    test 'should not replace when parent is blank' do
-        p = create_project
-        pm1 = create_project_media project: p, is_image: true
-        pm2 = create_project_media project: p, media: Blank.new
-        pm3 = create_project_media project: p, media: Blank.new
-        assert_no_difference 'ProjectMedia.count' do
-          assert_difference 'Relationship.count' do
-            Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.confirmed_type}})
-          end
-        end
-      end
-    """
+  test 'item suggested to single other item will link' do
+    p = create_project
+    pm1 = create_project_media project: p
+    pm2 = create_project_media project: p
+    test_relationship = Bot::Alegre.add_relationships(pm2, {pm1.id => {score: 1, relationship_type: Relationship.suggested_type}})
+    # check that it was created
+    assert test_relationship.present?
+    # check that it links the appropriate ids
+    assert_equal( test_relationship.source, pm1)
+    assert_equal( test_relationship.target, pm2)
+  end
 
-    test 'item suggested to single other item will link' do
-        p = create_project
-        pm1 = create_project_media project: p
-        pm2 = create_project_media project: p
-        test_relationship = Bot::Alegre.add_relationships(pm2, {pm1.id => {score: 1, relationship_type: Relationship.suggested_type}})
-        # check that it was created
-        assert test_relationship.present?
-        # check that it links the appropriate ids
-        assert_equal( test_relationship.source, pm1)
-        assert_equal( test_relationship.target, pm2)
-    end
+  test 'item confirmed to single other item will link' do
+    p = create_project
+    pm1 = create_project_media project: p
+    pm2 = create_project_media project: p
+    test_relationship = Bot::Alegre.add_relationships(pm2, {pm1.id => {score: 1, relationship_type: Relationship.confirmed_type}})
+    # check that it was created
+    assert test_relationship.present?
+    # check that it links the appropriate ids
+    assert_equal( test_relationship.source, pm1)
+    assert_equal( test_relationship.target, pm2)
+  end
 
-    test 'item confirmed to single other item will link' do
-        p = create_project
-        pm1 = create_project_media project: p
-        pm2 = create_project_media project: p
-        test_relationship = Bot::Alegre.add_relationships(pm2, {pm1.id => {score: 1, relationship_type: Relationship.confirmed_type}})
-        # check that it was created
-        assert test_relationship.present?
-        # check that it links the appropriate ids
-        assert_equal( test_relationship.source, pm1)
-        assert_equal( test_relationship.target, pm2)
-    end
+  test 'item suggested to parent of confirmed pair will link' do
+    p = create_project
+    pm1 = create_project_media project: p # parent
+    pm2 = create_project_media project: p # child
+    create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
 
-    test 'item suggested to parent of confirmed pair will link' do
-        p = create_project
-        pm1 = create_project_media project: p # parent
-        pm2 = create_project_media project: p # child
-        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
+    pm3 = create_project_media project: p # the new item to be suggested
+    test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.suggested_type}})
+    # check that it was created
+    assert test_relationship.present?
+    # check that it links the appropriate ids
+    assert_equal( test_relationship.source, pm1)
+    assert_equal( test_relationship.target, pm3)
+  end
 
-        pm3 = create_project_media project: p # the new item to be suggested
-        test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.suggested_type}})
-        # check that it was created
-        assert test_relationship.present?
-        # check that it links the appropriate ids
-        assert_equal( test_relationship.source, pm1)
-        assert_equal( test_relationship.target, pm3)
-    end
+  test 'item confirmed to parent of confirmed pair will link' do
+    p = create_project
+    pm1 = create_project_media project: p # parent
+    pm2 = create_project_media project: p # child
+    create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
 
-    test 'item confirmed to parent of confirmed pair will link' do
-        p = create_project
-        pm1 = create_project_media project: p # parent
-        pm2 = create_project_media project: p # child
-        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
+    pm3 = create_project_media project: p # the new item to be suggested
+    test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.confirmed_type}})
+    # check that it was created
+    assert test_relationship.present?
+    # check that it links the appropriate ids
+    assert_equal( test_relationship.source, pm1)
+    assert_equal( test_relationship.target, pm3)
+  end
 
-        pm3 = create_project_media project: p # the new item to be suggested
-        test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.confirmed_type}})
-        # check that it was created
-        assert test_relationship.present?
-        # check that it links the appropriate ids
-        assert_equal( test_relationship.source, pm1)
-        assert_equal( test_relationship.target, pm3)
-    end
+  test 'item suggested to parent of suggested pair will link' do
+    p = create_project
+    pm1 = create_project_media project: p # parent
+    pm2 = create_project_media project: p # child
+    create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.suggested_type
 
-    test 'item suggested to parent of suggested pair will link' do
-        p = create_project
-        pm1 = create_project_media project: p # parent
-        pm2 = create_project_media project: p # child
-        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.suggested_type
+    pm3 = create_project_media project: p # the new item to be suggested
+    test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.suggested_type}})
+    # check that it was created
+    assert test_relationship.present?
+    # check that it links the appropriate ids
+    assert_equal( test_relationship.source, pm1)
+    assert_equal( test_relationship.target, pm3)
+  end
 
-        pm3 = create_project_media project: p # the new item to be suggested
-        test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.suggested_type}})
-        # check that it was created
-        assert test_relationship.present?
-        # check that it links the appropriate ids
-        assert_equal( test_relationship.source, pm1)
-        assert_equal( test_relationship.target, pm3)
-    end
+  test 'item suggested to child of suggested pair will NOT link' do
+    # this the new thing: don't chain suggestions
+    p = create_project
+    pm1 = create_project_media project: p # parent
+    pm2 = create_project_media project: p # child
+    create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.suggested_type
 
-    test 'item suggested to child of suggested pair will NOT link' do
-        # this the new thing: don't chain suggestions
-        p = create_project
-        pm1 = create_project_media project: p # parent
-        pm2 = create_project_media project: p # child
-        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.suggested_type
+    pm3 = create_project_media project: p # the new item to be suggested
+    test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.suggested_type}})
+    # check that it was not created
+    assert_nil( test_relationship)
+    # check that it doesn't exist
+    assert Relationship.where(target_id: pm2.id, source_id: pm3.id).first.nil?
+  end
 
-        pm3 = create_project_media project: p # the new item to be suggested
-        test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.suggested_type}})
-        # check that it was not created
-        assert_nil( test_relationship)
-        # check that it doesn't exist
-        assert Relationship.where(target_id: pm2.id, source_id: pm3.id).first.nil?
- 
-    end
+  test 'item confirmed to parent of suggested pair will link' do
+    p = create_project
+    pm1 = create_project_media project: p # parent
+    pm2 = create_project_media project: p # child
+    create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.suggested_type
 
-    test 'item confirmed to parent of suggested pair will link' do
-        p = create_project
-        pm1 = create_project_media project: p # parent
-        pm2 = create_project_media project: p # child
-        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.suggested_type
+    pm3 = create_project_media project: p # the new item to be suggested
+    test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.confirmed_type}})
+    # check that it was created
+    assert test_relationship.present?
+    # check that it links the appropriate ids
+    assert_equal( test_relationship.source, pm1)
+    assert_equal( test_relationship.target, pm3)
+  end
 
-        pm3 = create_project_media project: p # the new item to be suggested
-        test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.confirmed_type}})
-        # check that it was created
-        assert test_relationship.present?
-        # check that it links the appropriate ids
-        assert_equal( test_relationship.source, pm1)
-        assert_equal( test_relationship.target, pm3)
-    end
+  test 'item confirmed to child of suggested pair will link and break relationship' do
+    # because we are adding a stronger relationship to the child, 
+    # the previous parent child relationship should be removed
+    p = create_project
+    pm1 = create_project_media project: p # parent
+    pm2 = create_project_media project: p # child
+    create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.suggested_type
 
-    test 'item confirmed to child of suggested pair will link and break relationship' do
-        # because we are adding a stronger relationship to the child, 
-        # the previous parent child relationship should be removed
-        p = create_project
-        pm1 = create_project_media project: p # parent
-        pm2 = create_project_media project: p # child
-        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.suggested_type
+    pm3 = create_project_media project: p # the new item to be suggested
+    test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.confirmed_type}})
+    # check that it was created
+    assert test_relationship.present?
+    # check that it links to the child
+    assert_equal( test_relationship.source, pm2)
+    assert_equal( test_relationship.target, pm3)
 
-        pm3 = create_project_media project: p # the new item to be suggested
-        test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.confirmed_type}})
-        # check that it was created
-        assert test_relationship.present?
-        # check that it links to the child
-        assert_equal( test_relationship.source, pm2)
-        assert_equal( test_relationship.target, pm3)
+    # check that the original link is removed
+    assert Relationship.where(target_id: pm2.id, source_id: pm1.id).first.nil? 
+  end
 
-        # check that the original link is removed
-        assert Relationship.where(target_id: pm2.id, source_id: pm1.id).first.nil? 
+  test 'item confirmed to child of confirmed pair will link to parent' do
+    # the links are good, but rewrite it as a link to the parent
+    p = create_project
+    pm1 = create_project_media project: p # parent
+    pm2 = create_project_media project: p # child
+    create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
 
-    end
+    pm3 = create_project_media project: p # the new item to be suggested
+    test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.confirmed_type}})
+    # check that it was created
+    assert test_relationship.present?
+    # check that it links the parent (not the child)
+    assert_equal( test_relationship.source, pm1)
+    assert_equal( test_relationship.target, pm3)
+  end
 
-    test 'item confirmed to child of confirmed pair will link to parent' do
-        # the links are good, but rewrite it as a link to the parent
-        p = create_project
-        pm1 = create_project_media project: p # parent
-        pm2 = create_project_media project: p # child
-        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
+  test 'item suggested to child of confirmed pair will link to parent' do
+    # the links are good, but rewrite it as a link to the parent
+    p = create_project
+    pm1 = create_project_media project: p # parent
+    pm2 = create_project_media project: p # child
+    create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
 
-        pm3 = create_project_media project: p # the new item to be suggested
-        test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.confirmed_type}})
-        # check that it was created
-        assert test_relationship.present?
-        # check that it links the parent (not the child)
-        assert_equal( test_relationship.source, pm1)
-        assert_equal( test_relationship.target, pm3)
-    end
-
-    test 'item suggested to child of confirmed pair will link to parent' do
-        # the links are good, but rewrite it as a link to the parent
-        p = create_project
-        pm1 = create_project_media project: p # parent
-        pm2 = create_project_media project: p # child
-        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
-
-        pm3 = create_project_media project: p # the new item to be suggested
-        test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.suggested_type}})
-        # check that it was created
-        assert test_relationship.present?
-        # check that it links the parent (not the child)
-        assert_equal( test_relationship.source, pm1)
-        assert_equal( test_relationship.target, pm3)
-    end
+    pm3 = create_project_media project: p # the new item to be suggested
+    test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.suggested_type}})
+    # check that it was created
+    assert test_relationship.present?
+    # check that it links the parent (not the child)
+    assert_equal( test_relationship.source, pm1)
+    assert_equal( test_relationship.target, pm3)
+  end
 
   def teardown
     super

--- a/test/models/bot/alegre_relationship_test.rb
+++ b/test/models/bot/alegre_relationship_test.rb
@@ -1,0 +1,194 @@
+# check that adding new suggested relation ships doesn't violate transitive similarity
+require_relative '../../test_helper'
+
+class Bot::AlegreRelationshipTest < ActiveSupport::TestCase
+  def setup
+    super
+    ft = DynamicAnnotation::FieldType.where(field_type: 'language').last || create_field_type(field_type: 'language', label: 'Language')
+    at = create_annotation_type annotation_type: 'language', label: 'Language'
+    create_field_instance annotation_type_object: at, name: 'language', label: 'Language', field_type_object: ft, optional: false
+    @bot = create_alegre_bot(name: "alegre", login: "alegre")
+    @bot.approve!
+    p = create_project
+    p.team.set_languages = ['en','pt','es']
+    p.team.save!
+    @bot.install_to!(p.team)
+    @team = p.team
+    m = create_claim_media quote: 'I like apples'
+    @pm = create_project_media project: p, media: m
+    create_flag_annotation_type
+    create_extracted_text_annotation_type
+    Sidekiq::Testing.inline!
+  end
+
+    """    
+    test 'should not replace when parent is blank' do
+        p = create_project
+        pm1 = create_project_media project: p, is_image: true
+        pm2 = create_project_media project: p, media: Blank.new
+        pm3 = create_project_media project: p, media: Blank.new
+        assert_no_difference 'ProjectMedia.count' do
+          assert_difference 'Relationship.count' do
+            Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.confirmed_type}})
+          end
+        end
+      end
+    """
+
+    test 'item suggested to single other item will link' do
+        p = create_project
+        pm1 = create_project_media project: p
+        pm2 = create_project_media project: p
+        test_relationship = Bot::Alegre.add_relationships(pm2, {pm1.id => {score: 1, relationship_type: Relationship.suggested_type}})
+        # check that it was created
+        assert test_relationship != nil
+        # check that it links the appropriate ids
+        assert_equal( test_relationship.source, pm1)
+        assert_equal( test_relationship.target, pm2)
+    end
+
+    test 'item confirmd to single other item will link' do
+        p = create_project
+        pm1 = create_project_media project: p
+        pm2 = create_project_media project: p
+        test_relationship = Bot::Alegre.add_relationships(pm2, {pm1.id => {score: 1, relationship_type: Relationship.confirmed_type}})
+        # check that it was created
+        assert test_relationship != nil
+        # check that it links the appropriate ids
+        assert_equal( test_relationship.source, pm1)
+        assert_equal( test_relationship.target, pm2)
+    end
+
+    test 'item suggested to parent of confirmed pair will link' do
+        p = create_project
+        pm1 = create_project_media project: p # parent
+        pm2 = create_project_media project: p # child
+        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
+
+        pm3 = create_project_media project: p # the new item to be suggested
+        test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.suggested_type}})
+        # check that it was created
+        assert test_relationship != nil
+        # check that it links the appropriate ids
+        assert_equal( test_relationship.source, pm1)
+        assert_equal( test_relationship.target, pm3)
+    end
+
+    test 'item confirmed to parent of confirmed pair will link' do
+        p = create_project
+        pm1 = create_project_media project: p # parent
+        pm2 = create_project_media project: p # child
+        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
+
+        pm3 = create_project_media project: p # the new item to be suggested
+        test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.confirmed_type}})
+        # check that it was created
+        assert test_relationship != nil
+        # check that it links the appropriate ids
+        assert_equal( test_relationship.source, pm1)
+        assert_equal( test_relationship.target, pm3)
+    end
+
+    test 'item suggested to parent of suggested pair will link' do
+        p = create_project
+        pm1 = create_project_media project: p # parent
+        pm2 = create_project_media project: p # child
+        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.suggested_type
+
+        pm3 = create_project_media project: p # the new item to be suggested
+        test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.suggested_type}})
+        # check that it was created
+        assert test_relationship != nil
+        # check that it links the appropriate ids
+        assert_equal( test_relationship.source, pm1)
+        assert_equal( test_relationship.target, pm3)
+    end
+
+    test 'item suggested to child of suggested pair will NOT link' do
+        # this the new thing: don't chain suggestions
+        p = create_project
+        pm1 = create_project_media project: p # parent
+        pm2 = create_project_media project: p # child
+        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.suggested_type
+
+        pm3 = create_project_media project: p # the new item to be suggested
+        test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.suggested_type}})
+        # check that it was created
+        assert_equal( test_relationship nil)
+ 
+    end
+
+    test 'item confirmed to parent of suggested pair will link' do
+        p = create_project
+        pm1 = create_project_media project: p # parent
+        pm2 = create_project_media project: p # child
+        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.suggested_type
+
+        pm3 = create_project_media project: p # the new item to be suggested
+        test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.confirmed_type}})
+        # check that it was created
+        assert test_relationship != nil
+        # check that it links the appropriate ids
+        assert_equal( test_relationship.source, pm1)
+        assert_equal( test_relationship.target, pm3)
+    end
+
+    test 'item confirmed to child of suggested pair will link and break relationship' do
+        # because we are adding a stronger relationship to the child, 
+        # the previous parent child relationship should be removed
+        p = create_project
+        pm1 = create_project_media project: p # parent
+        pm2 = create_project_media project: p # child
+        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.suggested_type
+
+        pm3 = create_project_media project: p # the new item to be suggested
+        test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.confirmed_type}})
+        # check that it was created
+        assert test_relationship != nil
+        # check that it links the parent
+        assert_equal( test_relationship.source, pm1)
+        assert_equal( test_relationship.target, pm3)
+
+        # check that the original link is removed
+        assert Relationship.where(target_id: pm2.id, source_id: pm1.id).first.nil? 
+
+    end
+
+    test 'item confirmed to child of confrimed pair will link to parent' do
+        # the links are good, but rewrite it as a link to the parent
+        p = create_project
+        pm1 = create_project_media project: p # parent
+        pm2 = create_project_media project: p # child
+        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
+
+        pm3 = create_project_media project: p # the new item to be suggested
+        test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.confirmed_type}})
+        # check that it was created
+        assert test_relationship != nil
+        # check that it links the parent (not the child)
+        assert_equal( test_relationship.source, pm1)
+        assert_equal( test_relationship.target, pm3)
+    end
+
+    test 'item suggested to child of confrimed pair will link to parent' do
+        # the links are good, but rewrite it as a link to the parent
+        p = create_project
+        pm1 = create_project_media project: p # parent
+        pm2 = create_project_media project: p # child
+        create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
+
+        pm3 = create_project_media project: p # the new item to be suggested
+        test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.suggested_type}})
+        # check that it was created
+        assert test_relationship != nil
+        # check that it links the parent (not the child)
+        assert_equal( test_relationship.source, pm1)
+        assert_equal( test_relationship.target, pm3)
+    end
+
+  def teardown
+    super
+    Bot::Alegre.unstub(:media_file_url)
+  end
+
+end

--- a/test/models/bot/alegre_relationship_test.rb
+++ b/test/models/bot/alegre_relationship_test.rb
@@ -41,19 +41,19 @@ class Bot::AlegreRelationshipTest < ActiveSupport::TestCase
         pm2 = create_project_media project: p
         test_relationship = Bot::Alegre.add_relationships(pm2, {pm1.id => {score: 1, relationship_type: Relationship.suggested_type}})
         # check that it was created
-        assert test_relationship != nil
+        assert test_relationship.present?
         # check that it links the appropriate ids
         assert_equal( test_relationship.source, pm1)
         assert_equal( test_relationship.target, pm2)
     end
 
-    test 'item confirmd to single other item will link' do
+    test 'item confirmed to single other item will link' do
         p = create_project
         pm1 = create_project_media project: p
         pm2 = create_project_media project: p
         test_relationship = Bot::Alegre.add_relationships(pm2, {pm1.id => {score: 1, relationship_type: Relationship.confirmed_type}})
         # check that it was created
-        assert test_relationship != nil
+        assert test_relationship.present?
         # check that it links the appropriate ids
         assert_equal( test_relationship.source, pm1)
         assert_equal( test_relationship.target, pm2)
@@ -68,7 +68,7 @@ class Bot::AlegreRelationshipTest < ActiveSupport::TestCase
         pm3 = create_project_media project: p # the new item to be suggested
         test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.suggested_type}})
         # check that it was created
-        assert test_relationship != nil
+        assert test_relationship.present?
         # check that it links the appropriate ids
         assert_equal( test_relationship.source, pm1)
         assert_equal( test_relationship.target, pm3)
@@ -83,7 +83,7 @@ class Bot::AlegreRelationshipTest < ActiveSupport::TestCase
         pm3 = create_project_media project: p # the new item to be suggested
         test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.confirmed_type}})
         # check that it was created
-        assert test_relationship != nil
+        assert test_relationship.present?
         # check that it links the appropriate ids
         assert_equal( test_relationship.source, pm1)
         assert_equal( test_relationship.target, pm3)
@@ -98,7 +98,7 @@ class Bot::AlegreRelationshipTest < ActiveSupport::TestCase
         pm3 = create_project_media project: p # the new item to be suggested
         test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.suggested_type}})
         # check that it was created
-        assert test_relationship != nil
+        assert test_relationship.present?
         # check that it links the appropriate ids
         assert_equal( test_relationship.source, pm1)
         assert_equal( test_relationship.target, pm3)
@@ -113,8 +113,10 @@ class Bot::AlegreRelationshipTest < ActiveSupport::TestCase
 
         pm3 = create_project_media project: p # the new item to be suggested
         test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.suggested_type}})
-        # check that it was created
-        assert_equal( test_relationship, nil)
+        # check that it was not created
+        assert_nil( test_relationship)
+        # check that it doesn't exist
+        assert Relationship.where(target_id: pm2.id, source_id: pm3.id).first.nil?
  
     end
 
@@ -127,7 +129,7 @@ class Bot::AlegreRelationshipTest < ActiveSupport::TestCase
         pm3 = create_project_media project: p # the new item to be suggested
         test_relationship = Bot::Alegre.add_relationships(pm3, {pm1.id => {score: 1, relationship_type: Relationship.confirmed_type}})
         # check that it was created
-        assert test_relationship != nil
+        assert test_relationship.present?
         # check that it links the appropriate ids
         assert_equal( test_relationship.source, pm1)
         assert_equal( test_relationship.target, pm3)
@@ -144,9 +146,9 @@ class Bot::AlegreRelationshipTest < ActiveSupport::TestCase
         pm3 = create_project_media project: p # the new item to be suggested
         test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.confirmed_type}})
         # check that it was created
-        assert test_relationship != nil
-        # check that it links the parent
-        assert_equal( test_relationship.source, pm1)
+        assert test_relationship.present?
+        # check that it links to the child
+        assert_equal( test_relationship.source, pm2)
         assert_equal( test_relationship.target, pm3)
 
         # check that the original link is removed
@@ -154,7 +156,7 @@ class Bot::AlegreRelationshipTest < ActiveSupport::TestCase
 
     end
 
-    test 'item confirmed to child of confrimed pair will link to parent' do
+    test 'item confirmed to child of confirmed pair will link to parent' do
         # the links are good, but rewrite it as a link to the parent
         p = create_project
         pm1 = create_project_media project: p # parent
@@ -164,13 +166,13 @@ class Bot::AlegreRelationshipTest < ActiveSupport::TestCase
         pm3 = create_project_media project: p # the new item to be suggested
         test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.confirmed_type}})
         # check that it was created
-        assert test_relationship != nil
+        assert test_relationship.present?
         # check that it links the parent (not the child)
         assert_equal( test_relationship.source, pm1)
         assert_equal( test_relationship.target, pm3)
     end
 
-    test 'item suggested to child of confrimed pair will link to parent' do
+    test 'item suggested to child of confirmed pair will link to parent' do
         # the links are good, but rewrite it as a link to the parent
         p = create_project
         pm1 = create_project_media project: p # parent
@@ -180,7 +182,7 @@ class Bot::AlegreRelationshipTest < ActiveSupport::TestCase
         pm3 = create_project_media project: p # the new item to be suggested
         test_relationship = Bot::Alegre.add_relationships(pm3, {pm2.id => {score: 1, relationship_type: Relationship.suggested_type}})
         # check that it was created
-        assert test_relationship != nil
+        assert test_relationship.present?
         # check that it links the parent (not the child)
         assert_equal( test_relationship.source, pm1)
         assert_equal( test_relationship.target, pm3)


### PR DESCRIPTION
https://meedan.atlassian.net/browse/CV2-2675
Alters the logic of how proposed similarity relationships are cached to deal with issues reported by users in which weak chains of similarity caused unrelated media to be suggested
- adds a test file that tries to enumerate the combinations of project media suggestions to cover the logc
- modifies the logic so that a suggestion to a suggestion will not be cached
- also implements the 'if a confirmed relationship is proposed to the child of a suggested relationship, break the (weaker) relationship with parent and form a new relationship cluster