### PR TITLE
Fixing consistent conflict error when saving tipline settings from web client after Rails 6 upgrade

### DIFF
--- a/app/graph/types/team_bot_installation_type.rb
+++ b/app/graph/types/team_bot_installation_type.rb
@@ -6,7 +6,11 @@ TeamBotInstallationType = GraphqlCrudOperations.define_default_type do
 
   field :json_settings, types.String
 
-  field :lock_version, types.Int
+  field :lock_version, types.Int do
+    resolve -> (team_bot_installation, _args, _ctx) {
+      team_bot_installation.reload.lock_version
+    }
+  end
 
   field :bot_user do
     type -> { BotUserType }

--- a/app/models/concerns/smooch_team_bot_installation.rb
+++ b/app/models/concerns/smooch_team_bot_installation.rb
@@ -27,7 +27,8 @@ module SmoochTeamBotInstallation
       # Save greeting images
       after_save do
         if self.bot_user&.identifier == 'smooch' && !self.skip_save_images && self.respond_to?(:saved_change_to_file?) && self.saved_change_to_file?
-          workflows = self.get_smooch_workflows
+          tbi = TeamBotInstallation.find(self.id) # Refresh lock version
+          workflows = tbi.get_smooch_workflows
           images_updated = false
           self.file.each_with_index do |image, i|
             next if image.blank?
@@ -35,9 +36,9 @@ module SmoochTeamBotInstallation
             workflows[i]['smooch_greeting_image'] = url
             images_updated = true
           end
-          self.set_smooch_workflows = workflows
-          self.skip_save_images = true
-          self.save!
+          tbi.set_smooch_workflows = workflows
+          tbi.skip_save_images = true
+          tbi.save!
           # Make sure that users will see the new image
           self.class.delay_for(1.second, { queue: 'smooch' }).reset_smooch_users_states(self.team_id) if images_updated
         end

--- a/test/controllers/graphql_controller_7_test.rb
+++ b/test/controllers/graphql_controller_7_test.rb
@@ -261,7 +261,7 @@ class GraphqlController7Test < ActionController::TestCase
     tbi = create_team_bot_installation team_id: t.id, user_id: b.id
     tu = create_team_user team: t, user: u, role: 'admin'
     authenticate_with_user(u)
-    query = 'mutation { updateTeamBotInstallation(input: { clientMutationId: "1", id: "' + tbi.graphql_id + '", json_settings: "{\"text_length_matching_threshold\":\"4\"}" }) { team_bot_installation { json_settings } } }'
+    query = 'mutation { updateTeamBotInstallation(input: { clientMutationId: "1", id: "' + tbi.graphql_id + '", json_settings: "{\"text_length_matching_threshold\":\"4\"}" }) { team_bot_installation { json_settings, lock_version } } }'
     post :create, params: { query: query, team: t.slug }
     assert_response :success
     query = 'query { node(id: "' + tbi.graphql_id + '") { ... on TeamBotInstallation { alegre_settings } } }'


### PR DESCRIPTION
After the upgrade to Rails 6, we started to get consistent HTTP 409 errors coming from the web client when saving tipline settings, even when nothing has changed. After some debugging locally, I noticed it was due to two reasons:

* (1) An `after_save` callback that was re-saving the tipline bot installation but with the outdated lock version
* (2) The `lock_version` GraphQL field returned as a result of the mutation contained an outdated value as well

Respective fixes:

* (1) Reload the bot installation before re-saving
* (2) Reload the bot installation before returning the `lock_version` value

Both issues and respective fixes are kind of similar. I guess it has to do with some different way on how Rails 6 caches values during a lifecycle of a request.

Fixes CV2-3079.