### PR TITLE
Ticket CV2-3389: Fixing Telugu string interpreted as markdown by WhatsApp Cloud API

### DIFF
--- a/config/tipline_strings.yml
+++ b/config/tipline_strings.yml
@@ -890,7 +890,7 @@ ta:
   unsubscribe_button_label: பதிவை ரத்து செய்
   unsubscribed: தற்சமயம் நீங்கள் எங்கள் செய்தி மடலைப் பெறும் வசதியை ரத்து செய்து இருக்கிறீர்கள்
 te:
-  add_more_details_state_button_label: ఇంకా_చేర్ఛండి
+  add_more_details_state_button_label: ఇంకా చేర్చండి
   ask_if_ready_state_button_label: రద్దు
   cancelled: అలాగే!
   confirm_preferred_language: మీరు ఎంచుకున్న భాషను కన్ఫర్మ్ చెయండి


### PR DESCRIPTION
Fixing Telugu string interpreted as markdown by WhatsApp Cloud API.