### PR TITLE
Remove conversations column from data report, for now

### DIFF
--- a/app/models/monthly_team_statistic.rb
+++ b/app/models/monthly_team_statistic.rb
@@ -12,7 +12,6 @@ class MonthlyTeamStatistic < ApplicationRecord
     platform_name: "Platform", # model method
     language: "Language",
     month: "Month", # model method
-    conversations_24hr: 'Conversations',
     average_messages_per_day: 'Average messages per day',
     unique_users: 'Unique users',
     returning_users: 'Returning users',

--- a/test/models/monthly_team_statistics_test.rb
+++ b/test/models/monthly_team_statistics_test.rb
@@ -44,7 +44,7 @@ class MonthlyTeamStatisticTest < ActiveSupport::TestCase
       start_date: DateTime.new(2020,4,1),
       end_date: DateTime.new(2020,4,15),
       conversations: 1, # deprecated, not included in .formatted_hash
-      conversations_24hr: 23,
+      conversations_24hr: 23, # removed for now
       average_messages_per_day: 2,
       unique_users: 3,
       returning_users: 4,
@@ -67,7 +67,6 @@ class MonthlyTeamStatisticTest < ActiveSupport::TestCase
     assert_equal hash["Platform"], "WhatsApp"
     assert_equal hash["Language"], "en"
     assert_equal hash["Month"], "Apr 2020"
-    assert_equal hash["Conversations"], 23
     assert_equal hash["Average messages per day"], 2
     assert_equal hash["Unique users"], 3
     assert_equal hash["Returning users"], 4

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -1158,10 +1158,10 @@ class TeamTest < ActiveSupport::TestCase
     t = create_team(name: 'Test team')
     assert_nil t.data_report
 
-    Rails.cache.write("data:report:#{t.id}", [{ 'Month' => 'Jan 2022', 'Conversations' => 200 }])
+    Rails.cache.write("data:report:#{t.id}", [{ 'Month' => 'Jan 2022', 'Unique users' => 200 }])
 
-    create_monthly_team_statistic(team: t, start_date: DateTime.new(2022, 2, 1), conversations_24hr: 3)
-    create_monthly_team_statistic(team: t, start_date: DateTime.new(2022, 1, 1), conversations_24hr: 2)
+    create_monthly_team_statistic(team: t, start_date: DateTime.new(2022, 2, 1), unique_users: 3)
+    create_monthly_team_statistic(team: t, start_date: DateTime.new(2022, 1, 1), unique_users: 2)
 
     data_report = t.data_report
     first_stat = data_report.first
@@ -1169,7 +1169,7 @@ class TeamTest < ActiveSupport::TestCase
     assert_equal 2, data_report.length
     assert_equal '1. Jan 2022', first_stat['Month']
     assert_equal 'Test team', first_stat['Org']
-    assert_equal 2, first_stat['Conversations']
+    assert_equal 2, first_stat['Unique users']
   end
 
   test "should have feeds" do


### PR DESCRIPTION
Partners are confused by the conversations column, since the data doesn't match what's in WhatsApp. As a result, we're moving it for now but still continuing to generate the data in the MonthlyTeamStastistic updated in the statistics rake task.

CV2-2969