### PR TITLE
In the Feed API, search for published reports under the current API key team if `feed_id` parameter is not passed

### DIFF
--- a/app/resources/api/v2/feed_resource.rb
+++ b/app/resources/api/v2/feed_resource.rb
@@ -35,11 +35,9 @@ module Api
         return ProjectMedia.none if team_ids.blank? || query.blank?
 
         if feed_id > 0
-          get_results_from_feed_teams(team_ids, feed_id, query, type, after, webhook_url, skip_save_request)
+          return get_results_from_feed_teams(team_ids, feed_id, query, type, after, webhook_url, skip_save_request)
         elsif ApiKey.current
-          get_results_from_api_key_teams(type, query, after)
-        else
-          ProjectMedia.none
+          return get_results_from_api_key_teams(type, query, after)
         end
       end
 

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -37,6 +37,21 @@ class FeedsControllerTest < ActionController::TestCase
     assert_response 401
   end
 
+  test "should request team data" do
+    a = create_api_key
+    b = create_bot_user
+    b.api_key = a
+    b.save!
+    create_team_user team: @t1, user: b
+    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id], nil).returns([@pm1])
+
+    authenticate_with_token a
+    get :index, params: { filter: { type: 'text', query: 'Foo' } }
+    assert_response :success
+    assert_equal 1, json_response['data'].size
+    assert_equal 1, json_response['meta']['record-count']
+  end
+
   test "should request feed data" do
     authenticate_with_token @a
     get :index, params: { filter: { type: 'text', query: 'Foo', feed_id: @f.id } }


### PR DESCRIPTION
## Description

In the current Feed API, the scope of the search are all teams that belong to the feed whose `feed_id` is passed as a parameter to the endpoint. This commit adds another behavior: if `feed_id` is not present, use the current API key team as the scope for the search.

Reference: CV2-2814.

## How has this been tested?

I implemented a unit test for this new supported case.

## Things to pay attention to during code review

The previous use case (search based on `feed_id`) should still work the same way as before.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

