### PR TITLE
New get_language_detection field

### DIFF
--- a/app/graph/mutations/team_mutations.rb
+++ b/app/graph/mutations/team_mutations.rb
@@ -16,6 +16,7 @@ module TeamMutations
     slack_notifications: 'str',
     language: 'str',
     languages: 'json',
+    language_detection: 'bool',
     list_columns: 'json',
     tipline_inbox_filters: 'str',
     suggested_matches_filters: 'str',

--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -40,6 +40,7 @@ TeamType = GraphqlCrudOperations.define_default_type do
   field :unconfirmed_count, types.Int
   field :get_languages, types.String
   field :get_language, types.String
+  field :get_language_detection, types.Boolean
   field :get_report, JsonStringType
   field :get_fieldsets, JsonStringType
   field :list_columns, JsonStringType

--- a/app/models/concerns/smooch_language.rb
+++ b/app/models/concerns/smooch_language.rb
@@ -11,7 +11,7 @@ module SmoochLanguage
       guessed_language = nil
       if state == 'waiting_for_message'
         Rails.cache.fetch("smooch:user_language:#{uid}") do
-          guessed_language = self.get_language(message, default_language)
+          guessed_language = team.get_language_detection ? self.get_language(message, default_language) : default_language
           guessed_language
         end
       end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -152,6 +152,10 @@ class Team < ApplicationRecord
     self.send(:set_language, language)
   end
 
+  def language_detection=(language_detection)
+    self.send(:set_language_detection, language_detection)
+  end
+
   def outgoing_urls_utm_code=(code)
     self.set_outgoing_urls_utm_code = code
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -156,6 +156,11 @@ class Team < ApplicationRecord
     self.send(:set_language_detection, language_detection)
   end
 
+  def get_language_detection
+    settings = self.settings.to_h.with_indifferent_access
+    settings.has_key?(:language_detection) ? settings[:language_detection] : true
+  end
+
   def outgoing_urls_utm_code=(code)
     self.set_outgoing_urls_utm_code = code
   end

--- a/public/relay.json
+++ b/public/relay.json
@@ -60771,6 +60771,20 @@
               "deprecationReason": null
             },
             {
+              "name": "get_language_detection",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "get_languages",
               "description": null,
               "args": [
@@ -77074,6 +77088,16 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "JsonStringType",
+                "ofType": null
+              },
+              "defaultValue": null
+            },
+            {
+              "name": "language_detection",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -556,6 +556,14 @@ class TeamTest < ActiveSupport::TestCase
     assert_equal ['en'], t.get_languages
   end
 
+  test 'should set and get language detection configuration' do
+    t = create_team
+    assert t.reload.get_language_detection
+    t.language_detection = false
+    t.save!
+    assert !t.reload.get_language_detection
+  end
+
   test "should match rule when item is read" do
     RequestStore.store[:skip_cached_field_update] = false
     RequestStore.store[:skip_delete_for_ever] = true


### PR DESCRIPTION
This adds a field get_language_detection to the graphql Team type and and language_detection field to the mutation and a setter to the Team model.
And changes logic in smooch_languages.rb to only have Alegre autodetect message if this new setting is enabled.