### PR TITLE
Allow feed licenses to be blank if feed is not published.

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -11,14 +11,15 @@ class Feed < ApplicationRecord
   belongs_to :team, optional: true
 
   before_validation :set_user_and_team, on: :create
-  validates_presence_of :name, :licenses
+  validates_presence_of :name
+  validates_presence_of :licenses, if: proc { |feed| feed.published }
   validate :saved_search_belongs_to_feed_teams
 
   after_create :create_feed_team
 
   PROHIBITED_FILTERS = ['team_id', 'feed_id', 'clusterize']
   LICENSES = { 1 => 'academic', 2 => 'commercial', 3 => 'open_source' }
-  validates_inclusion_of :licenses, in: LICENSES.keys
+  validates_inclusion_of :licenses, in: LICENSES.keys, if: proc { |feed| feed.published }
 
   # Filters for the whole feed: applies to all data from all teams
   def get_feed_filters

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -45,14 +45,25 @@ class FeedTest < ActiveSupport::TestCase
   end
 
   test "should validate licenses" do
-    assert_raises ActiveRecord::RecordInvalid do
-      create_feed licenses: []
+    assert_difference 'Feed.count' do
+      create_feed licenses: [1, 2], published: true
     end
     assert_difference 'Feed.count' do
-      create_feed licenses: [1, 2]
+      create_feed licenses: [1, 2], published: false
+    end
+
+    assert_raises ActiveRecord::RecordInvalid do
+      create_feed licenses: [], published: true
     end
     assert_raises ActiveRecord::RecordInvalid do
-      create_feed licenses: [1, 4]
+      create_feed licenses: [1, 4], published: true
+    end
+
+    assert_nothing_raised do
+      create_feed licenses: [], published: false
+    end
+    assert_nothing_raised do
+      create_feed licenses: [1, 4], published: false
     end
   end
 


### PR DESCRIPTION
## Description

Only require license to be present if feed is published.

Fixes: CV2-3193.

## How has this been tested?

A unit test was implemented for that.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

