### PR TITLE
Only generate new conversations after date cutoff

### DIFF
--- a/lib/tasks/data/statistics.rake
+++ b/lib/tasks/data/statistics.rake
@@ -46,15 +46,15 @@ namespace :check do
               row_attributes = CheckStatistics.get_statistics(month_start.to_date, period_end, team_id, platform, language)
 
               # Start date for new conversation calculation, with optional override for testing
-              cutoff_date = args.ignore_convo_cutoff ? DateTime.new(2023,1,1) : DateTime.new(2023,4,1)
-              CheckTracer.in_span("Check::TiplineMessageStatistics.monthly_conversations", attributes: tracing_attributes) do
-                row_attributes[:conversations_24hr] = tipline_message_statistics.monthly_conversations(
-                  Bot::Smooch::SUPPORTED_INTEGRATION_NAMES[platform],
-                  language,
-                  month_start,
-                  period_end,
-                  cutoff_date
-                )
+              if args.ignore_convo_cutoff || month_start >= DateTime.new(2023,4,1)
+                CheckTracer.in_span("Check::TiplineMessageStatistics.monthly_conversations", attributes: tracing_attributes) do
+                  row_attributes[:conversations_24hr] = tipline_message_statistics.monthly_conversations(
+                    Bot::Smooch::SUPPORTED_INTEGRATION_NAMES[platform],
+                    language,
+                    month_start,
+                    period_end
+                  )
+                end
               end
 
               partial_month = MonthlyTeamStatistic.find_by(team_id: team_id, platform: platform, language: language, start_date: month_start)


### PR DESCRIPTION
Previously we were storing 0 for months we were generating new conversations for. This made looking at data before the stated cutoff confusing, since it would show 0 instead of nil / "-". This makes it so that we don't even attempt to calculate conversations if something is before the date cutoff of April 1, when we're rolling this out, unless we specify to do so in the rake task.

CV2-2556