### PR TITLE
CV2-3056: get user language based on supported language

### DIFF
--- a/app/models/concerns/smooch_language.rb
+++ b/app/models/concerns/smooch_language.rb
@@ -4,10 +4,9 @@ module SmoochLanguage
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def get_user_language(uid, message = {}, state = nil, team_id = nil)
-      team_id ||= self.config['team_id']
-      team = Team.find_by_id(team_id)
-      default_language = team&.default_language
+    def get_user_language(uid, message = {}, state = nil)
+      team = Team.find(self.config['team_id'])
+      default_language = team.default_language
       supported_languages = self.get_supported_languages
       guessed_language = nil
       if state == 'waiting_for_message'

--- a/app/models/concerns/smooch_language.rb
+++ b/app/models/concerns/smooch_language.rb
@@ -4,9 +4,10 @@ module SmoochLanguage
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def get_user_language(uid, message = {}, state = nil)
-      team = Team.find(self.config['team_id'])
-      default_language = team.default_language
+    def get_user_language(uid, message = {}, state = nil, team_id = nil)
+      team_id ||= self.config['team_id']
+      team = Team.find_by_id(team_id)
+      default_language = team&.default_language
       supported_languages = self.get_supported_languages
       guessed_language = nil
       if state == 'waiting_for_message'

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -213,7 +213,7 @@ module SmoochSearch
     def send_search_results_to_user(uid, results, team_id)
       team = Team.find(team_id)
       redis = Redis.new(REDIS_CONFIG)
-      language = self.cached_user_language(uid)
+      language = self.get_user_language(uid, {}, nil, team_id)
       reports = results.collect{ |r| r.get_dynamic_annotation('report_design') }
       # Get reports languages
       reports_language = reports.map{|r| r&.report_design_field_value('language')}.uniq

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -213,7 +213,7 @@ module SmoochSearch
     def send_search_results_to_user(uid, results, team_id)
       team = Team.find(team_id)
       redis = Redis.new(REDIS_CONFIG)
-      language = self.get_user_language(uid, {}, nil, team_id)
+      language = self.get_user_language(uid)
       reports = results.collect{ |r| r.get_dynamic_annotation('report_design') }
       # Get reports languages
       reports_language = reports.map{|r| r&.report_design_field_value('language')}.uniq


### PR DESCRIPTION
Replace `language = self.cached_user_language(uid)` with a method `self.get_user_language(uid, {}, nil, team_id)` which verify that cached value exists in team language otherwise return the default team language as sometimes the cached value deleted from team languages