### PR TITLE
add rollback test to fetch test

### DIFF
--- a/test/models/bot/fetch_test.rb
+++ b/test/models/bot/fetch_test.rb
@@ -229,4 +229,15 @@ class Bot::FetchTest < ActiveSupport::TestCase
     assert_equal text, pm.title(true)
     assert_equal text, pm.fact_check_title(true)
   end
+
+  test "rollback everything if fact check can not be saved" do
+    cr = @claim_review.deep_dup
+    cr['identifier'] = random_string
+    cr['url'] = 'foo'
+    assert_no_difference 'ProjectMedia.count' do
+      assert_no_difference 'FactCheck.count' do
+        Bot::Fetch::Import.import_claim_review(cr, @team.id, @bot.id, 'undetermined', {}, false)     
+      end
+    end
+  end
 end


### PR DESCRIPTION
While trying to fix a bug regarding some empty fact checks ([CV2-2842](https://meedan.atlassian.net/browse/CV2-2842?atlOrigin=eyJpIjoiODlkNWM4Y2I2ZGZmNDE5NTk0ZGEzMmJhMzg0ODU4YmIiLCJwIjoiaiJ9)), we wrote this test to check if the transaction is working. We have not solved the bug, but this is a good test to keep.

[CV2-2842]: https://meedan.atlassian.net/browse/CV2-2842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ