### PR TITLE
Remove leading and trailing spaces from WhatsApp template placeholders.

### DIFF
--- a/app/models/concerns/smooch_resend.rb
+++ b/app/models/concerns/smooch_resend.rb
@@ -224,7 +224,8 @@ module SmoochResend
       return '' if namespace.blank? || template.blank?
       default_language = Team.where(id: self.config['team_id'].to_i).last&.default_language
       locale = (!language.blank? && [self.config['smooch_template_locales']].flatten.include?(language)) ? language : default_language
-      safe_placeholders = placeholders.collect{ |placeholder| placeholder.blank? ? '-' : placeholder } # Placeholders are mandatory in WhatsApp templates, so let's be sure they are not blank
+      # Placeholders are mandatory in WhatsApp templates, so let's be sure they are not blank and don't contain spaces, which can mess up with formatting, like bold
+      safe_placeholders = placeholders.collect{ |placeholder| placeholder.blank? ? '-' : placeholder.strip }
       if RequestStore.store[:smooch_bot_provider] == 'TURN'
         self.turnio_format_template_message(namespace, template, fallback, locale, file_url, safe_placeholders, file_type, preview_url)
       elsif RequestStore.store[:smooch_bot_provider] == 'CAPI'

--- a/app/models/tipline_newsletter.rb
+++ b/app/models/tipline_newsletter.rb
@@ -62,7 +62,7 @@ class TiplineNewsletter < ApplicationRecord
     timezone = self.timezone
 
     # If an offset is being passed, then it's in the new format... we used to support timezone names
-    if self.timezone.match?(/\W\d\d:\d\d/)
+    if self.timezone.to_s.match?(/\W\d\d:\d\d/)
       timezone = self.timezone.match(/\W\d\d:\d\d/)
     else
       timezone = self.timezone.to_s.upcase
@@ -273,7 +273,9 @@ class TiplineNewsletter < ApplicationRecord
 
   def not_scheduled_for_the_past
     if self.content_type == 'static' && self.scheduled_time.past?
-      errors.add(:send_on, I18n.t(:send_on_must_be_in_the_future))
+      field = :send_on
+      field = :time if self.scheduled_time.strftime('%Y-%m-%d') == Time.now.utc.strftime('%Y-%m-%d')
+      errors.add(field, I18n.t(:send_on_must_be_in_the_future))
     end
   end
 end


### PR DESCRIPTION
This way, formatting won't be messed up, like bold, for example.

Fixes CV2-3230.