### PR TITLE
Install bundler in production Dockerfile

### DIFF
--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -33,10 +33,22 @@ RUN apt-get update -qq && apt-get install -y curl
 #
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
 
-# dependencies
-#RUN add-apt-repository ppa:mc3man/trusty-media -y
-RUN apt-get update -qq && apt-get install -y libidn11-dev lsof nodejs git build-essential libpq-dev sqlite3 libsqlite3-dev graphicsmagick \
-     ffmpegthumbnailer libtag1-dev lz4 ffmpeg
+# sqlite3, lz4: for check:data:export_team task
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    build-essential \
+    ffmpegthumbnailer \
+    ffmpeg \
+    git \
+    graphicsmagick \
+    libidn11-dev \
+    # inotify-tools \
+    libpq-dev \
+    libtag1-dev \
+    libsqlite3-dev \
+    lz4 \
+    nodejs \
+    sqlite3 \
+    lsof
 
 # CMD and helper scripts
 COPY --chown=root:root production/bin /opt/bin
@@ -57,6 +69,8 @@ USER ${DEPLOYUSER}
 # so we mimic `--chown=${DEPLOYUSER}:www-data`
 COPY --chown=checkdeploy:www-data Gemfile ${DEPLOYDIR}/Gemfile
 COPY --chown=checkdeploy:www-data Gemfile.lock ${DEPLOYDIR}/Gemfile.lock
+RUN echo "gem: --no-rdoc --no-ri" > ~/.gemrc && gem install bundler -v "< 2.0"
+RUN bundle config force_ruby_platform true
 RUN bundle install --jobs 20 --retry 5 --deployment --without test development
 
 # copy in the code


### PR DESCRIPTION
Previously we weren't installing bundler in the production Dockerfile, which caused a problem building the image when we upgraded to Ruby 2.7.7. This adds bundler back into the Dockerfile, configures Bundler similarly to how we configure it in the development Dockerfile, and also formats the dependency list (installed via apt-get) so that it's easier to compare against the development Dockerfile--and adds git, which we didn't have installed in the prod Dockerfile, but were seeing warnings about at deploy time.

CV2-2669