### PR TITLE
Do not allow newsletter to be scheduled for the past - but only when publishing

### DIFF
--- a/app/models/tipline_newsletter.rb
+++ b/app/models/tipline_newsletter.rb
@@ -275,7 +275,7 @@ class TiplineNewsletter < ApplicationRecord
   end
 
   def not_scheduled_for_the_past
-    if self.content_type == 'static' && self.scheduled_time.past?
+    if self.enabled_was == false && self.enabled == true && self.content_type == 'static' && self.scheduled_time.past?
       field = :send_on
       field = :time if self.scheduled_time.strftime('%Y-%m-%d') == Time.now.utc.strftime('%Y-%m-%d')
       errors.add(field, I18n.t(:send_on_must_be_in_the_future))

--- a/test/models/tipline_newsletter_test.rb
+++ b/test/models/tipline_newsletter_test.rb
@@ -231,9 +231,22 @@ class TiplineNewsletterTest < ActiveSupport::TestCase
   end
     
   test 'should not schedule for the past' do
-    @newsletter.content_type = 'static'
-    @newsletter.send_on = Date.parse('2023-05-01')
-    assert !@newsletter.valid?
+    newsletter = @newsletter.dup
+    newsletter.enabled = false
+    newsletter.content_type = 'static'
+    newsletter.send_on = Date.parse('2023-05-01')
+    newsletter.save!
+    newsletter = TiplineNewsletter.find(newsletter.id)
+    assert_raises ActiveRecord::RecordInvalid do
+      newsletter.enabled = true
+      newsletter.send_on = Date.parse('2023-05-01')
+      newsletter.save!
+    end
+    assert_nothing_raised do
+      newsletter.enabled = false
+      newsletter.send_on = Date.parse('2023-05-01')
+      newsletter.save!
+    end
   end
   
   test 'should convert video header file' do


### PR DESCRIPTION
## Description

It should be always possible to pause a newsletter. So, the validation to see if the scheduled time is in the past should only happen when publishing a newsletter (e.g., changing `enabled` from `false` to `true`).

Fixes CV2-3382.

## How has this been tested?

An existing unit test was refactored to handle these two different situations.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

