### PR TITLE
CV2-2910: fix SyntaxError related to version metadata

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -57,14 +57,14 @@ class Relationship < ApplicationRecord
   def version_metadata(_object_changes = nil)
     by_check = BotUser.alegre_user&.id == User.current&.id
     source = self.source
-    source.nil? ? nil : {
+    source.nil? ? nil : ActiveRecord::Base.connection.quote_string({
       source: {
-        title: ActiveRecord::Base.connection.quote_string(source.title),
+        title: source.title,
         type: source.report_type,
-        url: ActiveRecord::Base.connection.quote_string(source.full_url),
+        url: source.full_url,
         by_check: by_check,
       }
-    }.to_json
+    }.to_json)
   end
 
   def self.confirmed_parent(pm)

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -99,7 +99,8 @@ class RelationshipTest < ActiveSupport::TestCase
       u = create_user
       create_team_user team: t, user: u, role: 'admin'
       with_current_user_and_team(u, t) do
-        pm_s = create_project_media team: t
+        # Try to create an item with title that trigger a version metadata error(CV2-2910)
+        pm_s = create_project_media team: t, quote: "Rahul Gandhi's interaction with Indian?param:test&Journalists Association in London"
         pm_t1 = create_project_media team: t
         pm_t2 = create_project_media team: t
         pm_t3 = create_project_media team: t


### PR DESCRIPTION
User `ActiveRecord::Base.connection.quote_string` for metadata json field instead of multiple use inside metadata array