### PR TITLE
Update rails-i18n revision on Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GIT
 
 GIT
   remote: https://github.com/meedan/rails-i18n.git
-  revision: e10d69e8fb9ce9b79d4883d2333303fb7359bba4
+  revision: 130e65e148b13fb166e041bc2df4c4d03f202ea1
   branch: rails-6-x
   specs:
     rails-i18n (6.0.0)
@@ -357,7 +357,7 @@ GEM
       ffi-compiler (>= 1.0, < 2.0)
     http_parser.rb (0.6.0)
     httpclient (2.8.3)
-    i18n (1.13.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     i18n-generators (1.1.3)
       mechanize
@@ -383,7 +383,7 @@ GEM
       activesupport (>= 4)
       railties (>= 4)
       request_store (~> 1.0)
-    loofah (2.21.2)
+    loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.8.1)
@@ -819,7 +819,7 @@ GEM
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
-    thor (1.2.1)
+    thor (1.2.2)
     thread_safe (0.3.6)
     timeout (0.3.2)
     tins (1.31.0)


### PR DESCRIPTION
Updated rails-i18n reference to include "bn" locale date format fix done in our fork. Tested manually on my local dev env.

A couple of patch updates sneaked in when I did bundle install but should be irrelevant
:)

Fixes CV2-3183