### PR TITLE
Differentiate message delivery failure errors

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -3,6 +3,9 @@ require 'check_state_machine'
 
 class Bot::Smooch < BotUser
   class MessageDeliveryError < StandardError; end
+  class FinalMessageDeliveryError < MessageDeliveryError; end
+  class TurnioMessageDeliveryError < MessageDeliveryError; end
+  class SmoochMessageDeliveryError < MessageDeliveryError; end
 
   MESSAGE_BOUNDARY = "\u2063"
 

--- a/app/models/concerns/smooch_resend.rb
+++ b/app/models/concerns/smooch_resend.rb
@@ -227,8 +227,9 @@ module SmoochResend
 
     def log_resend_error(message)
       if message['isFinalEvent']
-        error = Bot::Smooch::MessageDeliveryError.new('Could not deliver message to final user!')
-        CheckSentry.notify(error, error: message.dig('error'), uid: message.dig('appUser', '_id'), smooch_app_id: message.dig('app', '_id'), timestamp: message.dig('timestamp'))
+        api_error = message.dig('error')
+        exception = Bot::Smooch::FinalMessageDeliveryError.new("(#{api_error&.dig('code')}) #{api_error&.dig('message')}")
+        CheckSentry.notify(exception, error: api_error, uid: message.dig('appUser', '_id'), smooch_app_id: message.dig('app', '_id'), timestamp: message.dig('timestamp'))
       end
     end
 

--- a/test/models/concerns/smooch_turnio_test.rb
+++ b/test/models/concerns/smooch_turnio_test.rb
@@ -132,4 +132,40 @@ class SmoochTurnioTest < ActiveSupport::TestCase
     assert message['appUser']['conversationStarted']
     assert message['turnIo']
   end
+
+  test "#turnio_send_message_to_user sends a Sentry error for each error returned on failed response" do
+    errors = [
+      {
+        code: 2000,
+        details: { body: "number of localizable_params (3) does not match the expected number of params (1)" },
+        href: "https://developers.facebook.com/docs/whatsapp/faq#faq_1612022582274564",
+        title: "Number of parameters does not match the expected number of params"
+      },
+      {
+        code: 4000,
+        details: { body: "some sort of fake error" },
+        href: "https://example.com/errors",
+        title: "Facebook returns an array so presumably this happens in real life"
+      }
+    ]
+    WebMock.stub_request(:post, 'https://whatsapp.turn.io/v1/messages').to_return(status: 500, body: "{\"errors\": #{errors.to_json}}")
+
+    mock_error = mock('error')
+    Bot::Smooch::TurnioMessageDeliveryError.expects(:new).with('(2000) Number of parameters does not match the expected number of params').returns(mock_error)
+    Bot::Smooch::TurnioMessageDeliveryError.expects(:new).with('(4000) Facebook returns an array so presumably this happens in real life').returns(mock_error)
+    CheckSentry.expects(:notify).with(mock_error, uid: 'phone-12345:123456', error: errors[0].with_indifferent_access, type: 'template', template_name: 'template_123', template_language: 'en')
+    CheckSentry.expects(:notify).with(mock_error, uid: 'phone-12345:123456', error: errors[1].with_indifferent_access, type: 'template', template_name: 'template_123', template_language: 'en')
+
+    FakeSmoochTurnio.turnio_send_message_to_user('phone-12345:123456',
+      {
+        type: 'template',
+        template: {
+          name: 'template_123',
+          language: {
+            code: 'en'
+          }
+        }
+      }
+    )
+  end
 end

--- a/test/models/concerns/smooch_zendesk_test.rb
+++ b/test/models/concerns/smooch_zendesk_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class FakeSmoochZendesk
+  include SmoochZendesk
+
+  class << self
+    # Mock out config, which is normally set in the Smooch class as
+    # RequestStore.store[:smooch_bot_settings]
+    def config
+      { "smooch_app_id" => 'app-id' }
+    end
+  end
+end
+
+class SmoochZendeskTest < ActiveSupport::TestCase
+  test "#zendesk_send_message_to_user sends a Sentry error for each error returned on failed response" do
+    errors = {
+      code: "invalid_syntax",
+      description: "pt_BR is not a valid parameter"
+    }.with_indifferent_access
+
+    fake_api_error = SmoochApi::ApiError.new(response_body: "{\"error\": #{errors.to_json}}")
+    SmoochApi::ConversationApi.any_instance.stubs(:post_message).raises(fake_api_error)
+
+    mock_error = mock('error')
+    Bot::Smooch::SmoochMessageDeliveryError.expects(:new).with('(invalid_syntax) pt_BR is not a valid parameter').returns(mock_error)
+    CheckSentry.expects(:notify).with(mock_error, has_entries(smooch_app_id: 'app-id', uid: 'phone-12345:123456', smooch_body: anything, errors: errors))
+
+    FakeSmoochZendesk.zendesk_send_message_to_user('phone-12345:123456', 'fake text')
+  end
+end


### PR DESCRIPTION
Currently we just send up three types of errors for message delivery, which makes it hard to tell which ones we can do something about and which ones we can't. This breaks the messages into there different types (Smooch, TurnIO, and "final", which might want to be one of those two) and adds a unique error message for the underlying error code. The latter should let us ignore ones in Sentry that we can do nothing about.

CV2-2975