### PR TITLE
Consolidate message sending errors and limit data sent to Sentry

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -301,15 +301,15 @@ class Bot::Smooch < BotUser
         false
       end
     rescue StandardError => e
-      self.handle_exception(e, body)
+      self.handle_exception(e)
       false
     end
   end
 
-  def self.handle_exception(e, extra = {})
+  def self.handle_exception(e)
     raise(e) if Rails.env.development?
     Rails.logger.error("[Smooch Bot] Exception: #{e.message}")
-    CheckSentry.notify(e, { bot: 'Smooch', extra: extra })
+    CheckSentry.notify(e, { bot: 'Smooch' })
     raise(e) if e.is_a?(AASM::InvalidTransition) # Race condition: return 500 so Smooch can retry it later
   end
 

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -2,9 +2,7 @@ require 'digest'
 require 'check_state_machine'
 
 class Bot::Smooch < BotUser
-  class MessageDeliveryToSmoochUserError < StandardError; end
-  class MessageDeliveryToWhatsAppUserError < StandardError; end
-  class MessageDeliveryToFinalUserError < StandardError; end
+  class MessageDeliveryError < StandardError; end
 
   MESSAGE_BOUNDARY = "\u2063"
 

--- a/app/models/bot_user.rb
+++ b/app/models/bot_user.rb
@@ -155,7 +155,7 @@ class BotUser < User
       JSON.parse(result.to_json)['data']['node']
     rescue StandardError => e
       Rails.logger.error("[BotUser] Error performing GraphQL query: #{e.message}")
-      CheckSentry.notify(e, { bot_user: self.id, team_id: team.id, object_class: klass, object_id: object.id, query: query, result: result })
+      CheckSentry.notify(e, { bot_user: self.id, team_id: team.id, object_class: klass, object_id: object.id, query: query })
       { error: "Error performing GraphQL query" }.with_indifferent_access
     end
   end
@@ -180,6 +180,7 @@ class BotUser < User
       end
     rescue StandardError => e
       Rails.logger.error("[BotUser] Error calling bot #{self.identifier}: #{e.message}")
+      data.delete(:data) # Prevent sending potentially sensitive data to Sentry
       CheckSentry.notify(e, { bot: self.id, uri: uri, data: data })
       User.current = nil
       Team.current = nil

--- a/app/models/concerns/smooch_resend.rb
+++ b/app/models/concerns/smooch_resend.rb
@@ -226,7 +226,10 @@ module SmoochResend
     end
 
     def log_resend_error(message)
-      CheckSentry.notify(Bot::Smooch::MessageDeliveryToFinalUserError.new, message) if message['isFinalEvent']
+      if message['isFinalEvent']
+        error = Bot::Smooch::MessageDeliveryError.new('Could not deliver message to final user!')
+        CheckSentry.notify(error, error: message.dig('error'), uid: message.dig('appUser', '_id'), smooch_app_id: message.dig('app', '_id'), timestamp: message.dig('timestamp'))
+      end
     end
 
     def template_locale_options(team_slug = nil)

--- a/app/models/concerns/smooch_turnio.rb
+++ b/app/models/concerns/smooch_turnio.rb
@@ -266,8 +266,8 @@ module SmoochTurnio
       if response.code.to_i < 400
         ret = response
       else
-        e = Bot::Smooch::MessageDeliveryToWhatsAppUserError.new
-        CheckSentry.notify(e, { uid: uid, body: response.body, payload: payload, error: e.message, response: response })
+        e = Bot::Smooch::MessageDeliveryError.new('Could not send message to WhatsApp user!')
+        CheckSentry.notify(e, { uid: uid, to: to, smooch_body: response.body, smooch_response: response })
       end
       ret
     end

--- a/app/models/concerns/smooch_zendesk.rb
+++ b/app/models/concerns/smooch_zendesk.rb
@@ -76,7 +76,7 @@ module SmoochZendesk
         api_instance.post_message(app_id, uid, message_post_body)
       rescue SmoochApi::ApiError => e
         Rails.logger.error("[Smooch Bot] Exception when sending message #{params.inspect}: #{e.response_body}")
-        e2 = Bot::Smooch::MessageDeliveryToSmoochUserError.new(e)
+        e2 = Bot::Smooch::MessageDeliveryError.new('Could not send message to Smooch user')
         CheckSentry.notify(e2, { smooch_app_id: app_id, uid: uid, body: params, smooch_response: e.response_body })
         nil
       end


### PR DESCRIPTION
Previously we were sending whole bodies to Sentry, which triggered Sentry's sensitive data filters and prevented us from seeing some of the useful embedded data, like errors. This reduces the scope of what we're sending to Sentry to only things that will help us debug, and avoids sending identifiable information for users to the reporting service.

Lastly, it consolidates the custom exceptions relating to message sending to one (from three), since we don't expect to treat them differently. Instead, we just differentiate based on message.

CV2-2892