### PR TITLE
Minor changes for shared feed fact-checks view

### DIFF
--- a/app/lib/check_permissions.rb
+++ b/app/lib/check_permissions.rb
@@ -77,7 +77,7 @@ module CheckPermissions
 
   def get_create_permissions
     {
-      'Team' => [Project, Account, TeamUser, User, TagText, ProjectMedia, TiplineNewsletter],
+      'Team' => [Project, Account, TeamUser, User, TagText, ProjectMedia, TiplineNewsletter, Feed],
       'Account' => [Media, Link, Claim],
       'Media' => [ProjectMedia, Comment, Tag, Dynamic, Task],
       'Link' => [ProjectMedia, Comment, Tag, Dynamic, Task],

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -28,7 +28,7 @@ class Feed < ApplicationRecord
   end
 
   def filters
-    self.saved_search&.filters
+    self.saved_search&.filters.to_h
   end
 
   # Filters defined by each team
@@ -161,6 +161,6 @@ class Feed < ApplicationRecord
   end
 
   def create_feed_team
-    self.teams << self.team unless self.team.nil?
+    FeedTeam.create!(feed: self, team: self.team, shared: true) unless self.team.nil?
   end
 end

--- a/app/models/feed_team.rb
+++ b/app/models/feed_team.rb
@@ -18,7 +18,7 @@ class FeedTeam < ApplicationRecord
   end
 
   def filters
-    self.saved_search&.filters
+    self.saved_search&.filters.to_h
   end
 
   private

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -713,7 +713,7 @@ class AbilityTest < ActiveSupport::TestCase
     team_perms = [
       "bulk_create Tag", "bulk_update ProjectMedia", "create TagText", "read Team", "update Team", "destroy Team", "empty Trash",
       "create Project", "create Account", "create TeamUser", "create User", "create ProjectMedia", "invite Members",
-      "not_spam ProjectMedia", "restore ProjectMedia", "confirm ProjectMedia", "update ProjectMedia", "duplicate Team",
+      "not_spam ProjectMedia", "restore ProjectMedia", "confirm ProjectMedia", "update ProjectMedia", "duplicate Team", "create Feed",
       "manage TagText", "manage TeamTask", "set_privacy Project", "update Relationship", "destroy Relationship", "create TiplineNewsletter"
     ]
     project_perms = [

--- a/test/models/team_2_test.rb
+++ b/test/models/team_2_test.rb
@@ -302,7 +302,7 @@ class Team2Test < ActiveSupport::TestCase
       "destroy Team", "empty Trash", "create Project", "create ProjectMedia", "create Account", "create TeamUser",
       "create User", "invite Members", "not_spam ProjectMedia", "restore ProjectMedia", "confirm ProjectMedia", "update ProjectMedia",
       "duplicate Team", "manage TagText", "manage TeamTask", "set_privacy Project", "update Relationship",
-      "destroy Relationship", "create TiplineNewsletter"
+      "destroy Relationship", "create TiplineNewsletter", "create Feed"
     ].sort
 
     # load permissions as owner


### PR DESCRIPTION
## Description

* When there is no list associated with the shared feed, return an empty hash (`{}`) instead of null (`nil`)
* Expose feed permissions to the client, so UI components can be hidden/displayed accordingly

Reference: CV2-3209.

## How has this been tested?

Automated tests should cover all changes here.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

