### PR TITLE
CV2-3396: LINE supports Reply Buttons. Use them

### DIFF
--- a/app/models/concerns/smooch_menus.rb
+++ b/app/models/concerns/smooch_menus.rb
@@ -97,7 +97,7 @@ module SmoochMenus
         end
       end
 
-      if ['Telegram', 'Viber', 'Facebook Messenger'].include?(self.request_platform)
+      if ['Telegram', 'Viber', 'Facebook Messenger', 'LINE'].include?(self.request_platform)
         actions = []
         main.each do |section|
           section[:rows].each do |row|
@@ -241,7 +241,7 @@ module SmoochMenus
         fallback << self.format_fallback_text_menu_option(option, :value, :label)
       end
 
-      if ['Telegram', 'Viber', 'Facebook Messenger'].include?(self.request_platform)
+      if ['Telegram', 'Viber', 'Facebook Messenger', 'LINE'].include?(self.request_platform)
         actions = []
         options.each do |option|
           actions << {
@@ -278,7 +278,7 @@ module SmoochMenus
         }
       end
       text = text.join("\n\n")
-      if ['Telegram', 'Viber', 'Facebook Messenger'].include?(self.request_platform)
+      if ['Telegram', 'Viber', 'Facebook Messenger', 'LINE'].include?(self.request_platform)
         text = '🌐​' unless with_text
         self.send_message_to_user_with_single_section_menu(uid, text, options, self.get_string('languages', language))
       else


### PR DESCRIPTION
## Description

Smooch supports [Reply Buttons (aka quick replies)](https://docs.smooch.io/guide/line/#capabilities) for LINE. Let's use them!

References: CV2-3396

## How has this been tested?

Need help on how to test this!

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

