### PR TITLE
Add task to regenerate newsletter statistics on demand

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'minitest-retry'
   gem 'rails-controller-testing'
   gem 'pact-consumer-minitest'
-  gem 'mocha', '~>1.14.0'
+  gem 'mocha', '~>2.0'
 end
 
 group :doc do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -418,7 +418,8 @@ GEM
       minitest (> 5.3)
     minitest-retry (0.2.2)
       minitest (>= 5.0)
-    mocha (1.14.0)
+    mocha (2.0.2)
+      ruby2_keywords (>= 0.0.5)
     msgpack (1.4.5)
     multi_json (1.15.0)
     multi_xml (0.6.0)
@@ -948,7 +949,7 @@ DEPENDENCIES
   minitest (= 5.14.4)
   minitest-hooks
   minitest-retry
-  mocha (~> 1.14.0)
+  mocha (~> 2.0)
   multi_json (= 1.15.0)
   nokogiri (= 1.14.3)
   omniauth-facebook


### PR DESCRIPTION
* In number_of_newsletters_sent: tries to reduce the number of database calls, so removes Team.find and uses team_id within queries instead. Also exits early if there is no team bot installation, or if the date range is before we implemented newsletters. This is to make the return more consistent across the two places we now use it

* Creates new rake task that we intend to run on demand, to regenerate a monthly team statistic for any that have been previously saved. In future we want to expand this rake task to support more stats, but for now it only accepts one argument: unique_newsletters_sent. The arguments here should correspondt to the database value on MonthlyTeamStatistic that it wants to regenerate.

* Also updates Mocha since I was troubleshooting - we'll see if that causes any problems with tests. If so, I can move it into the update branch.

CV2-3049