### PR TITLE
Calculate number of newsletters actually delivered

### DIFF
--- a/app/models/monthly_team_statistic.rb
+++ b/app/models/monthly_team_statistic.rb
@@ -26,6 +26,7 @@ class MonthlyTeamStatistic < ApplicationRecord
     new_newsletter_subscriptions: 'New newsletter subscriptions',
     newsletter_cancellations: 'Newsletter cancellations',
     current_subscribers: 'Current subscribers',
+    newsletters_delivered: 'Newsletters delivered'
   }.freeze
 
   def formatted_hash

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -575,10 +575,10 @@ class Team < ApplicationRecord
   end
 
   def data_report
-    monthly_statisitcs = MonthlyTeamStatistic.where(team_id: self.id).order('start_date ASC')
-    if monthly_statisitcs.present?
+    monthly_statistics = MonthlyTeamStatistic.where(team_id: self.id).order('start_date ASC')
+    if monthly_statistics.present?
       index = 1
-      monthly_statisitcs.map do |stat|
+      monthly_statistics.map do |stat|
         hash = stat.formatted_hash
         hash['Org'] = self.name
         hash['Month'] = "#{index}. #{hash['Month']}"

--- a/db/migrate/20230711211928_add_newsletters_delivered_to_monthly_team_statistic.rb
+++ b/db/migrate/20230711211928_add_newsletters_delivered_to_monthly_team_statistic.rb
@@ -1,0 +1,5 @@
+class AddNewslettersDeliveredToMonthlyTeamStatistic < ActiveRecord::Migration[6.1]
+  def change
+    add_column :monthly_team_statistics, :newsletters_delivered, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_06_28_214314) do
+ActiveRecord::Schema.define(version: 2023_07_11_211928) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -386,6 +386,7 @@ ActiveRecord::Schema.define(version: 2023_06_28_214314) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "conversations_24hr"
+    t.integer "newsletters_delivered"
     t.index ["team_id", "platform", "language", "start_date"], name: "index_monthly_stats_team_platform_language_start", unique: true
     t.index ["team_id"], name: "index_monthly_team_statistics_on_team_id"
   end

--- a/lib/check_statistics.rb
+++ b/lib/check_statistics.rb
@@ -209,6 +209,11 @@ module CheckStatistics
           # Number of newsletter subscription cancellations
           statistics[:newsletter_cancellations] = Version.from_partition(team_id).where(created_at: start_date..end_date, team_id: team_id, item_type: 'TiplineSubscription', event_type: 'destroy_tiplinesubscription').where('object LIKE ?', "%#{platform_name}%").where('object LIKE ?', '%"language":"' + language + '"%').count
         end
+
+        CheckTracer.in_span('CheckStatistics#newsletters_delivered', attributes: tracing_attributes) do
+          # Number of newsletters effectively delivered, accounting for user errors for each platform
+          statistics[:newsletters_delivered] = TiplineMessage.where(created_at: start_date..end_date, team_id: team_id, platform: platform_name, language: language, direction: 'outgoing', event: 'newsletter').count
+        end
       end
       statistics
     end


### PR DESCRIPTION
## Description

Calculate the number of newsletters that were actually received by end users. So, if a newsletter is sent twice in a month, and the first one is received 2 of the 3 subscribers and the second is received by one of the 3 subscribers, who also received the first one, this means 3 newsletter deliveries.

Reference: CV2-3026.

## How has this been tested?

Existing statistics tests should cover it.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

