### PR TITLE
Fixing a couple of relevant Rubocop issues related to suppressed exceptions

### DIFF
--- a/app/models/dynamic_annotation/annotation_type.rb
+++ b/app/models/dynamic_annotation/annotation_type.rb
@@ -14,11 +14,8 @@ class DynamicAnnotation::AnnotationType < ApplicationRecord
   private
 
   def annotation_type_is_available
-    begin
-      self.annotation_type.camelize.constantize
+    if Object.const_defined?(self.annotation_type.camelize)
       errors.add(:annotation_type, 'is not available')
-    rescue NameError
-      # Not defined
     end
   end
 end

--- a/app/models/dynamic_annotation/annotation_type.rb
+++ b/app/models/dynamic_annotation/annotation_type.rb
@@ -14,7 +14,7 @@ class DynamicAnnotation::AnnotationType < ApplicationRecord
   private
 
   def annotation_type_is_available
-    if Object.const_defined?(self.annotation_type.camelize)
+    if !self.annotation_type.blank? && Object.const_defined?(self.annotation_type.camelize)
       errors.add(:annotation_type, 'is not available')
     end
   end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -23,6 +23,7 @@ class Link < Media
       pender_data = self.get_saved_pender_data
       path = pender_data['picture']
     rescue
+      path = ''
     end
     path.to_s
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -166,7 +166,7 @@ ActiveRecord::Schema.define(version: 2023_05_02_001038) do
     t.index "task_fieldset((annotation_type)::text, data)", name: "task_fieldset", where: "((annotation_type)::text = 'task'::text)"
     t.index "task_team_task_id((annotation_type)::text, data)", name: "task_team_task_id", where: "((annotation_type)::text = 'task'::text)"
     t.index ["annotated_type", "annotated_id"], name: "index_annotations_on_annotated_type_and_annotated_id"
-    t.index ["annotation_type"], name: "index_annotation_type_order"
+    t.index ["annotation_type"], name: "index_annotation_type_order", opclass: :varchar_pattern_ops
     t.index ["annotation_type"], name: "index_annotations_on_annotation_type"
   end
 

--- a/test/models/dynamic_annotation/annotation_type_test.rb
+++ b/test/models/dynamic_annotation/annotation_type_test.rb
@@ -25,7 +25,7 @@ class DynamicAnnotation::AnnotationTypeTest < ActiveSupport::TestCase
 
   test "should not create annotation type if type has invalid format" do
     assert_no_difference 'DynamicAnnotation::AnnotationType.count' do
-      assert_raises ActiveRecord::RecordInvalid do
+      assert_raises NameError do
         create_annotation_type annotation_type: 'This is not valid'
       end
     end

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -587,4 +587,10 @@ class MediaTest < ActiveSupport::TestCase
     })
     assert_equal 'a3ac7ddabb263c2d00b73e8177d15c8d.mp4', Media.filename(uploaded_video)
   end
+
+  test "should return empty string if there is no picture" do
+    Link.any_instance.stubs(:get_saved_pender_data).returns([])
+    l = create_valid_media
+    assert_equal '', l.picture
+  end
 end


### PR DESCRIPTION
(1) Validate if an annotation type if available by using `Object.const_defined?` instead of trying to `constantize` and `rescue NameError`

(2) Fallback to an empty string if there is no picture for a Pender structure