### PR TITLE
Prepend https:// to URLs if missing when adding UTM code and shortening

### DIFF
--- a/lib/url_rewriter.rb
+++ b/lib/url_rewriter.rb
@@ -21,6 +21,7 @@ class UrlRewriter
     # Ruby 2.7 freezes the empty string from nil.to_s, which causes an error within the rewriter
     Twitter::TwitterText::Rewriter.rewrite_entities(text || '', entities) do |entity, _codepoints|
       url = source.blank? ? entity[:url] : self.utmize(entity[:url], source)
+      url = "https://#{url}" unless url =~ /^https?:\/\//
       self.shorten(url, owner)
     end
   end

--- a/test/lib/url_rewriter_test.rb
+++ b/test/lib/url_rewriter_test.rb
@@ -31,4 +31,15 @@ class UrlRewriterTest < ActiveSupport::TestCase
       assert_equal output, UrlRewriter.shorten_and_utmize_urls(input, 'test')
     end
   end
+
+  test 'should add https:// to URLs' do
+    stub_configs({ 'short_url_host_display' => 'https://chck.media' }) do
+      UrlRewriter.shorten_and_utmize_urls('Visit meedan.com/check/pt now', nil)
+    end
+    assert_equal 'https://meedan.com/check/pt', Shortener::ShortenedUrl.last.url
+    stub_configs({ 'short_url_host_display' => 'https://chck.media' }) do
+      UrlRewriter.shorten_and_utmize_urls('Visit https://meedan.com/check/en now', nil)
+    end
+    assert_equal 'https://meedan.com/check/en', Shortener::ShortenedUrl.last.url
+  end
 end


### PR DESCRIPTION
Prepend https:// to URLs if missing when adding UTM code and shortening.