### PR TITLE
Make sure that a static newsletter can't be scheduled for the past.

### DIFF
--- a/app/models/tipline_newsletter.rb
+++ b/app/models/tipline_newsletter.rb
@@ -42,6 +42,7 @@ class TiplineNewsletter < ApplicationRecord
   validates :third_article, length: { maximum: proc { |newsletter| MAXIMUM_ARTICLE_LENGTH[newsletter.number_of_articles].to_i } }, allow_blank: true, allow_nil: true
   validate :send_every_is_a_list_of_days_of_the_week
   validate :header_file_is_supported_by_whatsapp
+  validate :not_scheduled_for_the_past
 
   after_save :reschedule_delivery
   after_commit :convert_header_file, on: [:create, :update]
@@ -268,5 +269,11 @@ class TiplineNewsletter < ApplicationRecord
     type = self.header_file.file.extension.downcase
     errors.add(:base, I18n.t(message, { max_size: "#{max_size}MB" })) if size_in_mb > max_size.to_f
     errors.add(:header_file, I18n.t('errors.messages.extension_white_list_error', { extension: type, allowed_types: allowed_types.join(', ') })) unless allowed_types.include?(type)
+  end
+
+  def not_scheduled_for_the_past
+    if self.content_type == 'static' && self.scheduled_time.past?
+      errors.add(:send_on, I18n.t(:send_on_must_be_in_the_future))
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -800,7 +800,8 @@ en:
     %{content}
 
     To stop receiving this newsletter, type "%{unsubscribe}".
-  send_every_must_be_a_list_of_days_of_the_week: The schedule must be a list of days of the week.
+  send_every_must_be_a_list_of_days_of_the_week: must be a list of days of the week.
+  send_on_must_be_in_the_future: can't be in the past.
   info:
     messages:
       sent_to_trash_by_rule: '"%{item_title}" has been sent to trash by an automation

--- a/test/models/tipline_newsletter_test.rb
+++ b/test/models/tipline_newsletter_test.rb
@@ -217,9 +217,15 @@ class TiplineNewsletterTest < ActiveSupport::TestCase
     @newsletter.content_type = 'rss'
     assert @newsletter.valid?
     @newsletter.content_type = 'static'
-    @newsletter.send_on = Date.parse('2023-01-25')
+    @newsletter.send_on = Time.now.tomorrow
     assert @newsletter.valid?
     @newsletter.content_type = 'foo'
+    assert !@newsletter.valid?
+  end
+
+  test 'should not schedule for the past' do
+    @newsletter.content_type = 'static'
+    @newsletter.send_on = Date.parse('2023-05-01')
     assert !@newsletter.valid?
   end
 


### PR DESCRIPTION
Adds a validation to the `TiplineNewsletter` model to be sure that a static newsletter can't be scheduled for the past. Includes a unit test and also fixes an unrelated error message copy.

Fixes: CV2-3212.