### PR TITLE
Do not log the response from external bot endpoint since it can be invalid

### DIFF
--- a/app/models/bot_user.rb
+++ b/app/models/bot_user.rb
@@ -180,7 +180,7 @@ class BotUser < User
         logged_data.delete(:team)
         logged_data[:team_id] = data[:team].id
         logged_data = logged_data.to_json
-        Rails.logged.info "[BotUser] Notified bot #{self.id} with payload #{logged_data}, the response was #{response.code}"
+        Rails.logger.info "[BotUser] Notified bot #{self.id} with payload #{logged_data}, the response was #{response.code}"
         response
       end
     rescue StandardError => e

--- a/app/models/bot_user.rb
+++ b/app/models/bot_user.rb
@@ -179,7 +179,8 @@ class BotUser < User
         logged_data = data.dup
         logged_data.delete(:team)
         logged_data[:team_id] = data[:team].id
-        Rails.logger.info "[BotUser] Notified bot #{self.id} with payload '#{logged_data.to_json}', the response was (#{response.code}): '#{response.body}'"
+        logged_data = logged_data.to_json
+        Rails.logged.info "[BotUser] Notified bot #{self.id} with payload #{logged_data}, the response was #{response.code}"
         response
       end
     rescue StandardError => e
@@ -322,7 +323,7 @@ class BotUser < User
       begin
         bot.notify_about_event(event, object, team, team_bot_installation) if bot.subscribed_to?(event) && (target_bot.blank? || bot.id == target_bot.id)
       rescue StandardError => e
-        CheckSentry.notify(e, { event: event, team_bot_installation_id:team_bot_installation.id})
+        CheckSentry.notify(e, { event: event, team_bot_installation_id: team_bot_installation.id })
       end
     end
   end


### PR DESCRIPTION
## Description

The response can be binary or contain invalid characters. It's enough if we log the response code.

Fixes CV2-3085.

## How has this been tested?

I was not able to reproduce the original issue.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

