### PR TITLE
CV2-3332 - Have TaggerBot consider multiple text fields for an item

### DIFF
--- a/app/models/bot/tagger.rb
+++ b/app/models/bot/tagger.rb
@@ -38,11 +38,28 @@ class Bot::Tagger < BotUser
       if body.dig(:event) == 'create_project_media' && !pm.nil?
         self.log("This item was just created, processing...", pm.id, Logger::INFO)
         # Search all text fields for all items in the workspace using only the cofigured vector model
-        # The ProjectMedia's title is the query
+
+        search_texts=[pm.title]
+        if pm.description!=pm.title
+          search_texts<<pm.description
+        end
+        if !pm&.claim_description&.description.nil?
+          search_texts<<pm&.claim_description&.description
+        end
+        if !pm&.claim_description&.context.nil?
+          search_texts<<pm&.claim_description&.context
+        end
+
+        # Search for each text field in `search_texts`
         # Do not use Elasticsearch. The threshold to use comes from the Tagger bot settings.
         # Method signature: get_items_with_similar_text(pm, fields, threshold, query_text, models, team_ids = [pm&.team_id])
-        results=Bot::Alegre.get_items_with_similar_text(pm, Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS,
-          [{ value: threshold }], pm.title, [Bot::Alegre.matching_model_to_use(pm.team_id)].flatten.reject{|m| m==Bot::Alegre::ELASTICSEARCH_MODEL})
+        results=[]
+        search_texts.each |query| do {
+          results<<Bot::Alegre.get_items_with_similar_text(pm, Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS,
+            [{ value: threshold }], query, [Bot::Alegre.matching_model_to_use(pm.team_id)].flatten.reject{|m| m==Bot::Alegre::ELASTICSEARCH_MODEL})
+        end
+        # Combine the list of hashes into one hash
+        results=results.reduce({}, :merge!)
         self.log("#{results.length} nearest neighbors #{results.keys()}", pm.id, Logger::INFO)
         self.log("Results: #{results}", pm.id, Logger::INFO)
 


### PR DESCRIPTION
## Description

Currently Tagger bot only considers the title of a ProjectMedia. It should also consider the ProjectMedia’s description (only if different from the title) as well as the Claim description if present

References: CV2-3332

## How has this been tested?

No additional automated tests, but all code is covered by existing tests. I've manually tested and verified the code is working as intended.

## Things to pay attention to during code review

I copied the `pm.send(field) if !pm.nil? && pm.respond_to?(field)` pattern from https://github.com/meedan/check-api/blob/5ae2abffc4f954d4d4ed69d52c4ed0590f7f103c/app/models/concerns/alegre_similarity.rb#L96 , but I'm not actually 100% certain of how the `send` and `respond_to` methods work. I'd appreciate an extra check and any insights :pray: 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I have commented my code in hard-to-understand areas, if any
- [x] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

