### PR TITLE
Validate static newsletter articles on the number of articles

### DIFF
--- a/app/models/tipline_newsletter.rb
+++ b/app/models/tipline_newsletter.rb
@@ -37,9 +37,9 @@ class TiplineNewsletter < ApplicationRecord
   validates_inclusion_of :language, in: ->(newsletter) { newsletter.team.get_languages.to_a }
   validates_inclusion_of :header_type, in: ['none', 'link_preview', 'audio', 'video', 'image']
   validates_inclusion_of :content_type, in: ['static', 'rss']
-  validates :first_article, length: { maximum: proc { |newsletter| MAXIMUM_ARTICLE_LENGTH[newsletter.number_of_articles].to_i } }, allow_blank: true, allow_nil: true
-  validates :second_article, length: { maximum: proc { |newsletter| MAXIMUM_ARTICLE_LENGTH[newsletter.number_of_articles].to_i } }, allow_blank: true, allow_nil: true
-  validates :third_article, length: { maximum: proc { |newsletter| MAXIMUM_ARTICLE_LENGTH[newsletter.number_of_articles].to_i } }, allow_blank: true, allow_nil: true
+  validates :first_article, length: { maximum: proc { |newsletter| MAXIMUM_ARTICLE_LENGTH[newsletter.number_of_articles].to_i } }, allow_blank: true, allow_nil: true, if: proc { |newsletter| newsletter.number_of_articles >= 1 }
+  validates :second_article, length: { maximum: proc { |newsletter| MAXIMUM_ARTICLE_LENGTH[newsletter.number_of_articles].to_i } }, allow_blank: true, allow_nil: true, if: proc { |newsletter| newsletter.number_of_articles >= 2 }
+  validates :third_article, length: { maximum: proc { |newsletter| MAXIMUM_ARTICLE_LENGTH[newsletter.number_of_articles].to_i } }, allow_blank: true, allow_nil: true, if: proc { |newsletter| newsletter.number_of_articles == 3 }
   validate :send_every_is_a_list_of_days_of_the_week
   validate :header_file_is_supported_by_whatsapp
 

--- a/test/models/tipline_newsletter_test.rb
+++ b/test/models/tipline_newsletter_test.rb
@@ -223,6 +223,13 @@ class TiplineNewsletterTest < ActiveSupport::TestCase
     assert !@newsletter.valid?
   end
 
+  test 'should allow zero articles' do
+    @newsletter.content_type = 'static'
+    @newsletter.number_of_articles = 0
+    @newsletter.first_article = 'Foo'
+    assert @newsletter.valid?
+  end
+
   test 'should convert video header file' do
     WebMock.stub_request(:get, /:9000/).to_return(body: File.read(File.join(Rails.root, 'test', 'data', 'rails.mp4')))
     TiplineNewsletter.any_instance.stubs(:new_file_uploaded?).returns(true)


### PR DESCRIPTION
Make sure that newsletter articles are validated depending on the number of articles selected. For example, we don't need to validate the second article if "number_of_articles" is 1.

Fixes: CV2-3210.