### PR TITLE
Use a different host for displaying shortened URLs.

### DIFF
--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -132,6 +132,7 @@ development: &default
   # REQUIRED to build short URLs
   #
   short_url_host: 'http://localhost:3000'
+  short_url_host_display: 'http://localhost:3000'
 
   # Exception reporting using Sentry
   #

--- a/lib/url_rewriter.rb
+++ b/lib/url_rewriter.rb
@@ -1,7 +1,8 @@
 class UrlRewriter
   def self.shorten(url, owner)
     key = Shortener::ShortenedUrl.generate(url, owner: owner).unique_key
-    CheckConfig.get('short_url_host') + '/' + key
+    host = CheckConfig.get('short_url_host_display') || CheckConfig.get('short_url_host')
+    host + '/' + key
   end
 
   def self.utmize(url, source)

--- a/test/lib/url_rewriter_test.rb
+++ b/test/lib/url_rewriter_test.rb
@@ -9,7 +9,7 @@ class UrlRewriterTest < ActiveSupport::TestCase
 
   test 'should shorten URL' do
     url = nil
-    stub_configs({ 'short_url_host' => 'https://chck.media' }) do
+    stub_configs({ 'short_url_host_display' => 'https://chck.media' }) do
       url = UrlRewriter.shorten('https://meedan.com/check', nil)
     end
     assert_match /^https:\/\/chck.media\/[^\/]{8}/, url
@@ -27,7 +27,7 @@ class UrlRewriterTest < ActiveSupport::TestCase
     Shortener::ShortenedUrl.any_instance.stubs(:unique_key).returns('1234xyzw')
     input = 'Hey, visit https://meedan.com and https://checkmedia.org/check?lang=en :)'
     output = 'Hey, visit https://chck.media/1234xyzw and https://chck.media/1234xyzw :)'
-    stub_configs({ 'short_url_host' => 'https://chck.media' }) do
+    stub_configs({ 'short_url_host_display' => 'https://chck.media' }) do
       assert_equal output, UrlRewriter.shorten_and_utmize_urls(input, 'test')
     end
   end


### PR DESCRIPTION
Sometimes, the host that we use to display shortened URLs is different from what the backend actually processed (for example, when redirection rules are applied at upstream level).

Reference: CV2-2751.