### PR TITLE
Add team_id to conversations calculation cache key

### DIFF
--- a/app/models/monthly_team_statistic.rb
+++ b/app/models/monthly_team_statistic.rb
@@ -12,8 +12,7 @@ class MonthlyTeamStatistic < ApplicationRecord
     platform_name: "Platform", # model method
     language: "Language",
     month: "Month", # model method
-    conversations: 'Conversations', # being deprecated after April 1, 2023
-    conversations_24hr: 'Conversations (updated)',
+    conversations_24hr: 'Conversations',
     average_messages_per_day: 'Average messages per day',
     unique_users: 'Unique users',
     returning_users: 'Returning users',

--- a/lib/check/tipline_message_statistics.rb
+++ b/lib/check/tipline_message_statistics.rb
@@ -15,16 +15,16 @@ module Check
         Rails.cache.delete_matched(/check:statistics:conversations:index:/)
       end
 
-      def cache_read(uid, language, platform)
-        Rails.cache.read(cache_key(uid, language, platform))
+      def cache_read(team_id, uid, language, platform)
+        Rails.cache.read(cache_key(team_id, uid, language, platform))
       end
 
-      def cache_reset(uid, language, platform)
-        Rails.cache.delete(cache_key(uid, language, platform))
+      def cache_reset(team_id, uid, language, platform)
+        Rails.cache.delete(cache_key(team_id, uid, language, platform))
       end
 
-      def cache_key(uid, language, platform)
-        "check:statistics:conversations:index:#{uid}-#{language}-#{platform}"
+      def cache_key(team_id, uid, language, platform)
+        "check:statistics:conversations:index:#{team_id}-#{uid}-#{language}-#{platform}"
       end
 
       def date_to_string(date)
@@ -43,7 +43,7 @@ module Check
       monthly_convos = 0
 
       monthly_uids.each do |uid|
-        cached_convo_index = cache_read(uid, language, platform)
+        cached_convo_index = cache_read(@team_id, uid, language, platform)
         messages = TiplineMessage.where(uid: uid, language: language, platform: platform, sent_at: (cached_convo_index || earliest_record)..range_end).order(:sent_at)
         next unless messages.any?
 
@@ -67,7 +67,7 @@ module Check
 
         # Mark the most recent conversation start we got to on this round.
         # Only update cache when calculating full months, since we'll want to re-calculate partial months.
-        cache_write(uid, language, platform, @conversation_start_index) if range_end == range_start.end_of_month
+        cache_write(@team_id, uid, language, platform, @conversation_start_index) if range_end == range_start.end_of_month
       end
 
       monthly_convos
@@ -75,8 +75,8 @@ module Check
 
     private
 
-    def cache_write(uid, language, platform, time)
-      Rails.cache.write(cache_key(uid, language, platform), time)
+    def cache_write(team_id, uid, language, platform, time)
+      Rails.cache.write(cache_key(team_id, uid, language, platform), time)
     end
 
     def track_conversation!(conversation_start)

--- a/test/lib/tasks/check/tipline_message_stastics_test.rb
+++ b/test/lib/tasks/check/tipline_message_stastics_test.rb
@@ -43,8 +43,8 @@ class TiplineMessageStatisticsTest < ActiveSupport::TestCase
     recent_convo_2 = create_tipline_message(team_id: @team_1.id, uid: 'abcdef', platform: "Telegram", language: "en", sent_at: @time) # 3, different uid
 
     Check::TiplineMessageStatistics.new(@team_1.id).monthly_conversations("Telegram", "en", @time.beginning_of_month, @time.end_of_month)
-    assert_equal recent_convo_1.sent_at, Check::TiplineMessageStatistics.cache_read("12345", "en", "Telegram")
-    assert_equal recent_convo_2.sent_at, Check::TiplineMessageStatistics.cache_read("abcdef", "en", "Telegram")
+    assert_equal recent_convo_1.sent_at, Check::TiplineMessageStatistics.cache_read(@team_1.id, "12345", "en", "Telegram")
+    assert_equal recent_convo_2.sent_at, Check::TiplineMessageStatistics.cache_read(@team_1.id, "abcdef", "en", "Telegram")
   end
 
   test ".monthly_conversations does not cache a conversation index when only calculating for a partial month" do
@@ -52,8 +52,8 @@ class TiplineMessageStatisticsTest < ActiveSupport::TestCase
     recent_convo_2 = create_tipline_message(team_id: @team_1.id, uid: 'abcdef', platform: "Telegram", language: "en", sent_at: @time) # 3, different uid
 
     Check::TiplineMessageStatistics.new(@team_1.id).monthly_conversations("Telegram", "en", @time.beginning_of_month, (@time.end_of_month - 1.day))
-    assert_nil Check::TiplineMessageStatistics.cache_read("12345", "en", "Telegram")
-    assert_nil Check::TiplineMessageStatistics.cache_read("abcdef", "en", "Telegram")
+    assert_nil Check::TiplineMessageStatistics.cache_read(@team_1.id, "12345", "en", "Telegram")
+    assert_nil Check::TiplineMessageStatistics.cache_read(@team_1.id, "abcdef", "en", "Telegram")
   end
 
   test ".monthly_conversations uses the cached conversation index as the starting point for calcluations when present" do

--- a/test/models/monthly_team_statistics_test.rb
+++ b/test/models/monthly_team_statistics_test.rb
@@ -43,7 +43,7 @@ class MonthlyTeamStatisticTest < ActiveSupport::TestCase
       language: "en",
       start_date: DateTime.new(2020,4,1),
       end_date: DateTime.new(2020,4,15),
-      conversations: 1,
+      conversations: 1, # deprecated, not included in .formatted_hash
       conversations_24hr: 23,
       average_messages_per_day: 2,
       unique_users: 3,
@@ -67,8 +67,7 @@ class MonthlyTeamStatisticTest < ActiveSupport::TestCase
     assert_equal hash["Platform"], "WhatsApp"
     assert_equal hash["Language"], "en"
     assert_equal hash["Month"], "Apr 2020"
-    assert_equal hash["Conversations"], 1
-    assert_equal hash["Conversations (updated)"], 23
+    assert_equal hash["Conversations"], 23
     assert_equal hash["Average messages per day"], 2
     assert_equal hash["Unique users"], 3
     assert_equal hash["Returning users"], 4

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -1160,8 +1160,8 @@ class TeamTest < ActiveSupport::TestCase
 
     Rails.cache.write("data:report:#{t.id}", [{ 'Month' => 'Jan 2022', 'Conversations' => 200 }])
 
-    create_monthly_team_statistic(team: t, start_date: DateTime.new(2022, 2, 1), conversations: 3)
-    create_monthly_team_statistic(team: t, start_date: DateTime.new(2022, 1, 1), conversations: 2)
+    create_monthly_team_statistic(team: t, start_date: DateTime.new(2022, 2, 1), conversations_24hr: 3)
+    create_monthly_team_statistic(team: t, start_date: DateTime.new(2022, 1, 1), conversations_24hr: 2)
 
     data_report = t.data_report
     first_stat = data_report.first


### PR DESCRIPTION
Uids are not guaranteed to be unique across teams, so we need to make sure that our cache key for calculating statistics includes the team_id in its key so that we don't accidentally impact cache keys for multiple teams.

CV2-2556