### PR TITLE
Use redis_cache_store, which is built into Rails

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
     require 'sidekiq/middleware/i18n'
     redis_config = YAML.load_file(file)
     redis_url = { host: redis_config[:redis_host], port: redis_config[:redis_port], db: redis_config[:redis_database], namespace: "cache_checkapi_#{Rails.env}" }
-    config.cache_store = :redis_store, redis_url
+    config.cache_store = :redis_cache_store, redis_url
   end
 
   # Store uploaded files on the local file system (see config/storage.yml for options).

--- a/config/initializers/03_sidekiq.rb
+++ b/config/initializers/03_sidekiq.rb
@@ -25,7 +25,7 @@ if File.exist?(file)
   Rails.application.configure do
     config.active_job.queue_adapter = :sidekiq
     redis_url = { host: SIDEKIQ_CONFIG[:redis_host], port: SIDEKIQ_CONFIG[:redis_port], db: SIDEKIQ_CONFIG[:redis_database], namespace: "cache_checkapi_#{Rails.env}" }
-    config.cache_store = :redis_store, redis_url
+    config.cache_store = :redis_cache_store, redis_url
   end
 
   redis_config = { url: "redis://#{SIDEKIQ_CONFIG[:redis_host]}:#{SIDEKIQ_CONFIG[:redis_port]}/#{SIDEKIQ_CONFIG[:redis_database]}", namespace: "sidekiq_checkapi_#{Rails.env}", network_timeout: 5 }


### PR DESCRIPTION
Previously we were using redis_store as our cache store, but it began causing problems because it is not compatible with cache versioning introduced by default in Rails 5.2. This store was provided by the redis-rails gem, wherease redis_cache_store was introduced in 5.2 as the out-of-the-box way to use redis as the Rails cache store, and does support cache versioning. So, we switch it. Configuration should be compatible.

We still use the redis-rails gem directly in other places, so we keep it as a dependency.

CV2-2669