### PR TITLE
Get ID of message sent through Smooch

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -932,7 +932,7 @@ class Bot::Smooch < BotUser
 
   def self.get_id_from_send_response(response)
     response_body = self.safely_parse_response_body(response)
-    (RequestStore.store[:smooch_bot_provider] == 'TURN' || RequestStore.store[:smooch_bot_provider] == 'CAPI') ? response_body&.dig('messages', 0, 'id') : response&.message&.id
+    (RequestStore.store[:smooch_bot_provider] == 'TURN' || RequestStore.store[:smooch_bot_provider] == 'CAPI') ? response_body&.dig('messages', 0, 'id') : response&.body&.message&.id
   end
 
   def self.save_smooch_response(response, pm, query_date, fallback_template = nil, lang = 'en', custom = {}, expire = nil)

--- a/app/models/concerns/smooch_zendesk.rb
+++ b/app/models/concerns/smooch_zendesk.rb
@@ -91,7 +91,7 @@ module SmoochZendesk
         )
       end
       # Convert to something that looks like a HTTP response
-      OpenStruct.new(body: response_body.inspect, code: response_code)
+      OpenStruct.new(body: response_body, code: response_code)
     end
 
     # https://docs.smooch.io/guide/whatsapp#shorthand-syntax

--- a/app/models/concerns/smooch_zendesk.rb
+++ b/app/models/concerns/smooch_zendesk.rb
@@ -77,11 +77,11 @@ module SmoochZendesk
         response_body = api_instance.post_message(app_id, uid, message_post_body) # It will raise an exception if message can't be sent
         response_code = 200
       rescue SmoochApi::ApiError => e
-        response_body = begin JSON.parse(e.response_body) rescue {} end
+        response_body = begin JSON.parse(e.response_body) rescue nil end
         response_code = 400
         Rails.logger.error("[Smooch Bot] Exception when sending message #{params.inspect}: #{e.response_body}")
 
-        error = response_body.dig('error')
+        error = response_body.to_h.dig('error')
         e2 = Bot::Smooch::SmoochMessageDeliveryError.new("(#{error&.dig('code')}) #{error&.dig('description')}")
         CheckSentry.notify(e2,
           smooch_app_id: app_id,

--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -44,11 +44,11 @@ class TiplineNewsletterWorker
         response = Bot::Smooch.send_message_to_user(ts.uid, newsletter.format_as_template_message)
 
         if response.code.to_i < 400
-          log team_id, language, "Newsletter sent to subscriber ##{ts.id}, response: (#{response.code}) #{response.body}"
+          log team_id, language, "Newsletter sent to subscriber ##{ts.id}, response: (#{response.code}) #{response.body.inspect}"
           Bot::Smooch.save_smooch_response(response, nil, Time.now.to_i, 'newsletter', language, {}, 24.hours)
           count += 1
         else
-          log team_id, language, "Could not send newsletter to subscriber ##{ts.id}: (#{response.code}) #{response.body}"
+          log team_id, language, "Could not send newsletter to subscriber ##{ts.id}: (#{response.code}) #{response.body.inspect}"
         end
       rescue StandardError => e
         log team_id, language, "Could not send newsletter to subscriber ##{ts.id} (exception): #{e.message}"

--- a/test/models/bot/smooch_4_test.rb
+++ b/test/models/bot/smooch_4_test.rb
@@ -18,7 +18,7 @@ class Bot::Smooch4Test < ActiveSupport::TestCase
       msgid = random_string
       pm = create_project_media
       publish_report(pm)
-      response = OpenStruct.new({ message: OpenStruct.new({ id: msgid }) })
+      response = OpenStruct.new({ body: OpenStruct.new(message: OpenStruct.new({ id: msgid })) })
       Bot::Smooch.save_smooch_response(response, pm, random_string, 'fact_check_status', 'en', { message: random_string })
       message = {
         app: {
@@ -41,7 +41,7 @@ class Bot::Smooch4Test < ActiveSupport::TestCase
       msgid = random_string
       pm = create_project_media
       publish_report(pm)
-      response = OpenStruct.new({ message: OpenStruct.new({ id: msgid }) })
+      response = OpenStruct.new({ body: OpenStruct.new(message: OpenStruct.new({ id: msgid })) })
       Bot::Smooch.save_smooch_response(response, pm, random_string, 'report', 'en')
       message = {
         app: {

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -73,11 +73,11 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
 
   def send_message_outside_24_hours_window(template, pm = nil)
     message_id = random_string
-    response = OpenStruct.new(message: OpenStruct.new(id: message_id))
+    response = OpenStruct.new(body: OpenStruct.new({ message: OpenStruct.new(id: message_id) }))
     Bot::Smooch.save_smooch_response(response, pm, Time.now.to_i, template, 'en')
 
     @msgid = random_string
-    response = OpenStruct.new(message: OpenStruct.new(id: @msgid))
+    response = OpenStruct.new(body: OpenStruct.new({ message: OpenStruct.new(id: @msgid) }))
     Bot::Smooch.stubs(:send_message_to_user).returns(response)
     assert_nil Rails.cache.read("smooch:original:#{@msgid}")
 


### PR DESCRIPTION
## Description

Just be sure that we can extract the ID of a message that is sent through Smooch.

References: CV2-3298.

## How has this been tested?

Existing tests should cover it.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)