### PR TITLE
Fix NameError Api::V1::BaseApiController#ping

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 require 'error_codes'
 require 'tracing_service'
+require 'check_sentry'
+
 class ApplicationController < ActionController::Base
   include HttpAcceptLanguage::AutoLocale
 


### PR DESCRIPTION
Can't reproduce this locally or in test, but it's happening in deployed envs. Likely because of autoloading differences? This should fix it.

CV2-2892