### PR TITLE
Fixing error `ActiveRecord::StaleObjectError` reported by Sentry.

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -678,7 +678,7 @@ class Bot::Alegre < BotUser
     )
     Rails.logger.info "[Alegre Bot] [ProjectMedia ##{target.id}] [Relationships 6/6] Sent Check notification with message type and opts of #{[message_type, message_opts].inspect}"
   end
-  
+
   def self.relationship_model_not_allowed(relationship_model)
     allowed_models = [MEAN_TOKENS_MODEL, INDIAN_MODEL, FILIPINO_MODEL, ELASTICSEARCH_MODEL, 'audio', 'image', 'video']
     models = relationship_model.split("|")

--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -31,7 +31,7 @@ class TiplineNewsletterWorker
             end
             tbi = TeamBotInstallation.find(tbi.id)
             User.current = BotUser.smooch_user
-            newsletter = tbi.settings['smooch_workflows'].to_a.find{ |workflow| workflow['smooch_workflow_language'] == language }['smooch_newsletter']
+            newsletter = tbi.settings['smooch_workflows'].to_a.find{ |w| w['smooch_workflow_language'] == language }['smooch_newsletter']
             tbi.skip_check_ability = true
             newsletter['smooch_newsletter_last_sent_at'] = Time.now
             tbi.save!

--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -29,7 +29,9 @@ class TiplineNewsletterWorker
                 log team_id, language, "Could not send newsletter to subscriber ##{ts.id}: #{e.message}"
               end
             end
+            tbi = TeamBotInstallation.find(tbi.id)
             User.current = BotUser.smooch_user
+            newsletter = tbi.settings['smooch_workflows'].to_a.find{ |workflow| workflow['smooch_workflow_language'] == language }['smooch_newsletter']
             tbi.skip_check_ability = true
             newsletter['smooch_newsletter_last_sent_at'] = Time.now
             tbi.save!


### PR DESCRIPTION
The fix is to reload the object before attempting to save.

Fixes CV2-3076.