### PR TITLE
cv2-3077: Validation errors should not be sent to Sentry, only to the client

### DIFF
--- a/app/controllers/api/v1/graphql_controller.rb
+++ b/app/controllers/api/v1/graphql_controller.rb
@@ -53,7 +53,7 @@ module Api
         # Mutations are not batched, so we can return errors in the root
         rescue ActiveRecord::RecordInvalid, RuntimeError, NameError, GraphQL::Batch::NestedError => e
           @output = parse_json_exception(e)
-          CheckSentry.notify(e) unless ActiveRecord::RecordInvalid
+          CheckSentry.notify(e) unless e.is_a?(ActiveRecord::RecordInvalid)
           render json: @output, status: 400
         rescue ActiveRecord::StaleObjectError, ActiveRecord::RecordNotUnique => e
           @output = format_error_message(e)

--- a/app/controllers/api/v1/graphql_controller.rb
+++ b/app/controllers/api/v1/graphql_controller.rb
@@ -53,7 +53,7 @@ module Api
         # Mutations are not batched, so we can return errors in the root
         rescue ActiveRecord::RecordInvalid, RuntimeError, NameError, GraphQL::Batch::NestedError => e
           @output = parse_json_exception(e)
-          CheckSentry.notify(e)
+          CheckSentry.notify(e) unless ActiveRecord::RecordInvalid
           render json: @output, status: 400
         rescue ActiveRecord::StaleObjectError, ActiveRecord::RecordNotUnique => e
           @output = format_error_message(e)

--- a/app/controllers/api/v1/graphql_controller.rb
+++ b/app/controllers/api/v1/graphql_controller.rb
@@ -53,7 +53,7 @@ module Api
         # Mutations are not batched, so we can return errors in the root
         rescue ActiveRecord::RecordInvalid, RuntimeError, NameError, GraphQL::Batch::NestedError => e
           @output = parse_json_exception(e)
-          CheckSentry.notify(e) unless e.is_a?(ActiveRecord::RecordInvalid)
+          CheckSentry.notify(e)
           render json: @output, status: 400
         rescue ActiveRecord::StaleObjectError, ActiveRecord::RecordNotUnique => e
           @output = format_error_message(e)

--- a/config/initializers/02_sentry.rb
+++ b/config/initializers/02_sentry.rb
@@ -7,7 +7,7 @@ Sentry.init do |config|
   config.traces_sample_rate = (CheckConfig.get('sentry_traces_sample_rate') || 0).to_f
 
   # Any exceptions we want to prevent sending to Sentry
-  # config.excluded_exceptions += ['Check::Exception::RetryLater']
+  config.excluded_exceptions += ['ActiveRecord::RecordInvalid']
 
   # Ignore exceptions raised in Sidekiq jobs unless they pass their retry limit
   # Ideally in future, we would not set this and instead would manually raise retryable


### PR DESCRIPTION
## Description

We were sending validation errors to Sentry, e.g: 'Project can't be blank'. We don't need to send those to Sentry, only to the client.

References: [cv2-3077](https://meedan.atlassian.net/browse/CV2-3077?atlOrigin=eyJpIjoiMzQ0MzVlZjhjNWZkNDJlYzg0ZDRmYzY2Y2JkMTU0YzIiLCJwIjoiaiJ9)

## How has this been tested?

No, since we don't send errors from the development environment. I'll test this on QA.
