### PR TITLE
CV2-3142: handle delete cached fields for relationship-bulk_destroy

### DIFF
--- a/app/models/concerns/relationship_bulk.rb
+++ b/app/models/concerns/relationship_bulk.rb
@@ -57,7 +57,11 @@ module RelationshipBulk
 
     def delete_cached_field(source_id, target_ids)
       # Clear cached fields
-      cached_fields = ['linked_items_count', 'suggestions_count', 'report_status', 'related_count', 'demand', 'last_seen']
+      # List fields with `model: Relationship`
+      cached_fields = [
+        'is_suggested', 'is_confirmed', 'linked_items_count', 'suggestions_count','report_status','related_count',
+        'demand', 'last_seen', 'sources_as_sentence', 'added_as_similar_by_name', 'confirmed_as_similar_by_name'
+      ]
       cached_fields.each do |name|
         Rails.cache.delete("check_cached_field:ProjectMedia:#{source_id}:#{name}")
         target_ids.each { |id| Rails.cache.delete("check_cached_field:ProjectMedia:#{id}:#{name}") }

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -139,6 +139,7 @@ class RelationshipTest < ActiveSupport::TestCase
   end
 
   test "should bulk-reject similar items" do
+    RequestStore.store[:skip_cached_field_update] = false
     with_versioning do
       setup_elasticsearch
       t = create_team
@@ -163,6 +164,9 @@ class RelationshipTest < ActiveSupport::TestCase
         assert_equal p2.id, pm_t1.reload.project_id
         assert_equal p2.id, pm_t2.reload.project_id
         assert_equal p.id, pm_t3.reload.project_id
+        # Verify cached fields
+        assert_not pm_t1.is_suggested
+        assert_not pm_t1.is_suggested(true)
       end
     end
   end


### PR DESCRIPTION
For `Relationship.bulk_destroy` there is a method that delete item cached fields `delete_cached_field` to enforce  create cached field with a new values 
I added all fields that related to `model: Relationship`
