### PR TITLE
Deleting access control to Sidekiq UI from the application side.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,7 @@ require 'sidekiq/cron/web'
 
 Rails.application.routes.draw do
   mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/api/graphql'
-
-  authenticate :api_user, -> (user) { user.is_admin } do
-    mount Sidekiq::Web => '/sidekiq'
-  end
+  mount Sidekiq::Web => '/sidekiq'
 
   namespace :api, defaults: { format: 'json' } do
     # Call v2 API by passing header: 'Accept: application/vnd.api+json'


### PR DESCRIPTION
## Description

This must be controled by a different layer, for example, DNS, load balancer, etc.

Reference: DEVOPS-417.

## How has this been tested?

* Locally: Should be able to access just fine
* Production: There should be an authorization layer in front

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

