### PR TITLE
Ensure that WhatsApp template placeholders are never blank.

### DIFF
--- a/app/models/concerns/smooch_resend.rb
+++ b/app/models/concerns/smooch_resend.rb
@@ -245,10 +245,11 @@ module SmoochResend
       template = self.config["smooch_template_name_for_#{template_name}"] || template_name
       default_language = Team.where(id: self.config['team_id'].to_i).last&.default_language
       locale = (!language.blank? && [self.config['smooch_template_locales']].flatten.include?(language)) ? language : default_language
+      safe_placeholders = placeholders.collect{ |placeholder| placeholder.blank? ? '-' : placeholder } # Placeholders are mandatory in WhatsApp templates, so let's be sure they are not blank
       if RequestStore.store[:smooch_bot_provider] == 'TURN'
-        self.turnio_format_template_message(namespace, template, fallback, locale, image, placeholders)
+        self.turnio_format_template_message(namespace, template, fallback, locale, image, safe_placeholders)
       else
-        self.zendesk_format_template_message(namespace, template, fallback, locale, image, placeholders, header)
+        self.zendesk_format_template_message(namespace, template, fallback, locale, image, safe_placeholders, header)
       end
     end
 

--- a/app/models/concerns/smooch_zendesk.rb
+++ b/app/models/concerns/smooch_zendesk.rb
@@ -100,7 +100,7 @@ module SmoochZendesk
         output << "#{key}=[[#{value}]]"
       end
       placeholders.each do |placeholder|
-        output << "body_text=[[#{placeholder.gsub(/\s+/, ' ')}]]"
+        output << "body_text=[[#{placeholder.to_s.gsub(/\s+/, ' ')}]]"
       end
       output << '))&'
       output.join('')

--- a/test/models/bot/smooch_7_test.rb
+++ b/test/models/bot/smooch_7_test.rb
@@ -477,4 +477,9 @@ class Bot::Smooch7Test < ActiveSupport::TestCase
     CheckSentry.expects(:notify).once
     Bot::Smooch.log_resend_error({ 'isFinalEvent' => true })
   end
+
+  test "should be sure that template placeholders are not blank" do
+    template_message = Bot::Smooch.format_template_message('test', ['foo', nil, 'bar'], nil, 'fallback', 'en')
+    assert_match 'body_text=[[foo]]body_text=[[-]]body_text=[[bar]]', template_message
+  end
 end


### PR DESCRIPTION
Placeholders in WhatsApp templates are mandatory. In order to be safe and guarantee message delivery (even if some placeholder is missing), let’s fallback to a default value when some placeholder value is not provided, this way we can guarantee that the message will be delivered.

Fixes CV2-3003.