### PR TITLE
push images built by commit to ecr

### DIFF
--- a/.github/workflows/ci-push-image.yml
+++ b/.github/workflows/ci-push-image.yml
@@ -51,6 +51,7 @@ jobs:
         echo "Pushing to $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
         docker buildx build \
           --cache-from "type=local,src=/tmp/.buildx-cache" \
+          --cache-to "type=local,dest=/tmp/.buildx-cache-new" \
           --output "type=image,push=true" \
           --tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
           --file ./Dockerfile ./
@@ -58,6 +59,7 @@ jobs:
         echo "Pushing to $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH"
         docker buildx build \
           --cache-from "type=local,src=/tmp/.buildx-cache" \
+          --cache-to "type=local,dest=/tmp/.buildx-cache-new" \
           --output "type=image,push=true" \
           --tag $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH \
           --file ./Dockerfile ./

--- a/.github/workflows/ci-push-image.yml
+++ b/.github/workflows/ci-push-image.yml
@@ -1,0 +1,68 @@
+name: Build and Push
+
+on:
+  push:
+    branches:
+      - '!develop'
+      - '!master'
+
+jobs:
+  build-test-deploy:
+    runs-on: ubuntu-latest
+
+    outputs:
+      image: ${{ steps.build-image.outputs.image }}
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        aws-region: eu-west-1
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Set up Docker Buildx
+      uses: crazy-max/ghaction-docker-buildx@v3
+
+    - name: Cache Docker layers
+      uses: actions/cache@v2
+      id: cache
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
+
+    - name: Docker Buildx (+ push)
+      id: push-image-to-ecr
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        ECR_REPOSITORY: ${{ github.event.repository.name }}
+        IMAGE_TAG: ${{ github.sha }}
+      run: |
+        BRANCH=$(echo "${GITHUB_REF#refs/*/}" | sed 's/.*\///')
+        # push with git sha
+        echo "Pushing to $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+        docker buildx build \
+          --cache-from "type=local,src=/tmp/.buildx-cache" \
+          --output "type=image,push=true" \
+          --tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+          --file ./Dockerfile ./
+        # push docker tag to indicate branch
+        echo "Pushing to $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH"
+        docker buildx build \
+          --cache-from "type=local,src=/tmp/.buildx-cache" \
+          --output "type=image,push=true" \
+          --tag $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH \
+          --file ./Dockerfile ./
+
+    - name: Reset cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/ci-push-image.yml
+++ b/.github/workflows/ci-push-image.yml
@@ -17,11 +17,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v2
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        role-to-assume: ${{ secrets.AWS_OIDC_ROLE_TO_ASSUME }}
         aws-region: eu-west-1
 
     - name: Login to Amazon ECR

--- a/.github/workflows/ci-push-image.yml
+++ b/.github/workflows/ci-push-image.yml
@@ -63,6 +63,7 @@ jobs:
           --file ./Dockerfile ./
 
     - name: Reset cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      id: reset-cache
+      run: |
+        rm -rf /tmp/.buildx-cachGe
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/ci-push-image.yml
+++ b/.github/workflows/ci-push-image.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-push:
     runs-on: ubuntu-latest
+    environment: QA
 
     outputs:
       image: ${{ steps.build-image.outputs.image }}

--- a/.github/workflows/ci-push-image.yml
+++ b/.github/workflows/ci-push-image.yml
@@ -47,20 +47,14 @@ jobs:
         IMAGE_TAG: ${{ github.sha }}
       run: |
         BRANCH=$(echo "${GITHUB_REF#refs/*/}" | sed 's/.*\///')
-        # push with git sha
+        # push with git sha and branch
         echo "Pushing to $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
         docker buildx build \
           --cache-from "type=local,src=/tmp/.buildx-cache" \
           --cache-to "type=local,dest=/tmp/.buildx-cache-new" \
+          --platform "linux/amd64,linux/arm64" \
           --output "type=image,push=true" \
           --tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
-          --file ./Dockerfile ./
-        # push docker tag to indicate branch
-        echo "Pushing to $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH"
-        docker buildx build \
-          --cache-from "type=local,src=/tmp/.buildx-cache" \
-          --cache-to "type=local,dest=/tmp/.buildx-cache-new" \
-          --output "type=image,push=true" \
           --tag $ECR_REGISTRY/$ECR_REPOSITORY:$BRANCH \
           --file ./Dockerfile ./
 

--- a/.github/workflows/ci-push-image.yml
+++ b/.github/workflows/ci-push-image.yml
@@ -61,5 +61,5 @@ jobs:
     - name: Reset cache
       id: reset-cache
       run: |
-        rm -rf /tmp/.buildx-cachGe
+        rm -rf /tmp/.buildx-cache
         mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/ci-push-image.yml
+++ b/.github/workflows/ci-push-image.yml
@@ -13,7 +13,6 @@ permissions:
 jobs:
   build-push:
     runs-on: ubuntu-latest
-    environment: QA
 
     outputs:
       image: ${{ steps.build-image.outputs.image }}

--- a/.github/workflows/ci-push-image.yml
+++ b/.github/workflows/ci-push-image.yml
@@ -1,10 +1,10 @@
-name: Build and Push
+name: Build and Push To ECR
 
 on:
   push:
-    branches:
-      - '!develop'
-      - '!master'
+    branches-ignore:
+      - 'develop'
+      - 'master'
 
 jobs:
   build-test-deploy:

--- a/.github/workflows/ci-push-image.yml
+++ b/.github/workflows/ci-push-image.yml
@@ -6,6 +6,10 @@ on:
       - 'develop'
       - 'master'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-push-image.yml
+++ b/.github/workflows/ci-push-image.yml
@@ -7,7 +7,7 @@ on:
       - 'master'
 
 jobs:
-  build-test-deploy:
+  build-push:
     runs-on: ubuntu-latest
 
     outputs:


### PR DESCRIPTION
This creates a Github Actions workflow to build and push arm64 and amd64 images for all non-deploy branch (ie. develop and master) commits to our private repository. This will not be triggered by forks from external contributors.

Pushed images will be tagged with both git sha (ie. `873f96246cebf3196ac4a566bd5157d61c94df0f`) and branch name (innermost sub-branch after last `/`).