### PR TITLE
Avoid circular relationships.

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -16,6 +16,7 @@ class Relationship < ApplicationRecord
   validate :relationship_type_is_valid, :items_are_from_the_same_team
   validate :target_not_pulished_report, on: :create
   validate :similar_item_exists, on: :create, if: proc { |r| r.is_suggested? }
+  validate :cant_be_related_to_itself
   validates :relationship_type, uniqueness: { scope: [:source_id, :target_id], message: :already_exists }, on: :create
 
   before_create :destroy_suggest_item, if: proc { |r| r.is_confirmed? }
@@ -302,5 +303,9 @@ class Relationship < ApplicationRecord
     # Check if same item already exists as a suggested item
     Relationship.where(source_id: self.source_id, target_id: self.target_id)
     .where('relationship_type = ?', Relationship.suggested_type.to_yaml).destroy_all
+  end
+
+  def cant_be_related_to_itself
+    errors.add(:base, I18n.t(:item_cant_be_related_to_itself)) if self.source_id == self.target_id
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -726,6 +726,7 @@ en:
   flag_likelihood_5: High (more content will be detected)
   flag_likelihood_7: Manual
   relationship_not_same_team: Related items must exist in the same workspace
+  item_cant_be_related_to_itself: "Item can't be related to itself"
   target_is_published: Target should not have a published report
   similar_item_exists: Sorry, this item already added as a similar item.
   bulk_operation_limit_error: Sorry, the maximum number of items to be processed at

--- a/db/migrate/20230329123127_add_index_to_avoid_relationship_circular_dependency.rb
+++ b/db/migrate/20230329123127_add_index_to_avoid_relationship_circular_dependency.rb
@@ -1,0 +1,32 @@
+class AddIndexToAvoidRelationshipCircularDependency < ActiveRecord::Migration[5.2]
+  def change
+    # Ensure we don't have any circular relationships before creating the index
+    # Copied from lib/tasks/ensure_no_circular_relationships.rake
+    batch_size = 10
+    offset = 0
+    unique_cases = {}
+    any_cases = 0
+    loop do
+      # Query the circular relationships table with a limit and offset
+      circular_relationships = Relationship.joins('JOIN relationships AS r2 ON relationships.target_id = r2.source_id AND relationships.source_id = r2.target_id').limit(batch_size).offset(offset)
+      # Do something with the circular relationships, e.g. print them to the console
+      circular_relationships.each do |relationship|
+        any_cases += 1
+        key = [relationship.source_id, relationship.target_id].sort
+        if unique_cases[key] || key.uniq.count == 1
+          puts "Deleting relationship ##{relationship.id} between source #{relationship.source_id} and target #{relationship.target_id}"
+          relationship.delete
+        else
+          # Otherwise, add the key to the hash table and keep the current relationship
+          unique_cases[key] = true
+        end
+      end
+      # Break the loop if no more records are found
+      break if circular_relationships.empty?
+      # Increment the offset for the next batch
+      offset += batch_size
+    end
+
+    execute 'CREATE UNIQUE INDEX ON relationships (LEAST(source_id, target_id), GREATEST(source_id, target_id))'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_03_10_202330) do
+ActiveRecord::Schema.define(version: 2023_03_31_222716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,7 +26,6 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
 
   create_table "accounts", id: :serial, force: :cascade do |t|
     t.integer "user_id"
-    t.integer "team_id"
     t.string "url"
     t.text "omniauth_info"
     t.string "uid"
@@ -35,6 +34,7 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "team_id"
     t.index ["uid", "provider", "token", "email"], name: "index_accounts_on_uid_and_provider_and_token_and_email"
     t.index ["url"], name: "index_accounts_on_url", unique: true
     t.index ["user_id"], name: "index_accounts_on_user_id"
@@ -49,13 +49,13 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
     t.integer "annotator_id"
     t.text "entities"
     t.text "data"
-    t.string "file"
-    t.integer "lock_version", default: 0, null: false
-    t.boolean "locked", default: false
-    t.text "attribution"
-    t.text "fragment"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "file"
+    t.text "attribution"
+    t.integer "lock_version", default: 0, null: false
+    t.boolean "locked", default: false
+    t.text "fragment"
     t.index "task_fieldset((annotation_type)::text, data)", name: "task_fieldset", where: "((annotation_type)::text = 'task'::text)"
     t.index "task_team_task_id((annotation_type)::text, data)", name: "task_team_task_id", where: "((annotation_type)::text = 'task'::text)"
     t.index ["annotated_type", "annotated_id"], name: "index_annotations_on_annotated_type_and_annotated_id"
@@ -66,20 +66,20 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
   create_table "api_keys", id: :serial, force: :cascade do |t|
     t.string "access_token", default: "", null: false
     t.datetime "expire_at"
-    t.jsonb "rate_limits", default: {}
-    t.string "application"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "application"
+    t.jsonb "rate_limits", default: {}
   end
 
   create_table "assignments", id: :serial, force: :cascade do |t|
     t.integer "assigned_id", null: false
     t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "assigned_type"
     t.integer "assigner_id"
     t.text "message"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["assigned_id", "assigned_type", "user_id"], name: "index_assignments_on_assigned_id_and_assigned_type_and_user_id", unique: true
     t.index ["assigned_id", "assigned_type"], name: "index_assignments_on_assigned_id_and_assigned_type"
     t.index ["assigned_id"], name: "index_assignments_on_assigned_id"
@@ -112,9 +112,9 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
     t.text "description"
     t.bigint "user_id", null: false
     t.bigint "project_media_id", null: false
-    t.text "context"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "context"
     t.index ["project_media_id"], name: "index_claim_descriptions_on_project_media_id", unique: true
     t.index ["user_id"], name: "index_claim_descriptions_on_user_id"
   end
@@ -122,20 +122,20 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
   create_table "clusters", force: :cascade do |t|
     t.integer "project_medias_count", default: 0
     t.integer "project_media_id"
-    t.datetime "first_item_at"
-    t.datetime "last_item_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "first_item_at"
+    t.datetime "last_item_at"
     t.index ["project_media_id"], name: "index_clusters_on_project_media_id", unique: true
   end
 
   create_table "dynamic_annotation_annotation_types", primary_key: "annotation_type", id: :string, force: :cascade do |t|
     t.string "label", null: false
     t.text "description"
-    t.boolean "singleton", default: true
-    t.jsonb "json_schema"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "singleton", default: true
+    t.jsonb "json_schema"
     t.index ["json_schema"], name: "index_dynamic_annotation_annotation_types_on_json_schema", using: :gin
   end
 
@@ -158,7 +158,7 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "dynamic_annotation_fields", id: :serial, force: :cascade do |t|
+  create_table "dynamic_annotation_fields", id: :integer, default: -> { "nextval('new_dynamic_annotation_fields_id_seq'::regclass)" }, force: :cascade do |t|
     t.integer "annotation_id", null: false
     t.string "field_name", null: false
     t.string "annotation_type", null: false
@@ -169,14 +169,11 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
     t.datetime "updated_at", null: false
     t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
-    t.index ["annotation_id"], name: "index_dynamic_annotation_fields_on_annotation_id"
-    t.index ["annotation_type"], name: "index_dynamic_annotation_fields_on_annotation_type"
     t.index ["field_name"], name: "index_dynamic_annotation_fields_on_field_name"
     t.index ["field_type"], name: "index_dynamic_annotation_fields_on_field_type"
     t.index ["value"], name: "fetch_unique_id", unique: true, where: "(((field_name)::text = 'external_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
     t.index ["value"], name: "index_status", where: "((field_name)::text = 'verification_status_status'::text)"
     t.index ["value"], name: "smooch_user_unique_id", unique: true, where: "(((field_name)::text = 'smooch_user_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
-    t.index ["value"], name: "translation_request_id", unique: true, where: "((field_name)::text = 'translation_request_id'::text)"
     t.index ["value_json"], name: "index_dynamic_annotation_fields_on_value_json", using: :gin
   end
 
@@ -186,9 +183,9 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
     t.string "title"
     t.bigint "user_id", null: false
     t.bigint "claim_description_id", null: false
-    t.string "language", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "language", default: "", null: false
     t.index ["claim_description_id"], name: "index_fact_checks_on_claim_description_id", unique: true
     t.index ["language"], name: "index_fact_checks_on_language"
     t.index ["user_id"], name: "index_fact_checks_on_user_id"
@@ -199,9 +196,9 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
     t.bigint "feed_id", null: false
     t.jsonb "filters", default: {}
     t.jsonb "settings", default: {}
-    t.boolean "shared", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "shared", default: false
     t.index ["feed_id"], name: "index_feed_teams_on_feed_id"
     t.index ["team_id", "feed_id"], name: "index_feed_teams_on_team_id_and_feed_id", unique: true
     t.index ["team_id"], name: "index_feed_teams_on_team_id"
@@ -211,9 +208,9 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
     t.string "name", null: false
     t.jsonb "filters", default: {}
     t.jsonb "settings", default: {}
-    t.boolean "published", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "published", default: false
   end
 
   create_table "login_activities", id: :serial, force: :cascade do |t|
@@ -237,11 +234,11 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
     t.integer "user_id"
     t.integer "account_id"
     t.string "url"
-    t.string "file"
-    t.string "quote"
-    t.string "type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "quote"
+    t.string "type"
+    t.string "file"
     t.index ["url"], name: "index_medias_on_url", unique: true
   end
 
@@ -313,21 +310,21 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
   end
 
   create_table "project_medias", id: :serial, force: :cascade do |t|
-    t.integer "project_id"
     t.integer "media_id"
-    t.integer "user_id"
-    t.integer "source_id"
-    t.integer "cluster_id"
-    t.integer "team_id"
-    t.jsonb "channel", default: {"main"=>0}
-    t.boolean "read", default: false, null: false
-    t.integer "sources_count", default: 0, null: false
-    t.integer "archived", default: 0
-    t.integer "cached_annotations_count", default: 0
-    t.integer "targets_count", default: 0, null: false
-    t.integer "last_seen"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.integer "cached_annotations_count", default: 0
+    t.integer "archived", default: 0
+    t.integer "targets_count", default: 0, null: false
+    t.integer "sources_count", default: 0, null: false
+    t.integer "team_id"
+    t.boolean "read", default: false, null: false
+    t.integer "source_id"
+    t.integer "project_id"
+    t.integer "last_seen"
+    t.integer "cluster_id"
+    t.jsonb "channel", default: {"main"=>0}
     t.index ["channel"], name: "index_project_medias_on_channel"
     t.index ["cluster_id"], name: "index_project_medias_on_cluster_id"
     t.index ["last_seen"], name: "index_project_medias_on_last_seen"
@@ -341,18 +338,18 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
   create_table "projects", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "team_id"
-    t.integer "project_group_id"
     t.string "title"
     t.boolean "is_default", default: false
     t.text "description"
     t.string "lead_image"
-    t.string "token"
-    t.integer "assignments_count", default: 0
-    t.integer "privacy", default: 0, null: false
-    t.integer "archived", default: 0
-    t.text "settings"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "archived", default: 0
+    t.text "settings"
+    t.string "token"
+    t.integer "assignments_count", default: 0
+    t.integer "project_group_id"
+    t.integer "privacy", default: 0, null: false
     t.index ["id"], name: "index_projects_on_id"
     t.index ["is_default"], name: "index_projects_on_is_default"
     t.index ["privacy"], name: "index_projects_on_privacy"
@@ -364,24 +361,24 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
   create_table "relationships", id: :serial, force: :cascade do |t|
     t.integer "source_id", null: false
     t.integer "target_id", null: false
-    t.integer "user_id"
     t.string "relationship_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.float "weight", default: 0.0
+    t.integer "confirmed_by"
+    t.datetime "confirmed_at"
+    t.string "source_field"
+    t.string "target_field"
+    t.string "model"
+    t.jsonb "details", default: "{}"
     t.float "original_weight", default: 0.0
-    t.float "float", default: 0.0
     t.jsonb "original_details", default: "{}"
     t.string "original_relationship_type"
     t.string "original_model"
     t.integer "original_source_id"
     t.string "original_source_field"
-    t.integer "confirmed_by"
-    t.datetime "confirmed_at"
-    t.float "weight", default: 0.0
-    t.string "source_field"
-    t.string "target_field"
-    t.string "model"
-    t.jsonb "details", default: "{}"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.index "LEAST(source_id, target_id), GREATEST(source_id, target_id)", name: "relationships_least_greatest_idx", unique: true
     t.index ["relationship_type"], name: "index_relationships_on_relationship_type"
     t.index ["source_id", "target_id", "relationship_type"], name: "relationship_index", unique: true
     t.index ["target_id"], name: "index_relationships_on_target_id", unique: true
@@ -391,18 +388,18 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
     t.bigint "feed_id", null: false
     t.string "request_type", null: false
     t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "request_id"
     t.integer "media_id"
-    t.integer "fact_checked_by_count", default: 0, null: false
-    t.integer "project_medias_count", default: 0, null: false
     t.integer "medias_count", default: 0, null: false
     t.integer "requests_count", default: 0, null: false
     t.datetime "last_submitted_at"
     t.string "webhook_url"
     t.datetime "last_called_webhook_at"
     t.integer "subscriptions_count", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer "fact_checked_by_count", default: 0, null: false
+    t.integer "project_medias_count", default: 0, null: false
     t.index ["feed_id"], name: "index_requests_on_feed_id"
     t.index ["media_id"], name: "index_requests_on_media_id"
     t.index ["request_id"], name: "index_requests_on_request_id"
@@ -435,15 +432,15 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
 
   create_table "sources", id: :serial, force: :cascade do |t|
     t.integer "user_id"
-    t.integer "team_id"
     t.string "name"
     t.string "slogan"
     t.string "avatar"
-    t.integer "archived", default: 0
-    t.string "file"
-    t.integer "lock_version", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "team_id"
+    t.string "file"
+    t.integer "archived", default: 0
+    t.integer "lock_version", default: 0, null: false
   end
 
   create_table "tag_texts", id: :serial, force: :cascade do |t|
@@ -466,12 +463,12 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
     t.integer "team_id", null: false
     t.integer "order", default: 0
     t.string "associated_type", default: "ProjectMedia", null: false
-    t.string "fieldset", default: "", null: false
-    t.boolean "show_in_browser_extension", default: true, null: false
-    t.string "json_schema"
-    t.text "conditional_info"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "json_schema"
+    t.string "fieldset", default: "", null: false
+    t.boolean "show_in_browser_extension", default: true, null: false
+    t.text "conditional_info"
     t.index ["team_id", "fieldset", "associated_type"], name: "index_team_tasks_on_team_id_and_fieldset_and_associated_type"
   end
 
@@ -483,33 +480,35 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
     t.string "invitation_token"
     t.string "raw_invitation_token"
     t.datetime "invitation_accepted_at"
-    t.string "file"
-    t.text "settings"
-    t.string "role"
-    t.string "status", default: "member"
-    t.string "invitation_email"
-    t.integer "lock_version", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "role"
+    t.string "status", default: "member"
+    t.text "settings"
+    t.string "invitation_email"
+    t.string "file"
+    t.integer "lock_version", default: 0, null: false
     t.index ["team_id", "user_id"], name: "index_team_users_on_team_id_and_user_id", unique: true
     t.index ["type"], name: "index_team_users_on_type"
     t.index ["user_id", "team_id", "status"], name: "index_team_users_on_user_id_and_team_id_and_status"
+    t.index ["user_id", "team_id"], name: "index_team_users_on_user_id_and_team_id"
   end
 
   create_table "teams", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "logo"
-    t.boolean "private", default: true, null: false
+    t.boolean "private", default: true
     t.integer "archived", default: 0
-    t.string "country"
-    t.text "description"
-    t.string "slug"
-    t.boolean "inactive", default: false
-    t.text "settings"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "description"
+    t.string "slug"
+    t.text "settings"
+    t.boolean "inactive", default: false
+    t.string "country"
     t.index ["country"], name: "index_teams_on_country"
     t.index ["inactive"], name: "index_teams_on_inactive"
+    t.index ["slug"], name: "index_teams_on_slug"
     t.index ["slug"], name: "unique_team_slugs", unique: true
   end
 
@@ -528,6 +527,25 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
     t.index ["external_id"], name: "index_tipline_messages_on_external_id", unique: true
     t.index ["team_id"], name: "index_tipline_messages_on_team_id"
     t.index ["uid"], name: "index_tipline_messages_on_uid"
+  end
+
+  create_table "tipline_newsletters", force: :cascade do |t|
+    t.string "introduction", null: false
+    t.string "rss_feed_url"
+    t.text "first_article"
+    t.text "second_article"
+    t.text "third_article"
+    t.integer "number_of_articles", default: 0, null: false
+    t.string "send_every"
+    t.string "timezone"
+    t.time "time"
+    t.datetime "last_sent_at"
+    t.string "language"
+    t.boolean "enabled", default: false, null: false
+    t.bigint "team_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["team_id"], name: "index_tipline_newsletters_on_team_id"
   end
 
   create_table "tipline_subscriptions", id: :serial, force: :cascade do |t|
@@ -568,32 +586,31 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
     t.integer "invitation_limit"
     t.integer "invited_by_id"
     t.string "invited_by_type"
-    t.datetime "last_accepted_terms_at"
-    t.string "image"
-    t.string "type"
-    t.integer "source_id"
-    t.boolean "is_active", default: true
-    t.boolean "is_admin", default: false
-    t.integer "current_project_id"
-    t.integer "integer"
-    t.text "settings"
-    t.datetime "last_active_at"
-    t.text "cached_teams"
-    t.integer "current_team_id"
-    t.boolean "completed_signup", default: true
-    t.integer "api_key_id"
-    t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "image"
+    t.integer "current_team_id"
+    t.text "settings"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
+    t.boolean "is_admin", default: false
+    t.text "cached_teams"
+    t.string "type"
+    t.integer "api_key_id"
+    t.integer "source_id"
+    t.string "unconfirmed_email"
+    t.integer "current_project_id"
+    t.boolean "is_active", default: true
+    t.datetime "last_accepted_terms_at"
     t.string "encrypted_otp_secret"
     t.string "encrypted_otp_secret_iv"
     t.string "encrypted_otp_secret_salt"
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.string "otp_backup_codes", array: true
+    t.boolean "completed_signup", default: true
+    t.datetime "last_active_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true, where: "((email IS NOT NULL) AND ((email)::text <> ''::text))"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
@@ -613,11 +630,11 @@ ActiveRecord::Schema.define(version: 2023_03_10_202330) do
     t.text "object_changes"
     t.datetime "created_at"
     t.text "meta"
+    t.string "event_type"
+    t.text "object_after"
     t.integer "associated_id"
     t.string "associated_type"
-    t.string "event_type"
     t.integer "team_id"
-    t.text "object_after"
     t.index ["associated_id"], name: "index_versions_on_associated_id"
     t.index ["event_type"], name: "index_versions_on_event_type"
     t.index ["item_type", "item_id", "whodunnit"], name: "index_versions_on_item_type_and_item_id_and_whodunnit"

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -224,4 +224,20 @@ class RelationshipTest < ActiveSupport::TestCase
     r.destroy!
     assert_queries(0, '=') { assert_nil pm2.added_as_similar_by_name }
   end
+
+  test "should avoid circular relationship" do
+    t = create_team
+    pm1 = create_project_media team: t
+    pm2 = create_project_media team: t
+    assert_nothing_raised do
+      create_relationship source_id: pm1.id, target_id: pm2.id
+    end
+    assert_raises 'ActiveRecord::RecordNotUnique' do
+      create_relationship source_id: pm2.id, target_id: pm1.id
+    end
+    pm3 = create_project_media
+    assert_raises 'ActiveRecord::RecordInvalid' do
+      create_relationship source_id: pm3.id, target_id: pm3.id
+    end
+  end
 end


### PR DESCRIPTION
* Adds a migration to delete current circular relationships and to add an index that avoids them
* Adds a unit test that reproduces the issue
* Adds a model validation to avoid that an item has a relationship with itself

Fixes CV2-2887.