### PR TITLE
Send more specific information to Sentry for message failure

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,11 +23,11 @@ class ApplicationController < ActionController::Base
     team_id = current_api_user&.current_team_id
     api_key_id = ApiKey.current&.id
 
-    CheckSentry.set_user_info(user_id, team_id: team_id, api_key: api_key_id)
+    CheckSentry.set_user_info(user_id, team_id: team_id, api_key_id: api_key_id)
     TracingService.add_attributes_to_current_span(
       'app.user.id' => user_id,
       'app.user.team_id' => team_id,
-      'app.api_key' => api_key_id,
+      'app.api_key_id' => api_key_id,
     )
   end
 

--- a/app/models/concerns/smooch_turnio.rb
+++ b/app/models/concerns/smooch_turnio.rb
@@ -267,7 +267,14 @@ module SmoochTurnio
         ret = response
       else
         e = Bot::Smooch::MessageDeliveryError.new('Could not send message to WhatsApp user!')
-        CheckSentry.notify(e, { uid: uid, smooch_body: response.body, smooch_response: response })
+        response_body = begin JSON.parse(response.body) rescue {} end
+        CheckSentry.notify(e, {
+          uid: uid,
+          errors: response_body.dig('errors'),
+          type: payload.dig(:type),
+          template_name: payload.dig(:template, :name),
+          template_tanguage: payload.dig(:template, :language, :code)
+        })
       end
       ret
     end

--- a/app/models/concerns/smooch_zendesk.rb
+++ b/app/models/concerns/smooch_zendesk.rb
@@ -77,7 +77,13 @@ module SmoochZendesk
       rescue SmoochApi::ApiError => e
         Rails.logger.error("[Smooch Bot] Exception when sending message #{params.inspect}: #{e.response_body}")
         e2 = Bot::Smooch::MessageDeliveryError.new('Could not send message to Smooch user')
-        CheckSentry.notify(e2, { smooch_app_id: app_id, uid: uid, smooch_body: params, smooch_response: e.response_body })
+        response_body = begin JSON.parse(e.response_body) rescue {} end
+        CheckSentry.notify(e2, {
+          smooch_app_id: app_id,
+          uid: uid,
+          smooch_body: params,
+          errors: response_body.dig('error')
+        })
         nil
       end
     end

--- a/lib/check_sentry.rb
+++ b/lib/check_sentry.rb
@@ -10,13 +10,13 @@ class CheckSentry
       end
     end
 
-    def set_user_info(id, team_id: nil, api_key: nil)
+    def set_user_info(id, team_id: nil, api_key_id: nil)
       Sentry.set_user(id: id)
 
-      if team_id || api_key
+      if team_id || api_key_id
         # .configure_scope sets contextual information for entire event lifecycle
         Sentry.configure_scope do |scope|
-          scope.set_context('application', {'user.team_id' => team_id, 'api_key' => api_key})
+          scope.set_context('application', {'user.team_id' => team_id, 'api_key_id' => api_key_id})
         end
       end
     end

--- a/test/controllers/base_api_controller_test.rb
+++ b/test/controllers/base_api_controller_test.rb
@@ -132,7 +132,7 @@ class BaseApiControllerTest < ActionController::TestCase
 
     authenticate_with_user(user)
 
-    CheckSentry.expects(:set_user_info).with(user.id, team_id: team.id, api_key: nil)
+    CheckSentry.expects(:set_user_info).with(user.id, team_id: team.id, api_key_id: nil)
 
     get :me, params: {}
   end
@@ -143,7 +143,7 @@ class BaseApiControllerTest < ActionController::TestCase
 
     authenticate_with_token(api_key)
 
-    CheckSentry.expects(:set_user_info).with(nil, team_id: nil, api_key: api_key.id)
+    CheckSentry.expects(:set_user_info).with(nil, team_id: nil, api_key_id: api_key.id)
 
     get :version, params: {}
   end
@@ -160,7 +160,7 @@ class BaseApiControllerTest < ActionController::TestCase
     TracingService.expects(:add_attributes_to_current_span).with({
       'app.user.id' => user.id,
       'app.user.team_id' => team.id,
-      'app.api_key' => nil
+      'app.api_key_id' => nil
     })
 
     get :me, params: {}
@@ -175,7 +175,7 @@ class BaseApiControllerTest < ActionController::TestCase
     TracingService.expects(:add_attributes_to_current_span).with({
       'app.user.id' => nil,
       'app.user.team_id' => nil,
-      'app.api_key' => api_key.id
+      'app.api_key_id' => api_key.id
     })
 
     get :version, params: {}

--- a/test/lib/check_sentry_test.rb
+++ b/test/lib/check_sentry_test.rb
@@ -25,7 +25,7 @@ class CheckSentryTest < ActiveSupport::TestCase
     error = StandardError.new('test error')
 
     scope_mock = mock('scope')
-    scope_mock.expects(:set_context).with('application', {'user.team_id' => 1, 'api_key' => nil})
+    scope_mock.expects(:set_context).with('application', {'user.team_id' => 1, 'api_key_id' => nil})
 
     Sentry.expects(:set_user).with(id: 5)
     Sentry.stubs(:configure_scope).yields(scope_mock).returns(true)
@@ -37,11 +37,11 @@ class CheckSentryTest < ActiveSupport::TestCase
     error = StandardError.new('test error')
 
     scope_mock = mock('scope')
-    scope_mock.expects(:set_context).with('application', {'user.team_id' => nil, 'api_key' => 3})
+    scope_mock.expects(:set_context).with('application', {'user.team_id' => nil, 'api_key_id' => 3})
 
     Sentry.expects(:set_user).with(id: nil)
     Sentry.stubs(:configure_scope).yields(scope_mock).returns(true)
 
-    CheckSentry.set_user_info(nil, api_key: 3)
+    CheckSentry.set_user_info(nil, api_key_id: 3)
   end
 end


### PR DESCRIPTION
Try to appease the default data scrubber gods

CV2-2892

Tested for final user error locally, but could not trigger Smooch or WhatsApp errors, so we'll have to see on QA.