### PR TITLE
CV2-2723: update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -898,7 +898,6 @@ DEPENDENCIES
   elasticsearch-model (= 7.1.1)
   elasticsearch-persistence (= 7.1.1)
   elasticsearch-transport (= 7.10.1)
-  execjs
   faker
   file_validators
   filesize


### PR DESCRIPTION
Run `bundle install`  to updated Gemfile.lock with latest changes and fix deployment error
```
 You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.
```