### PR TITLE
[don't merge] Update Node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV LANGUAGE C.UTF-8
 
 RUN apt-get update -qq && apt-get install -y --no-install-recommends curl
 
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 
 # sqlite3, lz4: for check:data:export_team task
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update -qq && apt-get install -y curl
 #
 # SYSTEM CONFIG
 #
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 
 # dependencies
 #RUN add-apt-repository ppa:mc3man/trusty-media -y


### PR DESCRIPTION
Node 12 has reached end of life. Security support for 14 ends at end of April. The latest LTS release is 18, so we'll try to upgrade to that.

CV2-2723