### PR TITLE
cv2-3060: make seed.rb file more resilient

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -75,154 +75,156 @@ def create_claim_description(user, project, team)
   ClaimDescription.create!(description: Faker::Company.catch_phrase, context: Faker::Lorem.sentence, user: user, project_media: create_blank(project, team))
 end
 
-p '...Seeding...'
-p 'Making Team / Workspace...'
-team = create_team(name: Faker::Company.name)
+ActiveRecord::Base.transaction do
+  p '...Seeding...'
+  p 'Making Team / Workspace...'
+  team = create_team(name: Faker::Company.name)
 
-p 'Making User...'
-user = create_user(name: data[:user_name], login: data[:user_name], password: data[:user_password], password_confirmation: data[:user_password], email: Faker::Internet.safe_email(name: data[:user_name]), is_admin: true)
+  p 'Making User...'
+  user = create_user(name: data[:user_name], login: data[:user_name], password: data[:user_password], password_confirmation: data[:user_password], email: Faker::Internet.safe_email(name: data[:user_name]), is_admin: true)
 
-p 'Making Project...'
-project = create_project(title: team.name, team_id: team.id, user: user, description: '')
+  p 'Making Project...'
+  project = create_project(title: team.name, team_id: team.id, user: user, description: '')
 
-p 'Making Team User...'
-create_team_user(team: team, user: user, role: 'admin')
+  p 'Making Team User...'
+  create_team_user(team: team, user: user, role: 'admin')
 
-p 'Making Medias...'
-p 'Making Medias and Project Medias: Claims...'
-9.times { Claim.create!(user_id: user.id, quote: Faker::Quotes::Shakespeare.hamlet_quote) }
-create_project_medias(user, project, team)
-add_claim_descriptions_and_fact_checks(user)
+  p 'Making Medias...'
+  p 'Making Medias and Project Medias: Claims...'
+  9.times { Claim.create!(user_id: user.id, quote: Faker::Quotes::Shakespeare.hamlet_quote) }
+  create_project_medias(user, project, team)
+  add_claim_descriptions_and_fact_checks(user)
 
-p 'Making Medias and Project Medias: Links...'
-data[:link_media_links].each { |link_media_link| Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}") }
-create_project_medias(user, project, team)
-add_claim_descriptions_and_fact_checks(user)
+  p 'Making Medias and Project Medias: Links...'
+  data[:link_media_links].each { |link_media_link| Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}") }
+  create_project_medias(user, project, team)
+  add_claim_descriptions_and_fact_checks(user)
 
-p 'Making Medias and Project Medias: Audios...'
-data[:audios].each { |audio| UploadedAudio.create!(user_id: user.id, file: open_file(audio)) }
-create_project_medias(user, project, team)
-add_claim_descriptions_and_fact_checks(user)
+  p 'Making Medias and Project Medias: Audios...'
+  data[:audios].each { |audio| UploadedAudio.create!(user_id: user.id, file: open_file(audio)) }
+  create_project_medias(user, project, team)
+  add_claim_descriptions_and_fact_checks(user)
 
-p 'Making Medias and Project Medias: Images...'
-data[:images].each { |image| UploadedImage.create!(user_id: user.id, file: open_file(image))}
-create_project_medias(user, project, team)
-add_claim_descriptions_and_fact_checks(user)
+  p 'Making Medias and Project Medias: Images...'
+  data[:images].each { |image| UploadedImage.create!(user_id: user.id, file: open_file(image))}
+  create_project_medias(user, project, team)
+  add_claim_descriptions_and_fact_checks(user)
 
-p 'Making Medias and Project Medias: Videos...'
-data[:videos].each { |video| UploadedVideo.create!(user_id: user.id, file: open_file(video)) }
-create_project_medias(user, project, team)
-add_claim_descriptions_and_fact_checks(user)
+  p 'Making Medias and Project Medias: Videos...'
+  data[:videos].each { |video| UploadedVideo.create!(user_id: user.id, file: open_file(video)) }
+  create_project_medias(user, project, team)
+  add_claim_descriptions_and_fact_checks(user)
 
-p 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
-data[:fact_check_links].each { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link+"?timestamp=#{Time.now.to_f}", user, project, team)) }
+  p 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
+  data[:fact_check_links].each { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link+"?timestamp=#{Time.now.to_f}", user, project, team)) }
 
-p 'Making Relationship between Claims...'
-relationship_claims = []
-project_medias_for_relationship_claims = []
-data[:quotes].each { |quote| relationship_claims.push(Claim.create!(user_id: user.id, quote: quote)) }
-relationship_claims.each { |claim| project_medias_for_relationship_claims.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: claim))}
+  p 'Making Relationship between Claims...'
+  relationship_claims = []
+  project_medias_for_relationship_claims = []
+  data[:quotes].each { |quote| relationship_claims.push(Claim.create!(user_id: user.id, quote: quote)) }
+  relationship_claims.each { |claim| project_medias_for_relationship_claims.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: claim))}
 
-Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[1].id, relationship_type: Relationship.confirmed_type)
-Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[2].id, relationship_type: Relationship.confirmed_type)
-Relationship.create!(source_id: project_medias_for_relationship_claims[3].id, target_id: project_medias_for_relationship_claims[4].id, relationship_type: Relationship.suggested_type)
+  Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[1].id, relationship_type: Relationship.confirmed_type)
+  Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[2].id, relationship_type: Relationship.confirmed_type)
+  Relationship.create!(source_id: project_medias_for_relationship_claims[3].id, target_id: project_medias_for_relationship_claims[4].id, relationship_type: Relationship.suggested_type)
 
-p 'Making Relationship between Images...'
-project_medias_for_images = []
-2.times { project_medias_for_images.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedImage.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.png'))))) }
-Relationship.create!(source_id: project_medias_for_images[0].id, target_id: project_medias_for_images[1].id, relationship_type: Relationship.confirmed_type)
+  p 'Making Relationship between Images...'
+  project_medias_for_images = []
+  2.times { project_medias_for_images.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedImage.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.png'))))) }
+  Relationship.create!(source_id: project_medias_for_images[0].id, target_id: project_medias_for_images[1].id, relationship_type: Relationship.confirmed_type)
 
-p 'Making Relationship between Audios...'
-project_medias_for_audio = []
-2.times { project_medias_for_audio.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedAudio.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.mp3'))))) }
-Relationship.create!(source_id: project_medias_for_audio[0].id, target_id: project_medias_for_audio[1].id, relationship_type: Relationship.confirmed_type)
+  p 'Making Relationship between Audios...'
+  project_medias_for_audio = []
+  2.times { project_medias_for_audio.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedAudio.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.mp3'))))) }
+  Relationship.create!(source_id: project_medias_for_audio[0].id, target_id: project_medias_for_audio[1].id, relationship_type: Relationship.confirmed_type)
 
-p 'Making Tipline requests...'
-9.times do
-  claim_media = Claim.create!(user_id: user.id, quote: Faker::Lorem.paragraph(sentence_count: 10))
-    project_media = ProjectMedia.create!(project: project, team: team, media: claim_media)
+  p 'Making Tipline requests...'
+  9.times do
+    claim_media = Claim.create!(user_id: user.id, quote: Faker::Lorem.paragraph(sentence_count: 10))
+      project_media = ProjectMedia.create!(project: project, team: team, media: claim_media, channel: { main: CheckChannels::ChannelCodes::WHATSAPP })
 
-    tipline_user_name = Faker::Name.first_name.downcase
-    tipline_user_surname = Faker::Name.last_name
-    tipline_text = Faker::Lorem.paragraph(sentence_count: 10)
-    phone = [ Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone, Faker::PhoneNumber.cell_phone_in_e164, Faker::PhoneNumber.phone_number_with_country_code, Faker::PhoneNumber.cell_phone_with_country_code].sample
-    uid = random_string
+      tipline_user_name = Faker::Name.first_name.downcase
+      tipline_user_surname = Faker::Name.last_name
+      tipline_text = Faker::Lorem.paragraph(sentence_count: 10)
+      phone = [ Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone, Faker::PhoneNumber.cell_phone_in_e164, Faker::PhoneNumber.phone_number_with_country_code, Faker::PhoneNumber.cell_phone_with_country_code].sample
+      uid = random_string
 
-    # Tipline user
-    smooch_user_data = {
-    'id': uid,
-    'raw': {
-        '_id': uid,
-        'givenName': tipline_user_name,
-        'surname': tipline_user_surname,
-        'signedUpAt': Time.now.to_s,
-        'properties': {},
-        'conversationStarted': true,
-        'clients': [
-        {
-            'id': random_string,
-            'status': 'active',
-            'externalId': phone,
-            'active': true,
-            'lastSeen': Time.now.to_s,
-            'platform': 'whatsapp',
-            'integrationId': random_string,
-            'displayName': phone,
-            'raw': {
-            'profile': {
-                'name': tipline_user_name
-            },
-            'from': phone
-            }
-        }
-        ],
-        'pendingClients': []
-    },
-    'identifier': random_string,
-    'app_name': random_string
-    }
+      # Tipline user
+      smooch_user_data = {
+      'id': uid,
+      'raw': {
+          '_id': uid,
+          'givenName': tipline_user_name,
+          'surname': tipline_user_surname,
+          'signedUpAt': Time.now.to_s,
+          'properties': {},
+          'conversationStarted': true,
+          'clients': [
+          {
+              'id': random_string,
+              'status': 'active',
+              'externalId': phone,
+              'active': true,
+              'lastSeen': Time.now.to_s,
+              'platform': 'whatsapp',
+              'integrationId': random_string,
+              'displayName': phone,
+              'raw': {
+              'profile': {
+                  'name': tipline_user_name
+              },
+              'from': phone
+              }
+          }
+          ],
+          'pendingClients': []
+      },
+      'identifier': random_string,
+      'app_name': random_string
+      }
 
-    fields = {
-    smooch_user_id: uid,
-    smooch_user_app_id: random_string,
-    smooch_user_data: smooch_user_data.to_json
-    }
+      fields = {
+      smooch_user_id: uid,
+      smooch_user_app_id: random_string,
+      smooch_user_data: smooch_user_data.to_json
+      }
 
-    Dynamic.create!(annotation_type: 'smooch_user', annotated: team, annotator: BotUser.smooch_user, set_fields: fields.to_json)
+      Dynamic.create!(annotation_type: 'smooch_user', annotated: team, annotator: BotUser.smooch_user, set_fields: fields.to_json)
 
-    # Tipline request
-    smooch_data = {
-    'role': 'appUser',
-    'source': {
-        'type': 'whatsapp',
-        'id': random_string,
-        'integrationId': random_string,
-        'originalMessageId': random_string,
-        'originalMessageTimestamp': Time.now.to_i
-    },
-    'authorId': uid,
-    'name': tipline_user_name,
-    '_id': random_string,
-    'type': 'text',
-    'received': Time.now.to_f,
-    'text': tipline_text,
-    'language': 'en',
-    'mediaUrl': nil,
-    'mediaSize': 0,
-    'archived': 3,
-    'app_id': random_string
-    }
+      # Tipline request
+      smooch_data = {
+      'role': 'appUser',
+      'source': {
+          'type': 'whatsapp',
+          'id': random_string,
+          'integrationId': random_string,
+          'originalMessageId': random_string,
+          'originalMessageTimestamp': Time.now.to_i
+      },
+      'authorId': uid,
+      'name': tipline_user_name,
+      '_id': random_string,
+      'type': 'text',
+      'received': Time.now.to_f,
+      'text': tipline_text,
+      'language': 'en',
+      'mediaUrl': nil,
+      'mediaSize': 0,
+      'archived': 3,
+      'app_id': random_string
+      }
 
-    fields = {
-    smooch_request_type: 'default_requests',
-    smooch_data: smooch_data.to_json
-    }
+      fields = {
+      smooch_request_type: 'default_requests',
+      smooch_data: smooch_data.to_json
+      }
 
-    a = Dynamic.new(annotation_type: 'smooch', annotated: project_media, annotator: BotUser.smooch_user)
-    a.set_fields = fields.to_json
-    a.save!
+      a = Dynamic.new(annotation_type: 'smooch', annotated: project_media, annotator: BotUser.smooch_user)
+      a.set_fields = fields.to_json
+      a.save!
+  end
+
+  add_claim_descriptions_and_fact_checks(user)
+
+  p "Created — user: #{data[:user_name]} — email: #{user.email} — password : #{data[:user_password]}"
 end
-
-add_claim_descriptions_and_fact_checks(user)
-
-p "Created — user: #{data[:user_name]} — email: #{user.email} — password : #{data[:user_password]}"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -147,9 +147,8 @@ ActiveRecord::Base.transaction do
 
   if answer == "1"
     puts 'Making Relationship between Claims...'
-    relationship_claims = []
     project_medias_for_relationship_claims = []
-    data[:quotes].each { |quote| relationship_claims.push(Claim.create!(user_id: user.id, quote: quote)) }
+    relationship_claims = data[:quotes].map { |quote| Claim.create!(user_id: user.id, quote: quote) }
     relationship_claims.each { |claim| project_medias_for_relationship_claims.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: claim))}
 
     Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[1].id, relationship_type: Relationship.confirmed_type)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -169,65 +169,65 @@ ActiveRecord::Base.transaction do
   puts 'Making Tipline requests...'
   9.times do
     claim_media = Claim.create!(user_id: user.id, quote: Faker::Lorem.paragraph(sentence_count: 10))
-      project_media = ProjectMedia.create!(project: project, team: team, media: claim_media, channel: { main: CheckChannels::ChannelCodes::WHATSAPP })
+    project_media = ProjectMedia.create!(project: project, team: team, media: claim_media, channel: { main: CheckChannels::ChannelCodes::WHATSAPP })
 
-      tipline_user_name = Faker::Name.first_name.downcase
-      tipline_user_surname = Faker::Name.last_name
-      tipline_text = Faker::Lorem.paragraph(sentence_count: 10)
-      phone = [ Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone, Faker::PhoneNumber.cell_phone_in_e164, Faker::PhoneNumber.phone_number_with_country_code, Faker::PhoneNumber.cell_phone_with_country_code].sample
-      uid = random_string
+    tipline_user_name = Faker::Name.first_name.downcase
+    tipline_user_surname = Faker::Name.last_name
+    tipline_text = Faker::Lorem.paragraph(sentence_count: 10)
+    phone = [ Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone, Faker::PhoneNumber.cell_phone_in_e164, Faker::PhoneNumber.phone_number_with_country_code, Faker::PhoneNumber.cell_phone_with_country_code].sample
+    uid = random_string
 
-      # Tipline user
-      smooch_user_data = {
+    # Tipline user
+    smooch_user_data = {
       'id': uid,
       'raw': {
-          '_id': uid,
-          'givenName': tipline_user_name,
-          'surname': tipline_user_surname,
-          'signedUpAt': Time.now.to_s,
-          'properties': {},
-          'conversationStarted': true,
-          'clients': [
+        '_id': uid,
+        'givenName': tipline_user_name,
+        'surname': tipline_user_surname,
+        'signedUpAt': Time.now.to_s,
+        'properties': {},
+        'conversationStarted': true,
+        'clients': [
           {
-              'id': random_string,
-              'status': 'active',
-              'externalId': phone,
-              'active': true,
-              'lastSeen': Time.now.to_s,
-              'platform': 'whatsapp',
-              'integrationId': random_string,
-              'displayName': phone,
-              'raw': {
+            'id': random_string,
+            'status': 'active',
+            'externalId': phone,
+            'active': true,
+            'lastSeen': Time.now.to_s,
+            'platform': 'whatsapp',
+            'integrationId': random_string,
+            'displayName': phone,
+            'raw': {
               'profile': {
-                  'name': tipline_user_name
+                'name': tipline_user_name
               },
               'from': phone
-              }
+            }
           }
-          ],
-          'pendingClients': []
+        ],
+        'pendingClients': []
       },
       'identifier': random_string,
       'app_name': random_string
-      }
+    }
 
-      fields = {
+    fields = {
       smooch_user_id: uid,
       smooch_user_app_id: random_string,
       smooch_user_data: smooch_user_data.to_json
-      }
+    }
 
-      Dynamic.create!(annotation_type: 'smooch_user', annotated: team, annotator: BotUser.smooch_user, set_fields: fields.to_json)
+    Dynamic.create!(annotation_type: 'smooch_user', annotated: team, annotator: BotUser.smooch_user, set_fields: fields.to_json)
 
-      # Tipline request
-      smooch_data = {
+    # Tipline request
+    smooch_data = {
       'role': 'appUser',
       'source': {
-          'type': 'whatsapp',
-          'id': random_string,
-          'integrationId': random_string,
-          'originalMessageId': random_string,
-          'originalMessageTimestamp': Time.now.to_i
+        'type': 'whatsapp',
+        'id': random_string,
+        'integrationId': random_string,
+        'originalMessageId': random_string,
+        'originalMessageTimestamp': Time.now.to_i
       },
       'authorId': uid,
       'name': tipline_user_name,
@@ -240,16 +240,14 @@ ActiveRecord::Base.transaction do
       'mediaSize': 0,
       'archived': 3,
       'app_id': random_string
-      }
+    }
 
-      fields = {
+    fields = {
       smooch_request_type: 'default_requests',
       smooch_data: smooch_data.to_json
-      }
+    }
 
-      a = Dynamic.new(annotation_type: 'smooch', annotated: project_media, annotator: BotUser.smooch_user)
-      a.set_fields = fields.to_json
-      a.save!
+    a = Dynamic.create!(annotation_type: 'smooch', annotated: project_media, annotator: BotUser.smooch_user, set_fields: fields.to_json)
   end
 
   add_claim_descriptions_and_fact_checks(user)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -45,7 +45,7 @@ end
 
 def humanize_link(link)
   path = URI.parse(link).path
-    path.remove('/post/').underscore.humanize
+  path.remove('/post/').underscore.humanize
 end
 
 def create_description(project_media)
@@ -80,33 +80,33 @@ puts "If you want to add more data to an existing user: press 2 then enter"
 print ">> "
 answer = STDIN.gets.chomp
 
-if answer == "1"
-  p 'Making Team / Workspace...'
-  team = create_team(name: Faker::Company.name)
-
-  p 'Making User...'
-  user = create_user(name: data[:user_name], login: data[:user_name], password: data[:user_password], password_confirmation: data[:user_password], email: Faker::Internet.safe_email(name: data[:user_name]), is_admin: true)
-
-  p 'Making Project...'
-  project = create_project(title: team.name, team_id: team.id, user: user, description: '')
-
-  p 'Making Team User...'
-  create_team_user(team: team, user: user, role: 'admin')
-end
-
-if answer == "2"
-  puts "Type user name then press enter"
-  print ">> "
-  name = STDIN.gets.chomp.downcase
-
-  puts "Fetching User, Project, Team User and Team..."
-  user = User.find_by(name: name)
-  project = Project.find_by(user_id: user.id)
-  team_user = TeamUser.find_by(user_id: user.id)
-  team = Team.find_by(id: team_user.team_id)
-end
-
 ActiveRecord::Base.transaction do
+  if answer == "1"
+    p 'Making Team / Workspace...'
+    team = create_team(name: Faker::Company.name)
+  
+    p 'Making User...'
+    user = create_user(name: data[:user_name], login: data[:user_name], password: data[:user_password], password_confirmation: data[:user_password], email: Faker::Internet.safe_email(name: data[:user_name]), is_admin: true)
+  
+    p 'Making Project...'
+    project = create_project(title: team.name, team_id: team.id, user: user, description: '')
+  
+    p 'Making Team User...'
+    create_team_user(team: team, user: user, role: 'admin')
+  end
+  
+  if answer == "2"
+    puts "Type user name then press enter"
+    print ">> "
+    name = STDIN.gets.chomp.downcase
+  
+    puts "Fetching User, Project, Team User and Team..."
+    user = User.find_by(name: name)
+    project = Project.find_by(user_id: user.id)
+    team_user = TeamUser.find_by(user_id: user.id)
+    team = Team.find_by(id: team_user.team_id)
+  end
+  
   p 'Making Medias...'
   p 'Making Medias and Project Medias: Claims...'
   9.times { Claim.create!(user_id: user.id, quote: Faker::Quotes::Shakespeare.hamlet_quote) }
@@ -119,7 +119,7 @@ ActiveRecord::Base.transaction do
     create_project_medias(user, project, team)
     add_claim_descriptions_and_fact_checks(user)
   rescue
-    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links, Please make sure Pender is working properly and running."
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
   end
 
   p 'Making Medias and Project Medias: Audios...'
@@ -141,7 +141,7 @@ ActiveRecord::Base.transaction do
   begin
     data[:fact_check_links].each { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link+"?timestamp=#{Time.now.to_f}", user, project, team)) }
   rescue
-    puts "Couldn't create Imported Fact Checks. Other medias will still be created. \nIn order to create Imported Fact Checks, Please make sure Pender is working properly and running."
+    puts "Couldn't create Imported Fact Checks. Other medias will still be created. \nIn order to create Imported Fact Checks make sure Pender is running."
   end
 
   if answer == "1"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -96,9 +96,13 @@ ActiveRecord::Base.transaction do
   add_claim_descriptions_and_fact_checks(user)
 
   p 'Making Medias and Project Medias: Links...'
-  data[:link_media_links].each { |link_media_link| Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}") }
-  create_project_medias(user, project, team)
-  add_claim_descriptions_and_fact_checks(user)
+  begin
+    data[:link_media_links].each { |link_media_link| Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}") }
+    create_project_medias(user, project, team)
+    add_claim_descriptions_and_fact_checks(user)
+  rescue
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links, Please make sure Pender is working properly and running."
+  end
 
   p 'Making Medias and Project Medias: Audios...'
   data[:audios].each { |audio| UploadedAudio.create!(user_id: user.id, file: open_file(audio)) }
@@ -116,7 +120,11 @@ ActiveRecord::Base.transaction do
   add_claim_descriptions_and_fact_checks(user)
 
   p 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
-  data[:fact_check_links].each { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link+"?timestamp=#{Time.now.to_f}", user, project, team)) }
+  begin
+    data[:fact_check_links].each { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link+"?timestamp=#{Time.now.to_f}", user, project, team)) }
+  rescue
+    puts "Couldn't create Imported Fact Checks. Other medias will still be created. \nIn order to create Imported Fact Checks, Please make sure Pender is working properly and running."
+  end
 
   p 'Making Relationship between Claims...'
   relationship_claims = []

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -93,9 +93,7 @@ ActiveRecord::Base.transaction do
 
     puts 'Making Team User...'
     create_team_user(team: team, user: user, role: 'admin')
-  end
-
-  if answer == "2"
+  elsif answer == "2"
     puts "Type user name then press enter"
     print ">> "
     name = STDIN.gets.chomp.downcase
@@ -252,9 +250,7 @@ ActiveRecord::Base.transaction do
 
   if answer == "1"
     puts "Created — user: #{data[:user_name]} — email: #{user.email} — password : #{data[:user_password]}"
-  end
-
-  if answer == "2"
+  elsif answer == "2"
     puts "Data added to user: #{user.name}"
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -95,7 +95,7 @@ create_project_medias(user, project, team)
 add_claim_descriptions_and_fact_checks(user)
 
 p 'Making Medias and Project Medias: Links...'
-data[:link_media_links].each { |link_media_link| Link.create!(user_id: user.id, url: link_media_link) }
+data[:link_media_links].each { |link_media_link| Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}") }
 create_project_medias(user, project, team)
 add_claim_descriptions_and_fact_checks(user)
 
@@ -115,7 +115,7 @@ create_project_medias(user, project, team)
 add_claim_descriptions_and_fact_checks(user)
 
 p 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
-data[:fact_check_links].each { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
+data[:fact_check_links].each { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link+"?timestamp=#{Time.now.to_f}", user, project, team)) }
 
 p 'Making Relationship between Claims...'
 relationship_claims = []

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -145,26 +145,24 @@ ActiveRecord::Base.transaction do
   puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
   data[:fact_check_links].each { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
 
-  if answer == "1"
-    puts 'Making Relationship between Claims...'
-    project_medias_for_relationship_claims = []
-    relationship_claims = data[:quotes].map { |quote| Claim.create!(user_id: user.id, quote: quote) }
-    relationship_claims.each { |claim| project_medias_for_relationship_claims.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: claim))}
+  puts 'Making Relationship between Claims...'
+  project_medias_for_relationship_claims = []
+  relationship_claims = data[:quotes].map { |quote| Claim.create!(user_id: user.id, quote: quote) }
+  relationship_claims.each { |claim| project_medias_for_relationship_claims.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: claim))}
 
-    Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[1].id, relationship_type: Relationship.confirmed_type)
-    Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[2].id, relationship_type: Relationship.confirmed_type)
-    Relationship.create!(source_id: project_medias_for_relationship_claims[3].id, target_id: project_medias_for_relationship_claims[4].id, relationship_type: Relationship.suggested_type)
+  Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[1].id, relationship_type: Relationship.confirmed_type)
+  Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[2].id, relationship_type: Relationship.confirmed_type)
+  Relationship.create!(source_id: project_medias_for_relationship_claims[3].id, target_id: project_medias_for_relationship_claims[4].id, relationship_type: Relationship.suggested_type)
 
-    puts 'Making Relationship between Images...'
-    project_medias_for_images = []
-    2.times { project_medias_for_images.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedImage.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.png'))))) }
-    Relationship.create!(source_id: project_medias_for_images[0].id, target_id: project_medias_for_images[1].id, relationship_type: Relationship.confirmed_type)
+  puts 'Making Relationship between Images...'
+  project_medias_for_images = []
+  2.times { project_medias_for_images.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedImage.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.png'))))) }
+  Relationship.create!(source_id: project_medias_for_images[0].id, target_id: project_medias_for_images[1].id, relationship_type: Relationship.confirmed_type)
 
-    puts 'Making Relationship between Audios...'
-    project_medias_for_audio = []
-    2.times { project_medias_for_audio.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedAudio.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.mp3'))))) }
-    Relationship.create!(source_id: project_medias_for_audio[0].id, target_id: project_medias_for_audio[1].id, relationship_type: Relationship.confirmed_type)
-  end
+  puts 'Making Relationship between Audios...'
+  project_medias_for_audio = []
+  2.times { project_medias_for_audio.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedAudio.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.mp3'))))) }
+  Relationship.create!(source_id: project_medias_for_audio[0].id, target_id: project_medias_for_audio[1].id, relationship_type: Relationship.confirmed_type)
 
   puts 'Making Tipline requests...'
   9.times do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -101,14 +101,14 @@ ActiveRecord::Base.transaction do
     puts "Fetching User, Project, Team User and Team..."
     user = User.find_by(email: email)
 
-    if TeamUser.find_by(user_id: user.id).nil?
+    if user.team_users.first.nil?
       team = create_team(name: Faker::Company.name)
       project = create_project(title: team.name, team_id: team.id, user: user, description: '')
       create_team_user(team: team, user: user, role: 'admin')
     else 
-      team_user = TeamUser.find_by(user_id: user.id)
-      team = Team.find_by(id: team_user.team_id)
-      project = Project.find_by(user_id: user.id) 
+      team_user = user.team_users.first
+      team = team_user.team
+      project = user.projects.first
     end
   end
 
@@ -143,7 +143,7 @@ ActiveRecord::Base.transaction do
   add_claim_descriptions_and_fact_checks(user)
 
   puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
-    data[:fact_check_links].each { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
+  data[:fact_check_links].each { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
 
   if answer == "1"
     puts 'Making Relationship between Claims...'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -94,15 +94,22 @@ ActiveRecord::Base.transaction do
     puts 'Making Team User...'
     create_team_user(team: team, user: user, role: 'admin')
   elsif answer == "2"
-    puts "Type user name then press enter"
+    puts "Type user email then press enter"
     print ">> "
-    name = STDIN.gets.chomp.downcase
+    email = STDIN.gets.chomp
 
     puts "Fetching User, Project, Team User and Team..."
-    user = User.find_by(name: name)
-    project = Project.find_by(user_id: user.id)
-    team_user = TeamUser.find_by(user_id: user.id)
-    team = Team.find_by(id: team_user.team_id)
+    user = User.find_by(email: email)
+
+    if TeamUser.find_by(user_id: user.id).nil?
+      team = create_team(name: Faker::Company.name)
+      project = create_project(title: team.name, team_id: team.id, user: user, description: '')
+      create_team_user(team: team, user: user, role: 'admin')
+    else 
+      team_user = TeamUser.find_by(user_id: user.id)
+      team = Team.find_by(id: team_user.team_id)
+      project = Project.find_by(user_id: user.id) 
+    end
   end
 
   puts 'Making Medias...'
@@ -251,6 +258,6 @@ ActiveRecord::Base.transaction do
   if answer == "1"
     puts "Created — user: #{data[:user_name]} — email: #{user.email} — password : #{data[:user_password]}"
   elsif answer == "2"
-    puts "Data added to user: #{user.name}"
+    puts "Data added to user: #{user.email}"
   end
 end


### PR DESCRIPTION
### **What we did, how and why**

**Making  it more resilient**
1. make the `seed.rb` file less dependent on Pender
     - if for some reason Pender isn't up and running we still want the seed file to run
     - **how:** we added `exception handling` to `Link.create!`
         - if there is an issue during Link creation:
             - everything will be created except Link Medias
             - a warning will be printed to the user, letting them know Links were not created due to probably a Pender error
             
2. if there is another failure we don't want to keep inconsistent data
    - **how:** we wrapped everything in a transaction
    - if something fails (except for Link creation), everything is rolled back

3. we want to be able to run the `seed.rb` file more than once
    - we had an issue running it multiple times because the url for `Link.create!` needs to be unique
    - **how:** we added timestamps to the urls

4. we want the user to be able to add more users or add more data to a existing user
    - **how:** we get the input  from the user and move from there

**Small fixes**
1. add `channel` to tipline requests, so we are able to see the requests in Tipline inbox
2. add `channel` to imported fact-checks, so we are able to see the requests in the imported fact-checks tab

### **What it looks like when it runs succesfully**
<img width="739" alt="0 2-run-new-user" src="https://user-images.githubusercontent.com/87862340/236072391-ef19d64d-5f09-4f36-a7a7-b19afa41c00f.png">

<img width="738" alt="0 1-run-add-to-user" src="https://user-images.githubusercontent.com/87862340/236072387-ffd90832-a9d1-49cf-853d-8c320b02a0c5.png">

### **Documentation**
After this is finished, the documentation needs to be updated
