### PR TITLE
Fix/cv2 3113 3085 sentry issues

### DIFF
--- a/app/controllers/api/v1/graphql_controller.rb
+++ b/app/controllers/api/v1/graphql_controller.rb
@@ -22,7 +22,7 @@ module Api
 
       def batch
         parse_graphql_result do |context|
-          queries = params[:_json].map do |param|
+          queries = params[:_json]&.map do |param|
             {
               query: param[:query],
               variables: prepare_query_variables(param[:variables]),
@@ -35,7 +35,7 @@ module Api
               id: result.query.context[:id],
               payload: result.to_h
             }
-          end
+          end unless queries.nil?
           results
         end
       end

--- a/app/models/bot_user.rb
+++ b/app/models/bot_user.rb
@@ -175,7 +175,11 @@ class BotUser < User
         request = Net::HTTP::Post.new(uri.request_uri, headers)
         request.body = data.to_json
         response = http.request(request)
-        Rails.logger.info "[BotUser] Notified bot #{self.id} with payload '#{data.to_json}', the response was (#{response.code}): '#{response.body}'"
+        # Log data with team_id only to avoid Encoding::CompatibilityError
+        logged_data = data.dup
+        logged_data.delete(:team)
+        logged_data[:team_id] = data[:team].id
+        Rails.logger.info "[BotUser] Notified bot #{self.id} with payload '#{logged_data.to_json}', the response was (#{response.code}): '#{response.body}'"
         response
       end
     rescue StandardError => e


### PR DESCRIPTION
 - Use `&.` before map method to avoid an error related to nil value (CV2-3113)
 - Minimize data for Rails.logger.info and use `team_id` instead of Team object to overcome Encoding::CompatibilityError error between data in `team` object and data in `data` object and not sure if this fix will handle encoding error or not (CV2-3085)