### PR TITLE
Remove references to non-existent file server file

### DIFF
--- a/docker-background.sh
+++ b/docker-background.sh
@@ -3,9 +3,6 @@
 # Wait for API
 until curl --silent -XGET --fail http://api:${SERVER_PORT}; do printf '.'; sleep 1; done
 
-# Static Files Server
-bundle exec ruby bin/static-files-server &
-
 if [[ ${RAILS_ENV} == "development" ]]; then
   bin/sidekiq
 else

--- a/production/bin/start_background.sh
+++ b/production/bin/start_background.sh
@@ -22,8 +22,5 @@ workers 2
 worker_timeout 120
 EOF
 
-echo "starting static files server in background"
-bundle exec ruby bin/static-files-server &
-
 echo "starting sidekiq"
-bundle exec sidekiq 
+bundle exec sidekiq


### PR DESCRIPTION
We no longer need this and the file it references was removed in a previous commit, but I missed these lines.