### PR TITLE
CV2-3276: fix Sentry issue

### DIFF
--- a/app/models/concerns/smooch_capi.rb
+++ b/app/models/concerns/smooch_capi.rb
@@ -37,7 +37,11 @@ module SmoochCapi
     end
 
     def get_capi_message_text(message)
-      message.dig('text', 'body') || message.dig('interactive', 'list_reply', 'title') || message.dig('interactive', 'button_reply', 'title') || message.dig(message['type'], 'caption') || ''
+      begin
+        message.dig('text', 'body') || message.dig('interactive', 'list_reply', 'title') || message.dig('interactive', 'button_reply', 'title') || message.dig(message['type'], 'caption') || ''
+      rescue
+        ''
+      end
     end
 
     def store_capi_media(media_id, mime_type)


### PR DESCRIPTION
## Description

Fix Sentry issue `TypeError: no implicit conversion of String into Integer` related to dig method

`dig` method triggered this error for the cases like this `{a:  []}.dig(:a, :b)` so I rescue the dig and return empty string

References: CV2-3276

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

