### PR TITLE
Fixing how `Team.current` is set for feed API requests.

### DIFF
--- a/app/resources/api/v2/feed_resource.rb
+++ b/app/resources/api/v2/feed_resource.rb
@@ -23,7 +23,7 @@ module Api
 
       def self.records(options = {}, skip_save_request = false)
         team_ids = self.workspaces(options).map(&:id)
-        Team.current ||= team_ids[0]
+        Team.current ||= Team.find_by_id(team_ids[0].to_i)
         filters = options[:filters] || {}
         query = filters.dig(:query).to_a.join(',')
         query = CGI.unescape(query)


### PR DESCRIPTION
## Description

It should be an object, not an ID.

Fixes: CV2-2814.

## How has this been tested?

Current tests should cover this.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

