### PR TITLE
Don't send "to" to Sentry, since it may be the user's phone number

### DIFF
--- a/app/models/concerns/smooch_turnio.rb
+++ b/app/models/concerns/smooch_turnio.rb
@@ -267,7 +267,7 @@ module SmoochTurnio
         ret = response
       else
         e = Bot::Smooch::MessageDeliveryError.new('Could not send message to WhatsApp user!')
-        CheckSentry.notify(e, { uid: uid, to: to, smooch_body: response.body, smooch_response: response })
+        CheckSentry.notify(e, { uid: uid, smooch_body: response.body, smooch_response: response })
       end
       ret
     end

--- a/app/models/concerns/smooch_zendesk.rb
+++ b/app/models/concerns/smooch_zendesk.rb
@@ -77,7 +77,7 @@ module SmoochZendesk
       rescue SmoochApi::ApiError => e
         Rails.logger.error("[Smooch Bot] Exception when sending message #{params.inspect}: #{e.response_body}")
         e2 = Bot::Smooch::MessageDeliveryError.new('Could not send message to Smooch user')
-        CheckSentry.notify(e2, { smooch_app_id: app_id, uid: uid, body: params, smooch_response: e.response_body })
+        CheckSentry.notify(e2, { smooch_app_id: app_id, uid: uid, smooch_body: params, smooch_response: e.response_body })
         nil
       end
     end


### PR DESCRIPTION
Also makes the smooch data key consistent so that we can whitelist it in the Sentry data scrubbing.

CV2-2892