### PR TITLE
Tipline improvements and fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -224,7 +224,7 @@ Metrics/CyclomaticComplexity:
                  A complexity metric that is strongly correlated to the number
                  of test cases needed to validate a method.
   Enabled: true
-  Max: 10
+  Max: 11
 
 Metrics/LineLength:
   Description: 'Limit lines to 80 characters.'

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -430,7 +430,7 @@ class Bot::Smooch < BotUser
         self.get_supported_languages.each do |l|
           i = self.get_next_menu_item_number(i)
           options << {
-            'smooch_menu_option_keyword' => [l, i].join(','),
+            'smooch_menu_option_keyword' => i.to_s,
             'smooch_menu_option_value' => l
           }
         end

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -935,10 +935,14 @@ class Bot::Smooch < BotUser
     (RequestStore.store[:smooch_bot_provider] == 'TURN' || RequestStore.store[:smooch_bot_provider] == 'CAPI') ? response_body&.dig('messages', 0, 'id') : response&.message&.id
   end
 
-  def self.save_smooch_response(response, pm, query_date, fallback_template = nil, lang = 'en', custom = {})
+  def self.save_smooch_response(response, pm, query_date, fallback_template = nil, lang = 'en', custom = {}, expire = nil)
     return false if response.nil? || fallback_template.nil?
     id = self.get_id_from_send_response(response)
-    Rails.cache.write('smooch:original:' + id, { project_media_id: pm&.id, fallback_template: fallback_template, language: lang, query_date: (query_date || Time.now.to_i) }.merge(custom).to_json) unless id.blank?
+    unless id.blank?
+      key = 'smooch:original:' + id
+      value = { project_media_id: pm&.id, fallback_template: fallback_template, language: lang, query_date: (query_date || Time.now.to_i) }.merge(custom).to_json
+      Rails.cache.write(key, value, expires_in: expire)
+    end
   end
 
   def self.send_report_from_parent_to_child(parent_id, target_id)

--- a/app/models/concerns/smooch_turnio.rb
+++ b/app/models/concerns/smooch_turnio.rb
@@ -97,7 +97,7 @@ module SmoochTurnio
     end
 
     def get_turnio_message_text(message)
-      self.get_capi_message_text(message)
+      Bot::Smooch.get_capi_message_text(message)
     end
 
     def get_turnio_message_uid(message)

--- a/app/models/concerns/smooch_turnio.rb
+++ b/app/models/concerns/smooch_turnio.rb
@@ -256,10 +256,7 @@ module SmoochTurnio
       req = Net::HTTP::Post.new(uri.request_uri, 'Content-Type' => 'application/json', 'Authorization' => "Bearer #{self.config['turnio_token']}")
       req.body = payload.to_json
       response = http.request(req)
-      ret = nil
-      if response.code.to_i < 400
-        ret = response
-      else
+      if response.code.to_i >= 400
         response_body = Bot::Smooch.safely_parse_response_body(response)
         errors = response_body&.dig('errors')
         errors.to_a.each do |error|
@@ -273,7 +270,7 @@ module SmoochTurnio
           )
         end
       end
-      ret
+      response
     end
   end
 end

--- a/app/models/concerns/smooch_turnio.rb
+++ b/app/models/concerns/smooch_turnio.rb
@@ -97,7 +97,7 @@ module SmoochTurnio
     end
 
     def get_turnio_message_text(message)
-      message.dig('text', 'body') || message.dig('interactive', 'list_reply', 'title') || message.dig('interactive', 'button_reply', 'title') || ''
+      self.get_capi_message_text(message)
     end
 
     def get_turnio_message_uid(message)

--- a/app/models/tipline_newsletter.rb
+++ b/app/models/tipline_newsletter.rb
@@ -134,6 +134,7 @@ class TiplineNewsletter < ApplicationRecord
   end
 
   def articles
+    return @articles unless @articles.to_a.empty?
     articles = []
     if self.content_type == 'static'
       [:first_article, :second_article, :third_article].each do |article|
@@ -142,13 +143,14 @@ class TiplineNewsletter < ApplicationRecord
     elsif self.content_type == 'rss' && !self.rss_feed_url.blank?
       articles = RssFeed.new(self.rss_feed_url).get_articles(self.number_of_articles)
     end
-    articles.reject{ |article| article.blank? }.first(self.number_of_articles).collect do |article|
+    @articles = articles.reject{ |article| article.blank? }.first(self.number_of_articles).collect do |article|
       if self.team.get_shorten_outgoing_urls || self.content_type == 'rss'
         UrlRewriter.shorten_and_utmize_urls(article, self.team.get_outgoing_urls_utm_code, self)
       else
         article
       end
     end
+    @articles
   end
 
   def body

--- a/app/models/tipline_newsletter.rb
+++ b/app/models/tipline_newsletter.rb
@@ -164,7 +164,8 @@ class TiplineNewsletter < ApplicationRecord
       file_url = self.header_media_url
       file_type = HEADER_TYPE_MAPPING[self.header_type]
     end
-    params = [date, self.introduction, self.articles].flatten.reject{ |param| param.blank? }
+    introduction = UrlRewriter.shorten_and_utmize_urls(self.introduction, self.team.get_outgoing_urls_utm_code, self)
+    params = [date, introduction, self.articles].flatten.reject{ |param| param.blank? }
     preview_url = (self.header_type == 'link_preview')
     Bot::Smooch.format_template_message(self.whatsapp_template_name, params, file_url, self.build_content, self.language, file_type, preview_url)
   end

--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -43,10 +43,14 @@ class TiplineNewsletterWorker
 
         response = Bot::Smooch.send_message_to_user(ts.uid, newsletter.format_as_template_message)
 
-        log team_id, language, "Newsletter sent to subscriber ##{ts.id}, response: (#{response.code}) #{response.body}"
-        count += 1
+        if response.code.to_i < 400
+          log team_id, language, "Newsletter sent to subscriber ##{ts.id}, response: (#{response.code}) #{response.body}"
+          count += 1
+        else
+          log team_id, language, "Could not send newsletter to subscriber ##{ts.id}: (#{response.code}) #{response.body}"
+        end
       rescue StandardError => e
-        log team_id, language, "Could not send newsletter to subscriber ##{ts.id}: #{e.message}"
+        log team_id, language, "Could not send newsletter to subscriber ##{ts.id} (exception): #{e.message}"
       end
     end
     finish = Time.now

--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -45,6 +45,7 @@ class TiplineNewsletterWorker
 
         if response.code.to_i < 400
           log team_id, language, "Newsletter sent to subscriber ##{ts.id}, response: (#{response.code}) #{response.body}"
+          Bot::Smooch.save_smooch_response(response, nil, Time.now.to_i, 'newsletter', language, {}, 24.hours)
           count += 1
         else
           log team_id, language, "Could not send newsletter to subscriber ##{ts.id}: (#{response.code}) #{response.body}"

--- a/test/models/bot/smooch_3_test.rb
+++ b/test/models/bot/smooch_3_test.rb
@@ -431,9 +431,9 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
     @installation.save!
     Bot::Smooch.get_installation('turnio_secret', 'test')
     WebMock.stub_request(:post, 'https://whatsapp.turn.io/v1/messages').to_return(status: 200, body: '{}')
-    assert_not_nil Bot::Smooch.turnio_send_message_to_user('test:123456', 'Test')
+    assert_equal 200, Bot::Smooch.turnio_send_message_to_user('test:123456', 'Test').code.to_i
     WebMock.stub_request(:post, 'https://whatsapp.turn.io/v1/messages').to_return(status: 404, body: '{}')
-    assert_nil Bot::Smooch.turnio_send_message_to_user('test:123456', 'Test 2')
+    assert_equal 404, Bot::Smooch.turnio_send_message_to_user('test:123456', 'Test 2').code.to_i
   end
 
   test "should resend turn.io message" do

--- a/test/workers/tipline_newsletter_worker_test.rb
+++ b/test/workers/tipline_newsletter_worker_test.rb
@@ -17,8 +17,16 @@ class TiplineNewsletterWorkerTest < ActiveSupport::TestCase
     end
   end
 
-  test "should not crash if error happens when sending newsletter to some subscriber" do
+  test "should not crash if exception happens when sending newsletter to some subscriber" do
     Bot::Smooch.stubs(:send_message_to_user).raises(StandardError)
+    assert_nothing_raised do
+      TiplineNewsletterWorker.perform_async(@team.id, 'en')
+    end
+    Bot::Smooch.unstub(:send_message_to_user)
+  end
+
+  test "should not crash if error happens when sending newsletter to some subscriber" do
+    Bot::Smooch.stubs(:send_message_to_user).returns(OpenStruct.new(code: 400))
     assert_nothing_raised do
       TiplineNewsletterWorker.perform_async(@team.id, 'en')
     end


### PR DESCRIPTION
## Description

This branch implements a bunch of small improvements and fixes for tiplines, specially for the newsletter feature.

**Output more clear error message in log when newsletter can't be sent to a subscriber** (CV2-3372)
Make sure that all tipline providers (Smooch, On-Prem and CAPI) return a response object with attributes `code` and `body` for the `send_message_to_user` method. In the tipline newsletter delivery job, log successful deliveries and failed deliveries according to the `response.code`.

**When sending a newsletter, be sure that RSS content is not re-fetched for each subscriber** (CV2-3371)
"Cache" newsletter articles in memory, so, for the same `TiplineNewsletter` object loaded in memory, the method `articles` won't re-fetch static articles or articles from an RSS feed after the first time this method is called. This is for performance reasons... when a newsletter is delivered, that method is called several times (once for each subscription), so RSS newsletters can take a long time if there are many subscribers and the RSS URL doesn't load fast enough.

**Shorten URLs in newsletter introduction** (CV2-3259)
Pretty straightforward, just need to call a method around the newsletter introduction to shorten the URLs.

**Set event `newsletter` for `TiplineMessage` records related to newsletter deliveries** (CV2-3298)
Save the sent message ID so that the "newsletter" delivery event can be stored in the `TiplineMessage`.

**Get caption for media files sent to on-prem tiplines** (CV2-3288)
This is bug fixes. Affects only WhatsApp tiplines currently running on the on-prem API. The fix is to simply reuse the same incoming message parser used for tiplines running in the WhatsApp Cloud API.

**Avoid edge cases where a message is misinterpreted as a language code** (CV2-3312)
For example, "hi" misinterpreted as "Hindi".

## How has this been tested?

Unit tests for all cases. 100% coverage should be maintained.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

