### PR TITLE
Default rate limit for API keys

### DIFF
--- a/app/models/concerns/project_media_private.rb
+++ b/app/models/concerns/project_media_private.rb
@@ -144,7 +144,7 @@ module ProjectMediaPrivate
 
   def rate_limit_not_exceeded
     if ApiKey.current && ApiKey.current.respond_to?(:rate_limits)
-      limit = ApiKey.current.rate_limits.with_indifferent_access[:created_items_per_minute]
+      limit = ApiKey.current.rate_limits.with_indifferent_access[:created_items_per_minute] || CheckConfig.get('api_key_rate_limit_created_items_per_minute', 30)
       raise Check::TooManyRequestsError if limit && ProjectMedia.where(team_id: self.team_id, created_at: Time.now.ago(1.minute)..Time.now).count >= limit
     end
   end

--- a/app/models/concerns/project_media_private.rb
+++ b/app/models/concerns/project_media_private.rb
@@ -144,8 +144,8 @@ module ProjectMediaPrivate
 
   def rate_limit_not_exceeded
     if ApiKey.current && ApiKey.current.respond_to?(:rate_limits)
-      limit = ApiKey.current.rate_limits.with_indifferent_access[:created_items_per_minute] || CheckConfig.get('api_key_rate_limit_created_items_per_minute', 30)
-      raise Check::TooManyRequestsError if limit && ProjectMedia.where(team_id: self.team_id, created_at: Time.now.ago(1.minute)..Time.now).count >= limit
+      limit = ApiKey.current.rate_limits.to_h.with_indifferent_access[:created_items_per_minute] || CheckConfig.get('api_key_rate_limit_created_items_per_minute', 30)
+      raise Check::TooManyRequestsError if limit && ProjectMedia.where(team_id: self.team_id, created_at: Time.now.ago(1.minute)..Time.now).count >= limit.to_i
     end
   end
 end

--- a/app/models/concerns/project_media_private.rb
+++ b/app/models/concerns/project_media_private.rb
@@ -144,7 +144,7 @@ module ProjectMediaPrivate
 
   def rate_limit_not_exceeded
     if ApiKey.current && ApiKey.current.respond_to?(:rate_limits)
-      limit = ApiKey.current.rate_limits.to_h.with_indifferent_access[:created_items_per_minute] || CheckConfig.get('api_key_rate_limit_created_items_per_minute', 30)
+      limit = ApiKey.current.rate_limits.to_h.with_indifferent_access[:created_items_per_minute] || CheckConfig.get('api_key_rate_limit_created_items_per_minute', 60)
       raise Check::TooManyRequestsError if limit && ProjectMedia.where(team_id: self.team_id, created_at: Time.now.ago(1.minute)..Time.now).count >= limit.to_i
     end
   end


### PR DESCRIPTION
## Description

Apply a default rate limit for item creation even when the API key doesn't define it.

References: CV2-3395.

## How has this been tested?

Existing tests should cover it.

## Things to pay attention to during code review

Is 60 a good default value? It means 1 item created per second.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

