### PR TITLE
Do not schedule a newsletter to the past and do not try to parse an empty RSS feed URL

### DIFF
--- a/app/graph/types/team_bot_installation_type.rb
+++ b/app/graph/types/team_bot_installation_type.rb
@@ -49,7 +49,7 @@ TeamBotInstallationType = GraphqlCrudOperations.define_default_type do
     resolve -> (obj, args, ctx) do
       return nil unless obj.bot_user.login == 'smooch'
       ability = ctx[:ability] || Ability.new
-      if ability.can?(:preview_rss_feed, Team.current)
+      if ability.can?(:preview_rss_feed, Team.current) && !args[:rss_feed_url].blank?
         Bot::Smooch.render_articles_from_rss_feed(args[:rss_feed_url], args[:number_of_articles])
       else
         I18n.t(:cant_preview_rss_feed)

--- a/app/models/tipline_newsletter.rb
+++ b/app/models/tipline_newsletter.rb
@@ -213,7 +213,7 @@ class TiplineNewsletter < ApplicationRecord
     if self.content_type == 'rss'
       Sidekiq::Cron::Job.create(name: name, cron: self.cron_notation, class: 'TiplineNewsletterWorker', args: [self.team_id, self.language, Time.now.to_i])
     elsif self.content_type == 'static'
-      TiplineNewsletterWorker.perform_at(self.scheduled_time, self.team_id, self.language, Time.now.to_i)
+      TiplineNewsletterWorker.perform_at(self.scheduled_time, self.team_id, self.language, Time.now.to_i) if self.scheduled_time > Time.now
     end
   end
 


### PR DESCRIPTION
- Don't schedule a newsletter to the past
- Don't try to parse an empty RSS feed URL