### PR TITLE
Update production.rb for use in deployed environments

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -78,7 +78,7 @@ module Check
         enable_starttls_auto: true
       }
     end
-    config.action_mailer.default_url_options = { host: ENV.fetch('smtp_default_url_host', cfg['smtp_default_url_host']) }
+    config.action_mailer.default_url_options = { host: ENV['smtp_default_url_host'] || cfg['smtp_default_url_host'] }
 
     # CORS config
     allowed_origins = ENV['allowed_origins'] || cfg['allowed_origins']

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,6 +40,7 @@ module Check
 
     cfg = YAML.load_file("#{Rails.root}/config/config.yml")[Rails.env]
 
+    # i18n
     config.i18n.fallbacks = ['en']
     config.i18n.default_locale = 'en'
     config.i18n.enforce_available_locales = false
@@ -51,6 +52,18 @@ module Check
       config.i18n.available_locales = [locale].flatten
     end
 
+    # Cache configuration
+    sidekiq_config_for_env = File.join(Rails.root, 'config', "sidekiq-#{Rails.env}.yml")
+    sidekiq_config = File.exist?(sidekiq_config_for_env) ? sidekiq_config_for_env : File.join(Rails.root, 'config', "sidekiq.yml")
+
+    if File.exist?(sidekiq_config) && !Rails.env.test?
+      require 'sidekiq/middleware/i18n'
+      redis_config = YAML.load_file(sidekiq_config)
+      redis_url = { host: redis_config[:redis_host], port: redis_config[:redis_port], db: redis_config[:redis_database], namespace: "cache_checkapi_#{Rails.env}" }
+      config.cache_store = :redis_cache_store, redis_url
+    end
+
+    # actionmailer config
     smtp_host = ENV['smtp_host'] || cfg['smtp_host']
     smtp_port = ENV['smtp_port'] || cfg['smtp_port']
     smtp_user = ENV['smtp_user'] || cfg['smtp_user']
@@ -65,7 +78,9 @@ module Check
         enable_starttls_auto: true
       }
     end
+    config.action_mailer.default_url_options = { host: ENV.fetch('smtp_default_url_host', cfg['smtp_default_url_host']) }
 
+    # CORS config
     allowed_origins = ENV['allowed_origins'] || cfg['allowed_origins']
     authorization_header = ENV['authorization_header'] || cfg['authorization_header']
     config.middleware.insert_before 0, Rack::Cors do

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -153,6 +153,7 @@ development: &default
   smtp_port: 587
   smtp_user: # '<GMAIL USERNAME>'
   smtp_pass: # '<GMAIL PASSWORD>'
+  smtp_default_url_host: 'http://localhost:3333' # Used to construct URLs for links in email
 
   # Pusher notification service https://pusher.com/channels
   #

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,9 +22,8 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  # config.public_file_server.enabled = true
 
-  # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
@@ -81,18 +80,14 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  # config.log_formatter = ::Logger::Formatter.new
-
-  # Use a different logger for distributed setups.
-  # require "syslog/logger"
-  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
-
-  # if ENV["RAILS_LOG_TO_STDOUT"].present?
-  #   logger           = ActiveSupport::Logger.new(STDOUT)
-  #   logger.formatter = config.log_formatter
-  #   config.logger    = ActiveSupport::TaggedLogging.new(logger)
-  # end
+  config.lograge.enabled = true
+  config.lograge.custom_options = lambda do |event|
+    options = event.payload.slice(:request_id, :user_id)
+    options[:params] = event.payload[:params].except("controller", "action")
+    options
+  end
+  config.lograge.formatter = Lograge::Formatters::Json.new
+  config.logger = ActiveSupport::Logger.new(STDOUT)
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,7 +24,6 @@ Rails.application.configure do
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
-  config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false
@@ -36,7 +35,6 @@ Rails.application.configure do
   # config.active_storage.service = :test
 
   config.action_mailer.perform_caching = false
-  config.action_mailer.default_url_options = { host: 'http://localhost:3000' }
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the

--- a/production/bin/create_configs.sh
+++ b/production/bin/create_configs.sh
@@ -85,24 +85,6 @@ echo "Starting application configuration. Processing ENV settings."
     fi
   fi
 
-  # Populate production environment config from SSM:
-  WORKTMP=$(mktemp)
-  if [[ -z ${environments_production+x} ]]; then
-    missing_configs="$missing_configs environments_production,"
-    echo "Error: missing environments_production ENV setting. Using defaults."
-  else
-    echo ${environments_production} | base64 -d > $WORKTMP
-    if (( $? != 0 )); then
-      missing_configs="$missing_configs environments_production,"
-      echo "Error: could not decode ENV var: ${environments_production} . Using defaults."
-      rm $WORKTMP
-    else
-      echo "Using decoded database config from ENV var: ${environments_production} ."
-      mv $WORKTMP environments/production.rb
-      sha1sum environments/production.rb
-    fi
-  fi
-
   # Populate credentials from SSM:
   WORKTMP=$(mktemp)
   if [[ -z ${credentials_config+x} ]]; then


### PR DESCRIPTION
Previously we were loading a Base64 encoded string of a previous production.rb for Live and QA configuration in deployed environments, meaning what we had committed to config/environments/production.rb was being ignored.

This commit updates our committed production.rb with what was currently on QA / live, and refactors shared config to application.rb and extracts an environment variable for differing config across live & QA.

Lastly, it removes the step in our deployment where we try to create the production.rb file from SSM. Instead, it will use what's in repo.

CV2-3055