### PR TITLE
Fallback to long URL if shortening fails

### DIFF
--- a/lib/url_rewriter.rb
+++ b/lib/url_rewriter.rb
@@ -1,8 +1,12 @@
 class UrlRewriter
   def self.shorten(url, owner)
-    key = Shortener::ShortenedUrl.generate(url, owner: owner).unique_key
-    host = CheckConfig.get('short_url_host_display') || CheckConfig.get('short_url_host')
-    host + '/' + key
+    begin
+      key = Shortener::ShortenedUrl.generate(url, owner: owner).unique_key
+      host = CheckConfig.get('short_url_host_display') || CheckConfig.get('short_url_host')
+      host + '/' + key
+    rescue
+      url
+    end
   end
 
   def self.utmize(url, source)

--- a/test/lib/url_rewriter_test.rb
+++ b/test/lib/url_rewriter_test.rb
@@ -42,4 +42,12 @@ class UrlRewriterTest < ActiveSupport::TestCase
     end
     assert_equal 'https://meedan.com/check/en', Shortener::ShortenedUrl.last.url
   end
+
+  test 'should fallback to long URL if shortening fails' do
+    Shortener::ShortenedUrl.stubs(:generate).returns(nil)
+    url = random_url
+    assert_nothing_raised do
+      assert_equal url, UrlRewriter.shorten(url, nil)
+    end
+  end
 end


### PR DESCRIPTION
When it fails to generate a shortened URL, fallback to the long URL. Includes a unit test to reproduce the exact same issue reported by Sentry.

Fixes CV2-3218.