### PR TITLE
CV2-2872 - count Chinese and Japanese words better

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -196,9 +196,10 @@ class Bot::Alegre < BotUser
     # Get the number of space-separated words (Does not work with Chinese/Japanese)
     space_separted_words = text.gsub(/[^\p{L}\s]/u, '').strip.chomp.split(/\s+/).size
 
-    # This splits the text on any non unicode word boundary (works with Chinese, Japanese)
+    # This removes URLs
+    # Then it splits the text on any non unicode word boundary (works with Chinese, Japanese)
     # We then clean each word and remove any empty ones
-    unicode_words = text.scan(/(?u)\w+/).map{|w| w.gsub(/[^\p{L}\s]/u, '').strip.chomp}.reject{|w| w.length==0}
+    unicode_words = text.gsub(/https?:\/\/\S+/u, '').scan(/(?u)\w+/).map{|w| w.gsub(/[^\p{L}\s]/u, '').strip.chomp}.reject{|w| w.length==0}
     # For each word, we:
     # Get the number of Chinese characters. We'll assume one character is like one word
     # Get the number of Japanese hiragana/katakana (kana) characters.

--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -214,7 +214,10 @@ class Bot::Alegre < BotUser
 
   def self.get_items_from_similar_text(team_id, text, fields = nil, threshold = nil, models = nil, fuzzy = false)
     team_ids = [team_id].flatten
-    return {} if text.blank? || self.get_number_of_words(text) < 3
+    if text.blank? || self.get_number_of_words(text) < 3
+      Rails.logger.info("[Alegre Bot] get_items_from_similar_text returning early due to blank/short text #{text}")
+      return {}
+    end
     fields ||= ALL_TEXT_SIMILARITY_FIELDS
     threshold ||= self.get_threshold_for_query('text', nil, true)
     models ||= [self.matching_model_to_use(team_ids)].flatten
@@ -727,7 +730,7 @@ class Bot::Alegre < BotUser
     unless pm.alegre_matched_fields.blank?
       fields_size = []
       pm.alegre_matched_fields.uniq.each do |field|
-        fields_size << pm.send(field).to_s.split(/\s/).length if pm.respond_to?(field)
+        fields_size << self.get_number_of_words(pm.send(field)) if pm.respond_to?(field)
       end
       is_short = fields_size.max < length_threshold unless fields_size.blank?
     end

--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -201,11 +201,12 @@ class Bot::Alegre < BotUser
     # We then clean each word and remove any empty ones
     unicode_words = text.gsub(/https?:\/\/\S+/u, '').scan(/(?u)\w+/).map{|w| w.gsub(/[^\p{L}\s]/u, '').strip.chomp}.reject{|w| w.length==0}
     # For each word, we:
-    # Get the number of Chinese characters. We'll assume one character is like one word
+    # Get the number of Chinese characters. We'll assume two characters are like one word
     # Get the number of Japanese hiragana/katakana (kana) characters.
     # Kana are definitely not one word each, but who really knows.
     # For the purpose of this function, we'll assume 4 kana equate to one word
-    unicode_words = unicode_words.map{|w| [1,w.scan(/\p{Han}/).size + (w.scan(/\p{Katakana}|\p{Hiragana}/).size/4.0).ceil].max}.sum()
+    unicode_words = unicode_words.map{|w| [1,
+      (w.scan(/\p{Han}/).size/2.0).ceil) + (w.scan(/\p{Katakana}|\p{Hiragana}/).size/4.0).ceil].max}.sum()
 
     # Return whichever is larger of our two methods for counting words
     [space_separted_words, unicode_words].max

--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -206,7 +206,7 @@ class Bot::Alegre < BotUser
     # Kana are definitely not one word each, but who really knows.
     # For the purpose of this function, we'll assume 4 kana equate to one word
     unicode_words = unicode_words.map{|w| [1,
-      (w.scan(/\p{Han}/).size/2.0).ceil) + (w.scan(/\p{Katakana}|\p{Hiragana}/).size/4.0).ceil].max}.sum()
+      (w.scan(/\p{Han}/).size/2.0).ceil + (w.scan(/\p{Katakana}|\p{Hiragana}/).size/4.0).ceil].max}.sum()
 
     # Return whichever is larger of our two methods for counting words
     [space_separted_words, unicode_words].max

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -146,7 +146,7 @@ module SmoochSearch
           text = [link.pender_data['description'].to_s, text.to_s.gsub(/https?:\/\/[^\s]+/, '').strip].max_by(&:length)
         end
         return [] if text.blank?
-        words = text.split(/\s+/)
+        words = Bot::Alegre.get_number_of_words(text)
         Rails.logger.info "[Smooch Bot] Search query (text): #{text}"
         if words.size <= self.max_number_of_words_for_keyword_search
           results = self.search_by_keywords_for_similar_published_fact_checks(words, after, team_ids, feed_id, language)

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -146,9 +146,9 @@ module SmoochSearch
           text = [link.pender_data['description'].to_s, text.to_s.gsub(/https?:\/\/[^\s]+/, '').strip].max_by(&:length)
         end
         return [] if text.blank?
-        words = Bot::Alegre.get_number_of_words(text)
+        words = text.split(/\s+/)
         Rails.logger.info "[Smooch Bot] Search query (text): #{text}"
-        if words.size <= self.max_number_of_words_for_keyword_search
+        if Bot::Alegre.get_number_of_words(text) <= self.max_number_of_words_for_keyword_search
           results = self.search_by_keywords_for_similar_published_fact_checks(words, after, team_ids, feed_id, language)
         else
           alegre_results = Bot::Alegre.get_merged_similar_items(pm, [{ value: self.get_text_similarity_threshold }], Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS, text, team_ids)

--- a/app/models/concerns/team_rules.rb
+++ b/app/models/concerns/team_rules.rb
@@ -21,6 +21,7 @@ module TeamRules
       return false unless pm.media&.type == 'Claim'
       smooch_message = get_smooch_message(pm)
       return false if smooch_message['text'].blank?
+      #TODO: Consider using Bot::Alegre.number_of_words
       smooch_message['text'].to_s.gsub(Bot::Smooch::MESSAGE_BOUNDARY, '').split(/\s+/).select{ |w| (w =~ /^[0-9]+$/).nil? }.size <= value.to_i
     end
 

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -530,6 +530,15 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
   test "should get number of words" do
     assert_equal 4, Bot::Alegre.get_number_of_words('58 This   is a test !!! 123 😊')
     assert_equal 1, Bot::Alegre.get_number_of_words(random_url)
+    # For Chinese characters we'll count the number of characters
+    assert_equal 2, Bot::Alegre.get_number_of_words('中国')
+    # For Japanese kana, we'll take the number of kana divided by 4 (rounded up)
+    assert_equal 2, Bot::Alegre.get_number_of_words('にほんごがすきい')
+    # Korean Hangul is generally space separated and should be counted as such
+    assert_equal 2, Bot::Alegre.get_number_of_words('한국어가 멋지다')
+    # All together - 10 words as below
+    # '韓国語で'=>4, 'おいしい'=>1, 'は'=>1, '맛있는'=>1, 'です'=>1, 'Test'=>1, 'string'=>1
+    assert_equal 10, Bot::Alegre.get_number_of_words('韓国語で「おいしい」は「맛있는」です。Test string!😊')
   end
 
   test "should be able to request deletion from index for a media given specific field" do

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -530,7 +530,7 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
   test "should get number of words" do
     assert_equal 4, Bot::Alegre.get_number_of_words('58 This   is a test !!! 123 😊')
     assert_equal 1, Bot::Alegre.get_number_of_words(random_url)
-    # For Chinese characters we'll count the number of characters divied by 1.6 (rounded up)
+    # For Chinese characters we'll count the number of characters divied by 2 (rounded up)
     assert_equal 1, Bot::Alegre.get_number_of_words('中国')
     # For Japanese kana, we'll take the number of kana divided by 4 (rounded up)
     assert_equal 2, Bot::Alegre.get_number_of_words('にほんごがすきい')

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -537,8 +537,8 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
     # Korean Hangul is generally space separated and should be counted as such
     assert_equal 2, Bot::Alegre.get_number_of_words('한국어가 멋지다')
     # All together - 10 words as below
-    # '韓国語で'=>4, 'おいしい'=>1, 'は'=>1, '맛있는'=>1, 'です'=>1, 'Test'=>1, 'string'=>1
-    assert_equal 10, Bot::Alegre.get_number_of_words('韓国語で「おいしい」は「맛있는」です。Test string!😊')
+    # '韓国語で'=>3, 'おいしい'=>1, 'は'=>1, '맛있는'=>1, 'です'=>1, 'Test'=>1, 'string'=>1
+    assert_equal 9, Bot::Alegre.get_number_of_words('韓国語で「おいしい」は「맛있는」です。Test string!😊')
   end
 
   test "should be able to request deletion from index for a media given specific field" do

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -530,8 +530,8 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
   test "should get number of words" do
     assert_equal 4, Bot::Alegre.get_number_of_words('58 This   is a test !!! 123 😊')
     assert_equal 1, Bot::Alegre.get_number_of_words(random_url)
-    # For Chinese characters we'll count the number of characters
-    assert_equal 2, Bot::Alegre.get_number_of_words('中国')
+    # For Chinese characters we'll count the number of characters divied by 1.6 (rounded up)
+    assert_equal 1, Bot::Alegre.get_number_of_words('中国')
     # For Japanese kana, we'll take the number of kana divided by 4 (rounded up)
     assert_equal 2, Bot::Alegre.get_number_of_words('にほんごがすきい')
     # Korean Hangul is generally space separated and should be counted as such


### PR DESCRIPTION
## Description

Per CV2-2872 we have an issue where Chinese and Japanese sentences are counted as only one word simply because they are not space-separated. 

This ticket counts two Chinese characters as one word and 4-Japanese kana as one word. This is simple and let's us continue using regular expressions in Ruby without having to do anything more in-depth.

References: CV2-2872

## How has this been tested?

Additional tests added

## Things to pay attention to during code review

N/A

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I have commented my code in hard-to-understand areas, if any
- [x] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)



[CV2-2872]: https://meedan.atlassian.net/browse/CV2-2872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ