### PR TITLE
CV2-3319: Install tx cli and updates strings downloaded with new client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libtag1-dev \
     lsof
 
+# tx client
+RUN curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
+
 # install our app
 WORKDIR /app
 COPY Gemfile /app/Gemfile

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -1,4 +1,3 @@
----
 ar:
   statuses:
     ids:
@@ -25,7 +24,7 @@ ar:
         label: قيد التقدم
         description: بدأ العمل على العنصر، لكن تتم الترجمة بعد
       not_true:
-        label: مزيف
+        label: 'مزيف'
         description: 'النتيجة :  محتوى العنصر غير صحيح'
       verified:
         label: صحيح
@@ -76,10 +75,8 @@ ar:
     messages:
       invalid_password: كلمة السّر غير صالحة
       invalid_qrcode: رمز التحقق غير صالح
-      extension_white_list_error: 'لا يمكن إستخدام امتداد الملف  %{extension} ، الامتدادات
-        المسموحة هي: %{allowed_types}'
-      invalid_size: لا بد أن تكون الصورة بين %{min_width}x%{min_height} و %{max_width}x%{max_height}
-        بكسل
+      extension_white_list_error: 'لا يمكن أن تكون من نوع %{extension}، الأنواع المسموح بها : %{allowed_types}'
+      invalid_size: لا بد أن تكون الصورة بين %{min_width}x%{min_height} و %{max_width}x%{max_height} بكسل
       mini_magick_processing_error: 'عذراً ، لم ننجح في معالجة الصورة. الخطأ هو: %{e}'
       annotation_mandatory_fields: يرجى تحديد جميع الحقول المطلوبة
       annotation_type_does_not_exist: غير موجود
@@ -88,17 +85,17 @@ ar:
       image_too_large: عذراً ، لا ندعم صور أكبر من %{max_size}.
       video_too_large: عذراً ، لا ندعم فيديوهات أكبر من %{max_size}.
       audio_too_large: عذراً ، لا ندعم ملفّات صوتيّة أكبر من %{max_size}.
-      pender_conflict: هذا الرابط قيد المعالجة بالفعل. يرجى المحاولة مجدداً بعد بضع
-        ثوانٍ.
+      pender_conflict: هذا الرابط قيد المعالجة بالفعل. يرجى المحاولة مجدداً بعد بضع ثوانٍ.
       pender_url_invalid: هذا الرابط غير صالح.
       pender_url_unsafe: هذا الرابط غير آمن.
-      pender_could_not_parse: "‫لا يمكن معالجة هذا الرابط. إذا تكرر هذا الخطأ، يُرجى
-        التواصل عبر العنوان %{support_email}."
+      pender_could_not_parse: ‫لا يمكن معالجة هذا الرابط. إذا تكرر هذا الخطأ، يُرجى التواصل عبر العنوان %{support_email}.
       invalid_format_for_languages: صيغة اللغة غير صالحة. المتوقع `['en', 'ar', …]`
       invalid_project_media_channel_value: عذرا، لا ندعم هذه الغرفة
       invalid_project_media_channel_update: عذراً، لقد تعذر عليك تحديث الغرفة
       invalid_project_media_archived_value: عذرا، إن القيم المؤرشفة غير مدعومة
       invalid_fact_check_language_value: عذرا، قيمة اللغة غير مدعومة
+      fact_check_empty_title_and_summary: عذرا، يجب ملء العنوان أو الملخص
+      invalid_feed_saved_search_value: يجب أن ينتمي إلى مساحة العمل و التي تشكل جزءا من هذا الموجز
   activerecord:
     models:
       link: رابط
@@ -159,20 +156,15 @@ ar:
           few: قصير جداً (الحد الأدنى %{count} حروف)
           many: قصير جداً (الحد الأدنى %{count} حروف)
           other: قصير جداً (الحد الأدنى %{count} حروف)
-  slack_webhook_format_wrong: صيغة ‫مِشبَك Slack‬ غير صالحة. الصيغة المتوقعة هي «
-    https://hooks.slack.com/services/XXXXX/XXXXXXXXXX »
+  slack_webhook_format_wrong: صيغة ‫مِشبَك Slack‬ غير صالحة. الصيغة المتوقعة هي « https://hooks.slack.com/services/XXXXX/XXXXXXXXXX »
   slug_is_reserved: مأخوذ
   invalid_media_item: العنصر غير صالح
-  invalid_default_status_for_custom_verification_status: إن المُعَرِّف الافتراضي لحالة
-    التحقق غير صالح
-  invalid_active_status_for_custom_verification_status: مُعَرِّف الحالة الفعّالة غير
-    صالح
+  invalid_default_status_for_custom_verification_status: إن المُعَرِّف الافتراضي لحالة التحقق غير صالح
+  invalid_active_status_for_custom_verification_status: مُعَرِّف الحالة الفعّالة غير صالح
   invalid_label_for_custom_verification_status: علامة الحالة مطلوبة
-  invalid_id_for_custom_verification_status: مُعَرِّف حالة التحقق مطلوب و يقبل الأحرف
-    والأرقام و'-' و '_' فقط
-  invalid_statuses_format_for_custom_verification_status: 'حالات التحقق الخاصة غير
-    صالحة. المتوقع هو صيغات صحيحة لكل من: العلامة، المُعَرِّف ، الوصف ، والأسلوب.'
-  mail_account_confirmation: تأكيد الحساب %{app_name}
+  invalid_id_for_custom_verification_status: مُعَرِّف حالة التحقق مطلوب و يقبل الأحرف والأرقام و'-' و '_' فقط
+  invalid_statuses_format_for_custom_verification_status: 'حالات التحقق الخاصة غير صالحة. المتوقع هو صيغات صحيحة لكل من: العلامة، المُعَرِّف ، الوصف ، والأسلوب.'
+  mail_account_confirmation: "تأكيد الحساب %{app_name}"
   slack:
     fields:
       assigned: المُكَلَّف
@@ -187,49 +179,40 @@ ar:
       project_media: العنصر
       attribution: تمّت الإجابة بواسطة
     messages:
-      analysis_verification_status_status_changed: 'قام%{user} بتغيير الحالة إلى:
-        %{value}'
-      analysis_title_changed: 'قام %{user} بتغيير عنوان التحليل إلى: %{value}'
-      analysis_content_changed: 'قام %{user} بتغيير محتوى التحليل إلى: %{value}'
-      tasks_create: 'قام %{user} بإضافة مهمة: %{title}'
-      tasks_edit: قام %{user} بتحرير مهمة %{title}
-      tasks_answer_create: 'قام %{user} بإجابة مهمة %{title}: %{answer}'
-      tasks_answer_edit: 'قام %{user} بتحرير إجابة مهمة %{title}: %{answer}'
-      metadata_create: 'قام %{user} بإضافة حقل للبيانات الوصفيّة: %{title}'
-      metadata_edit: قام %{user} بتحرير حقل في البيانات الوصفيّة %{title}
-      metadata_answer_create: 'قام %{user} بضبط قيمة في البيانات الوصفيّة %{title}:
-        %{answer}'
-      metadata_answer_edit: 'قام %{user} بتحرير قيمة في البيانات الوصفيّة %{title}:
-        %{answer}'
-      project_media_comment: قام %{user} (%{role} في %{team}) بإضافة ملحوظة الى %{parent_type}
-      project_media_create: قام %{user} (%{role} في %{team}) بإرسال عنصر جديد
-      project_media_create_related: قام %{user} (%{role} في %{team}) بإنشاء %{type}
-        مرتبط
-      project_media_update: قام %{user} (%{role} في %{team}) بتحديث عنصر
-      project_media_move_to: قام %{user} (%{role} في %{team}) بنقل عنصر إلى %{project}
-      project_media_added_to_list: قام %{user} (%{role} في %{team}) بإضافة عنصر إلى
-        مجلد %{list_name}
-      project_media_status: قام %{user} (%{role} في %{team}) بتغيير حالة %{workflow}
-        %{type}
-      project_media_assign: قام المستخدم %{user} (%{role} في %{team}) بتكليف %{type}
-      project_media_unassign: قام المستخدم %{user} (%{role} في %{team}) بإلغاء تكليف
-        %{type}
-      project_source_comment: قام %{user} (%{role} في %{team}) بإضافة ملحوظة الى %{parent_type}
-      project_source_create: قام %{user} (%{role} في %{team}) بإنشاء %{type}
-      project_source_update: قام %{user} (%{role} في %{team}) بتحرير %{type}
-      project_create: قام %{user} (%{role} في %{team}) بإنشاء مجلد
-      project_assign: قام المستخدم %{user} (%{role} في %{team}) بتعيين مجلد
-      project_unassign: قام المستخدم %{user} (%{role} في %{team}) بإلغاء تعيين مجلد
-      user_member: إنضم %{user} الى مساحة العمل %{team}
-      user_requested: طلب %{user} الانضمام الى مساحة العمل %{team}
-      user_invited: تمت دعوة %{user} الى مساحة العمل %{team}
-      user_banned: تم حظر %{user} من مساحة العمل %{team}
+      analysis_verification_status_status_changed: "قام%{user} بتغيير الحالة إلى: %{value}"
+      analysis_title_changed: "قام %{user} بتغيير عنوان التحليل إلى: %{value}"
+      analysis_content_changed: "قام %{user} بتغيير محتوى التحليل إلى: %{value}"
+      tasks_create: "قام %{user} بإضافة مهمة: %{title}"
+      tasks_edit: "قام %{user} بتحرير مهمة %{title}"
+      tasks_answer_create: "قام %{user} بإجابة مهمة %{title}: %{answer}"
+      tasks_answer_edit: "قام %{user} بتحرير إجابة مهمة %{title}: %{answer}"
+      metadata_create: "قام %{user} بإضافة حقل للبيانات الوصفيّة: %{title}"
+      metadata_edit: "قام %{user} بتحرير حقل في البيانات الوصفيّة %{title}"
+      metadata_answer_create: "قام %{user} بضبط قيمة في البيانات الوصفيّة %{title}: %{answer}"
+      metadata_answer_edit: "قام %{user} بتحرير قيمة في البيانات الوصفيّة %{title}: %{answer}"
+      project_media_comment: "قام %{user} (%{role} في %{team}) بإضافة ملحوظة الى %{parent_type}"
+      project_media_create: "قام %{user} (%{role} في %{team}) بإرسال عنصر جديد"
+      project_media_create_related: "قام %{user} (%{role} في %{team}) بإنشاء %{type} مرتبط"
+      project_media_update: "قام %{user} (%{role} في %{team}) بتحديث عنصر"
+      project_media_move_to: "قام %{user} (%{role} في %{team}) بنقل عنصر إلى %{project}"
+      project_media_added_to_list: "قام %{user} (%{role} في %{team}) بإضافة عنصر إلى مجلد %{list_name}"
+      project_media_status: "قام %{user} (%{role} في %{team}) بتغيير حالة %{workflow} %{type}"
+      project_media_assign: "قام المستخدم %{user} (%{role} في %{team}) بتكليف %{type}"
+      project_media_unassign: "قام المستخدم %{user} (%{role} في %{team}) بإلغاء تكليف %{type}"
+      project_source_comment: "قام %{user} (%{role} في %{team}) بإضافة ملحوظة الى %{parent_type}"
+      project_source_create: "قام %{user} (%{role} في %{team}) بإنشاء %{type}"
+      project_source_update: "قام %{user} (%{role} في %{team}) بتحرير %{type}"
+      project_create: "قام %{user} (%{role} في %{team}) بإنشاء مجلد"
+      project_assign: "قام المستخدم %{user} (%{role} في %{team}) بتعيين مجلد"
+      project_unassign: "قام المستخدم %{user} (%{role} في %{team}) بإلغاء تعيين مجلد"
+      user_member: "إنضم %{user} الى مساحة العمل %{team}"
+      user_requested: "طلب %{user} الانضمام الى مساحة العمل %{team}"
+      user_invited: "تمت دعوة %{user} الى مساحة العمل %{team}"
+      user_banned: "تم حظر %{user} من مساحة العمل %{team}"
   mail_view_welcome: مرحباً بكم في %{app_name}
-  mail_view_register: 'إنك على وشك الانتهاء من تسجيل حسابك على %{app_name}! يرجى تأكيد
-    بريدك الإلكتروني بالضّغط على الرّابط التالي:'
+  mail_view_register: 'إنك على وشك الانتهاء من تسجيل حسابك على %{app_name}! يرجى تأكيد بريدك الإلكتروني بالضّغط على الرّابط التالي:'
   mail_confirm_button: تأكيد الحساب
-  slack_restricted_join_to_members: عذراً، لا يمكنك الانضمام إلى %{team_name} حيث
-    أنه محصور على أعضاء مساحات عمل %{teams} على Slack.
+  slack_restricted_join_to_members: عذراً، لا يمكنك الانضمام إلى %{team_name} حيث أنه محصور على أعضاء مساحات عمل %{teams} على Slack.
   admin:
     actions:
       send_reset_password_email:
@@ -242,8 +225,7 @@ ar:
         menu: تكرار مساحة العمل
         done: تم التّكرار
         are_you_sure_you_want_to_copy_team:
-          html: هل تأكدت من رغبتك في تكرار مساحة العمل <strong>%{team}</strong>؟ سيتم
-            نسخ جميع البيانات المرتبطة كذلك.
+          html: هل تأكدت من رغبتك في تكرار مساحة العمل <strong>%{team}</strong>؟ سيتم نسخ جميع البيانات المرتبطة كذلك.
         the_team_is_being_copied: تكرار مساحة العمل جارٍ
         url_when_ready:
           html: فور جاهزيّتها ، ستكون مساحة العمل المُكررة متاحة في <strong>%{copy_url}</strong>
@@ -270,16 +252,16 @@ ar:
   role_: مسؤول النظام
   oembed_credit: تمت الإضافة بواسطة %{user} (%{role}) في %{date}
   oembed_notes_count:
-    zero: لا توجد ملحوظات
-    one: ملحوظة واحدة
-    two: ملحوظتان
+    zero: "لا توجد ملحوظات"
+    one: "ملحوظة واحدة"
+    two: "ملحوظتان"
     few: "%{count} ملحوظات"
     many: "%{count} ملحوظة"
     other: "%{count} ملحوظات "
   oembed_completed_tasks_count:
-    zero: لا توجد مهام مكتملة
-    one: مهمة مكتملة واحدة
-    two: مهمتان مكتملتان
+    zero: "لا توجد مهام مكتملة"
+    one: "مهمة مكتملة واحدة"
+    two: "مهمتان مكتملتان"
     few: "%{count} مهام مكتملة"
     many: "%{count} مهمة مكتملة"
     other: "%{count} مهام مكتملة"
@@ -289,16 +271,15 @@ ar:
   oembed_expand_all: توسيع الكل
   oembed_collapse_all: طيّ الكل
   oembed_resolved_tasks_count:
-    zero: لا توجد مهام مكتملة
-    one: مهمة واحدة مكتملة
-    two: مهمتان مكتملتان
+    zero: "لا توجد مهام مكتملة"
+    one: "مهمة واحدة مكتملة"
+    two: "مهمتان مكتملتان"
     few: "%{count} مهام مكتملة"
     many: "%{count} مهمة مكتملة"
     other: "%{count} المهمّات المكتملة"
   oembed_notes: ملحوظات
   duplicate_source: هذا المصدر موجود بالفعل
-  geolocation_invalid_value: الموقع غير صالح. المتوقع صيغة صالحة من نوع (/GeoJSON
-    (http://geojson.org
+  geolocation_invalid_value: الموقع غير صالح. المتوقع صيغة صالحة من نوع (/GeoJSON (http://geojson.org
   url_invalid_value: إن العنوان المُرسَل التالي غير صالح
   datetime_invalid_date: التاريخ غير صالح
   error_team_archived: عذراً، لا يمكن إضافة مجلد لمساحة عمل في سلة المهملات
@@ -308,50 +289,46 @@ ar:
   error_annotated_archived: عذراً ، لا يمكن إضافة تعليق لعنصر في سلة المهملات
   only_super_admin_can_do_this: عذراً ، هذه العملية متاحة لمسؤولي النظام فقط
   cant_change_custom_statuses: |-
-    عذرًا ، لا يمكن تعديل تعريفات الحالة لأن بعض الحالات قد تصبح مفقودة. مُعرّفات الحالة اﻵتية : %{statuses} قيد الاستخدام للعناصر التالية :
-    %{others_amount} %{urls}
+      عذرًا ، لا يمكن تعديل تعريفات الحالة لأن بعض الحالات قد تصبح مفقودة. مُعرّفات الحالة اﻵتية : %{statuses} قيد الاستخدام للعناصر التالية :
+      %{others_amount} %{urls}
   account_exists: هذا الحساب موجود بالفعل
   media_exists: هذا العنصر موجود بالفعل
   source_exists: هذا المصدر موجود بالفعل
-  email_exists: " مستخدم بالفعل"
-  banned_user: عذراً ، لقد تم حظرك من %{app_name}. يرجى التواصل مع فريق الدعم إن كان
-    هناك خطأ.
+  email_exists: ' مستخدم بالفعل'
+  banned_user: عذراً ، لقد تم حظرك من %{app_name}. يرجى التواصل مع فريق الدعم إن كان هناك خطأ.
   devise:
     mailer:
       reset_password_instructions:
-        subject: تعليمات إعادة ضبط كلمة السّر لِ %{app_name}
+        subject: "تعليمات إعادة ضبط كلمة السّر لِ %{app_name}"
         header_title: إعادة تعيين كلمة السّر
         header_text: لقد تلقينا طلبك لإعادة تعيين كلمة السّر لِ %{app_name}
         action: إعادة تعيين كلمة السّر
         expiry: مدة صلاحية الرابط %{expire} ساعات.
         instruction_1: يرجى الضغط هنا لتقديم طلب جديد.
-        instruction_2: إذا لم تقوموا بهذا الطّلب، أو كنتم تواجهون صعوبة في إعادة تعيين
-          كلمة السّر الخاصّة بكم ، يرجى الاتصال بنا على %{support_email}.
+        instruction_2: إذا لم تقوموا بهذا الطّلب، أو كنتم تواجهون صعوبة في إعادة تعيين كلمة السّر الخاصّة بكم ، يرجى الاتصال بنا على %{support_email}.
       invitation_instructions:
-        subject: لقد دعاك %{user} للانضمام إلى مساحة العمل %{team}
+        subject: "لقد دعاك %{user} للانضمام إلى مساحة العمل %{team}"
         hello: مرحباً %{name}
         someone_invited_you_default:
-          html: لديك دعوة من%{name} للانضمام إلى مساحة العمل %{team}بصفه %{role}.
+          html: "لديك دعوة من%{name} للانضمام إلى مساحة العمل %{team}بصفه %{role}."
         someone_invited_you_custom:
-          html: 'لديك دعوة من %{name} للانضمام إلى مساحة العمل %{team} بصفه %{role}:'
+          html: "لديك دعوة من %{name} للانضمام إلى مساحة العمل %{team} بصفه %{role}:"
         accept: قبول الدعوة
         accept_until: ستنتهي صلاحيّة هذه الدعوة  في %{due_date}.
         ignore: لرفض الدعوة ، يُمكنكم تجاهل هذه الرسالة.
-        app_team: مساحة العمل %{app}
+        app_team: "مساحة العمل %{app}"
     failure:
       unconfirmed: يرجى مراجعة بريدك الالكتروني لتأكيد حسابك.
   user_invitation:
-    invited: تمت دعوة %{email} لمساحة العمل هذه من قبل.
+    invited: "تمت دعوة %{email} لمساحة العمل هذه من قبل."
     member: "%{email} عضو بالفعل."
     team_found: مساحة العمل غير موجودة.
     invalid: رمز الدعوة غير صالح.
     no_invitation: لا توجد دعوة لمساحة العمل %{name}
-  error_user_is_not_a_team_member: عذراً، لا يمكن تعيين مهام لغير أعضاء مساحة العمل
-    هذه
-  error_login_with_exists_account: 'عذرًا ، هذا الحسب هذا مُستخدم من قبل مستخدم أو
-    مستخدمة آخرى  '
-  error_login_2fa: " يُرجى إكمال تسجيل الدخول بإضافة رمز المصادقة."
-  error_record_not_found: 'لم يتم العثور على %{type} #%{id} '
+  error_user_is_not_a_team_member: عذراً، لا يمكن تعيين مهام لغير أعضاء مساحة العمل هذه
+  error_login_with_exists_account: 'عذرًا ، هذا الحسب هذا مُستخدم من قبل مستخدم أو مستخدمة آخرى  '
+  error_login_2fa: ' يُرجى إكمال تسجيل الدخول بإضافة رمز المصادقة.'
+  error_record_not_found: "لم يتم العثور على %{type} #%{id} "
   mails_notifications:
     greeting: مرحباً يا %{username}،
     greeting_anonymous: مرحباً !
@@ -362,33 +339,32 @@ ar:
     register:
       subject: حساب جديد لك على %{app_name}
       header_text: |-
-        تم التسجيل بنجاح على %{app_name}
-        <br>
-        للدخول على الموقع يجب اتباع هذا الرابط : %{url}. و إدخال الإيميل وكلمة السر: %{password}
+          تم التسجيل بنجاح على %{app_name}
+          <br>
+          للدخول على الموقع يجب اتباع هذا الرابط : %{url}. و إدخال الإيميل وكلمة السر: %{password}
       login_button: الدخول إلى %{app_name}
       footer_text: شكراً على انضمامكم ونتمنى لكم يوما جيداً!
     duplicated:
       subject: 'كيفية تسجيل دخولك على %{app_name} '
       header_title: حساب مُكَرَّر
       one_email: |-
-        <p> نود أن نذكركم ونساعدكم في تسجيل الدخول على %{app_name}.</p>
-        <p>ما الذي جرى؟ لقد حاولتم تسجيل الدّخول على %{app_name} باستخدام  %{user_provider} المرتبط بِ %{user_email}.
-        ولكن البريد الإلكتروني مرتبط أيضاً بحساب آخر على %{duplicate_provider} في %{app_name}.</p>
-        <p>ما الذي يمكنكم فعله الآن؟ قوموا بتسجيل الدخول باستخدام  %{duplicate_provider}.</p>
-        <p> بذلك، سيتم تسجيل دخولكم بذات الحساب الذي كنتم تستخدمونه من قبل. للمساعدة راسلونا على %{support_email}.</p>
+          <p> نود أن نذكركم ونساعدكم في تسجيل الدخول على %{app_name}.</p>
+          <p>ما الذي جرى؟ لقد حاولتم تسجيل الدّخول على %{app_name} باستخدام  %{user_provider} المرتبط بِ %{user_email}.
+          ولكن البريد الإلكتروني مرتبط أيضاً بحساب آخر على %{duplicate_provider} في %{app_name}.</p>
+          <p>ما الذي يمكنكم فعله الآن؟ قوموا بتسجيل الدخول باستخدام  %{duplicate_provider}.</p>
+          <p> بذلك، سيتم تسجيل دخولكم بذات الحساب الذي كنتم تستخدمونه من قبل. للمساعدة راسلونا على %{support_email}.</p>
       both_emails: |-
-        <p>نود تذكيركم ومساعدتكم  في تسجيل الدخول على %{app_name}.</p>
-        <p> لقد حاولت تسجيل حساب جديد على %{app_name} باستخدام بريد إلكتروني مسجّل مُسبقاً.</p>
-        <p>حاولوا تسجيل الدّخول باستخدام البريد الإلكتروني وكلمة المرور بدلاً من إنشاء حساب جديد.</p>
-        <p>بذلك سيتم الدّخول باستخدام نفس الحساب المسجل سابقاً. للمزيد من المساعدة راسلونا على %{support_email}.</p>
+          <p>نود تذكيركم ومساعدتكم  في تسجيل الدخول على %{app_name}.</p>
+          <p> لقد حاولت تسجيل حساب جديد على %{app_name} باستخدام بريد إلكتروني مسجّل مُسبقاً.</p>
+          <p>حاولوا تسجيل الدّخول باستخدام البريد الإلكتروني وكلمة المرور بدلاً من إنشاء حساب جديد.</p>
+          <p>بذلك سيتم الدّخول باستخدام نفس الحساب المسجل سابقاً. للمزيد من المساعدة راسلونا على %{support_email}.</p>
       email: البريد الإلكتروني
     invitation:
       title: دعوة جديدة
     delete_user:
       subject: "[%{team}] تم حذف مستخدم"
       header_title: تم حذف المستخدم/ة
-      header_text: لقد حُذف حساب مستخدم ثم أعيد تخصيص المستخدم %{anonymous} ليتكلف
-        بمحتواه ومُعرِّفه %{id}
+      header_text: لقد حُذف حساب مستخدم ثم أعيد تخصيص المستخدم %{anonymous} ليتكلف بمحتواه ومُعرِّفه %{id}
       anonymous: مجهول/ة
     admin_mailer:
       team_download_subject: "[%{team}] لقطة بيانات مساحة العمل جاهزة للتحميل"
@@ -397,22 +373,17 @@ ar:
         dump: لقطة للبيانات
         csv: تقرير
         images: أرشيف الصور
-      team_dump_text: 'لقد طلبت لقطة للبيانات في مساحة العمل %{team} - لتحميلها يمكنكم
-        استخدام الرابط : %{link}'
+      team_dump_text: 'لقد طلبت لقطة للبيانات في مساحة العمل %{team} - لتحميلها يمكنكم استخدام الرابط : %{link}'
       team_dump_button: تحميل بيانات مساحة العمل
-      decompress_text: سوف يتم تنزيل %{type} كملف مضغوط ومشفر. لفك الضغط ، الرجاء
-        استخدام كلمة السّر %{password}
+      decompress_text: سوف يتم تنزيل %{type} كملف مضغوط ومشفر. لفك الضغط ، الرجاء استخدام كلمة السّر %{password}
       expire_note: ستنتهي صلاحية هذا الرابط بعد %{days} أيام.
       team_import_subject: تمت عملية استيراد البيانات
       team_import_title: استيراد البيانات
-      team_import_text: "<p>تمت عملية استيراد البيانات إلى %{app_name}. يمكنكم فحص
-        %{worksheet_url} لمراجعة الحالة لكل عنصر قبل استيراده.</p><p>يمكنكم إعادة
-        الاستيراد بعد تصحيح أي أخطاء موجودة هنا - لن يتم تكرار العناصر التي سبق استيرادها.</p>"
+      team_import_text: "<p>تمت عملية استيراد البيانات إلى %{app_name}. يمكنكم فحص %{worksheet_url} لمراجعة الحالة لكل عنصر قبل استيراده.</p><p>يمكنكم إعادة الاستيراد بعد تصحيح أي أخطاء موجودة هنا - لن يتم تكرار العناصر التي سبق استيرادها.</p>"
     task_resolved:
       subject: "[%{team} - %{project}] تمت اجابة مهمة"
       header_title: تمت الإجابة عن المهمّة
-      header_text: لقد أُجيب عن مهمة في المجلد %{project}، التابع لـ %{team}، من طرف
-        %{author}.
+      header_text: "لقد أُجيب عن مهمة في المجلد %{project}، التابع لـ %{team}، من طرف %{author}."
       section_title: من أو ما هو مصدر العنصر؟
       status: الحالة
       media_h: العنصر
@@ -420,8 +391,7 @@ ar:
       label: العنصر
       subject: "[%{team} - %{project}] تم تصنيف حالة العنصر أنه %{status}"
       header_title: تم تحديث حالة العنصر
-      header_text: لقد حُدثَت حالة عنصر في المجلد %{project}، التابع لـ %{team}، من
-        طرف %{author}.
+      header_text: "لقد حُدثَت حالة عنصر في المجلد %{project}، التابع لـ %{team}، من طرف %{author}."
       section_title: تم التصنيف أنه %{status}.
       added_to: تمت الإضافة الى %{app_name}
       update_h: آخر تحديث
@@ -435,24 +405,18 @@ ar:
       unassign_media_subject: "[%{team} - %{project}] تم إلغاء تخصيصك بعنصر"
       assign_project_title: المجلد المُخصَّص
       unassign_project_title: لا أحد مكلف بالمجلد
-      assign_project_text: قام المؤلف %{author} بتخصيص المجلد %{project} التابع لـ
-        %{team}.
-      unassign_project_text: قام المؤلف %{author} بإلغاء تخصيص المجلد %{project} التابع
-        لـ %{team}.
+      assign_project_text: "قام المؤلف %{author} بتخصيص المجلد %{project} التابع لـ %{team}."
+      unassign_project_text: "قام المؤلف %{author} بإلغاء تخصيص المجلد %{project} التابع لـ %{team}."
       assign_task_title: تخصيص مهمة
       unassign_task_title: مهمة غير مُخصَّصة
-      assign_task_text: قام المؤلف %{author} بتعيين مهمة في المجلد %{project} التابع
-        لـ %{team}.
-      unassign_task_text: قام المؤلف %{author} بإلغاء تعيين مهمة في المجلد %{project}
-        التابع لـ %{team}.
+      assign_task_text: "قام المؤلف %{author} بتعيين مهمة في المجلد %{project} التابع لـ %{team}."
+      unassign_task_text: "قام المؤلف %{author} بإلغاء تعيين مهمة في المجلد %{project} التابع لـ %{team}."
       assign_media_title: العنصر المُخصَّص
       unassign_media_title: تمّ إلغاء تخصيص العنصر
-      assign_media_text: قام المؤلف %{author} بتخصيص عنصر في مجلد %{project} التابع
-        لـ %{team}.
-      unassign_media_text: قام المؤلف %{author} بإلغاء تخصيص عنصر في المجلد %{project}
-        التابع لـ %{team}.
-      assign_log: قام المؤلف %{author} بتخصيص %{model} لـ %{username}
-      unassign_log: قام المؤلف %{author} بإلغاء تخصيص %{model} عن %{username}
+      assign_media_text: "قام المؤلف %{author} بتخصيص عنصر في مجلد %{project} التابع لـ %{team}."
+      unassign_media_text: "قام المؤلف %{author} بإلغاء تخصيص عنصر في المجلد %{project} التابع لـ %{team}."
+      assign_log: "قام المؤلف %{author} بتخصيص %{model} لـ %{username}"
+      unassign_log: "قام المؤلف %{author} بإلغاء تخصيص %{model} عن %{username}"
       assign_by: عُيِّن من طرف
       unassign_by: لقد أُلغِي التخصيص من طرف
       project_button: العودة إلى صفحة المجلد
@@ -463,14 +427,11 @@ ar:
       rejected_subject: لم تتم الموافقة على طلبك للإنضمام إلى %{team}
       approved_subject: مرحباً بك في مساحة العمل %{team}
       request_title: طلب انضمام إلى مساحة العمل %{team}
-      request_text: "%{name} (%{email}) يريدون الإنضمام إلى مساحة العمل %{team} عبر
-        %{app_name}. يمكنكم معالجة هذا الطلب بالضغط على الرابط %{url}."
+      request_text: "%{name} (%{email}) يريدون الإنضمام إلى مساحة العمل %{team} عبر %{app_name}. يمكنكم معالجة هذا الطلب بالضغط على الرابط %{url}."
       approved_title: مرحبًا بك في مساحة العمل %{team}
-      approved_text: تمت الموافقة على طلب انضمامكم إلى مساحة عمل %{team} على%{app_name}.
-        يمكنكم الآن الذهاب إلى %{url} والبدء في المساهمة!
+      approved_text: تمت الموافقة على طلب انضمامكم إلى مساحة عمل %{team} على%{app_name}. يمكنكم الآن الذهاب إلى %{url} والبدء في المساهمة!
       rejected_title: تم رفض الطلب
-      rejected_text: عذراً ، لم تتم الموافقة على طلبك للإنضمام إلى مساحة العمل %{team}على
-        %{app_name} .
+      rejected_text: عذراً ، لم تتم الموافقة على طلبك للإنضمام إلى مساحة العمل %{team}على %{app_name} .
   mail_security:
     device_subject: 'تنبيه: تسجيل دخول جديد على %{app_name} عبر %{browser} على %{platform}'
     ip_subject: 'تنبيه: هناك تسجيل دخول جديد أو غير اعتيادي على %{app_name}'
@@ -480,12 +441,9 @@ ar:
     devise_name: "%{browser} على %{platform}"
     failed: تم اكتشاف محاولات فاشلة لتسجيل الدخول
     password_text: 'يرجى إعادة تعيين كلمة السّر الخاصة بكم فوراً '
-    device_text: يبدو أنك سجلت الدخول مؤخرًا إلى حسابك على %{app_name} من جهاز جديد.
-      إن لم يكن كذلك، مِن اﻷفضل %{change_password}
-    ip_text: يبدو أنك سجلت الدخول مؤخرًا إلى حسابك على %{app_name} من موقع جديد. إن
-      لم يكن كذلك، مِن اﻷفضل  %{change_password}
-    failed_text: يبدو أنّكم أجريتم محاولات متعددة لتسجيل الدخول إلى %{app_name}. إذا
-      كنت أنت ، تجاهلي الرسالة. لست أنت؟ ننصحكم بتغيير كلمة السِّر. %{change_password}
+    device_text: يبدو أنك سجلت الدخول مؤخرًا إلى حسابك على %{app_name} من جهاز جديد. إن لم يكن كذلك، مِن اﻷفضل %{change_password}
+    ip_text: يبدو أنك سجلت الدخول مؤخرًا إلى حسابك على %{app_name} من موقع جديد. إن لم يكن كذلك، مِن اﻷفضل  %{change_password}
+    failed_text: يبدو أنّكم أجريتم محاولات متعددة لتسجيل الدخول إلى %{app_name}. إذا كنت أنت ، تجاهلي الرسالة. لست أنت؟ ننصحكم بتغيير كلمة السِّر. %{change_password}
     time_h: الوقت
     device_h: الجهاز
     location_h: الموقع
@@ -499,54 +457,46 @@ ar:
   archive_keep_backup: خزنة الفيديوهات
   archive_pender_archive: لقطة للشاشة
   archive_archive_org: Archive.org
-  workflow_status_is_not_valid: 'حالة غير صالحة: ''%{status}'' (يجب أن تكون واحدة
-    من %{valid})'
+  workflow_status_is_not_valid: 'حالة غير صالحة: ''%{status}'' (يجب أن تكون واحدة من %{valid})'
   workflow_status_permission_error: عذراً ، لا يمكنكم تغيير هذه الحالة.
-  blank_default_status_for_custom_verification_status: يرجى إضافة قيمة افتراضية لحالات
-    التحقق الخاصة
-  blank_active_status_for_custom_verification_status: يرجى أضافة قيمة فعّالة لحالات
-    التحقق الخاصة
+  blank_default_status_for_custom_verification_status: يرجى إضافة قيمة افتراضية لحالات التحقق الخاصة
+  blank_active_status_for_custom_verification_status: يرجى أضافة قيمة فعّالة لحالات التحقق الخاصة
   bot_name_exists_for_this_team: هناك بوت آخر بنفس الاسم في مساحة العمل هذه
   bot_team_id_doesnt_exist: عذراً ، لا توجد مساحة عمل بهذا المُعَرِّف
   bot_team_id_mandatory_to_create: عذراً ، يجب اختيار مساحة العمل قبل إضافة بوت
-  bot_not_approved_for_installation: عذراً ، لا يمكن تثبيت هذا البوت ﻷنه لم تتم الموافقة
-    عليه
+  bot_not_approved_for_installation: عذراً ، لا يمكن تثبيت هذا البوت ﻷنه لم تتم الموافقة عليه
+  only_admins_can_approve_or_list_bots: عذراً ، إن الموافقة على أي بوت أو استعراضه متاحة فقط لمسؤولي النظام
   could_not_save_related_bot_data: عذراً ، لم نتمكّن من إضافة البوت لمساحة العمل هذه
-  bot_cant_add_response_to_task: 'عذراً، لا يمكن للبوت الإجابة عن مهمّة بشكل مباشر
-    - ولكن، يمكن إرسال اقتراح ﻹجابة '
+  bot_cant_add_response_to_task: 'عذراً، لا يمكن للبوت الإجابة عن مهمّة بشكل مباشر - ولكن، يمكن إرسال اقتراح ﻹجابة '
   bot_cant_add_review_to_task: عذراً ، لا يمكن البوت مراجعة أي مهام
-  task_suggestion_invalid_value: اقتراح المهمة غير صالح. المتوقع JSON  متضمنا `suggestion`
-    (سيتم نسخ القيمه الفعلية إلى إجابة المهمّة حين يتم القبول) و `comment` (يتم إظهاره
-    للمستخدمين)
+  task_suggestion_invalid_value: اقتراح المهمة غير صالح. المتوقع JSON  متضمنا `suggestion` (سيتم نسخ القيمه الفعلية إلى إجابة المهمّة حين يتم القبول) و `comment` (يتم إظهاره للمستخدمين)
   tag_text_id_not_found: الوسم غير موجود
   annotation_type_language_label: اللغة
   smooch_bot_message_confirmed: |-
-    شكراً. لقد أضيف طلبك إلى قائمة انتظار التحقق.
+      شكراً. لقد أضيف طلبك إلى قائمة انتظار التحقق.
 
-    سنحاول إرسال تقرير إليك خلال 24 ساعة، لكن أعذرونا لأننا لا نستطيع الرّد على كل طلب.
+      سنحاول إرسال تقرير إليك خلال 24 ساعة، لكن أعذرونا لأننا لا نستطيع الرّد على كل طلب.
   smooch_bot_message_unconfirmed: نظراً لعدم ردّكم  بـ 1 ، لن نقوم بمعالجة طلبك. شكراً.
   smooch_bot_message_type_unsupported: عذرًا ، لا ندعم هذا النوع من الرسائل.
   smooch_bot_message_size_unsupported: عذراً ، لا ندعم ملفات أكبر من %{max_size}.
   smooch_bot_result: |-
-    [تقرير التحقّق] تمّ تصنيف العنصر الذي أرسلته لنا أنه *%{status}*.
+      [تقرير التحقّق] تمّ تصنيف العنصر الذي أرسلته لنا أنه *%{status}*.
 
-    فيما يلي الخطوات التي اتخذناها لتحديد ذلك : %{url}
+      فيما يلي الخطوات التي اتخذناها لتحديد ذلك : %{url}
   smooch_bot_ask_for_confirmation: |-
-    شكراً لإرسالكم هذا الطلب. هل تودون منّا التحقق من صحة محتواه ؟
+      شكراً لإرسالكم هذا الطلب. هل تودون منّا التحقق من صحة محتواه ؟
 
-    للاجابة بِ نعم ، * الرّجاء الرّد بـ 1 *. أي رد آخر سينهي المحادثة.
+      للاجابة بِ نعم ، * الرّجاء الرّد بـ 1 *. أي رد آخر سينهي المحادثة.
   smooch_bot_ask_for_tos: |-
-    شكرا لتواصلكم مع Check Message !
+      شكرا لتواصلكم مع Check Message !
 
-    يمكنكم استخدام هذه الخدمة لطلب التحقق من الأخبار والمعلومات. Check Message متوفر لكم بموجب شروط الخدمة التالية: %{tos}. استمراركم باستخدام هذه الخدمة ، *يعني موافقتكم على الالتزام بهذه الشروط*. إذا لم توافقوا على ذلك، بإمكانكم التوقف عن استخدام Check Message.
-  smooch_bot_window_closing: إن حجم الطلبات مرتفع للغاية ، ولم نتمكن من معالجة طلبك
-    بعد. شكراً على الانتظار.
+      يمكنكم استخدام هذه الخدمة لطلب التحقق من الأخبار والمعلومات. Check Message متوفر لكم بموجب شروط الخدمة التالية: %{tos}. استمراركم باستخدام هذه الخدمة ، *يعني موافقتكم على الالتزام بهذه الشروط*. إذا لم توافقوا على ذلك، بإمكانكم التوقف عن استخدام Check Message.
+  smooch_bot_window_closing: إن حجم الطلبات مرتفع للغاية ، ولم نتمكن من معالجة طلبك بعد. شكراً على الانتظار.
   smooch_bot_not_final: |-
-    [تقرير التحقق - تصحيح] لقد حدث خطأ في تصنيف العنصر الذي أرسلته لنا على أنه *%{status}*.
+      [تقرير التحقق - تصحيح] لقد حدث خطأ في تصنيف العنصر الذي أرسلته لنا على أنه *%{status}*.
 
-    ما زال العنصر في قائمة اﻹنتظار للمزيد من التحقق.
-  smooch_bot_disabled: شكرا على هذه الرسالة. لا نستطيع الرّد بأي من تقارير التحقق
-    ، حيث أن هذا المشروع لم يعد نشطاً.
+      ما زال العنصر في قائمة اﻹنتظار للمزيد من التحقق.
+  smooch_bot_disabled: شكرا على هذه الرسالة. لا نستطيع الرّد بأي من تقارير التحقق ، حيث أن هذا المشروع لم يعد نشطاً.
   smooch_bot_result_changed: "❗️تم *تحديث* تقصي الحقائق الذي أرسلناه لك بمعلومات جديدة"
   permissions_info:
     roles:
@@ -555,8 +505,7 @@ ar:
       editor:
         description: يدير المحرّرون مساحة العمل والمجلدات.
       collaborator:
-        description: بإمكان الشركاء إضافة عناصر جديدة للتحقق منها. وهم في الغالب من
-          الجمهور.
+        description: بإمكان الشركاء إضافة عناصر جديدة للتحقق منها. وهم في الغالب من الجمهور.
     permissions:
       sections:
         project_management:
@@ -595,20 +544,16 @@ ar:
             edit_tasks: إنشاء وتحرير مهام مساحة العمل
             roles: تحرير الأدوار فى مساحة العمل
             third_party: إضافة التكامل مع أطراف ثالثة
-            invite_admin: 'دعوة المسؤولين على مساحة العمل أو الموافقة علبهم أو إزالتهم
-              منها '
+            invite_admin: 'دعوة المسؤولين على مساحة العمل أو الموافقة علبهم أو إزالتهم منها '
             invite_members: دعوة أعضاء مساحة العمل، الموافقة عليهم، أو إزالتهم
   team_clone:
     user_not_authorized: للأسف، لا يُسمَح لك تكرار هذا الفريق.
   team_import:
     invalid_google_spreadsheet_url: رابط جدول البيانات غير صالح %{spreadsheet_url}
     not_found_google_spreadsheet_url: جدول البيانات غير موجود في %{spreadsheet_url}
-    cannot_authenticate_with_the_credentials: لا يمكن المصادقة على Google Drive ببيانات
-      المرور الحالية. يرجى تبليغ فريق الدعم عن هذه الحادثة.
-    team_not_present: لم يتم العثور على مساحة العمل الحالية أثناء استيراد البيانات.
-      يرجى تبليغ فريق الدعم عن هذه الحادثة.
-    user_not_present: لم يتم العثور على المستخدم(ة) الحالي(ة) أثناء استيراد البيانات.
-      يرجى تبليغ فريق الدعم عن هذه الحادثة.
+    cannot_authenticate_with_the_credentials: لا يمكن المصادقة على Google Drive ببيانات المرور الحالية. يرجى تبليغ فريق الدعم عن هذه الحادثة.
+    team_not_present: لم يتم العثور على مساحة العمل الحالية أثناء استيراد البيانات. يرجى تبليغ فريق الدعم عن هذه الحادثة.
+    user_not_present: لم يتم العثور على المستخدم(ة) الحالي(ة) أثناء استيراد البيانات. يرجى تبليغ فريق الدعم عن هذه الحادثة.
     user_not_authorized: عذراً ، لا يُسمَح لك باستيراد البيانات لمساحة العمل هذه.
     invalid_project: مجلد غير صالح %{project}
     invalid_user: المؤلف غير صالح %{user}
@@ -618,8 +563,7 @@ ar:
     blank_project: حقل المجلد الفارغ غير صالح
     invalid_annotator: المُعقِّب غير صالح %{user}
     invalid_assignee: مُكلّف غير صالح %{user}
-  cant_mutate_inactive_object: عذرًا ، هناك عملية جارية لهذا العنصر ، لذا لا يمكنكم
-    تغييره الآن. الرجاء إعادة المحاولة لاحقاً.
+  cant_mutate_inactive_object: عذرًا ، هناك عملية جارية لهذا العنصر ، لذا لا يمكنكم تغييره الآن. الرجاء إعادة المحاولة لاحقاً.
   embed_expand_all: توسيع الكل
   embed_collapse_all: طيّ الكل
   embed_tasks: المهام
@@ -632,17 +576,16 @@ ar:
   smooch_requests_desc: اﻷكثر طلباً
   bot_request_url_invalid: رابط البوت غير صالح
   smooch_facebook_success: |
-    تم بنجاح!
-    أصبح خطك الساخن (Tipline) متصلا اﻵن بمِرْسال فيسبوك Facebook Messenger.
-    سيقوم خط الساخن بمعالجة أي رسالة مُستلَمة من صفحة فيسبوك هذه.
-    يرجى إعادة تحميل صفحة إعدادات الخط الساخن لمشاهدة التغييرات الجديدة.
+      تم بنجاح!
+      أصبح خطك الساخن (Tipline) متصلا اﻵن بمِرْسال فيسبوك Facebook Messenger.
+      سيقوم خط الساخن بمعالجة أي رسالة مُستلَمة من صفحة فيسبوك هذه.
+      يرجى إعادة تحميل صفحة إعدادات الخط الساخن لمشاهدة التغييرات الجديدة.
   smooch_twitter_success: |
-    تم بنجاح!
-    لقد أصبح خطك الساخن  (Tipline) الآن متصلا بتويتر.
-    سيقوم الخط الساخن بمعالجة أي رسالة مباشرة جرى استلامها انطلاقا من حساب تويتر هذا.
-    يرجى إعادة تحميل صفحة إعدادات الخط الساخن لمشاهدة التغييرات الجديدة.
-  must_select_exactly_one_facebook_page: يُرجى تحديد صفحة واحدة من فيسبوك لكي يتم
-    وصلها بالخط الساخن (Tipline).
+      تم بنجاح!
+      لقد أصبح خطك الساخن  (Tipline) الآن متصلا بتويتر.
+      سيقوم الخط الساخن بمعالجة أي رسالة مباشرة جرى استلامها انطلاقا من حساب تويتر هذا.
+      يرجى إعادة تحميل صفحة إعدادات الخط الساخن لمشاهدة التغييرات الجديدة.
+  must_select_exactly_one_facebook_page: يُرجى تحديد صفحة واحدة من فيسبوك لكي يتم وصلها بالخط الساخن (Tipline).
   invalid_task_answer: تنسيق إجابة المهمة غير صالح
   team_rule_name: اسم فريد يصف ما تفعله القاعدة
   team_rule_project_ids: تطبيق على المجلد
@@ -652,8 +595,7 @@ ar:
   team_rule_conditions: إذا
   team_rule_condition: إذا
   team_rule_condition_definition: تحديد الشرط
-  team_rule_has_less_than_x_words: يتضمن نص الطلب بالضبط عدد الكلمات التالية (أو عددا
-    أقل منها)
+  team_rule_has_less_than_x_words: يتضمن نص الطلب بالضبط عدد الكلمات التالية (أو عددا أقل منها)
   team_rule_title_matches_regexp: عنوان العنصر يوافق التعبير القياسي الآتي
   team_rule_request_matches_regexp: الطلب يوافق التعبير القياسي الآتي
   team_rule_type_is: نوع العنصر هو
@@ -661,10 +603,8 @@ ar:
   team_rule_type_is_link: رابط
   team_rule_type_is_uploadedimage: صورة
   team_rule_type_is_uploadedvideo: فيديو
-  team_rule_contains_keyword: الطلب يحتوي على كلمة واحدة على الأقل من الكلمات المفتاحيّة
-    اﻵتية
-  team_rule_title_contains_keyword: يضم المحتوى كلمة أو أكثر من الكلمات المفتاحية
-    التالية
+  team_rule_contains_keyword: الطلب يحتوي على كلمة واحدة على الأقل من الكلمات المفتاحيّة اﻵتية
+  team_rule_title_contains_keyword: يضم المحتوى كلمة أو أكثر من الكلمات المفتاحية التالية
   team_rule_extracted_text_contains_keyword: النص المستخلص يتضمن كلمة مفتاحية
   team_rule_select_type: تحديد النوع
   team_rule_select_language: تحديد اللغة
@@ -706,10 +646,8 @@ ar:
   team_rule_item_is_read: 'تمت قراءة العنصر '
   team_rule_field_from_fieldset_tasks_value_is: المهمة لها إجابة محددة
   team_rule_field_from_fieldset_metadata_value_is: التعقيب له قيمة محددة
-  team_rule_field_from_fieldset_tasks_value_contains_keyword: إجابة المهمة تتضمن كلمة
-    مفتاحية
-  team_rule_field_from_fieldset_metadata_value_contains_keyword: قيمة التعقيب تتضمن
-    كلمة مفتاحية
+  team_rule_field_from_fieldset_tasks_value_contains_keyword: إجابة المهمة تتضمن كلمة مفتاحية
+  team_rule_field_from_fieldset_metadata_value_contains_keyword: قيمة التعقيب تتضمن كلمة مفتاحية
   team_rule_select_field_metadata: تحديد التعقيب
   team_rule_select_field_value_metadata: تحديد القيمة
   team_rule_select_field_tasks: اختيار مهمة
@@ -733,28 +671,21 @@ ar:
   flag_likelihood_5: عالي (سيجري الكشف عن محتوى أكثر)
   flag_likelihood_7: يدوي
   relationship_not_same_team: يجب أن تكون العناصر ذات الصلة  في مساحة العمل ذاتها
+  item_cant_be_related_to_itself: "لا يمكن أن يرتبط العنصر بنفسه"
   target_is_published: لا يمكن أن يكون للمستهدف تقرير منشور
   similar_item_exists: عذرا، لقد أضيف بالفعل هذا العنصر على أنه عنصر مشابه.
-  bulk_operation_limit_error: عذراً، الحد الأقصى لعدد العناصر التى يمكن معالجتها في
-    آنِ واحد هو %{limit}
-  must_provide_fallback_when_deleting_status_in_use: هذه الحالة مستخدمة حاليّاً، لِحذفها،
-    يرجى تقديم حالة احتياطية
-  embed_no_content_yet: إنشاء التقرير جار. قد تستغرق هذه العملية بضع دقائق. يرجى إعادة
-    تحميل الصفحة.
+  bulk_operation_limit_error: عذراً، الحد الأقصى لعدد العناصر التى يمكن معالجتها في آنِ واحد هو %{limit}
+  must_provide_fallback_when_deleting_status_in_use: هذه الحالة مستخدمة حاليّاً، لِحذفها، يرجى تقديم حالة احتياطية
+  embed_no_content_yet: إنشاء التقرير جار. قد تستغرق هذه العملية بضع دقائق. يرجى إعادة تحميل الصفحة.
   language_format_invalid: تنسيق اللغة غير صالح. يجب أن تكون بالترميز  ISO 639-1.
-  languages_format_invalid: تنسيق اللغات غير صالح. يجب أن تكون على شكل قائمة بالترميز
-    ISO 639-1
-  cant_change_status_if_item_is_published: عذراً ، لا يمكن تغيير الحالة بينما التقرير
-    منشور
+  languages_format_invalid: تنسيق اللغات غير صالح. يجب أن تكون على شكل قائمة بالترميز ISO 639-1
+  cant_change_status_if_item_is_published: عذراً ، لا يمكن تغيير الحالة بينما التقرير منشور
   fetch_bot_service_unsupported: الخدمة غير مدعومة
   task_options_must_be_array: خيارات المهمة يجب أن تكون على شكل قائمة
   fieldset_not_defined_by_team: يجب أن تكون مجموعة الحقول مدعومة من قبل مساحة العمل
-  cant_change_field_type_or_options_when_answered: لا يمكن تغيير نوع الحقل لأنه قد
-    مُليءَ من قبل ببعض الإجابات.
-  replace_by_media_in_the_same_team: عذراً، لا يمكن استبدال هذا العنصر إلا بآخر من
-    نفس مساحة العمل
-  replace_blank_media_only: 'عذراً، في الوقت الحالي لا يمكنكم إلّا استبدال العناصر
-    الخالية  '
+  cant_change_field_type_or_options_when_answered: لا يمكن تغيير نوع الحقل لأنه قد مُليءَ من قبل ببعض الإجابات.
+  replace_by_media_in_the_same_team: عذراً، لا يمكن استبدال هذا العنصر إلا بآخر من نفس مساحة العمل
+  replace_blank_media_only: 'عذراً، في الوقت الحالي لا يمكنكم إلّا استبدال العناصر الخالية  '
   cant_preview_rss_feed: عذراً، لا يوجد عندك تصريح لمعاينة موجز RSS.
   list_column_demand: الطلبات
   list_column_share_count: مشاركات فيسبوك
@@ -772,53 +703,48 @@ ar:
   list_column_published_by: تم نشر التقرير بواسطة
   list_column_fact_check_published_on: لقد نُشر التقصي من الحقيقة بتاريخ
   list_column_related_count: ذات صلة
+  list_column_suggestions_count: الاقتراحات
   list_column_folder: مجلد
   list_column_creator_name: تم الإنشاء بواسطة
   list_column_fact_check_title: تقصي الحقائق
   list_column_team_name: مساحة العمل
   list_column_sources_as_sentence: المصدر
   go_back_to_check: العودة إلى Check
-  project_cant_have_children_if_has_parent: يوجد هذا المجلد ضمن مجلد آخر، لذا لا يمكن
-    أن يحوي مجلدا بداخله
+  project_cant_have_children_if_has_parent: يوجد هذا المجلد ضمن مجلد آخر، لذا لا يمكن أن يحوي مجلدا بداخله
   project_group_must_be_under_same_team: يجب أن تكون المجموعة ضمن نفس مساحة العمل
   unique_default_folder_per_team: يجب أن تحتوي مساحة العمل على مجلد افتراضي واحد
-  center_is_not_part_of_another_cluster: لا يمكن أن يكون مركز هذا التجمع جزءا من تجمع
-    آخر
+  center_is_not_part_of_another_cluster: لا يمكن أن يكون مركز هذا التجمع جزءا من تجمع آخر
   smooch_bot_message_subscribed: |-
-    لقد اشتركت الآن.
+      لقد اشتركت الآن.
 
-    *يُرجى إرسال 0* للعودة إلى القائمة الرئيسية.
+      *يُرجى إرسال 0* للعودة إلى القائمة الرئيسية.
   smooch_bot_message_unsubscribed: |-
-    تم إلغاء اشتراكك.
+      تم إلغاء اشتراكك.
 
-    *يُرجى إرسال 0* للعودة إلى القائمة الرئيسية.
+      *يُرجى إرسال 0* للعودة إلى القائمة الرئيسية.
   subscribe: اشتراك
   unsubscribe: إلغاء الاشتراك
   smooch_message_subscription_header_subscribed: أنت حاليا *مشترك* في رسالتنا الإخبارية.
-  smooch_message_subscription_header_unsubscribed: أنت حاليا *غير مشترك* في رسالتنا
-    الإخبارية.
+  smooch_message_subscription_header_unsubscribed: أنت حاليا *غير مشترك* في رسالتنا الإخبارية.
   smooch_bot_message_newsletter_fallback: |-
-    أهلا! إليك النشرة الجامعة الأسبوعية.
+      أهلا! إليك النشرة الجامعة الأسبوعية.
 
-    هذه الرسالة الإخبارية قد تم نشرها على %{platform} بواسطة %{team}. إليك أهم الحقائق للأسبوع %{date}:
+      هذه الرسالة الإخبارية قد تم نشرها على %{platform} بواسطة %{team}. إليك أهم الحقائق للأسبوع %{date}:
 
-    %{content}
+      %{content}
 
-    لإلغاء الاشتراك في هذه النشرة، يُرجى كتابة "%{unsubscribe}".
+      لإلغاء الاشتراك في هذه النشرة، يُرجى كتابة "%{unsubscribe}".
+  send_every_must_be_a_list_of_days_of_the_week: يجب أن تكون قائمة أيام الأسبوع.
+  send_on_must_be_in_the_future: لا يمكن أن تكون في الماضي.
   info:
     messages:
-      sent_to_trash_by_rule: أُرسِل "%{item_title}" إلى المهملات بواسطة قاعدة آلية.
-      moved_to_project_by_rule: نُقل "%{item_title}" إلى المجلد "[%{list_name}](%{list_link})"
-        بواسطة قاعدة آلية.
+      sent_to_trash_by_rule: 'أُرسِل "%{item_title}" إلى المهملات بواسطة قاعدة آلية.'
+      moved_to_project_by_rule: 'نُقل "%{item_title}" إلى المجلد "[%{list_name}](%{list_link})" بواسطة قاعدة آلية.'
       banned_submitter_by_rule: لقد تم منع طالب "%{item_title}" بواسطة قاعدة آلية.
-      copied_to_project_by_rule: نُسخ "%{item_title}" إلى المجلد "[%{list_name}](%{list_link})"
-        بواسطة قاعدة آلية.
-      related_to_confirmed_similar: لقد تم تأكيد أن "%{item_title}" مشابه لـ "%{similar_item_title}".
-      related_to_suggested_similar: لقد تم اقتراح "%{item_title}" كمتشابه مع "%{similar_item_title}".
-      sent_message_to_requestors_on_status_change: لقد أُرسِل تحديث ذو الحالة "%{status}"
-        إلى %{requestors_count} مستخدم قد طلبها.
-      tagged_by_rule: لقد وُضع الوسم "%{tag}" على "%{item_title}" بواسطة قاعدة آلية.
-      moved_to_private_folder: لقد تم نقل "%{item_title}" إلى مجلد ليس لديك تصريح
-        الوصول إليه.
-      add_warning_cover_by_rule: 'لقد تمت إضافة غطاء تحذيري للعنصر « %{item_title}
-        » لكونه يحتوي على مواد حساسة '
+      copied_to_project_by_rule: 'نُسخ "%{item_title}" إلى المجلد "[%{list_name}](%{list_link})" بواسطة قاعدة آلية.'
+      related_to_confirmed_similar: 'لقد تم تأكيد أن "%{item_title}" مشابه لـ "%{similar_item_title}".'
+      related_to_suggested_similar: 'لقد تم اقتراح "%{item_title}" كمتشابه مع "%{similar_item_title}".'
+      sent_message_to_requestors_on_status_change: لقد أُرسِل تحديث ذو الحالة "%{status}" إلى %{requestors_count} مستخدم قد طلبها.
+      tagged_by_rule: 'لقد وُضع الوسم "%{tag}" على "%{item_title}" بواسطة قاعدة آلية.'
+      moved_to_private_folder: 'لقد تم نقل "%{item_title}" إلى مجلد ليس لديك تصريح الوصول إليه.'
+      add_warning_cover_by_rule: 'لقد تمت إضافة غطاء تحذيري للعنصر « %{item_title} » لكونه يحتوي على مواد حساسة '

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,25 +41,25 @@ en:
         description: Translation has been reviewed and approved for publishing
       error:
         label: Error
-        description: 
+        description:
       false:
         label: false
         description: 'Conclusion: the item''s content is false'
       inconclusive:
         label: Inconclusive
-        description: 
+        description:
       misleading:
         label: Misleading
-        description: 
+        description:
       disputed:
         label: Disputed
-        description: 
+        description:
       out_of_scope:
         label: Out of Scope
-        description: 
+        description:
       junk:
         label: Junk
-        description: 
+        description:
       unstarted:
         label: Unstarted
         description: Default, just added, no work has started
@@ -83,6 +83,7 @@ en:
     messages:
       invalid_password: Invalid password
       invalid_qrcode: Invalid validation code
+      # This string is preceded by the name of the file being validated.
       extension_white_list_error: 'cannot be of type %{extension}, allowed types: %{allowed_types}'
       invalid_size: must be between %{min_width}x%{min_height} and %{max_width}x%{max_height}
         pixels

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,4 +1,3 @@
----
 es:
   statuses:
     ids:
@@ -25,7 +24,7 @@ es:
         label: En progreso
         description: El trabajo ha comenzado, pero aún no se realizó ninguna traducción
       not_true:
-        label: Falso
+        label: 'Falso'
         description: 'Conclusión: el contenido del ítem es falso'
       verified:
         label: Verificado
@@ -76,12 +75,9 @@ es:
     messages:
       invalid_password: Contraseña incorrecta
       invalid_qrcode: Código de validación incorrecto
-      extension_white_list_error: 'no puede tener tipo  %{extension}, tipos permitidos:
-        %{allowed_types}'
-      invalid_size: debe ser entre %{min_width}x%{min_height} y %{max_width}x%{max_height}
-        pixeles
-      mini_magick_processing_error: 'Lo sentimos, no pudimos procesar la imagen. El
-        error fue: %{e}'
+      extension_white_list_error: 'no puede ser de tipo %{extension}, tipos permitidos: %{allowed_types}'
+      invalid_size: debe ser entre %{min_width}x%{min_height} y %{max_width}x%{max_height} pixeles
+      mini_magick_processing_error: 'Lo sentimos, no pudimos procesar la imagen. El error fue: %{e}'
       annotation_mandatory_fields: Por favor configure todos los campos obligatorios
       annotation_type_does_not_exist: no existe
       invalid_attribution: Atribución inválida
@@ -89,20 +85,17 @@ es:
       image_too_large: Lo sentimos, no procesamos imágenes más grandes que %{max_size}.
       video_too_large: Lo sentimos, no procesamos vídeos más grandes que %{max_size}.
       audio_too_large: Lo sentimos, no procesamos audios más grandes que %{max_size}.
-      pender_conflict: Este enlace ya está siendo analizado. Por favor, intente de
-        nuevo en unos segundos.
+      pender_conflict: Este enlace ya está siendo analizado. Por favor, intente de nuevo en unos segundos.
       pender_url_invalid: Este enlace es inválido.
       pender_url_unsafe: Este enlace no es seguro.
-      pender_could_not_parse: No pudimos analizar este enlace. Por favor contacta
-        %{support_email} si el error persiste.
-      invalid_format_for_languages: Formato de idiomas no válido. Se espera `['en',
-        'ar', ...]`
+      pender_could_not_parse: No pudimos analizar este enlace. Por favor contacta %{support_email} si el error persiste.
+      invalid_format_for_languages: Formato de idiomas no válido. Se espera `['en', 'ar', ...]`
       invalid_project_media_channel_value: Lo sentimos, el valor del canal no es compatible
-      invalid_project_media_channel_update: Lo sentimos, no pudiste actualizar el
-        valor del canal
-      invalid_project_media_archived_value: Lo sentimos, el valor archivado no es
-        compatible
+      invalid_project_media_channel_update: Lo sentimos, no pudiste actualizar el valor del canal
+      invalid_project_media_archived_value: Lo sentimos, el valor archivado no es compatible
       invalid_fact_check_language_value: Lo sentimos, valor de idioma no admitido
+      fact_check_empty_title_and_summary: Lo sentimos, debes llenar el título o resumen
+      invalid_feed_saved_search_value: debe pertenecer a un área de trabajo que sea parte de este feed
   activerecord:
     models:
       link: Enlace
@@ -163,16 +156,11 @@ es:
   slack_webhook_format_wrong: Webhook de Slack no válido. Se espera el formato `https://hooks.slack.com/services/XXXXX/XXXXXXXXXX`
   slug_is_reserved: Está reservado
   invalid_media_item: El ítem no es válido
-  invalid_default_status_for_custom_verification_status: El identificador de estado
-    predeterminado es inválido
-  invalid_active_status_for_custom_verification_status: El identificador de estado
-    activo es inválido
+  invalid_default_status_for_custom_verification_status: El identificador de estado predeterminado es inválido
+  invalid_active_status_for_custom_verification_status: El identificador de estado activo es inválido
   invalid_label_for_custom_verification_status: La etiqueta de estado es obligatorio
-  invalid_id_for_custom_verification_status: El identificador de estado e obligatorio
-    e acepta solo letras, números, guiones y underscores
-  invalid_statuses_format_for_custom_verification_status: 'Los estados de verificación
-    personalizados son inválidos. Deben tener entradas válidas para: etiqueta, identificador,
-    descripción y estilo.'
+  invalid_id_for_custom_verification_status: El identificador de estado e obligatorio e acepta solo letras, números, guiones y underscores
+  invalid_statuses_format_for_custom_verification_status: 'Los estados de verificación personalizados son inválidos. Deben tener entradas válidas para: etiqueta, identificador, descripción y estilo.'
   mail_account_confirmation: "%{app_name} confirmación de cuenta"
   slack:
     fields:
@@ -197,23 +185,18 @@ es:
       tasks_answer_edit: "%{user} editó la respuesta de la tarea %{title}: %{answer}"
       metadata_create: "%{user} añadió un campo de metadatos: %{title}"
       metadata_edit: "%{user} editó el campo de metadatos %{title}"
-      metadata_answer_create: "%{user} estaleció el valor de los metadatos %{title}:
-        %{answer}"
+      metadata_answer_create: "%{user} estaleció el valor de los metadatos %{title}: %{answer}"
       metadata_answer_edit: "%{user} editó el valor de los metadatos %{title}: %{answer} "
       project_media_comment: "%{user} (%{role} at %{team}) añadió una nota a una  %{parent_type}"
       project_media_create: "%{user}(%{role} en %{team}) envió un nuevo ítem"
-      project_media_create_related: "%{user} (%{role} at %{team}) añadió un %{type}
-        relacionado"
+      project_media_create_related: "%{user} (%{role} at %{team}) añadió un %{type} relacionado"
       project_media_update: "%{user}(%{role} en %{team}) actualizó un ítem"
       project_media_move_to: "%{user}(%{role}en %{team}) movió un ítem a %{project}"
-      project_media_added_to_list: "%{user}(%{role}en%{team}) añadió un ítem a la
-        carpeta%{list_name}"
-      project_media_status: "%{user} (%{role} at %{team}) cambiar el %{workflow} del
-        estado a %{type}"
+      project_media_added_to_list: "%{user}(%{role}en%{team}) añadió un ítem a la carpeta%{list_name}"
+      project_media_status: "%{user} (%{role} at %{team}) cambiar el %{workflow} del estado a %{type}"
       project_media_assign: "%{user} (%{role} at %{team}) asignado un %{type}"
       project_media_unassign: "%{user} (%{role} at %{team}) desasigno un %{type}"
-      project_source_comment: "%{user} (%{role} at %{team}) añadió una nota a una
-        %{parent_type}"
+      project_source_comment: "%{user} (%{role} at %{team}) añadió una nota a una %{parent_type}"
       project_source_create: "%{user} (%{role} at %{team}) añadido un %{type}"
       project_source_update: "%{user} (%{role} at %{team}) editado un %{type}"
       project_create: "%{user}(%{role}en%{team}) creó una carpeta"
@@ -224,11 +207,9 @@ es:
       user_invited: "%{user} fue invitado a unirse al área de trabajo %{team}"
       user_banned: "%{user}fue suspendido del área de trabajo %{team}"
   mail_view_welcome: Bienvenida / Bienvenido a %{app_name}
-  mail_view_register: "¡Estás a un solo paso de usar %{app_name}! Por favor, confirma
-    tu dirección de correo electrónico haciendo clic en el siguiente enlace:"
+  mail_view_register: '¡Estás a un solo paso de usar %{app_name}! Por favor, confirma tu dirección de correo electrónico haciendo clic en el siguiente enlace:'
   mail_confirm_button: Confirmar mi cuenta
-  slack_restricted_join_to_members: Lo sentimos, no puedes unirte a %{team_name} porque
-    está restringido a los miembros de la(s) área(s) de trabajo de Slack %{teams}.
+  slack_restricted_join_to_members: Lo sentimos, no puedes unirte a %{team_name} porque está restringido a los miembros de la(s) área(s) de trabajo de Slack %{teams}.
   admin:
     actions:
       send_reset_password_email:
@@ -241,12 +222,10 @@ es:
         menu: Duplicar área de trabajo
         done: duplicado
         are_you_sure_you_want_to_copy_team:
-          html: "¿Estás seguro(a) que quieres duplicar el área de trabajo <strong>%{team}</strong>?
-            Todos los datos relacionados también serán copiados."
+          html: ¿Estás seguro(a) que quieres duplicar el área de trabajo <strong>%{team}</strong>? Todos los datos relacionados también serán copiados.
         the_team_is_being_copied: El área de trabajo está siendo duplicada
         url_when_ready:
-          html: Cuando esté listo, el duplicado del área de trabajo estará disponible
-            en <strong>%{copy_url}</strong>
+          html: Cuando esté listo, el duplicado del área de trabajo estará disponible en <strong>%{copy_url}</strong>
     flash:
       delete_team_scheduled: El área de trabajo %{team} está siendo eliminada
   email_not_found: 'Correo electrónico no encontrado '
@@ -257,16 +236,11 @@ es:
       oembed: "%B %d, %Y"
       task: "%B %d, %Y a las %H:%M [TZ] (%z UTC)"
       email: "%B %d, %Y %I:%M %p %Z"
-  oembed_disclaimer_undetermined: Este item no ha sido verificado por el equipo de
-    %{team}
-  oembed_disclaimer_in_progress: Este item está siendo verificado por %{team} desde
-    %{date}
-  oembed_disclaimer_verified: Este item ha sido determinado para ser verificado por  %{team}
-    en %{date}
-  oembed_disclaimer_false: Este item ha sido determinado para ser falso por  %{team}
-    en %{date}
-  oembed_disclaimer_not_applicable: No se pudo llegar a ninguna conclusión sobre este
-    ítem por parte de %{team} a partir de%{date}
+  oembed_disclaimer_undetermined: Este item no ha sido verificado por el equipo de %{team}
+  oembed_disclaimer_in_progress: Este item está siendo verificado por %{team} desde %{date}
+  oembed_disclaimer_verified: Este item ha sido determinado para ser verificado por  %{team} en %{date}
+  oembed_disclaimer_false: Este item ha sido determinado para ser falso por  %{team} en %{date}
+  oembed_disclaimer_not_applicable: No se pudo llegar a ninguna conclusión sobre este ítem por parte de %{team} a partir de%{date}
   oembed_source_date: "%{date} en %{provider}"
   role_editor: editor
   role_admin: admin
@@ -275,11 +249,11 @@ es:
   role_: sysadmin
   oembed_credit: Añadido por %{user} (%{role}) %{date}
   oembed_notes_count:
-    one: Una nota
+    one: "Una nota"
     many: "%{count} notas"
     other: "%{count} notas"
   oembed_completed_tasks_count:
-    one: Una tarea completada
+    one: "Una tarea completada"
     many: "%{count} tareas completadas"
     other: "%{count} tareas completadas"
   oembed_verification_tasks: Tareas
@@ -288,53 +262,45 @@ es:
   oembed_expand_all: Expandir todo
   oembed_collapse_all: Contraer todo
   oembed_resolved_tasks_count:
-    one: 'Una tarea resuelta '
+    one: "Una tarea resuelta "
     many: "%{count} tareas resueltas"
     other: "%{count} tareas resueltas"
   oembed_notes: Notas
   duplicate_source: La fuente ya existe
-  geolocation_invalid_value: Ubicación inválida. Se espera una estructura GeoJSON
-    válida (http://geojson.org/)
+  geolocation_invalid_value: Ubicación inválida. Se espera una estructura GeoJSON válida (http://geojson.org/)
   url_invalid_value: La siguiente URL enviada es inválida
   datetime_invalid_date: Fecha inválida
-  error_team_archived: Lo sentimos, no puedes añadir una carpeta a un área de trabajo
-    eliminada
+  error_team_archived: Lo sentimos, no puedes añadir una carpeta a un área de trabajo eliminada
   error_project_archived: Lo sentimos, no puedes añadir un ítem a una carpeta eliminada
-  error_team_archived_for_source: Lo sentimos, no puedes añadir una fuente a una área
-    de trabajo eliminada
+  error_team_archived_for_source: Lo sentimos, no puedes añadir una fuente a una área de trabajo eliminada
   permission_error: Lo sentimos, no tienes autorización para realizar esta operación
   error_annotated_archived: Lo sentimos, no puedes añadir una nota a un ítem eliminado
-  only_super_admin_can_do_this: Lo sentimos, solo los administradores del sistema
-    pueden hacer este cambio
+  only_super_admin_can_do_this: Lo sentimos, solo los administradores del sistema pueden hacer este cambio
   cant_change_custom_statuses: |-
-    Lo sentimos, no puedes modificar las definiciones de estado porque algunos estados podrían perderse. Estos identificadores de estado: %{statuses} están en uso por los siguientes artículos:
-    %{urls} %{others_amount}
+      Lo sentimos, no puedes modificar las definiciones de estado porque algunos estados podrían perderse. Estos identificadores de estado: %{statuses} están en uso por los siguientes artículos:
+      %{urls} %{others_amount}
   account_exists: Esta cuenta ya existe
   media_exists: Este ítem ya existe
   source_exists: Esta fuente ya existe
   email_exists: ya está en uso
-  banned_user: Lo sentimos, tu cuenta ha sido suspendida de %{app_name}. Por favor
-    comunícate con nuestro equipo de soporte técnico si crees que ha sido un error.
+  banned_user: Lo sentimos, tu cuenta ha sido suspendida de %{app_name}. Por favor comunícate con nuestro equipo de soporte técnico si crees que ha sido un error.
   devise:
     mailer:
       reset_password_instructions:
         subject: "%{app_name} instrucciones para restablecer la contraseña"
         header_title: Solicitar restablecer contraseña
-        header_text: Hemos recibido tu solicitud para restablecer tu contraseña de
-          %{app_name}.
+        header_text: Hemos recibido tu solicitud para restablecer tu contraseña de %{app_name}.
         action: Restablecer tu contraseña
         expiry: 'Esta solicitud caducará en %{expire} horas. '
         instruction_1: 'Has click aquí para generar una nueva solicitud. '
-        instruction_2: Si tu no has hecho esta solicitud, o estás teniendo dificultades
-          para restablecer tu contraseña, ponte en contacto con nosotros %{support_email}
+        instruction_2: Si tu no has hecho esta solicitud, o estás teniendo dificultades para restablecer tu contraseña, ponte en contacto con nosotros %{support_email}
       invitation_instructions:
         subject: "%{user} te invitó a unirte al área de trabajo %{team}"
-        hello: "¡Hola %{name}!"
+        hello: ¡Hola %{name}!
         someone_invited_you_default:
           html: "%{name}te ha invitado a unirte al área de trabajo %{team} como %{role}."
         someone_invited_you_custom:
-          html: "%{name}te ha invitado a unirte al área de trabajo %{team} como %{role},
-            diciendo:"
+          html: "%{name}te ha invitado a unirte al área de trabajo %{team} como %{role}, diciendo:"
         accept: Aceptar invitación
         accept_until: Esta invitación expirará a las %{due_date}.
         ignore: Si no desea aceptar la invitación, ignore este correo electrónico.
@@ -347,16 +313,13 @@ es:
     team_found: Área de trabajo no encontrada.
     invalid: Código de invitación inválido.
     no_invitation: No existe invitación para el área de trabajo %{name}
-  error_user_is_not_a_team_member: Lo sentimos, solo puedes asignar a los miembros
-    de esta área de trabajo
-  error_login_with_exists_account: Lo sentimos, hay otro usuario que ya está usando
-    esta cuenta
-  error_login_2fa: 'Por favor completa tu inicio de sesión proporcionando un código
-    de autenticación. '
+  error_user_is_not_a_team_member: Lo sentimos, solo puedes asignar a los miembros de esta área de trabajo
+  error_login_with_exists_account: Lo sentimos, hay otro usuario que ya está usando esta cuenta
+  error_login_2fa: 'Por favor completa tu inicio de sesión proporcionando un código de autenticación. '
   error_record_not_found: "%{type} #%{id} no encontrado(a)"
   mails_notifications:
     greeting: Hola %{username},
-    greeting_anonymous: "¡Hola!"
+    greeting_anonymous: ¡Hola!
     project_view: Ver carpeta
     unsubscribe: 'Cancelar suscripción '
     unsubscribe_link: "%{unsubscribe} de estas notificaciones"
@@ -364,68 +327,59 @@ es:
     register:
       subject: Nueva cuenta para ti en  %{app_name}
       header_text: |-
-        ¡Te has registrado con éxito en %{app_name}!
+          ¡Te has registrado con éxito en %{app_name}!
 
-        Para iniciar sesión en el sitio, sigue este enlace:%{url}. Ingresa este correo electrónico y esta contraseña.%{password}
+          Para iniciar sesión en el sitio, sigue este enlace:%{url}. Ingresa este correo electrónico y esta contraseña.%{password}
       login_button: Iniciar sesión en %{app_name}
-      footer_text: "¡Gracias por unirte y esperamos que tengas un día increíble! "
+      footer_text: '¡Gracias por unirte y esperamos que tengas un día increíble! '
     duplicated:
       subject: Tu método de inicio de sesión para %{app_name}
       header_title: Cuenta duplicada
       one_email: |-
-        <p>Hola, este es un mensaje de ayuda para tu inicio de sesión en %{app_name}. </p>
-        <p> Lo que sucedió fue que intentaste ingresar a %{app_name} con una cuenta de %{user_provider} asociada a %{user_email}. Pero esta dirección de correo electrónico ya está asociada con esta cuenta de%{duplicate_provider} en %{app_name} .</p>
-        <p> Lo que debes hacer a continuación es iniciar sesión con %{duplicate_provider}. </p>
-        <p> Entonces iniciarás sesión con la cuenta que estabas utilizando anteriormente.
-        Si necesita ayuda adicional, ponte en contacto con nosotros %{support_email} .</p>
+          <p>Hola, este es un mensaje de ayuda para tu inicio de sesión en %{app_name}. </p>
+          <p> Lo que sucedió fue que intentaste ingresar a %{app_name} con una cuenta de %{user_provider} asociada a %{user_email}. Pero esta dirección de correo electrónico ya está asociada con esta cuenta de%{duplicate_provider} en %{app_name} .</p>
+          <p> Lo que debes hacer a continuación es iniciar sesión con %{duplicate_provider}. </p>
+          <p> Entonces iniciarás sesión con la cuenta que estabas utilizando anteriormente.
+          Si necesita ayuda adicional, ponte en contacto con nosotros %{support_email} .</p>
       both_emails: |-
-        <p>Hola, este es un mensaje de ayuda para tu inicio de sesión en %{app_name} .</p>
-        <p>Lo que sucedió fue que intentaste crear una cuenta nueva en %{app_name}, con un correo electrónico que está asociado a una cuenta que ya existe. </p>
-        <p> Intenta iniciar sesión con tu correo electrónico y contraseña, en lugar de crear una nueva cuenta. </p> <p> Entonces iniciarás sesión con la cuenta que estabas utilizando anteriormente.
-        Si necesita ayuda adicional, ponte en contacto con nosotros%{support_email}. </p>
+          <p>Hola, este es un mensaje de ayuda para tu inicio de sesión en %{app_name} .</p>
+          <p>Lo que sucedió fue que intentaste crear una cuenta nueva en %{app_name}, con un correo electrónico que está asociado a una cuenta que ya existe. </p>
+          <p> Intenta iniciar sesión con tu correo electrónico y contraseña, en lugar de crear una nueva cuenta. </p> <p> Entonces iniciarás sesión con la cuenta que estabas utilizando anteriormente.
+          Si necesita ayuda adicional, ponte en contacto con nosotros%{support_email}. </p>
       email: correo electrónico
     invitation:
       title: Nueva invitación
     delete_user:
       subject: "[%{team}] Un usuario fue eliminado"
       header_title: Usuario eliminado
-      header_text: Una cuenta de usuario se eliminó y su contenido se reasignó a %{id}
-        %{anonymous}
+      header_text: Una cuenta de usuario se eliminó y su contenido se reasignó a %{id} %{anonymous}
       anonymous: anónimo
     admin_mailer:
-      team_download_subject: "[%{team}] La captura de datos del área de trabajo está
-        lista para ser descargada"
+      team_download_subject: "[%{team}] La captura de datos del área de trabajo está lista para ser descargada"
       team_dump_title: Datos del área de trabajo
       types:
         dump: captura de datos
         csv: informe
         images: archivo de imágenes
-      team_dump_text: 'Solicitaste descargar una captura de datos del área de trabajo
-        %{project} - aquí está el enlace para descargarla: %{link}'
+      team_dump_text: 'Solicitaste descargar una captura de datos del área de trabajo %{project} - aquí está el enlace para descargarla: %{link}'
       team_dump_button: Descargar los datos del área de trabajo
-      decompress_text: El %{type} se descargará como un archivo comprimido y cifrado.
-        Para descomprimirlo, usa esta contraseña %{password}.
+      decompress_text: El %{type} se descargará como un archivo comprimido y cifrado. Para descomprimirlo, usa esta contraseña %{password}.
       expire_note: Ten en cuenta que este enlace caducará en %{days} días.
       team_import_subject: Tu importación de datos se ha completado
       team_import_title: Importación de datos
-      team_import_text: "<p>Se ha completado la importación de datos en %{app_name}.
-        Puedes mirar %{worksheet_url} para revisar el estado de cada ítem a importar.</p><p>
-        Recuerda que puedes reiniciar la importación después de corregir cualquier
-        error que se informe allí - los ítems previamente- importados no se duplicarán.
-        </p>"
+      team_import_text: "<p>Se ha completado la importación de datos en %{app_name}. Puedes mirar %{worksheet_url} para revisar el estado de cada ítem a importar.</p><p> Recuerda que puedes reiniciar la importación después de corregir cualquier error que se informe allí - los ítems previamente- importados no se duplicarán. </p>"
     task_resolved:
       subject: "[%{team} - %{project}] Tarea resuelta"
       header_title: Tarea respondida
       header_text: "%{author} respondió una tarea en la carpeta %{project} en %{team}."
-      section_title: "¿Quién o cuál es la fuente del ítem?"
+      section_title: ¿Quién o cuál es la fuente del ítem?
       status: Estado
       media_h: Ítem
     media_status:
       label: ítem
       subject: "[%{team} - %{project}] El estado del ítem fue marcado como %{status}"
       header_title: El estado del ítem ha sido actualizado
-      header_text: "%{author} actualizó el estado de un ítem en la carpeta %{project}
-        en %{team}."
+      header_text: "%{author} actualizó el estado de un ítem en la carpeta %{project} en %{team}."
       section_title: Marcado como %{status}.
       added_to: Añadido a %{app_name}
       update_h: Última actualización
@@ -444,13 +398,11 @@ es:
       assign_task_title: 'Tarea asignada '
       unassign_task_title: Tarea sin asignar
       assign_task_text: "%{author} asignó una tarea en la carpeta %{project} en %{team}."
-      unassign_task_text: "%{author} desasignó una tarea en la carpeta %{project}
-        en %{team}."
+      unassign_task_text: "%{author} desasignó una tarea en la carpeta %{project} en %{team}."
       assign_media_title: Ítem Asignado
       unassign_media_title: Ítem Desasignado
       assign_media_text: "%{author} asignó un ítem en la carpeta %{project} en %{team}."
-      unassign_media_text: "%{author} desasignó un ítem en la carpeta %{project} en
-        %{team}."
+      unassign_media_text: "%{author} desasignó un ítem en la carpeta %{project} en %{team}."
       assign_log: "%{author} asignó %{model} a %{username}"
       unassign_log: "%{author} desasignó %{model} a %{username}"
       assign_by: Asignado por
@@ -463,17 +415,13 @@ es:
       rejected_subject: Tu solicitud para unirte a %{team} no fue aprobada.
       approved_subject: 'Bienvenido(a) al área de trabajo %{team} '
       request_title: Solicitar unirse a área de trabajo %{team}
-      request_text: "%{name} (%{email}) quiere unirse a área de trabajo %{team} en
-        %{app_name}. Puedes procesas esta solicitud visitando %{url}."
+      request_text: "%{name} (%{email}) quiere unirse a área de trabajo %{team} en %{app_name}. Puedes procesas esta solicitud visitando %{url}."
       approved_title: 'Bienvenido(a) al área de trabajo %{team} '
-      approved_text: Tu solicitud para unirte a área de trabajo %{team} en %{app_name}fue
-        aprobada. Puedes ir a %{url} y empezar a contribuir.
+      approved_text: Tu solicitud para unirte a área de trabajo %{team} en %{app_name}fue aprobada. Puedes ir a %{url} y empezar a contribuir.
       rejected_title: Solicitud denegada
-      rejected_text: Lo sentimos, pero tu solicitud para unirte a área de trabajo
-        %{team} en %{app_name} no fue aprobada.
+      rejected_text: Lo sentimos, pero tu solicitud para unirte a área de trabajo %{team} en %{app_name} no fue aprobada.
   mail_security:
-    device_subject: 'Alerta de seguridad: Nuevo inicio de sesión de %{app_name} dede
-      %{browser} en %{platform}'
+    device_subject: 'Alerta de seguridad: Nuevo inicio de sesión de %{app_name} dede %{browser} en %{platform}'
     ip_subject: 'Alerta de seguridad: Nuevo o inusual inicio de sesión en %{app_name} '
     failed_subject: 'Alerta de seguridad: Intento fallido de inicio de sesión en  %{app_name}'
     ip: Has iniciado sesión desde %{location}
@@ -481,21 +429,15 @@ es:
     devise_name: "%{browser} en %{platform}"
     failed: 'Se han detectado Intentos fallidos de inicio de sesión '
     password_text: 'restablece tu contraseña inmediatamente '
-    device_text: Al parecer, recientemente has iniciado sesión en tu cuenta de %{app_name}
-      desde un nuevo dispositivo. Si no has sido tú, te recomendamos %{change_password}
-    ip_text: Al parecer,  recientemente has iniciado sesión en tu cuenta de %{app_name}
-      desde una nueva locación. Si no has sido tú,  te recomendamos %{change_password}
-    failed_text: Al parecer, han habido múltiples intentos fallidos de inicio de sesión
-      en tu cuenta de %{app_name}. Si has sido tú has caso omiso de este mensaje,
-      si no has sido tú te recomendamos %{change_password}
+    device_text: Al parecer, recientemente has iniciado sesión en tu cuenta de %{app_name} desde un nuevo dispositivo. Si no has sido tú, te recomendamos %{change_password}
+    ip_text: Al parecer,  recientemente has iniciado sesión en tu cuenta de %{app_name} desde una nueva locación. Si no has sido tú,  te recomendamos %{change_password}
+    failed_text: Al parecer, han habido múltiples intentos fallidos de inicio de sesión en tu cuenta de %{app_name}. Si has sido tú has caso omiso de este mensaje, si no has sido tú te recomendamos %{change_password}
     time_h: Tiempo
     device_h: Dispositivo
     location_h: Ubicación
-    location_disclaimer: "* La ubicación es aproximada según la dirección IP desde
-      la que se originó"
+    location_disclaimer: "* La ubicación es aproximada según la dirección IP desde la que se originó"
     ip_h: Dirección IP
-    privacy: "%{manage}tus notificaciones de correo electrónico • Aprende más acerca
-      de nuestras %{privacy}"
+    privacy: "%{manage}tus notificaciones de correo electrónico • Aprende más acerca de nuestras %{privacy}"
     privacy_text: Políticas de Privacidad
     manage_text: Gestionar
     privace_manage_plain: Gestiona tus notificaciones de correo electrónico
@@ -503,62 +445,46 @@ es:
   archive_keep_backup: Video Vault
   archive_pender_archive: Captura de pantalla
   archive_archive_org: Archive.org
-  workflow_status_is_not_valid: 'Estado no válido: ''%{status}'' (debe ser uno de
-    %{valid})'
-  workflow_status_permission_error: Lo sentimos, no tienes autorización para cambiar
-    este estado.
-  blank_default_status_for_custom_verification_status: Por favor proporciona un valor
-    predeterminado para los estados de verificación personalizados
-  blank_active_status_for_custom_verification_status: Por favor proporciona un valor
-    predeterminado para los estados de verificación personalizados
+  workflow_status_is_not_valid: 'Estado no válido: ''%{status}'' (debe ser uno de %{valid})'
+  workflow_status_permission_error: Lo sentimos, no tienes autorización para cambiar este estado.
+  blank_default_status_for_custom_verification_status: Por favor proporciona un valor predeterminado para los estados de verificación personalizados
+  blank_active_status_for_custom_verification_status: Por favor proporciona un valor predeterminado para los estados de verificación personalizados
   bot_name_exists_for_this_team: Ya existe un bot con ese nombre en esta área de trabajo
-  bot_team_id_doesnt_exist: Lo sentimos, no hay ninguna área de trabajo con el identificador
-    proporcionado
-  bot_team_id_mandatory_to_create: Lo sentimos, primero debes elegir una área de trabajo
-    para crear un bot
-  bot_not_approved_for_installation: 'Lo sentimos, este bot no fue aprobado y por
-    eso no se puede instalar '
-  could_not_save_related_bot_data: Lo sentimos, no se pudo agregar el bot a esta área
-    de trabajo
-  bot_cant_add_response_to_task: Lo sentimos, un bot no puede responder una tarea
-    directamente- por favor, envía una sugerencia de respuesta .
+  bot_team_id_doesnt_exist: Lo sentimos, no hay ninguna área de trabajo con el identificador proporcionado
+  bot_team_id_mandatory_to_create: Lo sentimos, primero debes elegir una área de trabajo para crear un bot
+  bot_not_approved_for_installation: 'Lo sentimos, este bot no fue aprobado y por eso no se puede instalar '
+  only_admins_can_approve_or_list_bots: Lo sentimos, sólo quienes administran el sistema pueden aprobar o listar bots
+  could_not_save_related_bot_data: Lo sentimos, no se pudo agregar el bot a esta área de trabajo
+  bot_cant_add_response_to_task: Lo sentimos, un bot no puede responder una tarea directamente- por favor, envía una sugerencia de respuesta .
   bot_cant_add_review_to_task: Lo sentimos, un bot no puede revisar una tarea.
-  task_suggestion_invalid_value: Sugerencia de tarea no válida. Se espera un objeto
-    JSON con atributos `suggestion` (el valor actual que se copia en la respuesta
-    de la tarea cuando se acepta) y `comment` (mostrado a los usuarios).
+  task_suggestion_invalid_value: Sugerencia de tarea no válida. Se espera un objeto JSON con atributos `suggestion` (el valor actual que se copia en la respuesta de la tarea cuando se acepta) y `comment` (mostrado a los usuarios).
   tag_text_id_not_found: Etiqueta no encontrada
   annotation_type_language_label: Idioma
   smooch_bot_message_confirmed: |-
-    ¡Gracias! tu solicitud se ha agregado a nuestra cola de verificación.
+      ¡Gracias! tu solicitud se ha agregado a nuestra cola de verificación.
 
-    Intentaremos obtener un informe dentro de las 24 horas, pero ten en cuenta que no podemos responder a todas las solicitudes.
-  smooch_bot_message_unconfirmed: 'Como no respondiste a la pregunta tecleando el
-    número 1,  no procesaremos más tu solicitud. ¡Gracias! '
+      Intentaremos obtener un informe dentro de las 24 horas, pero ten en cuenta que no podemos responder a todas las solicitudes.
+  smooch_bot_message_unconfirmed: 'Como no respondiste a la pregunta tecleando el número 1,  no procesaremos más tu solicitud. ¡Gracias! '
   smooch_bot_message_type_unsupported: 'Lo sentimos, no procesamos este tipo de mensaje. '
-  smooch_bot_message_size_unsupported: Lo sentimos, no procesamos archivos más grandes
-    que %{max_size}.
+  smooch_bot_message_size_unsupported: Lo sentimos, no procesamos archivos más grandes que %{max_size}.
   smooch_bot_result: |-
-    [Informe de Verificación] El mensaje que compartiste con nosotros ha sido marcado como  *%{status}*.
+      [Informe de Verificación] El mensaje que compartiste con nosotros ha sido marcado como  *%{status}*.
 
-    Este es el proceso que seguimos para llegar a esta conclusión: %{url}
+      Este es el proceso que seguimos para llegar a esta conclusión: %{url}
   smooch_bot_ask_for_confirmation: |-
-    Gracias por enviar este mensaje. ¿Quieres que verifiquemos este contenido?
+      Gracias por enviar este mensaje. ¿Quieres que verifiquemos este contenido?
 
-    Para decir sí, *por favor responde con 1*. Cualquier otra respuesta terminará con nuestra conversación.
+      Para decir sí, *por favor responde con 1*. Cualquier otra respuesta terminará con nuestra conversación.
   smooch_bot_ask_for_tos: |-
-    ¡Gracias por comunicarse con Check Message!
+      ¡Gracias por comunicarse con Check Message!
 
-    Puede utilizar este servicio para solicitar la verificación de hechos, y la investigación de noticias e información. Check Message es proporcionado a usted bajo estos términos de servicio: %{tos}. Al continuar utilizando este servicio, *usted acepta estar sujeto a estos términos*. Debe dejar de usar Check Message si no está de acuerdo.
-  smooch_bot_window_closing: "El volumen de solicitudes que hemos recibido en este
-    canal es bastante alto y aún no hemos podido resolver tu solicitud. \nGracias
-    por tu paciencia."
+      Puede utilizar este servicio para solicitar la verificación de hechos, y la investigación de noticias e información. Check Message es proporcionado a usted bajo estos términos de servicio: %{tos}. Al continuar utilizando este servicio, *usted acepta estar sujeto a estos términos*. Debe dejar de usar Check Message si no está de acuerdo.
+  smooch_bot_window_closing: "El volumen de solicitudes que hemos recibido en este canal es bastante alto y aún no hemos podido resolver tu solicitud. \nGracias por tu paciencia."
   smooch_bot_not_final: |-
-    [Informe de Verificación - CORRECCIÓN] El mensaje que compartiste con nosotros fue erróneamente marcado como *%{status}*.
-    Todavía está en nuestra cola de verificación para añadirle información adicional.
-  smooch_bot_disabled: Gracias por enviar este mensaje. No podemos devolver ningún
-    informe de verificación, porque este proyecto ya no está activo.
-  smooch_bot_result_changed: "❗️La verificación de datos que le enviamos se ha *actualizado*
-    con nueva información"
+      [Informe de Verificación - CORRECCIÓN] El mensaje que compartiste con nosotros fue erróneamente marcado como *%{status}*.
+      Todavía está en nuestra cola de verificación para añadirle información adicional.
+  smooch_bot_disabled: Gracias por enviar este mensaje. No podemos devolver ningún informe de verificación, porque este proyecto ya no está activo.
+  smooch_bot_result_changed: "❗️La verificación de datos que le enviamos se ha *actualizado* con nueva información"
   permissions_info:
     roles:
       admin:
@@ -566,8 +492,7 @@ es:
       editor:
         description: Las(os) editoras(es) administran el área de trabajo y las carpetas.
       collaborator:
-        description: Colaborador(a) puede añadir nueva información para verificar.
-          Usualmente son miembros del público.
+        description: Colaborador(a) puede añadir nueva información para verificar. Usualmente son miembros del público.
     permissions:
       sections:
         project_management:
@@ -606,25 +531,17 @@ es:
             edit_tasks: Crear y editar tareas del área de trabajo
             roles: Editar roles del área de trabajo
             third_party: Añadir integraciones de terceros
-            invite_admin: Invitar, aprobar y eliminar administradores(as) de área
-              de trabajo
+            invite_admin: Invitar, aprobar y eliminar administradores(as) de área de trabajo
             invite_members: Invitar, aprobar y eliminar miembros de área de trabajo
   team_clone:
     user_not_authorized: Lo sentimos, no tienes permitido duplicar este equipo.
   team_import:
     invalid_google_spreadsheet_url: URL de hoja de cálculo inválida %{spreadsheet_url}
     not_found_google_spreadsheet_url: Hoja de cálculo no encontrada en %{spreadsheet_url}
-    cannot_authenticate_with_the_credentials: No se pudo autenticar Google Drive con
-      las credenciales actuales. Por favor comunícate con nuestro equipo de soporte
-      técnico para notificarles este incidente.
-    team_not_present: La área de trabajo actual no se encontró durante la importación
-      de datos. Por favor comunícate con nuestro equipo de soporte técnico para notificarles
-      este incidente.
-    user_not_present: El usuario actual no se encontró durante la importación de datos.
-      Por favor comunícate con nuestro equipo de soporte técnico para notificarles
-      este incidente.
-    user_not_authorized: Lo sentimos, no tienes permitido importar data dentro de
-      esta área de trabajo.
+    cannot_authenticate_with_the_credentials: No se pudo autenticar Google Drive con las credenciales actuales. Por favor comunícate con nuestro equipo de soporte técnico para notificarles este incidente.
+    team_not_present: La área de trabajo actual no se encontró durante la importación de datos. Por favor comunícate con nuestro equipo de soporte técnico para notificarles este incidente.
+    user_not_present: El usuario actual no se encontró durante la importación de datos. Por favor comunícate con nuestro equipo de soporte técnico para notificarles este incidente.
+    user_not_authorized: Lo sentimos, no tienes permitido importar data dentro de esta área de trabajo.
     invalid_project: Carpeta inválida%{project}
     invalid_user: Autor inválido %{user}
     invalid_status: Estado inválido %{status}
@@ -633,9 +550,7 @@ es:
     blank_project: Campo de carpeta en blanco inválido
     invalid_annotator: Anotación inválida %{user}
     invalid_assignee: Usuario asignado inválido %{user}
-  cant_mutate_inactive_object: Lo sentimos, hay una operación pendiente para este
-    ítem, por lo que no puedes cambiarlo por ahora. Por favor, inténtalo de nuevo
-    más tarde.
+  cant_mutate_inactive_object: Lo sentimos, hay una operación pendiente para este ítem, por lo que no puedes cambiarlo por ahora. Por favor, inténtalo de nuevo más tarde.
   embed_expand_all: Expandir todo
   embed_collapse_all: Contraer todo
   embed_tasks: Tareas
@@ -648,28 +563,25 @@ es:
   smooch_requests_desc: Más solicitados
   bot_request_url_invalid: El URL del bot es inválido
   smooch_facebook_success: |
-    ¡Éxito!
-    Tu Tipline está ahora connectada a Facebook Messenger.
-    Cualquier mensaje recibido por esta Página de Facebook va a ser manejado por la Tipline.
+      ¡Éxito!
+      Tu Tipline está ahora connectada a Facebook Messenger.
+      Cualquier mensaje recibido por esta Página de Facebook va a ser manejado por la Tipline.
   smooch_twitter_success: |
-    ¡Éxito!
-    Tu Tipline está ahora connectada a Twitter.
-    Cualquier mensaje recibido por este perfil de Twitter va a ser manejado por la Tipline.
-    Por favor vuelve a cargar la página de configuración de tu Tipline para ver cambios nuevos
-  must_select_exactly_one_facebook_page: Por favor selecciona exactamente la página
-    de Facebook que quieres integrar con la Tipline.
+      ¡Éxito!
+      Tu Tipline está ahora connectada a Twitter.
+      Cualquier mensaje recibido por este perfil de Twitter va a ser manejado por la Tipline.
+      Por favor vuelve a cargar la página de configuración de tu Tipline para ver cambios nuevos
+  must_select_exactly_one_facebook_page: Por favor selecciona exactamente la página de Facebook que quieres integrar con la Tipline.
   invalid_task_answer: Formato de respuesta de tarea inválido
   team_rule_name: Un nombre único que identifica lo que hace esta regla
   team_rule_project_ids: Aplicar a carpeta
   team_rule_destination: Seleccionar carpeta de destino
-  team_rule_names_invalid: Los nombres de las reglas no pueden estar en blanco y deben
-    ser únicos
+  team_rule_names_invalid: Los nombres de las reglas no pueden estar en blanco y deben ser únicos
   team_rules: Reglas
   team_rule_conditions: Si
   team_rule_condition: Si
   team_rule_condition_definition: Seleccionar condición
-  team_rule_has_less_than_x_words: La solicitud tiene menos que (o exactamente) el
-    siguiente número de palabras
+  team_rule_has_less_than_x_words: La solicitud tiene menos que (o exactamente) el siguiente número de palabras
   team_rule_title_matches_regexp: El título del ítem coincide con esta expresión regular
   team_rule_request_matches_regexp: La solicitud coincide con esta expresión regular
   team_rule_type_is: El tipo de ítem es
@@ -677,10 +589,8 @@ es:
   team_rule_type_is_link: Enlace
   team_rule_type_is_uploadedimage: Imagen
   team_rule_type_is_uploadedvideo: Vídeo
-  team_rule_contains_keyword: La solicitud contiene una o más de las siguientes palabras
-    clave
-  team_rule_title_contains_keyword: El contenido contiene una o más de las siguientes
-    palabras clave
+  team_rule_contains_keyword: La solicitud contiene una o más de las siguientes palabras clave
+  team_rule_title_contains_keyword: El contenido contiene una o más de las siguientes palabras clave
   team_rule_extracted_text_contains_keyword: El texto extraído contiene palabra clave
   team_rule_select_type: Seleccionar tipo
   team_rule_select_language: 'Selecciona el idioma '
@@ -698,8 +608,7 @@ es:
   team_rule_send_to_trash: Mover a Papelera
   team_rule_move_to_project: Mover ítem a carpeta
   team_rule_copy_to_project: Añadir ítem a carpeta
-  team_rule_ban_submitter: Prohibir el remitente (sus futuros mensajes no aparecerán
-    en Check)
+  team_rule_ban_submitter: Prohibir el remitente (sus futuros mensajes no aparecerán en Check)
   team_rule_all_items: Todos los ítems
   team_rule_send_message_to_user: Enviar mensaje al usuario
   team_rule_action_value: Escribe mensaje aquí
@@ -723,10 +632,8 @@ es:
   team_rule_item_is_read: Ítem leído
   team_rule_field_from_fieldset_tasks_value_is: La tarea tiene una respuesta específica
   team_rule_field_from_fieldset_metadata_value_is: La anotación tiene un valor específico
-  team_rule_field_from_fieldset_tasks_value_contains_keyword: La respuesta de la tarea
-    contiene una palabra clave
-  team_rule_field_from_fieldset_metadata_value_contains_keyword: La anotación contiene
-    una palabra clave
+  team_rule_field_from_fieldset_tasks_value_contains_keyword: La respuesta de la tarea contiene una palabra clave
+  team_rule_field_from_fieldset_metadata_value_contains_keyword: La anotación contiene una palabra clave
   team_rule_select_field_metadata: Seleccionar anotación
   team_rule_select_field_value_metadata: Seleccionar valor
   team_rule_select_field_tasks: Seleccionar tarea
@@ -749,33 +656,23 @@ es:
   flag_likelihood_4: Probable
   flag_likelihood_5: Alto (se detectará más contenido)
   flag_likelihood_7: Manual
-  relationship_not_same_team: Los elementos relacionados deben existir en el misma
-    área de trabajo
+  relationship_not_same_team: Los elementos relacionados deben existir en el misma área de trabajo
+  item_cant_be_related_to_itself: "El ítem no puede estar relacionado consigo mismo"
   target_is_published: El objetivo no debe tener un informe publicado
   similar_item_exists: Lo sentimos, este ítem ya fue agregado como un ítem similar.
-  bulk_operation_limit_error: Lo sentimos, el número máximo de elementos que se procesarán
-    a la vez es %{limit}
-  must_provide_fallback_when_deleting_status_in_use: Este estado se está utilizando,
-    por lo que debe proporcionar un estado de reserva si desea eliminarlo
-  embed_no_content_yet: El informe se está generando. Este proceso puede demorar unos
-    minutos. Por favor actualice esta página.
-  language_format_invalid: El formato del idioma no es válido. Debe ser un código
-    ISO 639-1.
-  languages_format_invalid: El formato de idiomas no es válido. Se espera una lista
-    de códigos ISO 639-1.
-  cant_change_status_if_item_is_published: Lo sentimos, no puede cambiar el estado
-    mientras se publica el informe
+  bulk_operation_limit_error: Lo sentimos, el número máximo de elementos que se procesarán a la vez es %{limit}
+  must_provide_fallback_when_deleting_status_in_use: Este estado se está utilizando, por lo que debe proporcionar un estado de reserva si desea eliminarlo
+  embed_no_content_yet: El informe se está generando. Este proceso puede demorar unos minutos. Por favor actualice esta página.
+  language_format_invalid: El formato del idioma no es válido. Debe ser un código ISO 639-1.
+  languages_format_invalid: El formato de idiomas no es válido. Se espera una lista de códigos ISO 639-1.
+  cant_change_status_if_item_is_published: Lo sentimos, no puede cambiar el estado mientras se publica el informe
   fetch_bot_service_unsupported: Servicio no soportado
   task_options_must_be_array: Las opciones de tareas deben ser una lista
   fieldset_not_defined_by_team: Fieldset debe ser compatible con el área de trabajo
-  cant_change_field_type_or_options_when_answered: El tipo de campo no se puede cambiar
-    porque las respuestas ya se han completado
-  replace_by_media_in_the_same_team: Lo sentimos, solo puedes reemplazar este ítem
-    por otro ítem de la misma área de trabajo
-  replace_blank_media_only: Lo sentimos, pero por ahora solo puedes reemplazar ítems
-    en blanco
-  cant_preview_rss_feed: Lo sentimos, no tienes permiso para previsualizar una fuente
-    RSS.
+  cant_change_field_type_or_options_when_answered: El tipo de campo no se puede cambiar porque las respuestas ya se han completado
+  replace_by_media_in_the_same_team: Lo sentimos, solo puedes reemplazar este ítem por otro ítem de la misma área de trabajo
+  replace_blank_media_only: Lo sentimos, pero por ahora solo puedes reemplazar ítems en blanco
+  cant_preview_rss_feed: Lo sentimos, no tienes permiso para previsualizar una fuente RSS.
   list_column_demand: Solicitudes
   list_column_share_count: Compartidas en FB
   list_column_reaction_count: Reacciones en FB
@@ -792,59 +689,46 @@ es:
   list_column_published_by: Informe publicado por
   list_column_fact_check_published_on: Verificación de hechos publicada el
   list_column_related_count: Relacionado(s)
+  list_column_suggestions_count: Sugerencias
   list_column_folder: Carpeta
   list_column_creator_name: Creado por
   list_column_fact_check_title: Verificación de hechos
   list_column_team_name: Área de trabajo
   list_column_sources_as_sentence: Fuente
   go_back_to_check: Regresar a Check
-  project_cant_have_children_if_has_parent: Esta carpeta tiene una carpeta principal,
-    por lo que no puede tener una subcarpeta
-  project_group_must_be_under_same_team: La colección debe estar en la misma área
-    de trabajo
-  unique_default_folder_per_team: 'El área de trabajo sólo debería tener una carpeta
-    predeterminada '
-  center_is_not_part_of_another_cluster: El centro de este clúster no puede ser parte
-    de otro clúster
+  project_cant_have_children_if_has_parent: Esta carpeta tiene una carpeta principal, por lo que no puede tener una subcarpeta
+  project_group_must_be_under_same_team: La colección debe estar en la misma área de trabajo
+  unique_default_folder_per_team: 'El área de trabajo sólo debería tener una carpeta predeterminada '
+  center_is_not_part_of_another_cluster: El centro de este clúster no puede ser parte de otro clúster
   smooch_bot_message_subscribed: |-
-    Actualmente estás suscrita(o) a nuestro boletín.
+      Actualmente estás suscrita(o) a nuestro boletín.
 
-    Escribe 0 para ir al menú principal.
+      Escribe 0 para ir al menú principal.
   smooch_bot_message_unsubscribed: |-
-    Actualmente no estás suscrita(o) a nuestro boletín.
+      Actualmente no estás suscrita(o) a nuestro boletín.
 
-    Escribe 0 para ir al menú principal.
+      Escribe 0 para ir al menú principal.
   subscribe: Suscribirse
   unsubscribe: Cancelar suscripción
-  smooch_message_subscription_header_subscribed: Actualmente estás suscrita(o) a nuestro
-    boletín.
-  smooch_message_subscription_header_unsubscribed: Actualmente no estás suscrita(o)
-    a nuestro boletín.
+  smooch_message_subscription_header_subscribed: Actualmente estás suscrita(o) a nuestro boletín.
+  smooch_message_subscription_header_unsubscribed: Actualmente no estás suscrita(o) a nuestro boletín.
   smooch_bot_message_newsletter_fallback: |-
-    ¡Hola! Aquí están tus datos semanales. Este boletín fue publicado en %{platform} por %{team} en %{date}:
+      ¡Hola! Aquí están tus datos semanales. Este boletín fue publicado en %{platform} por %{team} en %{date}:
 
-    %{content}
+      %{content}
 
-    Para dejar de recibir este boletín, escribe "%{unsubscribe}".
+      Para dejar de recibir este boletín, escribe "%{unsubscribe}".
+  send_every_must_be_a_list_of_days_of_the_week: debe ser una lista de días de la semana.
+  send_on_must_be_in_the_future: no puede estar en pasado.
   info:
     messages:
-      sent_to_trash_by_rule: '%{item_title}" ha sido enviado a la papelera por una
-        regla de automatización.'
-      moved_to_project_by_rule: '"%{item_title}" se ha movido a la carpeta "[%{list_name}](%{list_link})"
-        por una regla de automatización.'
-      banned_submitter_by_rule: El/la solicitante de %{item_title} " ha sido prohibido(a)
-        por una regla de automatización.
-      copied_to_project_by_rule: '"%{item_title}" se ha copiado a la carpeta "[%{list_name}](%{list_link})"
-        por una relga de automatización.'
-      related_to_confirmed_similar: '"%{item_title}" se ha confirmado que es similar
-        a "%{similar_item_title}". '
-      related_to_suggested_similar: '"%{item_title}" se ha sugerido como similar a
-        "%{similar_item_title}".'
-      sent_message_to_requestors_on_status_change: "“Una actualización con estado%{status}”
-        \ ha sido enviada a %{requestors_count} solicitantes."
-      tagged_by_rule: '"%{item_title}" ha sido etiquetado como "%{tag}" por una regla
-        de automatización.'
-      moved_to_private_folder: '"%{item_title}" se ha movido a una carpeta a la que
-        no tienes acceso.'
-      add_warning_cover_by_rule: Se ha añadido una cubierta de advertencia al ítem
-        sensible "%{item_title}"
+      sent_to_trash_by_rule: '%{item_title}" ha sido enviado a la papelera por una regla de automatización.'
+      moved_to_project_by_rule: '"%{item_title}" se ha movido a la carpeta "[%{list_name}](%{list_link})" por una regla de automatización.'
+      banned_submitter_by_rule: El/la solicitante de %{item_title} " ha sido prohibido(a) por una regla de automatización.
+      copied_to_project_by_rule: '"%{item_title}" se ha copiado a la carpeta "[%{list_name}](%{list_link})" por una relga de automatización.'
+      related_to_confirmed_similar: '"%{item_title}" se ha confirmado que es similar a "%{similar_item_title}". '
+      related_to_suggested_similar: '"%{item_title}" se ha sugerido como similar a "%{similar_item_title}".'
+      sent_message_to_requestors_on_status_change: “Una actualización con estado%{status}”  ha sido enviada a %{requestors_count} solicitantes.
+      tagged_by_rule: '"%{item_title}" ha sido etiquetado como "%{tag}" por una regla de automatización.'
+      moved_to_private_folder: '"%{item_title}" se ha movido a una carpeta a la que no tienes acceso.'
+      add_warning_cover_by_rule: Se ha añadido una cubierta de advertencia al ítem sensible "%{item_title}"

--- a/config/locales/fil.yml
+++ b/config/locales/fil.yml
@@ -1,4 +1,3 @@
----
 fil:
   statuses:
     ids:
@@ -25,7 +24,7 @@ fil:
         label: Kasalukuyang Ginagawa
         description: Nasimulan na ang gawain, pero wala pang nagagawang pagsasalin
       not_true:
-        label: Mali
+        label: 'Mali'
         description: 'Konklusyon: hindi totoo ang nilalaman ng item'
       verified:
         label: Beripikado
@@ -74,30 +73,19 @@ fil:
     messages:
       invalid_password: Hindi wastong password
       invalid_qrcode: Hindi wastong validation code
-      extension_white_list_error: 'hindi maaaring magkaroon ng uring %{extension},
-        ang mga pinahihintulutang uri: %{allowed_types}'
-      invalid_size: dapat nasa pagitan ng %{min_width}x%{min_height} at %{max_width}x%{max_height}
-        pixels
-      mini_magick_processing_error: 'Paumanhin, hindi namin ma-proseso ang larawan.
-        Ito ang error: %{e}'
-      annotation_mandatory_fields: 'Mangyaring itakda ang lahat ng kinakailangan na
-        patlang. '
+      invalid_size: dapat nasa pagitan ng %{min_width}x%{min_height} at %{max_width}x%{max_height} pixels
+      mini_magick_processing_error: 'Paumanhin, hindi namin ma-proseso ang larawan. Ito ang error: %{e}'
+      annotation_mandatory_fields: 'Mangyaring itakda ang lahat ng kinakailangan na patlang. '
       annotation_type_does_not_exist: hindi umiiral
       invalid_attribution: Hindi wastong atribusyon
-      must_resolve_required_tasks_first: Dapat munang malutas ang mga kinakailangang
-        gawain
-      image_too_large: Paumanhin, hindi namin suportado ang mga larawang higit sa
-        %{max_size}
-      video_too_large: Paumanhin, hindi namin suportado ang mga video na higit sa
-        %{max_size}
-      audio_too_large: Paumanhin, hindi namin suportado ang mga audio file na higit
-        sa %{max_size}.
-      pender_conflict: Kasalukuyan nang pina-parse ang link. Mangyaring sumubok muli
-        pagkatapos ng ilang segundo.
+      must_resolve_required_tasks_first: Dapat munang malutas ang mga kinakailangang gawain
+      image_too_large: Paumanhin, hindi namin suportado ang mga larawang higit sa %{max_size}
+      video_too_large: Paumanhin, hindi namin suportado ang mga video na higit sa %{max_size}
+      audio_too_large: Paumanhin, hindi namin suportado ang mga audio file na higit sa %{max_size}.
+      pender_conflict: Kasalukuyan nang pina-parse ang link. Mangyaring sumubok muli pagkatapos ng ilang segundo.
       pender_url_invalid: Hindi wasto ang link na ito.
       pender_url_unsafe: Hindi ligtas ang link na ito.
-      invalid_format_for_languages: Hindi wastong format ng wika. Ang inaasahan ay
-        `['en', 'ar', …]`
+      invalid_format_for_languages: Hindi wastong format ng wika. Ang inaasahan ay `['en', 'ar', …]`
   activerecord:
     models:
       link: Link
@@ -153,21 +141,15 @@ fil:
         too_short:
           one: ay masyadong maikli (ang pinakakaunti ay 1 karakter)
           other: ay masyadong maikli (hindi bababa sa %{count} karakter)
-  slack_webhook_format_wrong: Hindi wastong Slack webhook. Ang format na inaasahan
-    ay `https://hooks.slack.com/services/XXXXX/XXXXXXXXXX`
+  slack_webhook_format_wrong: Hindi wastong Slack webhook. Ang format na inaasahan ay `https://hooks.slack.com/services/XXXXX/XXXXXXXXXX`
   slug_is_reserved: ay nakareserba na
   invalid_media_item: Hindi wasto ang item
-  invalid_default_status_for_custom_verification_status: Hindi wasto ang default na
-    status identifier
-  invalid_active_status_for_custom_verification_status: Hindi wasto ang aktibong status
-    identifier
+  invalid_default_status_for_custom_verification_status: Hindi wasto ang default na status identifier
+  invalid_active_status_for_custom_verification_status: Hindi wasto ang aktibong status identifier
   invalid_label_for_custom_verification_status: Kinakailangan ang label ng status
-  invalid_id_for_custom_verification_status: Kinakailangan ang status identifier at
-    ang nilalaman lang dapat ito ay maliliit na titik, numero, gitling, at salungguhit
-  invalid_statuses_format_for_custom_verification_status: 'Hindi wastong mga custom
-    verification status. Ang inaasahan ay mga wastong entry para sa: label, identifier,
-    pagkakalarawan, at istilo.'
-  mail_account_confirmation: Pagkumpirma ng account sa %{app_name}
+  invalid_id_for_custom_verification_status: Kinakailangan ang status identifier at ang nilalaman lang dapat ito ay maliliit na titik, numero, gitling, at salungguhit
+  invalid_statuses_format_for_custom_verification_status: 'Hindi wastong mga custom verification status. Ang inaasahan ay mga wastong entry para sa: label, identifier, pagkakalarawan, at istilo.'
+  mail_account_confirmation: "Pagkumpirma ng account sa %{app_name}"
   slack:
     fields:
       assigned: Itinalaga kay
@@ -181,46 +163,35 @@ fil:
       project_media: Item
       attribution: Sinagutan ni
     messages:
-      analysis_verification_status_status_changed: 'Binago ni %{user} ang status sa:
-        %{value}'
-      analysis_title_changed: 'Binago ni %{user} ang pamagat ng pagsusuri sa: %{value}'
-      analysis_content_changed: 'Binago ni %{user} ang nilalaman ng pagsusuri sa:
-        %{value}'
-      tasks_create: 'Nagdagdag si %{user} ng gawain: %{title}'
-      tasks_edit: In-edit ni %{user} ang gawaing %{title}
-      tasks_answer_create: 'Sinagutan ni %{user} ang gawaing %{title}: %{answer}'
-      tasks_answer_edit: 'In-edit ni %{user} ang sagot sa gawaing %{title}: %{answer}'
-      metadata_create: 'Nagdagdag si %{user} ng patlang pang-metadata: %{title}'
-      metadata_edit: In-edit ni %{user} ang patlang pang-metadata na %{title}
-      metadata_answer_create: 'Itinakda ni %{user} ang value ng metadata na %{title}:
-        %{answer}'
-      metadata_answer_edit: 'In-edit ni %{user} ang value ng metadata na %{title}:
-        %{answer}'
-      project_media_comment: Nagdagdag si %{user} (%{role} sa %{team}) ng note sa
-        %{parent_type}
-      project_media_create: Nagsumite si %{user} (%{role} sa %{team}) ng bagong item
-      project_media_create_related: Nagdagdag si %{user} (%{role} sa %{team}) ng kaugnay
-        na %{type}
-      project_media_update: Nag-update si %{user} (%{role} sa %{team}) ng item
-      project_media_status: Pinalitan ni %{user} (%{role} sa %{team}) ang %{workflow}
-        status ng isang %{type}
-      project_media_assign: Nagtalaga si %{user} (%{role} sa %{team}) ng %{type}
-      project_media_unassign: 'Inalis ni %{user} (%{role} sa %{team}) ang pagkakatalaga
-        ng %{type} '
-      project_source_comment: Nagdagdag si %{user} (%{role} sa %{team}) ng note sa
-        %{parent_type}
-      project_source_create: Nagdagdag si %{user} (%{role} sa %{team}) ng %{type}
-      project_source_update: Nag-edit si %{user} (%{role} sa %{team}) ng %{type}
-      user_member: Sumali si %{user} sa workspace na %{team}
-      user_requested: Humiling si %{user} na sumali sa workspace na %{team}
-      user_invited: Inanyayahan si %{user} na sumali sa workspace na %{team}
-      user_banned: Ipinagbawal si %{user} sa workspace na %{team}
+      analysis_verification_status_status_changed: "Binago ni %{user} ang status sa: %{value}"
+      analysis_title_changed: "Binago ni %{user} ang pamagat ng pagsusuri sa: %{value}"
+      analysis_content_changed: "Binago ni %{user} ang nilalaman ng pagsusuri sa: %{value}"
+      tasks_create: "Nagdagdag si %{user} ng gawain: %{title}"
+      tasks_edit: "In-edit ni %{user} ang gawaing %{title}"
+      tasks_answer_create: "Sinagutan ni %{user} ang gawaing %{title}: %{answer}"
+      tasks_answer_edit: "In-edit ni %{user} ang sagot sa gawaing %{title}: %{answer}"
+      metadata_create: "Nagdagdag si %{user} ng patlang pang-metadata: %{title}"
+      metadata_edit: "In-edit ni %{user} ang patlang pang-metadata na %{title}"
+      metadata_answer_create: "Itinakda ni %{user} ang value ng metadata na %{title}: %{answer}"
+      metadata_answer_edit: "In-edit ni %{user} ang value ng metadata na %{title}: %{answer}"
+      project_media_comment: "Nagdagdag si %{user} (%{role} sa %{team}) ng note sa %{parent_type}"
+      project_media_create: "Nagsumite si %{user} (%{role} sa %{team}) ng bagong item"
+      project_media_create_related: "Nagdagdag si %{user} (%{role} sa %{team}) ng kaugnay na %{type}"
+      project_media_update: "Nag-update si %{user} (%{role} sa %{team}) ng item"
+      project_media_status: "Pinalitan ni %{user} (%{role} sa %{team}) ang %{workflow} status ng isang %{type}"
+      project_media_assign: "Nagtalaga si %{user} (%{role} sa %{team}) ng %{type}"
+      project_media_unassign: "Inalis ni %{user} (%{role} sa %{team}) ang pagkakatalaga ng %{type} "
+      project_source_comment: "Nagdagdag si %{user} (%{role} sa %{team}) ng note sa %{parent_type}"
+      project_source_create: "Nagdagdag si %{user} (%{role} sa %{team}) ng %{type}"
+      project_source_update: "Nag-edit si %{user} (%{role} sa %{team}) ng %{type}"
+      user_member: "Sumali si %{user} sa workspace na %{team}"
+      user_requested: "Humiling si %{user} na sumali sa workspace na %{team}"
+      user_invited: "Inanyayahan si %{user} na sumali sa workspace na %{team}"
+      user_banned: "Ipinagbawal si %{user} sa workspace na %{team}"
   mail_view_welcome: Maligayang pagdating sa %{app_name}
-  mail_view_register: 'Isang hakbang na lang at magagamit mo na ang %{app_name}! Mangyaring
-    kumpirmahin ang iyong email address sa pag-click sa sumusunod na link:'
+  mail_view_register: 'Isang hakbang na lang at magagamit mo na ang %{app_name}! Mangyaring kumpirmahin ang iyong email address sa pag-click sa sumusunod na link:'
   mail_confirm_button: Kumpirmahin ang aking account
-  slack_restricted_join_to_members: 'Paumanhin, hindi ka pwedeng sumali sa %{team_name}dahil
-    mga miyembro lang ng Slack workspace(s) na %{teams} ang makakasali rito.  '
+  slack_restricted_join_to_members: 'Paumanhin, hindi ka pwedeng sumali sa %{team_name}dahil mga miyembro lang ng Slack workspace(s) na %{teams} ang makakasali rito.  '
   admin:
     actions:
       send_reset_password_email:
@@ -233,8 +204,7 @@ fil:
         menu: I-duplicate ang workspace
         done: na-duplicate
         are_you_sure_you_want_to_copy_team:
-          html: Sigurado ka bang nais mong i-duplicate ang workspace na <strong>%{team}</strong>?
-            Kokopyahin din ang lahat ng kaugnay na datos.
+          html: Sigurado ka bang nais mong i-duplicate ang workspace na <strong>%{team}</strong>? Kokopyahin din ang lahat ng kaugnay na datos.
         the_team_is_being_copied: Kasalukuyang nagaganap ang duplication ng workspace
         url_when_ready:
           html: Kapag handa na, makikita ang duplicate ng workspace sa <strong>%{copy_url}</strong>
@@ -249,24 +219,20 @@ fil:
       task: "%B %d, %Y at %H:%M [TZ] (%z UTC)"
       email: "%B %d, %Y %I:%M %p %Z"
   oembed_disclaimer_undetermined: Hindi pa nabeberipika ng %{team} ang item na ito
-  oembed_disclaimer_in_progress: Ang item na ito ay bineberipika ng %{team} nitong
-    %{date}
-  oembed_disclaimer_verified: Ang item na ito ay natukoy na beripikado ng %{team}
-    noong %{date}
-  oembed_disclaimer_false: Ang item na ito ay natukoy na hindi totoo ng %{team} noong
-    %{date}
-  oembed_disclaimer_not_applicable: Walang narating na konklusyon ang %{team} tungkol
-    sa item na ito nitong %{date}
+  oembed_disclaimer_in_progress: Ang item na ito ay bineberipika ng %{team} nitong %{date}
+  oembed_disclaimer_verified: Ang item na ito ay natukoy na beripikado ng %{team} noong %{date}
+  oembed_disclaimer_false: Ang item na ito ay natukoy na hindi totoo ng %{team} noong %{date}
+  oembed_disclaimer_not_applicable: Walang narating na konklusyon ang %{team} tungkol sa item na ito nitong %{date}
   oembed_source_date: "%{date} sa %{provider}"
   role_editor: tagapag-edit
   role_none: miyembro
   role_: sysadmin
   oembed_credit: Idinagdag ni %{user} (%{role}) %{date}
   oembed_notes_count:
-    one: Isang note
+    one: "Isang note"
     other: "%{count} na note"
   oembed_completed_tasks_count:
-    one: Isang nakumpletong gawain
+    one: "Isang nakumpletong gawain"
     other: "%{count} nakumpletong gawain"
   oembed_verification_tasks: Mga Gawain
   oembed_tasks: Mga Gawain
@@ -274,68 +240,55 @@ fil:
   oembed_expand_all: Palawakin lahat
   oembed_collapse_all: I-collapse lahat
   oembed_resolved_tasks_count:
-    one: Isang gawaing naresolba
+    one: "Isang gawaing naresolba"
     other: "%{count} nalutas na gawain"
   oembed_notes: Mga note
   duplicate_source: Dati na ang source
-  geolocation_invalid_value: Hindi wastong lokasyon. Ang inaasahan ay wastong GeoJSON
-    structure (http://geojson.org/)
+  geolocation_invalid_value: Hindi wastong lokasyon. Ang inaasahan ay wastong GeoJSON structure (http://geojson.org/)
   datetime_invalid_date: Hindi wastong petsa
-  error_team_archived_for_source: Paumanhin, hindi pwede magdagdag ng source sa binasurang
-    workspace
+  error_team_archived_for_source: Paumanhin, hindi pwede magdagdag ng source sa binasurang workspace
   permission_error: Paumanhin, hindi ka pinahihintulutang gawin ang operasyon na ito
-  error_annotated_archived: Paumanhin, hindi pwede magdagdag ng note sa binasurang
-    item
-  only_super_admin_can_do_this: Paumanhin, mga system administrator lang ang pwedeng
-    gumawa ng pagbabagong ito
+  error_annotated_archived: Paumanhin, hindi pwede magdagdag ng note sa binasurang item
+  only_super_admin_can_do_this: Paumanhin, mga system administrator lang ang pwedeng gumawa ng pagbabagong ito
   cant_change_custom_statuses: |-
-    Paumanhin, hindi mo pwedeng baguhin ang status definitions dahil mawawala ang ibang status. Ang mga status identifier na ito: %{statuses} ay ginagamit ng mga sumusunod na item:
-    %{urls} %{others_amount}
+      Paumanhin, hindi mo pwedeng baguhin ang status definitions dahil mawawala ang ibang status. Ang mga status identifier na ito: %{statuses} ay ginagamit ng mga sumusunod na item:
+      %{urls} %{others_amount}
   account_exists: Dati na ang account na ito
   media_exists: Dati na ang item na ito
   source_exists: Dati na ang source na ito
   email_exists: ay nakuha na
-  banned_user: 'Paumanhin, pinagbawal ang iyong account sa %{app_name}. Mangyaring
-    makipag-ugnay sa support team kung sa tingin mo ay isa itong pagkakamali. '
+  banned_user: 'Paumanhin, pinagbawal ang iyong account sa %{app_name}. Mangyaring makipag-ugnay sa support team kung sa tingin mo ay isa itong pagkakamali. '
   devise:
     mailer:
       reset_password_instructions:
-        subject: Mga panuto sa pag-reset ng password sa %{app_name}
+        subject: "Mga panuto sa pag-reset ng password sa %{app_name}"
         header_title: Kahilingan para i-reset ang password
-        header_text: Natanggap namin ang iyong kahilingang i-reset ang iyong password
-          sa %{app_name}.
+        header_text: Natanggap namin ang iyong kahilingang i-reset ang iyong password sa %{app_name}.
         action: I-reset ang iyong password
         expiry: Lilipas ang kahilingang ito sa loob ng %{expire} oras.
         instruction_1: Mag-click dito para gumawa ng bagong kahilingan.
-        instruction_2: Kung hindi ikaw ang gumawa ng kahilingang ito, o nahihirapan
-          ka sa pag-reset ng iyong password, mangyaring makipag-ugnay sa amin sa %{support_email}.
+        instruction_2: Kung hindi ikaw ang gumawa ng kahilingang ito, o nahihirapan ka sa pag-reset ng iyong password, mangyaring makipag-ugnay sa amin sa %{support_email}.
       invitation_instructions:
-        subject: Inanyayahan ka ni %{user} na sumali sa workspace na %{team}
+        subject: "Inanyayahan ka ni %{user} na sumali sa workspace na %{team}"
         hello: Kumusta %{name}
         someone_invited_you_default:
-          html: Inanyayahan ka ni %{name} na sumali sa workspace na %{team} bilang
-            %{role}.
+          html: "Inanyayahan ka ni %{name} na sumali sa workspace na %{team} bilang %{role}."
         someone_invited_you_custom:
-          html: 'Inanyayahan ka ni %{name} sa workspace na %{team} bilang %{role},
-            at nagsasabing:'
+          html: "Inanyayahan ka ni %{name} sa workspace na %{team} bilang %{role}, at nagsasabing:"
         accept: Tanggapin ang paanyaya
         accept_until: Lilipas ang paanyayang ito sa %{due_date}.
-        ignore: Kung ayaw mong tanggapin ang paanyaya, mangyaring huwag pansinin ang
-          email na ito.
-        app_team: Workspace ng %{app}
+        ignore: Kung ayaw mong tanggapin ang paanyaya, mangyaring huwag pansinin ang email na ito.
+        app_team: "Workspace ng %{app}"
     failure:
       unconfirmed: Mangyaring tingnan ang iyong email para maberipika ang iyong account.
   user_invitation:
     team_found: Hindi matagpuan ang workspace.
     invalid: Hindi wastong code ng paanyaya.
     no_invitation: Wala pang paanyaya para sa workspace na %{name}
-  error_user_is_not_a_team_member: Paumanhin, pwede ka lang magtalaga sa mga miyembro
-    nitong workspace
-  error_login_with_exists_account: Paumanhin, may ibang user nang gumagamit ng account
-    na ito
-  error_login_2fa: Mangyaring kumpletuhin ang iyong sign in sa pagbibigay ng authentication
-    code.
-  error_record_not_found: 'Hindi matagpuan ang %{type} #%{id}'
+  error_user_is_not_a_team_member: Paumanhin, pwede ka lang magtalaga sa mga miyembro nitong workspace
+  error_login_with_exists_account: Paumanhin, may ibang user nang gumagamit ng account na ito
+  error_login_2fa: Mangyaring kumpletuhin ang iyong sign in sa pagbibigay ng authentication code.
+  error_record_not_found: "Hindi matagpuan ang %{type} #%{id}"
   mails_notifications:
     greeting: Kumusta, %{username}?
     greeting_anonymous: Kumusta?
@@ -345,56 +298,48 @@ fil:
     register:
       subject: Bagong account para sa iyo sa %{app_name}
       header_text: |-
-        Matagumpay kang nakapag-sign-up sa %{app_name}!
-        <br>
-        Para makapag-login sa site, sundan ang link na ito: %{url}. Ilagay ang email address at password na ito: %{password}.
+          Matagumpay kang nakapag-sign-up sa %{app_name}!
+          <br>
+          Para makapag-login sa site, sundan ang link na ito: %{url}. Ilagay ang email address at password na ito: %{password}.
       login_button: Mag-login sa %{app_name}
       footer_text: Salamat sa pagsali at magandang araw sa iyo!
     duplicated:
       subject: Ang iyong paraan ng pag-login sa %{app_name}
       header_title: Duplicate Account
       one_email: |-
-        <p>Isa lamang itong paalala para matulungan kang masiguro ang pag-login sa %{app_name}.</p>
-        <p>Ang nangyari: Sinubukan mong mag-sign in sa %{app_name} gamit ang %{user_provider}-based account na naka-link sa %{user_email}.
-        Pero ang email address na ito ay nakaugnay na sa isang %{duplicate_provider}-based account sa %{app_name}.</p>
-        <p>Ang susunod na gagawin: Mag-sign in gamit ang %{duplicate_provider}.</p>
-        <p>Matapos ito, malo-login ka sa account na ginagamit mo noon.
-        Kung kailangan mo ng karagdagang tulong, mangyaring mag-email sa %{support_email}.</p>
+          <p>Isa lamang itong paalala para matulungan kang masiguro ang pag-login sa %{app_name}.</p>
+          <p>Ang nangyari: Sinubukan mong mag-sign in sa %{app_name} gamit ang %{user_provider}-based account na naka-link sa %{user_email}.
+          Pero ang email address na ito ay nakaugnay na sa isang %{duplicate_provider}-based account sa %{app_name}.</p>
+          <p>Ang susunod na gagawin: Mag-sign in gamit ang %{duplicate_provider}.</p>
+          <p>Matapos ito, malo-login ka sa account na ginagamit mo noon.
+          Kung kailangan mo ng karagdagang tulong, mangyaring mag-email sa %{support_email}.</p>
       both_emails: |-
-        <p>Isa lamang itong paalala para matulungan kang masiguro ang pag-login sa %{app_name}.</p>
-        <p>Ang nangyari: Sinubukan mong gumawa ng bagong email- based account sa %{app_name}, pero dati na ang account na ito.</p>
-        <p>Subukan mong mag-sign in gamit ang iyong email at password, sa halip na gumawa ng panibagong account.</p>
-        <p>Matapos ito, malo-login ka sa account na ginagamit mo noon. Kung kailangan mo ng karagdagang tulong, mangyaring mag-email sa %{support_email}.</p>
+          <p>Isa lamang itong paalala para matulungan kang masiguro ang pag-login sa %{app_name}.</p>
+          <p>Ang nangyari: Sinubukan mong gumawa ng bagong email- based account sa %{app_name}, pero dati na ang account na ito.</p>
+          <p>Subukan mong mag-sign in gamit ang iyong email at password, sa halip na gumawa ng panibagong account.</p>
+          <p>Matapos ito, malo-login ka sa account na ginagamit mo noon. Kung kailangan mo ng karagdagang tulong, mangyaring mag-email sa %{support_email}.</p>
       email: email
     invitation:
       title: Bagong Paanyaya
     delete_user:
       subject: "[%{team}] May user na binura"
       header_title: Binura ang User
-      header_text: May binurang user account at nilipat ang pagkakatalaga ng nilalaman
-        nito sa %{anonymous} user %{id}
+      header_text: May binurang user account at nilipat ang pagkakatalaga ng nilalaman nito sa %{anonymous} user %{id}
       anonymous: anonymous
     admin_mailer:
-      team_download_subject: "[%{team}] Handa nang ma-download ang workspace data
-        snapshot"
+      team_download_subject: "[%{team}] Handa nang ma-download ang workspace data snapshot"
       team_dump_title: Datos ng Workspace
       types:
         dump: data snapshot
         csv: ulat
         images: artsibo ng mga larawan
-      team_dump_text: 'Humingi ka ng data snapshot para sa workspace na %{team} -
-        narito ang link para ma-download ito: %{link}'
+      team_dump_text: 'Humingi ka ng data snapshot para sa workspace na %{team} - narito ang link para ma-download ito: %{link}'
       team_dump_button: I-download ang datos ng workspace
-      decompress_text: Ang %{type} ay mada-download bilang compressed at encrypted
-        na file. Para ma-decompress ito, mangyaring gamitin ang password na %{password}.
+      decompress_text: Ang %{type} ay mada-download bilang compressed at encrypted na file. Para ma-decompress ito, mangyaring gamitin ang password na %{password}.
       expire_note: Pakitandaan na lilipas ang link na ito sa loob ng %{days} araw.
       team_import_subject: Nakumpleto ang iyong pag-angkat ng datos
       team_import_title: Pag-angkat ng Datos
-      team_import_text: "<p>Natapos na ang iyong pag-angkat ng datos papasok sa %{app_name}.
-        Pwede mo itong makita sa %{worksheet_url} para masuri ang status ng bawat
-        item na iaangkat. Pakitandaan na pwede mong ulitin ang pag-aangkat pagkatapos
-        mong maayos ang anumang mga pagkakamaling naka-ulat doon - hindi madu-duplicate
-        ang mga item na nauna nang inangkat."
+      team_import_text: "<p>Natapos na ang iyong pag-angkat ng datos papasok sa %{app_name}. Pwede mo itong makita sa %{worksheet_url} para masuri ang status ng bawat item na iaangkat. Pakitandaan na pwede mong ulitin ang pag-aangkat pagkatapos mong maayos ang anumang mga pagkakamaling naka-ulat doon - hindi madu-duplicate ang mga item na nauna nang inangkat."
     task_resolved:
       subject: "[%{team} - %{project}] Nasagutan ang Gawain"
       header_title: Nasagutan ang Gawain
@@ -411,17 +356,15 @@ fil:
       tasks_h: Mga Nakumpletong Gawain
     assignment:
       assign_task_subject: "[%{team} - %{project}] May gawaing itinalaga sa iyo"
-      unassign_task_subject: "[%{team} - %{project}]  May gawaing inalis ang pagkakatalaga
-        sa iyo"
+      unassign_task_subject: "[%{team} - %{project}]  May gawaing inalis ang pagkakatalaga sa iyo"
       assign_media_subject: "[%{team} - %{project}] May item na itinalaga sa iyo"
-      unassign_media_subject: "[%{team} - %{project}] May item na inalis ang pagkakatalaga
-        sa iyo"
+      unassign_media_subject: "[%{team} - %{project}] May item na inalis ang pagkakatalaga sa iyo"
       assign_task_title: Gawaing Nakatalaga
       unassign_task_title: Gawaing Inalis sa Pagkakatalaga
       assign_media_title: Item na Nakatalaga
       unassign_media_title: Item na Inalis sa Pagkakatalaga
-      assign_log: Itinalaga ni %{author} ang %{model} kay %{username}
-      unassign_log: Inalis ni %{author} ang pagkakatalaga ng %{model} kay %{username}
+      assign_log: "Itinalaga ni %{author} ang %{model} kay %{username}"
+      unassign_log: "Inalis ni %{author} ang pagkakatalaga ng %{model} kay %{username}"
       assign_by: Itinalaga ni
       unassign_by: Inalis sa pagkakatalaga ni
     request_to_join:
@@ -431,40 +374,29 @@ fil:
       rejected_subject: Tinanggihan ang iyong kahilingang sumali sa %{team}
       approved_subject: Maligayang pagdating sa workspace na %{team}
       request_title: Kahilingang sumali sa workspace na %{team}
-      request_text: Nais sumali ni %{name} (%{email}) sa workspace na %{team} sa %{app_name}.
-        Pwede mong iproseso ang kahilingang ito sa pagbisita sa %{url}.
+      request_text: "Nais sumali ni %{name} (%{email}) sa workspace na %{team} sa %{app_name}. Pwede mong iproseso ang kahilingang ito sa pagbisita sa %{url}."
       approved_title: Maligayang pagdating sa workspace na %{team}
-      approved_text: Inaprubahan ang iyong kahilingang sumali sa workspace na %{team}
-        sa %{app_name}. Pwede ka nang pumunta sa %{url} at magsimulang mag-ambag.
+      approved_text: Inaprubahan ang iyong kahilingang sumali sa workspace na %{team} sa %{app_name}. Pwede ka nang pumunta sa %{url} at magsimulang mag-ambag.
       rejected_title: Tinanggihan ang Kahilingan
-      rejected_text: Paumanhin, tinanggihan ang iyong kahilingang sumali sa workspace
-        na %{team} sa %{app_name}.
+      rejected_text: Paumanhin, tinanggihan ang iyong kahilingang sumali sa workspace na %{team} sa %{app_name}.
   mail_security:
-    device_subject: 'Alertong panseguridad: May bagong login sa %{app_name} mula sa
-      %{browser} sa %{platform}'
+    device_subject: 'Alertong panseguridad: May bagong login sa %{app_name} mula sa %{browser} sa %{platform}'
     ip_subject: 'Alertong panseguridad: May bago o naiibang login sa %{app_name}'
-    failed_subject: 'Alertong panseguridad: Mga bigong pagtatangka na mag-login sa
-      %{app_name}'
+    failed_subject: 'Alertong panseguridad: Mga bigong pagtatangka na mag-login sa %{app_name}'
     ip: Nag-sign in ka mula sa %{location}
     device: Naka-sign in ka mula sa %{browser} sa %{platform}
     devise_name: "%{browser} sa %{platform}"
     failed: May mga natuklasang bigong pagtatangka sa pag-login
     password_text: agarang i-reset ang iyong password.
-    device_text: Mukhang nag-sign in ka kamakailan sa iyong %{app_name} account mula
-      sa bagong device. Kung hindi ikaw ito, kailangan mong %{change_password}
-    ip_text: Mukhang nag-sign in ka kamakailan sa iyong %{app_name} account mula sa
-      bagong lokasyon. Kung hindi ikaw ito, kailangan mong %{change_password}
-    failed_text: Mukhang ilang beses na may nagtangkang mag-login sa iyong %{app_name}
-      account. Kung ikaw ito, ligtas ang hindi pansinin ang email na ito. Kung hindi
-      ikaw ito, dapat mong %{change_password}
+    device_text: Mukhang nag-sign in ka kamakailan sa iyong %{app_name} account mula sa bagong device. Kung hindi ikaw ito, kailangan mong %{change_password}
+    ip_text: Mukhang nag-sign in ka kamakailan sa iyong %{app_name} account mula sa bagong lokasyon. Kung hindi ikaw ito, kailangan mong %{change_password}
+    failed_text: Mukhang ilang beses na may nagtangkang mag-login sa iyong %{app_name} account. Kung ikaw ito, ligtas ang hindi pansinin ang email na ito. Kung hindi ikaw ito, dapat mong %{change_password}
     time_h: Oras
     device_h: Device
     location_h: Lokasyon
-    location_disclaimer: "* Ang lokasyon ay tinatantiya base sa IP address na pinagmulan
-      nito."
+    location_disclaimer: "* Ang lokasyon ay tinatantiya base sa IP address na pinagmulan nito."
     ip_h: IP Address
-    privacy: "%{manage} ang iyong mga abiso sa email • Dagdagan ang kaalaman tungkol
-      sa aming %{privacy}"
+    privacy: "%{manage} ang iyong mga abiso sa email • Dagdagan ang kaalaman tungkol sa aming %{privacy}"
     privacy_text: Patakaran sa Pagkapribado
     manage_text: Mamahala
     privace_manage_plain: Mamahala sa mga abiso sa email
@@ -472,63 +404,46 @@ fil:
   archive_keep_backup: Video Vault
   archive_pender_archive: Screenshot
   archive_archive_org: Archive.org
-  workflow_status_is_not_valid: 'Hindi wastong status: ''%{status}'' (dapat kabilang
-    sa %{valid})'
-  workflow_status_permission_error: Paumahin, hindi ka pinahihintulutang baguhin ang
-    status na ito.
-  blank_default_status_for_custom_verification_status: Mangyaring magbigay ng default
-    na value para sa mga custom verification status
-  blank_active_status_for_custom_verification_status: Mangyaring magbigay ng aktibong
-    value para sa mga custom verification status
-  bot_name_exists_for_this_team: Meron nang bot sa pangalang binigay sa loob ng workspace
-    na ito
+  workflow_status_is_not_valid: 'Hindi wastong status: ''%{status}'' (dapat kabilang sa %{valid})'
+  workflow_status_permission_error: Paumahin, hindi ka pinahihintulutang baguhin ang status na ito.
+  blank_default_status_for_custom_verification_status: Mangyaring magbigay ng default na value para sa mga custom verification status
+  blank_active_status_for_custom_verification_status: Mangyaring magbigay ng aktibong value para sa mga custom verification status
+  bot_name_exists_for_this_team: Meron nang bot sa pangalang binigay sa loob ng workspace na ito
   bot_team_id_doesnt_exist: Paumanhin, walang workspace sa binigay na identifier
-  bot_team_id_mandatory_to_create: Paumanhin, kailangan mong pumili ng workspace para
-    makagawa ng bot
-  bot_not_approved_for_installation: Paumanhin, hindi naaprubahan ang bot na ito kaya
-    hindi ito ma-install
-  could_not_save_related_bot_data: Paumanhin, hindi maidagdag ang bot sa workspace
-    na ito
-  bot_cant_add_response_to_task: Paumanhin, hindi direktang nakasasagot ng gawain
-    ang isang bot - mangyaring magpadala na lamang ng mungkahing sagot
+  bot_team_id_mandatory_to_create: Paumanhin, kailangan mong pumili ng workspace para makagawa ng bot
+  bot_not_approved_for_installation: Paumanhin, hindi naaprubahan ang bot na ito kaya hindi ito ma-install
+  could_not_save_related_bot_data: Paumanhin, hindi maidagdag ang bot sa workspace na ito
+  bot_cant_add_response_to_task: Paumanhin, hindi direktang nakasasagot ng gawain ang isang bot - mangyaring magpadala na lamang ng mungkahing sagot
   bot_cant_add_review_to_task: Paumanhin, hindi nakasusuri ng gawain ang isang bot
-  task_suggestion_invalid_value: Hindi wasto ang mungkahing gawain. Ang inaasahan
-    ay JSON object na may mga attribute na `suggestion` (ang akwtal na value na ikinokopya
-    sa sagot sa gawain kapag tinanggap) at `comment` (ipinakikita sa mga user).
+  task_suggestion_invalid_value: Hindi wasto ang mungkahing gawain. Ang inaasahan ay JSON object na may mga attribute na `suggestion` (ang akwtal na value na ikinokopya sa sagot sa gawain kapag tinanggap) at `comment` (ipinakikita sa mga user).
   tag_text_id_not_found: Hindi matagpuan ang tag
   annotation_type_language_label: Wika
   smooch_bot_message_confirmed: |-
-    Salamat. Naipadala na ang iyong kahilingan sa aming pila pamberipikasyon.
+      Salamat. Naipadala na ang iyong kahilingan sa aming pila pamberipikasyon.
 
-    Sisikapin naming magpadala ng ulat sa loob ng 24 oras, pero mangyaring tandaan na hindi namin kayang masagutan ang bawat kahilingan.
-  smooch_bot_message_unconfirmed: Dahil hindi ka sumagot ng 1, hindi na namin ipo-proseso
-    pa ang iyong kahilingan. Salamat.
-  smooch_bot_message_type_unsupported: Paumanhin, hindi namin suportado ang ganitong
-    uri ng mensahe.
-  smooch_bot_message_size_unsupported: Paumanhin, hindi namin suportado ang mga file
-    na higit sa %{max_size}.
+      Sisikapin naming magpadala ng ulat sa loob ng 24 oras, pero mangyaring tandaan na hindi namin kayang masagutan ang bawat kahilingan.
+  smooch_bot_message_unconfirmed: Dahil hindi ka sumagot ng 1, hindi na namin ipo-proseso pa ang iyong kahilingan. Salamat.
+  smooch_bot_message_type_unsupported: Paumanhin, hindi namin suportado ang ganitong uri ng mensahe.
+  smooch_bot_message_size_unsupported: Paumanhin, hindi namin suportado ang mga file na higit sa %{max_size}.
   smooch_bot_result: |-
-    [Ulat Pamberipikasyon] Ang iyong binahaging item sa amin ay minarkahan bilang *%{status}*.
+      [Ulat Pamberipikasyon] Ang iyong binahaging item sa amin ay minarkahan bilang *%{status}*.
 
-    Narito ang mga ginawa naming hakbang para matukoy ito: %{url}
+      Narito ang mga ginawa naming hakbang para matukoy ito: %{url}
   smooch_bot_ask_for_confirmation: |-
-    Salamat sa pagpapadala ng kahilingang ito. Nais mo bang beripikahin namin ang nilalaman nito?
+      Salamat sa pagpapadala ng kahilingang ito. Nais mo bang beripikahin namin ang nilalaman nito?
 
-    Para magsabi ng oo, *mangyaring mag-reply ng 1*. Ang anumang ibang tugon ay tatapos sa ating pag-uusap.
+      Para magsabi ng oo, *mangyaring mag-reply ng 1*. Ang anumang ibang tugon ay tatapos sa ating pag-uusap.
   smooch_bot_ask_for_tos: |-
-    Salamat sa paglapit sa Check Message!
+      Salamat sa paglapit sa Check Message!
 
-    Pwede mong gamitin ang serbisyong ito para humiling ng pagbeberipika, pagfa-fact-check, at pagsisiyasat ng mga balita at impormasyon. Ang Check Message ay ipinagkakaloob sa iyo sa ilalim nitong mga Tuntunin ng Serbisyo: %{tos}. Sa patuloy na paggamit sa serbisyong ito, *sumasang-ayon kang magpailalim sa mga tuntuning ito*. Huminto sa paggamit ng Check Message sakaling hindi ka sumasang-ayon.
-  smooch_bot_window_closing: Napakarami ng mga kahilingan sa channel na ito, at hindi
-    pa namin nalulutas ang iyong kahilingan. Maraming salamat sa iyong pasensya.
+      Pwede mong gamitin ang serbisyong ito para humiling ng pagbeberipika, pagfa-fact-check, at pagsisiyasat ng mga balita at impormasyon. Ang Check Message ay ipinagkakaloob sa iyo sa ilalim nitong mga Tuntunin ng Serbisyo: %{tos}. Sa patuloy na paggamit sa serbisyong ito, *sumasang-ayon kang magpailalim sa mga tuntuning ito*. Huminto sa paggamit ng Check Message sakaling hindi ka sumasang-ayon.
+  smooch_bot_window_closing: Napakarami ng mga kahilingan sa channel na ito, at hindi pa namin nalulutas ang iyong kahilingan. Maraming salamat sa iyong pasensya.
   smooch_bot_not_final: |-
-    [Ulat Pamberipikasyon - PAGWAWASTO] Ang iyong binahaging mensahe sa amin ay maling namarkahan bilang *%{status}*.
+      [Ulat Pamberipikasyon - PAGWAWASTO] Ang iyong binahaging mensahe sa amin ay maling namarkahan bilang *%{status}*.
 
-    Nasa pila pa rin namin ito para sa karagdagang beripikasyon.
-  smooch_bot_disabled: Salamat sa pagpapadala ng mensaheng ito. Hindi kami makapagpadala
-    ng anumang ulat pamberipikasyon, dahil hindi na aktibo ang proyektong ito.
-  smooch_bot_result_changed: "❗️Ang ipinadala naming fact-check sa iyo ay *in-update*
-    ng bagong impormasyon"
+      Nasa pila pa rin namin ito para sa karagdagang beripikasyon.
+  smooch_bot_disabled: Salamat sa pagpapadala ng mensaheng ito. Hindi kami makapagpadala ng anumang ulat pamberipikasyon, dahil hindi na aktibo ang proyektong ito.
+  smooch_bot_result_changed: "❗️Ang ipinadala naming fact-check sa iyo ay *in-update* ng bagong impormasyon"
   permissions_info:
     permissions:
       sections:
@@ -560,28 +475,21 @@ fil:
             edit_tasks: Gumawa at mag-edit ng mga gawaing pang-workspace
             roles: I-edit ang mga papel sa workspace
             third_party: Magdagdag ng mga third-party integration
-            invite_members: Mag-anyaya, mag-apruba, at magtanggal ng mga miyembro
-              ng workspace
+            invite_members: Mag-anyaya, mag-apruba, at magtanggal ng mga miyembro ng workspace
   team_import:
     invalid_google_spreadsheet_url: Hindi wastong URL ng spreadsheet %{spreadsheet_url}
     not_found_google_spreadsheet_url: Hindi matagpuan ang spreadsheet sa %{spreadsheet_url}
-    cannot_authenticate_with_the_credentials: Hindi mapatunayan ang Google Drive gamit
-      ang kasalukuyang mga kredensyal. Mangyaring makipag-ugnay sa support team para
-      ipagbigay-alam sa kanila ang insidenteng ito.
-    team_not_present: Hindi matagpuan ang kasalukuyang workspace habang nag-aangkat
-      ng datos. Mangyaring ipagbigay-alam sa support team ang insidenteng ito.
-    user_not_present: Hindi matagpuan ang kasalukuyang user habang nag-aangkat ng
-      datos. Mangyaring ipagbigay-alam sa support team ang insidenteng ito.
-    user_not_authorized: Paumanhin, hindi ka pinahihintulutang mag-angkat ng datos
-      sa workspace na ito.
+    cannot_authenticate_with_the_credentials: Hindi mapatunayan ang Google Drive gamit ang kasalukuyang mga kredensyal. Mangyaring makipag-ugnay sa support team para ipagbigay-alam sa kanila ang insidenteng ito.
+    team_not_present: Hindi matagpuan ang kasalukuyang workspace habang nag-aangkat ng datos. Mangyaring ipagbigay-alam sa support team ang insidenteng ito.
+    user_not_present: Hindi matagpuan ang kasalukuyang user habang nag-aangkat ng datos. Mangyaring ipagbigay-alam sa support team ang insidenteng ito.
+    user_not_authorized: Paumanhin, hindi ka pinahihintulutang mag-angkat ng datos sa workspace na ito.
     invalid_user: Hindi wastong may-akda %{user}
     invalid_status: Hindi wastong status %{status}
     blank_user: Hindi maaaring blangko ang patlang para sa may-akda
     blank_annotator: Hindi maaaring blangko ang patlang para sa anotador
     invalid_annotator: Hindi wastong anotador %{user}
     invalid_assignee: Hindi wastong assignee %{user}
-  cant_mutate_inactive_object: 'Paumanhin, may nakabinbin na operasyon para sa item
-    na ito, kaya hindi mo ito pwedeng baguhin ngayon. Mangyaring subukan ulit mamaya. '
+  cant_mutate_inactive_object: 'Paumanhin, may nakabinbin na operasyon para sa item na ito, kaya hindi mo ito pwedeng baguhin ngayon. Mangyaring subukan ulit mamaya. '
   embed_expand_all: Palawakin lahat
   embed_collapse_all: I-collapse lahat
   embed_tasks: Mga gawain
@@ -595,23 +503,19 @@ fil:
   bot_request_url_invalid: Hindi wastong bot URL
   invalid_task_answer: Hindi wastong format para sa sagot sa gawaing ito
   team_rule_name: Kakaibang pangalan na nagtutukoy sa ginagawa nitong panuntunan
-  team_rule_names_invalid: Ang mga pangalan ng panuntunan ay hindi maaaring blangko
-    at dapat kakaiba
+  team_rule_names_invalid: Ang mga pangalan ng panuntunan ay hindi maaaring blangko at dapat kakaiba
   team_rules: Mga panuntunan
   team_rule_conditions: Kung
   team_rule_condition: Kung
   team_rule_condition_definition: Mamili ng kundisyon
-  team_rule_title_matches_regexp: Tugma ang pamagat ng item sa regular expression
-    na ito
-  team_rule_request_matches_regexp: Tugma ang kahilingan sa regular expression na
-    ito
+  team_rule_title_matches_regexp: Tugma ang pamagat ng item sa regular expression na ito
+  team_rule_request_matches_regexp: Tugma ang kahilingan sa regular expression na ito
   team_rule_type_is: Ang uri ng item ay
   team_rule_type_is_claim: Teksto
   team_rule_type_is_link: Link
   team_rule_type_is_uploadedimage: Larawan
   team_rule_type_is_uploadedvideo: Video
-  team_rule_contains_keyword: Ang kahilingan ay naglalaman ng isa o higit pa sa sumusunod
-    na mga keyword
+  team_rule_contains_keyword: Ang kahilingan ay naglalaman ng isa o higit pa sa sumusunod na mga keyword
   team_rule_select_type: Mamili ng uri
   team_rule_select_language: Mamili ng wika
   team_rule_select_user: Mamili ng katuwang
@@ -625,8 +529,7 @@ fil:
   team_rule_actions: Samakatuwid
   team_rule_action: Samakatuwid
   team_rule_action_definition: Mamili ng gagawin
-  team_rule_ban_submitter: Ipagbawal ang nagsumite (hindi na lalabas ang mga susunod
-    nilang mensahe sa Check)
+  team_rule_ban_submitter: Ipagbawal ang nagsumite (hindi na lalabas ang mga susunod nilang mensahe sa Check)
   team_rule_all_items: Lahat ng mga item
   team_rule_send_message_to_user: Ipadala ang mensahe sa user
   team_rule_action_value: I-type ang mensahe rito
@@ -648,8 +551,7 @@ fil:
   team_rule_item_user_is: Ginawa ang item ni
   team_rule_item_is_read: Nabasa na ang item
   team_rule_field_from_fieldset_tasks_value_is: May tiyak na sagot ang gawain
-  team_rule_field_from_fieldset_tasks_value_contains_keyword: May nilalamang keyword
-    ang sagot sa gawain
+  team_rule_field_from_fieldset_tasks_value_contains_keyword: May nilalamang keyword ang sagot sa gawain
   team_rule_select_field_value_metadata: Mamili ng value
   team_rule_select_field_tasks: Mamili ng gawain
   team_rule_select_field_value_tasks: Mamili ng sagot
@@ -665,25 +567,17 @@ fil:
   flag_likelihood_2: Walang katiyakan
   flag_likelihood_4: Maaari
   relationship_not_same_team: Kailangang nasa iisang workspace ang magkaugnay na item
-  bulk_operation_limit_error: Paumanhin, ang pinakamalaking bilang ng mga item na
-    pwedeng iproseso nang sabay-sabay ay %{limit}
-  must_provide_fallback_when_deleting_status_in_use: Ginagamit ang status na ito,
-    kaya kailangan mong magbigay ng fallback status kung gusto mo itong burahin
-  embed_no_content_yet: Binubuo ang ulat. Aabutin ng ilang minuto ang prosesong ito.
-    Mangyaring i-refresh ang pahinang ito.
-  language_format_invalid: Hindi wastong format ng wika. Ang inaasahan ay ISO 639-1
-    code.
-  languages_format_invalid: Hindi wastong format ng wika. Ang inaasahan ay listahan
-    ng mga ISO 639-1 code.
-  cant_change_status_if_item_is_published: Paumanhin, hindi mo pwedeng palitan ang
-    status habang nakalathala ang ulat
+  bulk_operation_limit_error: Paumanhin, ang pinakamalaking bilang ng mga item na pwedeng iproseso nang sabay-sabay ay %{limit}
+  must_provide_fallback_when_deleting_status_in_use: Ginagamit ang status na ito, kaya kailangan mong magbigay ng fallback status kung gusto mo itong burahin
+  embed_no_content_yet: Binubuo ang ulat. Aabutin ng ilang minuto ang prosesong ito. Mangyaring i-refresh ang pahinang ito.
+  language_format_invalid: Hindi wastong format ng wika. Ang inaasahan ay ISO 639-1 code.
+  languages_format_invalid: Hindi wastong format ng wika. Ang inaasahan ay listahan ng mga ISO 639-1 code.
+  cant_change_status_if_item_is_published: Paumanhin, hindi mo pwedeng palitan ang status habang nakalathala ang ulat
   fetch_bot_service_unsupported: Hindi suportado ang serbisyo
   task_options_must_be_array: Dapat listahan ang mga gawaing pagpipilian
   fieldset_not_defined_by_team: Suportado dapat ng workspace ang fieldset
-  replace_by_media_in_the_same_team: Paumanhin, mapapalitan mo lang ang item na ito
-    ng ibang item na mula sa parehong workspace.
-  replace_blank_media_only: Paumanhin, pero sa ngayon, mga blangkong item lang ang
-    pwede mong palitan.
+  replace_by_media_in_the_same_team: Paumanhin, mapapalitan mo lang ang item na ito ng ibang item na mula sa parehong workspace.
+  replace_blank_media_only: Paumanhin, pero sa ngayon, mga blangkong item lang ang pwede mong palitan.
   cant_preview_rss_feed: Paumanhin, wala kang pahintulot para tumingin ng RSS feed.
   list_column_demand: Mga kahilingan
   list_column_share_count: Mga Share sa FB

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,4 +1,3 @@
----
 fr:
   statuses:
     ids:
@@ -20,13 +19,12 @@ fr:
         description: Par défaut, vient d’être ajouté, aucun travail n’a été fait
       not_applicable:
         label: Non concluant
-        description: Aucune conclusion ne peut être tirée avec les données probantes
-          à disposition
+        description: Aucune conclusion ne peut être tirée avec les données probantes à disposition
       in_progress:
         label: En cours
         description: Le travail a commencé, mais aucune traduction n’a été faite
       not_true:
-        label: Faux
+        label: 'Faux'
         description: 'Conclusion : le contenu de l’élément est faux'
       verified:
         label: Vérifié
@@ -77,38 +75,27 @@ fr:
     messages:
       invalid_password: Le mot de passe est invalide
       invalid_qrcode: Le code de validation est invalide
-      extension_white_list_error: ne peut pas être de type %{extension}, les types
-        autorisés sont %{allowed_types}
+      extension_white_list_error: 'ne peut pas être de type %{extension}, les types autorisés sont :%{allowed_types}'
       invalid_size: doit faire entre %{min_width}x%{min_height} et %{max_width}x%{max_height} pixels
-      mini_magick_processing_error: Désolé, il nous a été impossible de traiter l’image.
-        L’erreur était %{e}
+      mini_magick_processing_error: 'Désolé, il nous a été impossible de traiter l’image. L’erreur était %{e}'
       annotation_mandatory_fields: Veuillez définir tous les champs obligatoires
       annotation_type_does_not_exist: n’existe pas
       invalid_attribution: L’attribution est invalide
-      must_resolve_required_tasks_first: Les tâches obligatoires doivent d’abord être
-        résolues
-      image_too_large: Désolé, nous ne prenons pas en charge les images supérieures
-        à %{max_size}.
-      video_too_large: Désolé, nous ne prenons pas en charge les vidéos supérieures
-        à %{max_size}.
-      audio_too_large: Désolé, nous ne prenons pas en charge les fichiers son supérieurs
-        à %{max_size}.
-      pender_conflict: Ce lien est déjà en cours d’analyse. Veuillez réessayer dans
-        quelques secondes.
+      must_resolve_required_tasks_first: Les tâches obligatoires doivent d’abord être résolues
+      image_too_large: Désolé, nous ne prenons pas en charge les images supérieures à %{max_size}.
+      video_too_large: Désolé, nous ne prenons pas en charge les vidéos supérieures à %{max_size}.
+      audio_too_large: Désolé, nous ne prenons pas en charge les fichiers son supérieurs à %{max_size}.
+      pender_conflict: Ce lien est déjà en cours d’analyse. Veuillez réessayer dans quelques secondes.
       pender_url_invalid: Ce lien est invalide.
       pender_url_unsafe: Ce lien n’est pas fiable.
-      pender_could_not_parse: 'Nous n’avons pas pu analyser ce lien. Veuillez contacter
-        %{support_email} si l’erreur persiste. '
-      invalid_format_for_languages: Le format de langue est invalide. Le format `['fr',
-        'en'…]` est attendu
-      invalid_project_media_channel_value: Désolé, la valeur de canal n’est pas prise
-        en charge
-      invalid_project_media_channel_update: Désolé, il ne vous a pas été possible
-        de mettre à jour la valeur du canal
-      invalid_project_media_archived_value: Désolé, la valeur archivée n’est pas prise
-        en charge
-      invalid_fact_check_language_value: Désolé, la valeur de langue n’est pas prise
-        en charge
+      pender_could_not_parse: 'Nous n’avons pas pu analyser ce lien. Veuillez contacter %{support_email} si l’erreur persiste. '
+      invalid_format_for_languages: Le format de langue est invalide. Le format `['fr', 'en'…]` est attendu
+      invalid_project_media_channel_value: Désolé, la valeur de canal n’est pas prise en charge
+      invalid_project_media_channel_update: Désolé, il ne vous a pas été possible de mettre à jour la valeur du canal
+      invalid_project_media_archived_value: Désolé, la valeur archivée n’est pas prise en charge
+      invalid_fact_check_language_value: Désolé, la valeur de langue n’est pas prise en charge
+      fact_check_empty_title_and_summary: Désolé, vous devez remplir le titre ou le résumé
+      invalid_feed_saved_search_value: doit appartenir à un espace de travail qui fait partie de ce fil
   activerecord:
     models:
       link: Lien
@@ -166,22 +153,15 @@ fr:
           one: est trop court (au moins 1 caractère)
           many: est trop court (au moins %{count} caractères)
           other: est trop court (au moins %{count} caractères)
-  slack_webhook_format_wrong: Le point d’ancrage Web Slack est invalide. Le format
-    `https://hooks.slack.com/services/XXXXX/XXXXXXXXXX` est attendu
+  slack_webhook_format_wrong: Le point d’ancrage Web Slack est invalide. Le format `https://hooks.slack.com/services/XXXXX/XXXXXXXXXX` est attendu
   slug_is_reserved: est réservé
   invalid_media_item: L’élément est invalide
-  invalid_default_status_for_custom_verification_status: L’identifiant d’état par
-    défaut est invalide
-  invalid_active_status_for_custom_verification_status: L’identifiant d’état actif
-    est invalide
+  invalid_default_status_for_custom_verification_status: L’identifiant d’état par défaut est invalide
+  invalid_active_status_for_custom_verification_status: L’identifiant d’état actif est invalide
   invalid_label_for_custom_verification_status: L’étiquette d’état est obligatoire
-  invalid_id_for_custom_verification_status: L’identifiant d’état est obligatoire
-    et ne doit comporter que des lettres minuscules, des chiffres, des tirets et des
-    traits de soulignement
-  invalid_statuses_format_for_custom_verification_status: 'Des états personnalisés
-    de vérification sont invalides. Des entrées valides sont attendues pour : étiquette,
-    identifiant, description et style.'
-  mail_account_confirmation: Confirmation de votre compte %{app_name}
+  invalid_id_for_custom_verification_status: L’identifiant d’état est obligatoire et ne doit comporter que des lettres minuscules, des chiffres, des tirets et des traits de soulignement
+  invalid_statuses_format_for_custom_verification_status: 'Des états personnalisés de vérification sont invalides. Des entrées valides sont attendues pour : étiquette, identifiant, description et style.'
+  mail_account_confirmation: "Confirmation de votre compte %{app_name}"
   slack:
     fields:
       assigned: Attribuée à
@@ -205,43 +185,31 @@ fr:
       tasks_answer_edit: "%{user} a modifié la réponse de la tâche %{title} : %{answer}"
       metadata_create: "%{user} a ajouté un champ de métadonnées : %{title}"
       metadata_edit: "%{user} a modifié le champ de métadonnées %{title}"
-      metadata_answer_create: "%{user} a défini la valeur des métadonnées %{title} :
-        %{answer}"
-      metadata_answer_edit: "%{user} a modifié la valeur des métadonnées %{title} :
-        %{answer}"
-      project_media_comment: "%{user} (%{role} de %{team}) a ajouté une note à un
-        ou une%{parent_type}"
+      metadata_answer_create: "%{user} a défini la valeur des métadonnées %{title} : %{answer}"
+      metadata_answer_edit: "%{user} a modifié la valeur des métadonnées %{title} : %{answer}"
+      project_media_comment: "%{user} (%{role} de %{team}) a ajouté une note à un ou une%{parent_type}"
       project_media_create: "%{user} (%{role} de %{team}) a envoyé un nouvel élément"
-      project_media_create_related: "%{user} (%{role} de %{team}) a ajouté un ou une
-        %{type} associé.e"
+      project_media_create_related: "%{user} (%{role} de %{team}) a ajouté un ou une %{type} associé.e"
       project_media_update: "%{user} (%{role} de %{team}) a mis un élément à jour"
-      project_media_move_to: "%{user} (%{role} de %{team}) a déplacé un élément vers
-        %{project}"
-      project_media_added_to_list: "%{user} (%{role} de %{team}) a ajouté un élément
-        au dossier %{list_name}"
-      project_media_status: "%{user} (%{role} de%{team}) a changé l’état %{workflow}
-        d’un/d’une %{type}"
+      project_media_move_to: "%{user} (%{role} de %{team}) a déplacé un élément vers %{project}"
+      project_media_added_to_list: "%{user} (%{role} de %{team}) a ajouté un élément au dossier %{list_name}"
+      project_media_status: "%{user} (%{role} de%{team}) a changé l’état %{workflow} d’un/d’une %{type}"
       project_media_assign: "%{user} (%{role} de %{team}) a attribué un ou une %{type}"
-      project_media_unassign: "%{user} (%{role} de %{team}) a retiré l’attribution
-        d’un ou une %{type}"
-      project_source_comment: "%{user} (%{role} de %{team}) a ajouté une note à un
-        ou une%{parent_type}"
+      project_media_unassign: "%{user} (%{role} de %{team}) a retiré l’attribution d’un ou une %{type}"
+      project_source_comment: "%{user} (%{role} de %{team}) a ajouté une note à un ou une%{parent_type}"
       project_source_create: "%{user} (%{role} de %{team}) a ajouté un ou une %{type}"
       project_source_update: "%{user} (%{role} de %{team}) a modifié un ou une %{type}"
       project_create: "%{user} (%{role} de %{team}) a créé un dossier"
       project_assign: "%{user} (%{role} de %{team}) a affecté un dossier"
-      project_unassign: "%{user} (%{role} de %{team}) a retiré l’attribution d’un
-        dossier"
+      project_unassign: "%{user} (%{role} de %{team}) a retiré l’attribution d’un dossier"
       user_member: "%{user} s’est joint à l’espace de travail %{team}"
       user_requested: "%{user} a demandé à se joindre à l’espace de travail %{team}"
       user_invited: "%{user} a été invité à se joindre à l’espace de travail %{team}"
       user_banned: "%{user} a été banni de l’espace de travail %{team}"
   mail_view_welcome: Bienvenue sur %{app_name}
-  mail_view_register: 'Vous n’êtes qu’à une étape pour de pouvoir utiliser %{app_name}.
-    Veuillez confirmer votre courriel en cliquant le lien suivant :'
+  mail_view_register: 'Vous n’êtes qu’à une étape pour de pouvoir utiliser %{app_name}. Veuillez confirmer votre courriel en cliquant le lien suivant :'
   mail_confirm_button: Confirmer mon compte
-  slack_restricted_join_to_members: Désolé, vous ne pouvez pas vous joindre à %{team_name},
-    car l’équipe est réservée aux membres des espaces de travail Slack %{teams}.
+  slack_restricted_join_to_members: Désolé, vous ne pouvez pas vous joindre à %{team_name}, car l’équipe est réservée aux membres des espaces de travail Slack %{teams}.
   admin:
     actions:
       send_reset_password_email:
@@ -254,12 +222,10 @@ fr:
         menu: Dupliquer l’espace de travail
         done: a été dupliquée
         are_you_sure_you_want_to_copy_team:
-          html: Voulez-vous vraiment dupliquer l’espace de travail <strong>%{team}</strong> ?
-            Toutes les données connexes seront aussi copiées.
+          html: Voulez-vous vraiment dupliquer l’espace de travail <strong>%{team}</strong> ? Toutes les données connexes seront aussi copiées.
         the_team_is_being_copied: La duplication de l’espace de travail est en cours
         url_when_ready:
-          html: Une fois prête, la copie de l’espace de travail sera accessible sur
-            <strong>%{copy_url}</strong>
+          html: Une fois prête, la copie de l’espace de travail sera accessible sur <strong>%{copy_url}</strong>
     flash:
       delete_team_scheduled: L’espace de travail %{team} est en cours de suppression
   email_not_found: L’adresse courriel est introuvable
@@ -271,14 +237,10 @@ fr:
       task: "%d %B %Y à %H h %M [TZ] (%z TUC)"
       email: "%d %B %Y %H h %M %p %Z"
   oembed_disclaimer_undetermined: Cet élément n’a pas été confirmé par %{team}
-  oembed_disclaimer_in_progress: Cet élément est en cours de vérification par %{team}
-    en date du %{date}
-  oembed_disclaimer_verified: Il a été déterminé que cet élément a été vérifié par
-    %{team} le %{date}
-  oembed_disclaimer_false: Le %{date}, %{team} a été déterminé que cet élément est
-    faux
-  oembed_disclaimer_not_applicable: Le %{date}, aucune conclusion n’a pu être tirée
-    par %{team} au sujet de cet élément
+  oembed_disclaimer_in_progress: Cet élément est en cours de vérification par %{team} en date du %{date}
+  oembed_disclaimer_verified: Il a été déterminé que cet élément a été vérifié par %{team} le %{date}
+  oembed_disclaimer_false: Le %{date}, %{team} a été déterminé que cet élément est faux
+  oembed_disclaimer_not_applicable: Le %{date}, aucune conclusion n’a pu être tirée par %{team} au sujet de cet élément
   oembed_source_date: "%{date} sur %{provider}"
   role_editor: rédacteur
   role_admin: administrateur
@@ -287,11 +249,11 @@ fr:
   role_: administrateur système
   oembed_credit: Ajouté par %{user} (%{role}) %{date}
   oembed_notes_count:
-    one: Une note
+    one: "Une note"
     many: "%{count} notes"
     other: "%{count} notes"
   oembed_completed_tasks_count:
-    one: Une tâche est remplie
+    one: "Une tâche est remplie"
     many: "%{count} tâches sont remplies"
     other: "%{count} tâches sont remplies"
   oembed_verification_tasks: Tâches
@@ -300,62 +262,49 @@ fr:
   oembed_expand_all: Tout développer
   oembed_collapse_all: Tout réduire
   oembed_resolved_tasks_count:
-    one: Une tâche résolue
+    one: "Une tâche résolue"
     many: "%{count} tâches résolues"
     other: "%{count} tâches résolues"
   oembed_notes: Notes
   duplicate_source: La source existe déjà
-  geolocation_invalid_value: Le lieu est invalide. Une structure GeoJSON valide est
-    attendue (http://geojson.org/)
+  geolocation_invalid_value: Le lieu est invalide. Une structure GeoJSON valide est attendue (http://geojson.org/)
   url_invalid_value: L’URL suivante indiquée est invalide
   datetime_invalid_date: La date est invalide
-  error_team_archived: Désolé, vous ne pouvez pas ajouter un dossier à un espace de
-    travail qui est dans la corbeille
-  error_project_archived: Désolé, vous ne pouvez pas ajouter un élément à un dossier
-    qui est dans la corbeille
-  error_team_archived_for_source: Désolé, vous ne pouvez pas ajouter une source à
-    un espace de travail qui est dans la corbeille
+  error_team_archived: Désolé, vous ne pouvez pas ajouter un dossier à un espace de travail qui est dans la corbeille
+  error_project_archived: Désolé, vous ne pouvez pas ajouter un élément à un dossier qui est dans la corbeille
+  error_team_archived_for_source: Désolé, vous ne pouvez pas ajouter une source à un espace de travail qui est dans la corbeille
   permission_error: Désolé, vous n’êtes pas autorisé à effectuer cette opération
-  error_annotated_archived: Désolé, vous ne pouvez pas ajouter une note à un élément
-    qui est dans la corbeille
-  only_super_admin_can_do_this: Désolé, seuls les administrateurs système peuvent
-    effectuer cet changement
+  error_annotated_archived: Désolé, vous ne pouvez pas ajouter une note à un élément qui est dans la corbeille
+  only_super_admin_can_do_this: Désolé, seuls les administrateurs système peuvent effectuer cet changement
   cant_change_custom_statuses: |-
-    Désolé, vous ne pouvez pas modifier les définitions des états, car certains états disparaîtraient. Ces identifiants d’état : %{statuses} sont utilisés par les articles suivants :
-    %{urls} %{others_amount}
+      Désolé, vous ne pouvez pas modifier les définitions des états, car certains états disparaîtraient. Ces identifiants d’état : %{statuses} sont utilisés par les articles suivants :
+      %{urls} %{others_amount}
   account_exists: Ce compte existe déjà
   media_exists: Cet élément existe déjà
   source_exists: Cette source existe déjà
   email_exists: est déjà utilisée
-  banned_user: Désolé, votre compte a été banni de %{app_name}. Veuillez contacter
-    l’équipe d’assistance si vous pensez que c’est une erreur.
+  banned_user: Désolé, votre compte a été banni de %{app_name}. Veuillez contacter l’équipe d’assistance si vous pensez que c’est une erreur.
   devise:
     mailer:
       reset_password_instructions:
-        subject: Instructions de réinitialisation du mot de passe de %{app_name}
+        subject: "Instructions de réinitialisation du mot de passe de %{app_name}"
         header_title: Demande de réinitialisation du mot de passe
-        header_text: Nous avons reçu votre demande de réinitialisation de votre mot
-          de passe %{app_name}.
+        header_text: Nous avons reçu votre demande de réinitialisation de votre mot de passe %{app_name}.
         action: Réinitialiser votre mot de passe
         expiry: Cette demande expirera dans %{expire} heures.
         instruction_1: Cliquez ici pour effectuer une nouvelle demande.
-        instruction_2: Si vous n’êtes pas à l’origine de cette demande ou si vous
-          éprouvez des difficultés à réinitialiser votre mot de passe, veuillez nous
-          contacter à %{support_email}.
+        instruction_2: Si vous n’êtes pas à l’origine de cette demande ou si vous éprouvez des difficultés à réinitialiser votre mot de passe, veuillez nous contacter à %{support_email}.
       invitation_instructions:
         subject: "%{user} vous a invité à vous joindre à l’espace de travail %{team}"
         hello: Bonjour, %{name}
         someone_invited_you_default:
-          html: "%{name} vous a invité à vous joindre à l’espace de travail %{team}
-            en tant que %{role}."
+          html: "%{name} vous a invité à vous joindre à l’espace de travail %{team} en tant que %{role}."
         someone_invited_you_custom:
-          html: "%{name} vous a invité à vous joindre à l’espace de travail %{team}
-            en tant que %{role}, en disant :"
+          html: "%{name} vous a invité à vous joindre à l’espace de travail %{team} en tant que %{role}, en disant :"
         accept: Accepter l’invitation
         accept_until: Cette invitation expirera le %{due_date}.
-        ignore: Si vous ne souhaitez pas accepter l’invitation, veuillez ignorer ce
-          courriel.
-        app_team: Espace de travail %{app}
+        ignore: Si vous ne souhaitez pas accepter l’invitation, veuillez ignorer ce courriel.
+        app_team: "Espace de travail %{app}"
     failure:
       unconfirmed: Veuillez consulter vos courriels afin de confirmer votre compte.
   user_invitation:
@@ -364,8 +313,7 @@ fr:
     team_found: L’espace de travail est introuvable.
     invalid: Le code d’invitation est invalide.
     no_invitation: Il n’existe aucune invitation pour l’espace de travail %{name}
-  error_user_is_not_a_team_member: Désolé, vous ne pouvez attribuer des tâches qu’à
-    des membres de cet espace de travail
+  error_user_is_not_a_team_member: Désolé, vous ne pouvez attribuer des tâches qu’à des membres de cet espace de travail
   error_login_with_exists_account: Désolé, un autre utilisateur utilise déjà ce compte
   error_login_2fa: Veuillez terminer votre connexion en indiquant un code d’authentification.
   error_record_not_found: "%{type} no %{id} est introuvable"
@@ -379,55 +327,46 @@ fr:
     register:
       subject: Votre nouveau compte sur %{app_name}
       header_text: |-
-        Vous vous êtes inscrit à %{app_name} avec succès.
-        <br>
-        Pour vous connecter au site, il vous suffit de suivre ce lien : %{url}. Saisissez cette adresse courriel et ce mot de passe : %{password}
+          Vous vous êtes inscrit à %{app_name}.
+          <br>
+          Pour vous connecter au site, il vous suffit de suivre ce lien : %{url}. Saisissez cette adresse courriel et ce mot de passe : %{password}
       login_button: Se connecter à %{app_name}
-      footer_text: Nous vous remercions de vous être joint à l’équipe. Passez une
-        excellente journée !
+      footer_text: Nous vous remercions de vous être joint à l’équipe. Passez une excellente journée !
     duplicated:
       subject: Votre mode de connexion pour %{app_name}
       header_title: Doublon de compte
       one_email: |-
-        <p>Ceci est un rappel amical pour s’assurer que vous connectez à %{app_name}.</p>
-        <p>Ce qui s’est passé : vous avez essayé de vous connecter avec un compte %{user_provider} relié %{user_email}, mais cette adresse courriel est déjà associée avec un compte %{duplicate_provider} sur %{app_name}.</p>
-        <p>Ce qu’il faut faire ensuite : connectez-vous à %{duplicate_provider}.</p>
-        <p>Vous serez alors connecté avec le compte que vous utilisiez auparavant. Pour toute aide supplémentaire, veuillez nous envoyer un courriel à %{support_email}.4
+          <p>Ceci est un rappel amical pour s’assurer que vous connectez à %{app_name}.</p>
+          <p>Ce qui s’est passé : vous avez essayé de vous connecter avec un compte %{user_provider} relié %{user_email}, mais cette adresse courriel est déjà associée avec un compte %{duplicate_provider} sur %{app_name}.</p>
+          <p>Ce qu’il faut faire ensuite : connectez-vous à %{duplicate_provider}.</p>
+          <p>Vous serez alors connecté avec le compte que vous utilisiez auparavant. Pour toute aide supplémentaire, veuillez nous envoyer un courriel à %{support_email}.4
       both_emails: |-
-        <p>Ceci est un rappel amical pour s’assurer que vous connectez à %{app_name}.</p>
-        <p>Ce qui s’est passé : vous avez essayé de créer un nouveau compte %{app_name} relié à une adresse courriel, mais ce compte existe déjà.</p>
-        <p>Essayez de vous connecter avec votre adresse courriel et votre mot de passe au lieu de créer un nouveau compte.</p>
-        <p>Vous serez alors connecté avec le compte que vous utilisiez auparavant. Pour toute aide supplémentaire, veuillez nous envoyer un courriel à %{support_email}.</p>
+          <p>Ceci est un rappel amical pour s’assurer que vous connectez à %{app_name}.</p>
+          <p>Ce qui s’est passé : vous avez essayé de créer un nouveau compte %{app_name} relié à une adresse courriel, mais ce compte existe déjà.</p>
+          <p>Essayez de vous connecter avec votre adresse courriel et votre mot de passe au lieu de créer un nouveau compte.</p>
+          <p>Vous serez alors connecté avec le compte que vous utilisiez auparavant. Pour toute aide supplémentaire, veuillez nous envoyer un courriel à %{support_email}.</p>
       email: courriel
     invitation:
       title: Nouvelle invitation
     delete_user:
       subject: "[%{team}] Un utilisateur a été supprimé"
       header_title: L’utilisateur a été supprimé
-      header_text: Un compte d’utilisateur a été supprimé et son contenu a été réattribué
-        à l’utilisateur %{anonymous} %{id}
+      header_text: Un compte d’utilisateur a été supprimé et son contenu a été réattribué à l’utilisateur %{anonymous} %{id}
       anonymous: anonyme
     admin_mailer:
-      team_download_subject: "[%{team}] L’instantané des données de l’espace de travail
-        est prêt à être téléchargé"
+      team_download_subject: "[%{team}] L’instantané des données de l’espace de travail est prêt à être téléchargé"
       team_dump_title: Données de l’espace de travail
       types:
         dump: instantané des données
         csv: rapport
         images: archive d’images
-      team_dump_text: 'Vous avez demandé un instantané des données de l’espace de
-        travail %{team}. Voici un lien pour le télécharger : %{link}'
+      team_dump_text: 'Vous avez demandé un instantané des données de l’espace de travail %{team}. Voici un lien pour le télécharger : %{link}'
       team_dump_button: Télécharger les données de l’espace de travail
-      decompress_text: Le %{type} sera téléchargé en tant que fichier compressé chiffré.
-        Pour le décompresser, veuillez utiliser le mot de passe %{password}.
+      decompress_text: Le %{type} sera téléchargé en tant que fichier compressé chiffré. Pour le décompresser, veuillez utiliser le mot de passe %{password}.
       expire_note: Veuillez noter que ce lien expirera dans %{days} jours.
       team_import_subject: L’importation de vos données est terminée
       team_import_title: Importation des données
-      team_import_text: "<p>Votre travail d’importation dans %{app_name} est terminé.
-        Vous pouvez consulter %{worksheet_url} pour examiner l’état de chaque élément
-        à importer.</p> <p>Notez que vous pourrez relancer l’importation après avoir
-        corrigé les erreurs qui y sont signalées. Les éléments déjà importés ne seront
-        pas dupliqués.</p>"
+      team_import_text: "<p>Votre travail d’importation dans %{app_name} est terminé. Vous pouvez consulter %{worksheet_url} pour examiner l’état de chaque élément à importer.</p> <p>Notez que vous pourrez relancer l’importation après avoir corrigé les erreurs qui y sont signalées. Les éléments déjà importés ne seront pas dupliqués.</p>"
     task_resolved:
       subject: "[%{team} – %{project}] Une tâche a reçu une réponse"
       header_title: Une tâche a reçu une réponse
@@ -439,38 +378,30 @@ fr:
       label: élément
       subject: "[%{team} – %{project}] Un élément a été marqué %{status}"
       header_title: L’état d’un élément a été mis à jour
-      header_text: "%{author} a mis à jour l’état d’un élément du dossier %{project}
-        de %{team}."
+      header_text: "%{author} a mis à jour l’état d’un élément du dossier %{project} de %{team}."
       section_title: Marqué %{status}.
       added_to: Ajouté à %{app_name}
       update_h: Dernière mise à jour
       tasks_h: Les tâches sont remplies
     assignment:
       assign_task_subject: "[%{team} – %{project}] Une tâche vous a été attribuée"
-      unassign_task_subject: "[%{team} – %{project}] L’attribution d’une tâche vous
-        a été retirée"
+      unassign_task_subject: "[%{team} – %{project}] L’attribution d’une tâche vous a été retirée"
       assign_project_subject: "[%{team} – %{project}] Un dossier vous a été attribué"
-      unassign_project_subject: "[%{team} – %{project}] L’attribution d’un dossier
-        vous a été retirée"
+      unassign_project_subject: "[%{team} – %{project}] L’attribution d’un dossier vous a été retirée"
       assign_media_subject: "[%{team} – %{project}] Un élément vous a été attribué"
-      unassign_media_subject: "[%{team} – %{project}] L’attribution d’un élément vous
-        a été retirée"
+      unassign_media_subject: "[%{team} – %{project}] L’attribution d’un élément vous a été retirée"
       assign_project_title: Le dossier a été attribué
       unassign_project_title: L’attribution du dossier a été retirée
       assign_project_text: "%{author} a attribué le dossier %{project} de %{team}."
-      unassign_project_text: "%{author} a retiré l’attribution du dossier %{project}
-        de %{team}."
+      unassign_project_text: "%{author} a retiré l’attribution du dossier %{project} de %{team}."
       assign_task_title: Une tâche a été attribuée
       unassign_task_title: L’attribution d’une tâche a été retirée
       assign_task_text: "%{author} a attribué une tâche du dossier %{project} de %{team}."
-      unassign_task_text: "%{author} a retiré l’attribution d’une tâche du dossier
-        %{project} de %{team}."
+      unassign_task_text: "%{author} a retiré l’attribution d’une tâche du dossier %{project} de %{team}."
       assign_media_title: Un élément a été attribué
       unassign_media_title: L’attribution d’un élément a été retirée
-      assign_media_text: "%{author} a attribué un élément du dossier %{project} de
-        %{team}."
-      unassign_media_text: "%{author} a retiré l’attribution d’un élément du dossier
-        %{project} de %{team}."
+      assign_media_text: "%{author} a attribué un élément du dossier %{project} de %{team}."
+      unassign_media_text: "%{author} a retiré l’attribution d’un élément du dossier %{project} de %{team}."
       assign_log: "%{author} a attribué %{model} à %{username}"
       unassign_log: "%{author} a retirer l’attribution de %{model} de %{username}"
       assign_by: Attribués par
@@ -483,40 +414,29 @@ fr:
       rejected_subject: Votre demande de vous joindre à %{team} n’a pas été approuvée
       approved_subject: Bienvenue à l’espace de travail de %{team}
       request_title: Demande de se joindre à l’espace de travail %{team}
-      request_text: "%{name} (%{email}) souhaite se joindre à %{team} sur %{app_name}.
-        Vous pouvez traiter cette demande sur %{url}."
+      request_text: "%{name} (%{email}) souhaite se joindre à %{team} sur %{app_name}. Vous pouvez traiter cette demande sur %{url}."
       approved_title: Bienvenue à l’espace de travail de %{team}
-      approved_text: Votre demande à vous joindre à l’espace de travail %{team} sur
-        %{app_name} a été approuvée. Vous pouvez maintenant accéder à %{url} et commencer
-        à contribuer.
+      approved_text: Votre demande à vous joindre à l’espace de travail %{team} sur %{app_name} a été approuvée. Vous pouvez maintenant accéder à %{url} et commencer à contribuer.
       rejected_title: Demande refusée
-      rejected_text: Désolé, votre demande de vous joindre à l’espace de travail %{team}
-        sur %{app_name} n’a pas été approuvée.
+      rejected_text: Désolé, votre demande de vous joindre à l’espace de travail %{team} sur %{app_name} n’a pas été approuvée.
   mail_security:
-    device_subject: 'Alerte de sécurité : Nouvelle connexion à %{app_name} de %{browser}
-      sur %{platform}'
+    device_subject: 'Alerte de sécurité : Nouvelle connexion à %{app_name} de %{browser} sur %{platform}'
     ip_subject: 'Alerte de sécurité : Connexion à %{app_name} nouvelle ou inhabituelle'
-    failed_subject: 'Alerte de sécurité : Tentatives de connexion infructueuses à
-      %{app_name} '
+    failed_subject: 'Alerte de sécurité : Tentatives de connexion infructueuses à %{app_name} '
     ip: Vous vous êtes connecté de %{location}
     device: Vous vous êtes connecté de %{browser} sur %{platform}
     devise_name: "%{browser} sur %{platform}"
     failed: Des tentatives de connexion infructueuses ont été détectées
     password_text: réinitialiser votre mot de passe immédiatement.
-    device_text: Il semble que vous vous êtes connecté récemment à votre compte %{app_name}
-      à partir d’un nouvel appareil. Si ce n’était pas vous, vous devriez %{change_password}
-    ip_text: Il semble que vous vous êtes connecté récemment à votre compte %{app_name}
-      à partir d’un nouveau lieu. Si ce n’était pas vous, vous devriez %{change_password}
-    failed_text: Il semble que plusieurs tentatives de connexion à votre compte %{app_name}
-      aient été effectuées. Si c’était vous, vous pouvez sans problème ignorer ce
-      courriel. Si ce n’était pas vous, vous devriez alors %{change_password}
+    device_text: Il semble que vous vous êtes connecté récemment à votre compte %{app_name} à partir d’un nouvel appareil. Si ce n’était pas vous, vous devriez %{change_password}
+    ip_text: Il semble que vous vous êtes connecté récemment à votre compte %{app_name} à partir d’un nouveau lieu. Si ce n’était pas vous, vous devriez %{change_password}
+    failed_text: Il semble que plusieurs tentatives de connexion à votre compte %{app_name} aient été effectuées. Si c’était vous, vous pouvez sans problème ignorer ce courriel. Si ce n’était pas vous, vous devriez alors %{change_password}
     time_h: Date et heure
     device_h: Appareil
     location_h: Lieu
     location_disclaimer: "* Le lieu est approximatif, d’après l’adresse IP de provenance."
     ip_h: Adresse IP
-    privacy: "%{manage} vos notifications par courriel • Apprenez-en davantage sur
-      notre %{privacy}"
+    privacy: "%{manage} vos notifications par courriel • Apprenez-en davantage sur notre %{privacy}"
     privacy_text: Politique de confidentialité
     manage_text: Gérer
     privace_manage_plain: Gérer vos notifications par courriel
@@ -524,65 +444,47 @@ fr:
   archive_keep_backup: Video Vault
   archive_pender_archive: Capture d’écran
   archive_archive_org: Archive.org
-  workflow_status_is_not_valid: L’état %{status} est invalide (devrait être un de
-    %{valid})
-  workflow_status_permission_error: Désolé, vous n’êtes pas autorisé à changer cet
-    état.
-  blank_default_status_for_custom_verification_status: Veuillez indiquer une valeur
-    par défaut pour les états personnalisés de vérification
-  blank_active_status_for_custom_verification_status: Veuillez indiquer une valeur
-    active pour les états personnalisés de vérification
-  bot_name_exists_for_this_team: Un robot du même nom existe déjà dans cet espace
-    de travail
-  bot_team_id_doesnt_exist: Désolé, il n’existe aucun espace de travail pour l’identifiant
-    indiqué
-  bot_team_id_mandatory_to_create: Désolé, vous devez choisir un espace de travail
-    afin de créer un robot
-  bot_not_approved_for_installation: Désolé, ce robot n’a pas été approuvé et il ne
-    peut donc pas être installé
-  could_not_save_related_bot_data: Désolé, il n’a pas été possible d’ajouter le robot
-    à cet espace de travail
-  bot_cant_add_response_to_task: Désolé, un robot ne peut pas répondre directement
-    à une tâche. Veuillez plutôt envoyer une suggestion de réponse
+  workflow_status_is_not_valid: 'L’état %{status} est invalide (devrait être un de %{valid})'
+  workflow_status_permission_error: Désolé, vous n’êtes pas autorisé à changer cet état.
+  blank_default_status_for_custom_verification_status: Veuillez indiquer une valeur par défaut pour les états personnalisés de vérification
+  blank_active_status_for_custom_verification_status: Veuillez indiquer une valeur active pour les états personnalisés de vérification
+  bot_name_exists_for_this_team: Un robot du même nom existe déjà dans cet espace de travail
+  bot_team_id_doesnt_exist: Désolé, il n’existe aucun espace de travail pour l’identifiant indiqué
+  bot_team_id_mandatory_to_create: Désolé, vous devez choisir un espace de travail afin de créer un robot
+  bot_not_approved_for_installation: Désolé, ce robot n’a pas été approuvé et il ne peut donc pas être installé
+  only_admins_can_approve_or_list_bots: Désolé, seuls les administrateurs système peuvent approuver ou lister les robots
+  could_not_save_related_bot_data: Désolé, il n’a pas été possible d’ajouter le robot à cet espace de travail
+  bot_cant_add_response_to_task: Désolé, un robot ne peut pas répondre directement à une tâche. Veuillez plutôt envoyer une suggestion de réponse
   bot_cant_add_review_to_task: Désolé, les robots ne peuvent pas examiner les tâches
-  task_suggestion_invalid_value: La suggestion de la tâche est invalide. Un objet
-    JSON avec les attributs `suggestion` (la valeur qui est copiée dans la réponse
-    de la tâche une fois acceptée) et `comment` (montré aux utilisateurs) est attendu.
+  task_suggestion_invalid_value: La suggestion de la tâche est invalide. Un objet JSON avec les attributs `suggestion` (la valeur qui est copiée dans la réponse de la tâche une fois acceptée) et `comment` (montré aux utilisateurs) est attendu.
   tag_text_id_not_found: L’étiquette est introuvable
   annotation_type_language_label: Langue
   smooch_bot_message_confirmed: |-
-    Merci. Votre demande est en attente de vérification.
+      Merci. Votre demande est en attente de vérification.
 
-    Nous tâcherons de vous envoyer un rapport sous 24 heures, mais notez qu’il nous est impossible de répondre à toutes les demandes.
-  smooch_bot_message_unconfirmed: Comme vous n’avez pas répondu par 1, nous ne poursuivrons
-    pas le traitement de votre demande. Merci.
-  smooch_bot_message_type_unsupported: Désolé, nous ne prenons pas en charge ce type
-    de message.
-  smooch_bot_message_size_unsupported: Désolé, nous ne prenons pas en charge les fichiers
-    supérieurs à %{max_size}.
+      Nous tâcherons de vous envoyer un rapport sous 24 heures, mais notez qu’il nous est impossible de répondre à toutes les demandes.
+  smooch_bot_message_unconfirmed: Comme vous n’avez pas répondu par 1, nous ne poursuivrons pas le traitement de votre demande. Merci.
+  smooch_bot_message_type_unsupported: Désolé, nous ne prenons pas en charge ce type de message.
+  smooch_bot_message_size_unsupported: Désolé, nous ne prenons pas en charge les fichiers supérieurs à %{max_size}.
   smooch_bot_result: |-
-    [Rapport de vérification] L’élément que vous avez partagé avec nous est marqué *%{status}*.
+      [Rapport de vérification] L’élément que vous avez partagé avec nous est marqué *%{status}*.
 
-    Voici les étapes que nous avons suivies pour arriver à cette conclusion : %{url}
+      Voici les étapes que nous avons suivies pour arriver à cette conclusion : %{url}
   smooch_bot_ask_for_confirmation: |-
-    Nous vous remercions de nous avoir envoyé cette demande. Voulez-vous que nous en vérifiions le contenu ?
+      Nous vous remercions de nous avoir envoyé cette demande. Voulez-vous que nous en vérifiions le contenu ?
 
-    Pour confirmer, *veuillez répondre par 1*. Toute autre réponse mettra fin à notre conversation.
+      Pour confirmer, *veuillez répondre par 1*. Toute autre réponse mettra fin à notre conversation.
   smooch_bot_ask_for_tos: |-
-    Nous vous remercions d’avoir contacté Check Message.
+      Nous vous remercions d’avoir contacté Check Message.
 
-    Vous pouvez utiliser ce service pour demander une vérification, une vérification de faits ou une enquête sur des nouvelles et des renseignements. Check Message vous est offert en vertu de ces Conditions générales d’utilisation : %{tos}. En poursuivant votre utilisation de ce service, *vous acceptez les modalités de ces conditions*. Si vous ne les acceptez pas, vous devriez cesser d’utiliser Check Message.
-  smooch_bot_window_closing: Le volume de demandes sur ce canal est très élevé et
-    nous n’avons pas encore pu résoudre votre demande. Nous vous remercions de votre
-    patience.
+      Vous pouvez utiliser ce service pour demander une vérification, une vérification de faits ou une enquête sur des nouvelles et des renseignements. Check Message vous est offert en vertu de ces Conditions générales d’utilisation : %{tos}. En poursuivant votre utilisation de ce service, *vous acceptez les modalités de ces conditions*. Si vous ne les acceptez pas, vous devriez cesser d’utiliser Check Message.
+  smooch_bot_window_closing: Le volume de demandes sur ce canal est très élevé et nous n’avons pas encore pu résoudre votre demande. Nous vous remercions de votre patience.
   smooch_bot_not_final: |-
-    [Rapport de vérification – CORRECTION] Le message que vous avez partagé avec nous a été incorrectement marqué *%{status}*.
+      [Rapport de vérification – CORRECTION] Le message que vous avez partagé avec nous a été incorrectement marqué *%{status}*.
 
-    Il est encore en attente de vérification plus approfondie.
-  smooch_bot_disabled: Nous vous remercions d’avoir envoyé ce message. Nous ne pouvons
-    plus envoyer de rapport de vérification, car ce projet n’est plus actif.
-  smooch_bot_result_changed: "❗️La vérification de faits que nous vous avons envoyée
-    a été *mise à jour* avec de nouveaux renseignements"
+      Il est encore en attente de vérification plus approfondie.
+  smooch_bot_disabled: Nous vous remercions d’avoir envoyé ce message. Nous ne pouvons plus envoyer de rapport de vérification, car ce projet n’est plus actif.
+  smooch_bot_result_changed: "❗️La vérification de faits que nous vous avons envoyée a été *mise à jour* avec de nouveaux renseignements"
   permissions_info:
     roles:
       admin:
@@ -590,8 +492,7 @@ fr:
       editor:
         description: Les rédacteurs gèrent l’espace de travail et les dossiers.
       collaborator:
-        description: Le collaborateur peut ajouter de nouveaux renseignements à confirmer.
-          Il est souvent un membre du public.
+        description: Le collaborateur peut ajouter de nouveaux renseignements à confirmer. Il est souvent un membre du public.
     permissions:
       sections:
         project_management:
@@ -630,24 +531,17 @@ fr:
             edit_tasks: Créer et modifier les tâches de l’espace de travail
             roles: Modifier les rôles des membres de l’espace de travail
             third_party: Ajouter des intégrations à des tiers
-            invite_admin: Inviter, approuver et supprimer les administrateurs de l’espace
-              de travail
-            invite_members: Inviter, approuver et supprimer les membres de l’espace
-              de travail
+            invite_admin: Inviter, approuver et supprimer les administrateurs de l’espace de travail
+            invite_members: Inviter, approuver et supprimer les membres de l’espace de travail
   team_clone:
     user_not_authorized: Désolé, vous n’êtes pas autorisé à dupliquer cette équipe.
   team_import:
     invalid_google_spreadsheet_url: L’URL de la feuille de calcul est invalide %{spreadsheet_url}
     not_found_google_spreadsheet_url: La feuille de calcul est introuvable sur %{spreadsheet_url}
-    cannot_authenticate_with_the_credentials: Il est impossible de se connecter au
-      Disque Google Drive avec les identifiants actuels. Veuillez contacter l’équipe
-      d’assistance pour leur signaler cet incident.
-    team_not_present: L’espace de travail actuel n’a pas été trouvé pendant l’importation
-      des données. Veuillez prévenir l’équipe d’assistance de cet incident.
-    user_not_present: L’utilisateur actuel n’a pas été trouvé pendant l’importation
-      des données. Veuillez prévenir l’équipe d’assistance de cet incident.
-    user_not_authorized: Désolé, vous n’êtes pas autorisé à importer des données dans
-      cet espace de travail.
+    cannot_authenticate_with_the_credentials: Il est impossible de se connecter au Disque Google Drive avec les identifiants actuels. Veuillez contacter l’équipe d’assistance pour leur signaler cet incident.
+    team_not_present: L’espace de travail actuel n’a pas été trouvé pendant l’importation des données. Veuillez prévenir l’équipe d’assistance de cet incident.
+    user_not_present: L’utilisateur actuel n’a pas été trouvé pendant l’importation des données. Veuillez prévenir l’équipe d’assistance de cet incident.
+    user_not_authorized: Désolé, vous n’êtes pas autorisé à importer des données dans cet espace de travail.
     invalid_project: La dossier %{project} est invalide
     invalid_user: L’auteur auteur est invalide %{user}
     invalid_status: L’état %{status} est invalide
@@ -656,8 +550,7 @@ fr:
     blank_project: Le champ Dossier ne peut pas être vide
     invalid_annotator: L’annotateur %{user} est invalide
     invalid_assignee: La personne à qui la tâche est attribuée %{user} est invalide
-  cant_mutate_inactive_object: Désolé, une opération est en cours pour cet élément
-    et vous ne pouvez donc pas le changer actuellement. Veuillez réessayer ultérieurement.
+  cant_mutate_inactive_object: Désolé, une opération est en cours pour cet élément et vous ne pouvez donc pas le changer actuellement. Veuillez réessayer ultérieurement.
   embed_expand_all: Tout développer
   embed_collapse_all: Tout réduire
   embed_tasks: Tâches
@@ -670,41 +563,35 @@ fr:
   smooch_requests_desc: Les plus demandés
   bot_request_url_invalid: L’URL du robot est invalide
   smooch_facebook_success: |
-    C’est réussi !
-    Votre ligne info Tipline est désormais connectée à Facebook Messenger.
-    Tout message reçu par cette page Facebook sera traité par la ligne info.
-    Afin de voir les nouveaux changements, veuillez recharger la page des paramètres du service Tipline.
+      C’est réussi !
+      Votre ligne info Tipline est désormais connectée à Facebook Messenger.
+      Tout message reçu par cette page Facebook sera traité par la ligne info.
+      Afin de voir les nouveaux changements, veuillez recharger la page des paramètres du service Tipline.
   smooch_twitter_success: |
-    C’est réussi !
-    Votre ligne info Tipline est désormais connectée à Twitter.
-    Tout message direct reçu par ce profil Twitter sera traité par le service Tipline.
-    Veuillez recharger la page des paramètres du service Tipline pour voir les nouveaux changements.
-  must_select_exactly_one_facebook_page: Veuillez sélectionner la page précise et
-    unique de Facebook que vous voulez intégrer au service Tipline.
+      C’est réussi !
+      Votre ligne info Tipline est désormais connectée à Twitter.
+      Tout message direct reçu par ce profil Twitter sera traité par le service Tipline.
+      Veuillez recharger la page des paramètres du service Tipline pour voir les nouveaux changements.
+  must_select_exactly_one_facebook_page: Veuillez sélectionner la page précise et unique de Facebook que vous voulez intégrer au service Tipline.
   invalid_task_answer: Le format de réponse de la tâche est invalide
   team_rule_name: Un nom unique qui décrit ce que cette règle fait
   team_rule_project_ids: Appliquer au dossier
   team_rule_destination: Sélectionnez le dossier de destination
-  team_rule_names_invalid: Les noms de règle ne peuvent pas être vides et doivent
-    être uniques
+  team_rule_names_invalid: Les noms de règle ne peuvent pas être vides et doivent être uniques
   team_rules: Règles
   team_rule_conditions: Si
   team_rule_condition: Si
   team_rule_condition_definition: Sélectionnez une condition
-  team_rule_has_less_than_x_words: Le texte de la demande comporte moins de (ou exactement)
-    le nombre de mots suivant
-  team_rule_title_matches_regexp: Le titre de l’élément correspond à cette expression
-    rationnelle
+  team_rule_has_less_than_x_words: Le texte de la demande comporte moins de (ou exactement) le nombre de mots suivant
+  team_rule_title_matches_regexp: Le titre de l’élément correspond à cette expression rationnelle
   team_rule_request_matches_regexp: La demande correspond à cette expression rationnelle
   team_rule_type_is: Le type de l’élément est
   team_rule_type_is_claim: Texte
   team_rule_type_is_link: Lien
   team_rule_type_is_uploadedimage: Image
   team_rule_type_is_uploadedvideo: Vidéo
-  team_rule_contains_keyword: La demande comprend l’un ou plusieurs des mots-clés
-    suivants
-  team_rule_title_contains_keyword: Le contenu comprend l’un ou plusieurs des mots-clés
-    suivants
+  team_rule_contains_keyword: La demande comprend l’un ou plusieurs des mots-clés suivants
+  team_rule_title_contains_keyword: Le contenu comprend l’un ou plusieurs des mots-clés suivants
   team_rule_extracted_text_contains_keyword: Le texte extrait comprend le mot-clé
   team_rule_select_type: Sélectionnez un type
   team_rule_select_language: Sélectionnez la langue
@@ -722,8 +609,7 @@ fr:
   team_rule_send_to_trash: Déplacer vers la corbeille
   team_rule_move_to_project: Déplacer l’élément vers un dossier
   team_rule_copy_to_project: Ajouter l’élément au dossier
-  team_rule_ban_submitter: Bannir l’expéditeur (ses futurs messages n’apparaîtront
-    pas dans Check)
+  team_rule_ban_submitter: Bannir l’expéditeur (ses futurs messages n’apparaîtront pas dans Check)
   team_rule_all_items: Tous les éléments
   team_rule_send_message_to_user: Envoyer un message à l’utilisateur
   team_rule_action_value: Rédigez votre message ici
@@ -747,10 +633,8 @@ fr:
   team_rule_item_is_read: L’élément a été lu
   team_rule_field_from_fieldset_tasks_value_is: La tâche à une réponse précise
   team_rule_field_from_fieldset_metadata_value_is: L’annotation a une valeur précise
-  team_rule_field_from_fieldset_tasks_value_contains_keyword: La réponse de la tâche
-    comprend le mot-clé
-  team_rule_field_from_fieldset_metadata_value_contains_keyword: La valeur d’annotation
-    comprend un mot-clé
+  team_rule_field_from_fieldset_tasks_value_contains_keyword: La réponse de la tâche comprend le mot-clé
+  team_rule_field_from_fieldset_metadata_value_contains_keyword: La valeur d’annotation comprend un mot-clé
   team_rule_select_field_metadata: Sélectionnez une annotation
   team_rule_select_field_value_metadata: Sélectionnez la valeur
   team_rule_select_field_tasks: Sélectionnez la tâche
@@ -773,32 +657,22 @@ fr:
   flag_likelihood_4: Probable
   flag_likelihood_5: Élevée (davantage de contenus seront détectés)
   flag_likelihood_7: Manuel
-  relationship_not_same_team: Les éléments associés doivent exister dans le même espace
-    de travail
+  relationship_not_same_team: Les éléments associés doivent exister dans le même espace de travail
+  item_cant_be_related_to_itself: "L’élément ne peut pas être lié à lui-même"
   target_is_published: La cible ne devrait pas avoir de rapport publié
   similar_item_exists: Désolé, cet élément est déjà ajouté en tant qu’élément semblable
-  bulk_operation_limit_error: Désolé, le nombre maximal d’éléments à traiter à la
-    fois est %{limit}
-  must_provide_fallback_when_deleting_status_in_use: Ce état est déjà utilisé, vous
-    devez donc indiquer un autre état si vous souhaitez le supprimer
-  embed_no_content_yet: Le rapport est en cours de génération. Ce processus peut prendre
-    quelques minutes. Veuillez actualiser cette page.
-  language_format_invalid: Le format de langue est invalide. Un code ISO 639-1 est
-    attendu.
-  languages_format_invalid: Le format des langues est invalide. Une liste de codes
-    ISO 639-1 est attendue.
-  cant_change_status_if_item_is_published: Désolé, vous ne pouvez pas changer l’état
-    alors que le rapport est publié
+  bulk_operation_limit_error: Désolé, le nombre maximal d’éléments à traiter à la fois est %{limit}
+  must_provide_fallback_when_deleting_status_in_use: Ce état est déjà utilisé, vous devez donc indiquer un autre état si vous souhaitez le supprimer
+  embed_no_content_yet: Le rapport est en cours de génération. Ce processus peut prendre quelques minutes. Veuillez actualiser cette page.
+  language_format_invalid: Le format de langue est invalide. Un code ISO 639-1 est attendu.
+  languages_format_invalid: Le format des langues est invalide. Une liste de codes ISO 639-1 est attendue.
+  cant_change_status_if_item_is_published: Désolé, vous ne pouvez pas changer l’état alors que le rapport est publié
   fetch_bot_service_unsupported: Le service n’est pas pris en charge
   task_options_must_be_array: Les options de la tâche doivent être une liste
-  fieldset_not_defined_by_team: "« Fieldset » devrait être pris en charge par l’espace
-    de travail"
-  cant_change_field_type_or_options_when_answered: Le type de champ ne peut pas être
-    changé, car des réponses ont déjà été inscrites
-  replace_by_media_in_the_same_team: Désolé, vous ne pouvez remplacer cet article
-    que par un autre article du même espace de travail
-  replace_blank_media_only: Désolé, mais vous ne pouvez pour l’instant que remplacer
-    que des articles vides
+  fieldset_not_defined_by_team: « Fieldset » devrait être pris en charge par l’espace de travail
+  cant_change_field_type_or_options_when_answered: Le type de champ ne peut pas être changé, car des réponses ont déjà été inscrites
+  replace_by_media_in_the_same_team: Désolé, vous ne pouvez remplacer cet article que par un autre article du même espace de travail
+  replace_blank_media_only: Désolé, mais vous ne pouvez pour l’instant que remplacer que des articles vides
   cant_preview_rss_feed: Désolé, vous n’êtes pas autorisé à voir l’aperçu d’un fil RSS.
   list_column_demand: Demandes
   list_column_share_count: Partages sur Facebook
@@ -816,58 +690,46 @@ fr:
   list_column_published_by: Rapport publié par
   list_column_fact_check_published_on: Vérification de faits publiés le
   list_column_related_count: Associés
+  list_column_suggestions_count: Suggestions
   list_column_folder: Dossier
   list_column_creator_name: Créé par
   list_column_fact_check_title: Vérification de faits
   list_column_team_name: Espace de travail
   list_column_sources_as_sentence: Source
   go_back_to_check: Retourner à Check
-  project_cant_have_children_if_has_parent: Ce dossier a un dossier parent et il ne
-    peut donc pas avoir un dossier enfant
-  project_group_must_be_under_same_team: La collection devrait être dans le même espace
-    de travail
-  unique_default_folder_per_team: L’espace de travail ne devrait avoir qu’un dossier
-    par défaut
-  center_is_not_part_of_another_cluster: Le centre de ce groupe ne peut pas faire
-    partie d’un autre groupe
+  project_cant_have_children_if_has_parent: Ce dossier a un dossier parent et il ne peut donc pas avoir un dossier enfant
+  project_group_must_be_under_same_team: La collection devrait être dans le même espace de travail
+  unique_default_folder_per_team: L’espace de travail ne devrait avoir qu’un dossier par défaut
+  center_is_not_part_of_another_cluster: Le centre de ce groupe ne peut pas faire partie d’un autre groupe
   smooch_bot_message_subscribed: |-
-    Vous êtes actuellement abonné à notre lettre d’information.
+      Vous êtes actuellement abonné à notre lettre d’information.
 
-    Tapez 0 pour accéder au menu principal.
+      Tapez 0 pour accéder au menu principal.
   smooch_bot_message_unsubscribed: |-
-    Vous n’êtes actuellement pas abonné à notre lettre d’information.
+      Vous n’êtes actuellement pas abonné à notre lettre d’information.
 
-    Tapez 0 pour accéder au menu principal.
+      Tapez 0 pour accéder au menu principal.
   subscribe: M’abonner
   unsubscribe: Me désabonner
-  smooch_message_subscription_header_subscribed: Vous êtes actuellement abonné à notre
-    lettre d’information.
-  smooch_message_subscription_header_unsubscribed: Vous n’êtes actuellement pas abonné
-    à notre lettre d’information.
+  smooch_message_subscription_header_subscribed: Vous êtes actuellement abonné à notre lettre d’information.
+  smooch_message_subscription_header_unsubscribed: Vous n’êtes actuellement pas abonné à notre lettre d’information.
   smooch_bot_message_newsletter_fallback: |-
-    Bonjour. Voici vos faits hebdomadaires. Cette lettre d’information a été publiée sur %{platform} par %{team} le %{date} :
+      Bonjour. Voici vos faits hebdomadaires. Cette lettre d’information a été publiée sur %{platform} par %{team} le %{date} :
 
-    %{content}
+      %{content}
 
-    Pour ne plus recevoir cette lettre d’information, tapez « %{unsubscribe} ».
+      Pour ne plus recevoir cette lettre d’information, tapez « %{unsubscribe} ».
+  send_every_must_be_a_list_of_days_of_the_week: doit être une liste de jours de la semaine.
+  send_on_must_be_in_the_future: ne peut pas être dans le passé.
   info:
     messages:
-      sent_to_trash_by_rule: "« %{item_title} » a été mis dans la corbeille par une
-        règle d’automatisation."
-      moved_to_project_by_rule: "« %{item_title} » a été déplacé dans le dossier « [%{list_name}](%{list_link}) »
-        par une règle d’automatisation."
-      banned_submitter_by_rule: Le demandeur de « %{item_title} » a été banni par
-        une règle d’automatisation.
-      copied_to_project_by_rule: "« %{item_title} » a été copié dans le dossier « [%{list_name}](%{list_link}) »
-        par une règle d’automatisation."
-      related_to_confirmed_similar: "« %{item_title} » a été confirmé comme semblable
-        à « %{similar_item_title} »."
-      related_to_suggested_similar: "« %{item_title} » a été suggéré comme semblable
-        à « %{similar_item_title} »."
-      sent_message_to_requestors_on_status_change: Une mise à jour dont l’état est
-        « %{status} » a été envoyée à %{requestors_count} demandeurs.
-      tagged_by_rule: "« %{item_title} » a été étiqueté « %{tag} » par une règle d’automatisation."
-      moved_to_private_folder: "« %{item_title} » a été déplacé vers un dossier auquel
-        vous n’avez pas accès."
-      add_warning_cover_by_rule: Une couverture d’avertissement a été ajoutée à l’élément
-        délicat « %{item_title} »
+      sent_to_trash_by_rule: '« %{item_title} » a été mis dans la corbeille par une règle d’automatisation.'
+      moved_to_project_by_rule: '« %{item_title} » a été déplacé dans le dossier « [%{list_name}](%{list_link}) » par une règle d’automatisation.'
+      banned_submitter_by_rule: Le demandeur de « %{item_title} » a été banni par une règle d’automatisation.
+      copied_to_project_by_rule: '« %{item_title} » a été copié dans le dossier « [%{list_name}](%{list_link}) » par une règle d’automatisation.'
+      related_to_confirmed_similar: '« %{item_title} » a été confirmé comme semblable à « %{similar_item_title} ».'
+      related_to_suggested_similar: '« %{item_title} » a été suggéré comme semblable à « %{similar_item_title} ».'
+      sent_message_to_requestors_on_status_change: Une mise à jour dont l’état est « %{status} » a été envoyée à %{requestors_count} demandeurs.
+      tagged_by_rule: '« %{item_title} » a été étiqueté « %{tag} » par une règle d’automatisation.'
+      moved_to_private_folder: '« %{item_title} » a été déplacé vers un dossier auquel vous n’avez pas accès.'
+      add_warning_cover_by_rule: Une couverture d’avertissement a été ajoutée à l’élément délicat « %{item_title} »

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1,4 +1,3 @@
----
 id:
   statuses:
     ids:
@@ -25,7 +24,7 @@ id:
         label: Sedang Berlangsung
         description: Pekerjaan telah dimulai, namun belum ada terjemahannya
       not_true:
-        label: Palsu
+        label: 'Palsu'
         description: 'Kesimpulan: konten dari perihal ini palsu'
       verified:
         label: Terverifikasi
@@ -76,36 +75,27 @@ id:
     messages:
       invalid_password: Kata sandi salah
       invalid_qrcode: Kode validasi salah
-      extension_white_list_error: 'tidak dapat memiliki tipe format %{extension},
-        tipe-tipe yang diijinkan: %{allowed_types}'
-      invalid_size: 'harus berukuran antara %{min_width}x%{min_height} dan %{max_width}x%{max_height}
-        piksel '
-      mini_magick_processing_error: 'Maaf, kami gagal memproses gambar. Kesalahan:
-        %{e}'
+      extension_white_list_error: 'tidak dapat memiliki tipe format %{extension}, tipe-tipe yang diijinkan: %{allowed_types}'
+      invalid_size: 'harus berukuran antara %{min_width}x%{min_height} dan %{max_width}x%{max_height} piksel '
+      mini_magick_processing_error: 'Maaf, kami gagal memproses gambar. Kesalahan: %{e}'
       annotation_mandatory_fields: Mohon atur semua bidang yang diwajibkan
       annotation_type_does_not_exist: tidak ada
       invalid_attribution: Atribusi salah
-      must_resolve_required_tasks_first: Tugas yang dibutuhkan harus diselesaikan
-        lebih dulu.
-      image_too_large: Maaf, kami tidak mendukung gambar berukuran lebih besar dari
-        %{max_size}.
-      video_too_large: Maaf, kami tidak mendukung video berukuran lebih besar dari
-        %{max_size}.
-      audio_too_large: Maaf, kami tidak mendukung audio berukuran lebih besar dari
-        %{max_size}.
-      pender_conflict: Tautan ini sudah diurai sebelumnya. Mohon coba lagi dalam beberapa
-        detik.
+      must_resolve_required_tasks_first: Tugas yang dibutuhkan harus diselesaikan lebih dulu.
+      image_too_large: Maaf, kami tidak mendukung gambar berukuran lebih besar dari %{max_size}.
+      video_too_large: Maaf, kami tidak mendukung video berukuran lebih besar dari %{max_size}.
+      audio_too_large: Maaf, kami tidak mendukung audio berukuran lebih besar dari %{max_size}.
+      pender_conflict: Tautan ini sudah diurai sebelumnya. Mohon coba lagi dalam beberapa detik.
       pender_url_invalid: Tautan ini salah.
       pender_url_unsafe: Tautan ini tidak aman.
-      pender_could_not_parse: Kami tidak dapat mengurai tautan ini. Silakan hubungi
-        %{support_email} jika kesalahannya terus berlanjut.
-      invalid_format_for_languages: Format bahasa salah. Format yang diharapkan `['en',
-        'ar', ....]`
+      pender_could_not_parse: Kami tidak dapat mengurai tautan ini. Silakan hubungi %{support_email} jika kesalahannya terus berlanjut.
+      invalid_format_for_languages: Format bahasa salah. Format yang diharapkan `['en', 'ar', ....]`
       invalid_project_media_channel_value: Maaf, nilai saluran tidak didukung
-      invalid_project_media_channel_update: Maaf, Anda tidak dapat memperbarui nilai
-        saluran
+      invalid_project_media_channel_update: Maaf, Anda tidak dapat memperbarui nilai saluran
       invalid_project_media_archived_value: Maaf, nilai yang diarsipkan tidak didukung
       invalid_fact_check_language_value: Maaf, bahasa tidak didukung
+      fact_check_empty_title_and_summary: Maaf, Anda harus mengisi judul atau ringkasan
+      invalid_feed_saved_search_value: harus menjadi milik ruang kerja yang merupakan bagian dari umpan ini
   activerecord:
     models:
       link: Tautan
@@ -167,11 +157,8 @@ id:
   invalid_default_status_for_custom_verification_status: Pengenal status bawaan salah
   invalid_active_status_for_custom_verification_status: Pengenal status aktif salah
   invalid_label_for_custom_verification_status: Label status harus diisi
-  invalid_id_for_custom_verification_status: Pengenal status adalah wajib dan harus
-    terdiri dari huruf kecil, nomor, tanda hubung dan garis bawah
-  invalid_statuses_format_for_custom_verification_status: 'Status verifikasi kustom
-    salah. Menunggu entri yang benar untuk: label, pengidentifikasi, deskripsi, dan
-    ragam.'
+  invalid_id_for_custom_verification_status: Pengenal status adalah wajib dan harus terdiri dari huruf kecil, nomor, tanda hubung dan garis bawah
+  invalid_statuses_format_for_custom_verification_status: 'Status verifikasi kustom salah. Menunggu entri yang benar untuk: label, pengidentifikasi, deskripsi, dan ragam.'
   mail_account_confirmation: "%{app_name} konfirmasi akun"
   slack:
     fields:
@@ -187,8 +174,7 @@ id:
       project_media: Perihal
       attribution: Dijawab oleh
     messages:
-      analysis_verification_status_status_changed: "%{user} mengubah status menjadi:
-        %{value}"
+      analysis_verification_status_status_changed: "%{user} mengubah status menjadi: %{value}"
       analysis_title_changed: "%{user} mengubah judul analisa menjadi: %{value}"
       analysis_content_changed: "%{user} mengubah konten analisa menjadi: %{value}"
       tasks_create: "%{user} menambahkan sebuah tugas: %{title}"
@@ -199,22 +185,16 @@ id:
       metadata_edit: "%{user} menyunting bidang metadata %{title}"
       metadata_answer_create: "%{user} mengatur nilai dari metadata %{title}: %{answer}"
       metadata_answer_edit: "%{user} menyunting nilai dari metadata %{title}: %{answer}"
-      project_media_comment: "%{user} (%{role} pada %{team}) menambahkan catatan pada
-        %{parent_type}"
+      project_media_comment: "%{user} (%{role} pada %{team}) menambahkan catatan pada %{parent_type}"
       project_media_create: "%{user} (%{role} pada %{team}) menyerahkan perihal baru"
-      project_media_create_related: "%{user} (%{role} pada %{team}) menambahkan sebuah
-        %{type} terkait"
+      project_media_create_related: "%{user} (%{role} pada %{team}) menambahkan sebuah %{type} terkait"
       project_media_update: "%{user} (%{role} pada %{team}) memperbarui sebuah perihal"
-      project_media_move_to: "%{user} (%{role} pada %{team}) memindahkan sebuah perihal
-        ke %{project}"
-      project_media_added_to_list: "%{user} (%{role} pada %{team}) menambahkan perihal
-        ke folder %{list_name}"
-      project_media_status: "%{user} (%{role} pada %{team}) mengubah status %{workflow}
-        dari %{type}"
+      project_media_move_to: "%{user} (%{role} pada %{team}) memindahkan sebuah perihal ke %{project}"
+      project_media_added_to_list: "%{user} (%{role} pada %{team}) menambahkan perihal ke folder %{list_name}"
+      project_media_status: "%{user} (%{role} pada %{team}) mengubah status %{workflow} dari %{type}"
       project_media_assign: "%{user} (%{role} pada %{team}) menugaskan sebuah %{type}"
       project_media_unassign: "%{user} (%{role} pada %{team}) membatalkan sebuah %{type}"
-      project_source_comment: "%{user} (%{role} pada %{team}) menambahkan catatan
-        pada %{parent_type}"
+      project_source_comment: "%{user} (%{role} pada %{team}) menambahkan catatan pada %{parent_type}"
       project_source_create: "%{user} (%{role} pada %{team}) menambahkan sebuah %{type}"
       project_source_update: "%{user} (%{role} pada %{team}) menyunting sebuah %{type}"
       project_create: "%{user} (%{role} pada %{team}) membuat sebuah folder"
@@ -225,11 +205,9 @@ id:
       user_invited: "%{user} diundang untuk bergabung ke ruang kerja %{team}"
       user_banned: "%{user} dilarang dari ruang kerja %{team}"
   mail_view_welcome: Selamat datang di %{app_name}
-  mail_view_register: 'Satu langkah lagi agar Anda dapat menggunakan %{app_name}!
-    Mohon konfirmasi alamat surel Anda dengan mengeklik tautan berikut:'
+  mail_view_register: 'Satu langkah lagi agar Anda dapat menggunakan %{app_name}! Mohon konfirmasi alamat surel Anda dengan mengeklik tautan berikut:'
   mail_confirm_button: Konfirmasi akun saya
-  slack_restricted_join_to_members: Maaf, Anda tidak dapat bergabung dengan %{team_name}
-    karena terbatas hanya untuk anggota ruang kerja %{teams} di Slack.
+  slack_restricted_join_to_members: Maaf, Anda tidak dapat bergabung dengan %{team_name} karena terbatas hanya untuk anggota ruang kerja %{teams} di Slack.
   admin:
     actions:
       send_reset_password_email:
@@ -242,8 +220,7 @@ id:
         menu: Gandakan ruang kerja
         done: digandakan
         are_you_sure_you_want_to_copy_team:
-          html: Apakah Anda yakin untuk menggandakan ruang kerja <strong>%{team}</strong>?
-            Semua data terkait juga akan disalin.
+          html: Apakah Anda yakin untuk menggandakan ruang kerja <strong>%{team}</strong>? Semua data terkait juga akan disalin.
         the_team_is_being_copied: Penggandaan ruang kerja sedang berlangsung
         url_when_ready:
           html: Saat sudah siap, ruang kerja hasil penggandaan akan berada di <strong>%{copy_url}</strong>
@@ -258,13 +235,10 @@ id:
       task: "%B %d, %Y at %H:%M [TZ] (%z UTC)"
       email: "%B %d, %Y %I:%M %p %Z"
   oembed_disclaimer_undetermined: Perihal ini belum diverifikasi oleh %{team}
-  oembed_disclaimer_in_progress: Perihal ini sedang diverifikasi oleh %{team} pada
-    %{date}
-  oembed_disclaimer_verified: Perihal ini telah ditentukan untuk diverifikasi oleh
-    %{team} pada %{date}
+  oembed_disclaimer_in_progress: Perihal ini sedang diverifikasi oleh %{team} pada %{date}
+  oembed_disclaimer_verified: Perihal ini telah ditentukan untuk diverifikasi oleh %{team} pada %{date}
   oembed_disclaimer_false: Perihal ini telah ditentukan palsu oleh %{team} pada %{date}
-  oembed_disclaimer_not_applicable: Tidak ada kesimpulan yang dapat diperoleh mengenai
-    perihal ini oleh %{team} pada %{date}
+  oembed_disclaimer_not_applicable: Tidak ada kesimpulan yang dapat diperoleh mengenai perihal ini oleh %{team} pada %{date}
   oembed_source_date: "%{date} pada %{provider}"
   role_editor: penyunting
   role_admin: administrator
@@ -288,47 +262,37 @@ id:
   geolocation_invalid_value: Lokasi salah. Menunggu struktur GeoJSON yang benar (http://geojson.org/)
   url_invalid_value: URL yang diserahkan berikut tidak valid
   datetime_invalid_date: Tanggal salah
-  error_team_archived: Maaf, Anda tidak dapat menambah folder ke ruang kerja yang
-    telah dihapus
-  error_project_archived: Maaf, Anda tidak dapat menambah perihal ke folder yang telah
-    dihapus
-  error_team_archived_for_source: Maaf, Anda tidak dapat menambah sumber pada ruang
-    kerja yang telah dihapus
+  error_team_archived: Maaf, Anda tidak dapat menambah folder ke ruang kerja yang telah dihapus
+  error_project_archived: Maaf, Anda tidak dapat menambah perihal ke folder yang telah dihapus
+  error_team_archived_for_source: Maaf, Anda tidak dapat menambah sumber pada ruang kerja yang telah dihapus
   permission_error: Maaf, Anda tidak diizinkan untuk melakukan tindakan ini
-  error_annotated_archived: Maaf, Anda tidak dapat menambah catatan pada perihal yang
-    telah dihapus
-  only_super_admin_can_do_this: Maaf, hanya administrator sistem yang dapat melakukan
-    pengubahan ini
+  error_annotated_archived: Maaf, Anda tidak dapat menambah catatan pada perihal yang telah dihapus
+  only_super_admin_can_do_this: Maaf, hanya administrator sistem yang dapat melakukan pengubahan ini
   cant_change_custom_statuses: |-
-    Maaf, Anda tidak dapat memodifikasi definisi status karena beberapa status akan hilang. Pengenal status ini: %{statuses} sedang digunakan oleh perihal berikut:
-    %{urls} %{others_amount}
+      Maaf, Anda tidak dapat memodifikasi definisi status karena beberapa status akan hilang. Pengenal status ini: %{statuses} sedang digunakan oleh perihal berikut:
+      %{urls} %{others_amount}
   account_exists: Akun ini sudah ada
   media_exists: Perihal ini sudah ada
   source_exists: Sumber ini sudah ada
   email_exists: sudah diambil
-  banned_user: 'Maaf, akun Anda telah dilarang dari %{app_name}. Mohon hubungi tim
-    dukungan jika Anda merasa ini adalah sebuah kesalahan. '
+  banned_user: 'Maaf, akun Anda telah dilarang dari %{app_name}. Mohon hubungi tim dukungan jika Anda merasa ini adalah sebuah kesalahan. '
   devise:
     mailer:
       reset_password_instructions:
-        subject: Instruksi pengaturan ulang kata sandi %{app_name}
+        subject: "Instruksi pengaturan ulang kata sandi %{app_name}"
         header_title: Permintaan pengaturan ulang kata sandi
-        header_text: Kami telah menerima permintaan Anda untuk mengatur ulang kata
-          sandi %{app_name} Anda.
+        header_text: Kami telah menerima permintaan Anda untuk mengatur ulang kata sandi %{app_name} Anda.
         action: Atur ulang kata sandi Anda
         expiry: Permintaan ini akan kedaluwarsa dalam %{expire} jam.
         instruction_1: Klik di sini untuk membuat permintaan baru.
-        instruction_2: Jika Anda tidak membuat permintaan ini, atau mengalami kesulitan
-          untuk mengatur ulang kata sandi Anda, mohon hubungi kami di %{support_email}.
+        instruction_2: Jika Anda tidak membuat permintaan ini, atau mengalami kesulitan untuk mengatur ulang kata sandi Anda, mohon hubungi kami di %{support_email}.
       invitation_instructions:
         subject: "%{user} mengundang Anda untuk bergabung ke ruang kerja %{team}"
         hello: Halo %{name}
         someone_invited_you_default:
-          html: "%{name} mengundang Anda untuk bergabung ke ruang kerja %{team} sebagai
-            %{role}."
+          html: "%{name} mengundang Anda untuk bergabung ke ruang kerja %{team} sebagai %{role}."
         someone_invited_you_custom:
-          html: "%{name} mengundang Anda untuk bergabung ke ruang kerja %{team} sebagai%{role},
-            dengan pesan:"
+          html: "%{name} mengundang Anda untuk bergabung ke ruang kerja %{team} sebagai%{role}, dengan pesan:"
         accept: Terima undangan
         accept_until: Undangan ini akan kedaluwarsa pada %{due_date}.
         ignore: Jika Anda tidak ingin menerima undangan tersebut, abaikan surel ini.
@@ -341,10 +305,8 @@ id:
     team_found: Ruang kerja tidak ditemukan.
     invalid: Kode undangan salah.
     no_invitation: Tidak ada undangan untuk ruang kerja %{name}
-  error_user_is_not_a_team_member: Maaf, Anda hanya dapat memberikan tugas pada anggota
-    ruang kerja ini
-  error_login_with_exists_account: Maaf, ada pengguna lain yang sudah menggunakan
-    akun ini
+  error_user_is_not_a_team_member: Maaf, Anda hanya dapat memberikan tugas pada anggota ruang kerja ini
+  error_login_with_exists_account: Maaf, ada pengguna lain yang sudah menggunakan akun ini
   error_login_2fa: Mohon lengkapi percobaan masuk Anda dengan memberikan kode autentikasi.
   error_record_not_found: "%{type} #%{id} tidak ditemukan"
   mails_notifications:
@@ -357,56 +319,48 @@ id:
     register:
       subject: Akun baru untuk Anda di %{app_name}
       header_text: |-
-        Anda telah berhasil melakukan pendaftaran di %{app_name}!
-        <br>
-        Untuk masuk ke situs, klik tautan ini: %{url}. Masukkan alamat surel dan kata sandi ini: %{password}
+          Anda telah berhasil melakukan pendaftaran di %{app_name}!
+          <br>
+          Untuk masuk ke situs, klik tautan ini: %{url}. Masukkan alamat surel dan kata sandi ini: %{password}
       login_button: Masuk ke %{app_name}
       footer_text: Terima kasih telah bergabung dan semoga harimu menyenangkan!
     duplicated:
       subject: Metode masuk Anda untuk %{app_name}
       header_title: Gandakan Akun
       one_email: |-
-        <p>Ini hanya pengingat untuk memastikan Anda masuk ke %{app_name}.</p>
-        <p>Apa yang terjadi: Anda mencoba masuk ke %{app_name} dengan akun %{user_provider} yang terhubung ke %{user_email}.
-        Namun alamat surel ini sudah terasosiasikan dengan sebuah akun %{duplicate_provider} di %{app_name}.</p>
-        <p>Apa yang harus dilakukan: Masuk dengan %{duplicate_provider}.</p>
-        <p>Kemudian Anda akan masuk dengan akun yang telah Anda gunakan sebelumnya.
-        Jika Anda memerlukan bantuan tambahan, mohon kirim surel ke %{support_email}.</p>
+          <p>Ini hanya pengingat untuk memastikan Anda masuk ke %{app_name}.</p>
+          <p>Apa yang terjadi: Anda mencoba masuk ke %{app_name} dengan akun %{user_provider} yang terhubung ke %{user_email}.
+          Namun alamat surel ini sudah terasosiasikan dengan sebuah akun %{duplicate_provider} di %{app_name}.</p>
+          <p>Apa yang harus dilakukan: Masuk dengan %{duplicate_provider}.</p>
+          <p>Kemudian Anda akan masuk dengan akun yang telah Anda gunakan sebelumnya.
+          Jika Anda memerlukan bantuan tambahan, mohon kirim surel ke %{support_email}.</p>
       both_emails: |-
-        <p>Ini hanya pengingat untuk memastikan Anda masuk ke %{app_name} .</p>
-        <p>Apa yang terjadi: Anda mencoba membuat akun baru dengan surel pada %{app_name}, namun akun ini sudah ada.</p>
-        <p>Coba masuk dengan alamat surel dan kata sandi Anda, alih-alih membuat akun baru.</p>
-        <p>Kemudian Anda akan masuk dengan akun yang telah Anda gunakan sebelumnya. Jika Anda memerlukan bantuan tambahan mohon kirim surel ke %{support_email}.</p>
+          <p>Ini hanya pengingat untuk memastikan Anda masuk ke %{app_name} .</p>
+          <p>Apa yang terjadi: Anda mencoba membuat akun baru dengan surel pada %{app_name}, namun akun ini sudah ada.</p>
+          <p>Coba masuk dengan alamat surel dan kata sandi Anda, alih-alih membuat akun baru.</p>
+          <p>Kemudian Anda akan masuk dengan akun yang telah Anda gunakan sebelumnya. Jika Anda memerlukan bantuan tambahan mohon kirim surel ke %{support_email}.</p>
       email: surel
     invitation:
       title: Undangan Baru
     delete_user:
       subject: "[%{team}] Pengguna telah dihapus"
       header_title: Pengguna telah dihapus
-      header_text: Sebuah akun pengguna telah dihapus dan kontennya telah ditugaskan
-        kembali ke pengguna %{anonymous}%{id}
+      header_text: Sebuah akun pengguna telah dihapus dan kontennya telah ditugaskan kembali ke pengguna %{anonymous}%{id}
       anonymous: anonim
     admin_mailer:
-      team_download_subject: "[%{team}] Snapshot data dari ruang kerja siap untuk
-        diunduh"
+      team_download_subject: "[%{team}] Snapshot data dari ruang kerja siap untuk diunduh"
       team_dump_title: Data Ruang kerja
       types:
         dump: snapshot data
         csv: laporan
         images: arsip gambar
-      team_dump_text: 'Anda meminta snapshot data untuk ruang kerja %{team} - berikut
-        tautan untuk mengunduhnya: %{link}'
+      team_dump_text: 'Anda meminta snapshot data untuk ruang kerja %{team} - berikut tautan untuk mengunduhnya: %{link}'
       team_dump_button: Unduh data ruang kerja
-      decompress_text: "%{type} akan diunduh sebagai berkas yang terkompresi dan terenkripsi.
-        Untuk membukanya, gunakan kata sandi %{password}."
+      decompress_text: '%{type} akan diunduh sebagai berkas yang terkompresi dan terenkripsi. Untuk membukanya, gunakan kata sandi %{password}.'
       expire_note: Mohon diingat bahwa tautan ini akan kedaluwarsa dalam %{days} hari.
       team_import_subject: Impor data Anda telah selesai
       team_import_title: Impor Data
-      team_import_text: "<p>Impor data ke dalam %{app_name} telah selesai. Anda dapat
-        memeriksa %{worksheet_url}untuk meninjau status dari setiap perihal untuk
-        diimpor.</p><p> Ingat bahwa Anda dapat memulai ulang proses impor setelah
-        Anda memperbaiki kesalahan yang dilaporkan di sana - perihal yang diimpor-sebelumnya
-        tidak akan digandakan.</p>"
+      team_import_text: "<p>Impor data ke dalam %{app_name} telah selesai. Anda dapat memeriksa %{worksheet_url}untuk meninjau status dari setiap perihal untuk diimpor.</p><p> Ingat bahwa Anda dapat memulai ulang proses impor setelah Anda memperbaiki kesalahan yang dilaporkan di sana - perihal yang diimpor-sebelumnya tidak akan digandakan.</p>"
     task_resolved:
       subject: "[%{team} - %{project}] Tugas Terjawab"
       header_title: Tugas Terjawab
@@ -416,28 +370,20 @@ id:
       media_h: Perihal
     media_status:
       label: perihal
-      subject: "[%{team} - %{project}] Sebuah status perihal telah ditandai sebagai
-        %{status}"
+      subject: "[%{team} - %{project}] Sebuah status perihal telah ditandai sebagai %{status}"
       header_title: Status Perihal Diperbarui
-      header_text: "%{author} memperbarui status dari perihal dalam folder %{project}
-        pada %{team}."
+      header_text: "%{author} memperbarui status dari perihal dalam folder %{project} pada %{team}."
       section_title: Ditandai sebagai %{status}.
       added_to: Ditambahkan ke %{app_name}
       update_h: Pembaruan Terakhir
       tasks_h: Tugas Selesai
     assignment:
-      assign_task_subject: "[%{team} - %{project}] Sebuah tugas telah diberikan kepada
-        Anda"
-      unassign_task_subject: "[%{team} - %{project}] Sebuah tugas telah dibatalkan
-        dari Anda"
-      assign_project_subject: "[%{team} - %{project}] Sebuah folder telah ditugaskan
-        kepada Anda"
-      unassign_project_subject: "[%{team} - %{project}] Sebuah folder telah dibatalkan
-        dari Anda"
-      assign_media_subject: "[%{team} - %{project}] Sebuah perihal telah ditugaskan
-        kepada Anda"
-      unassign_media_subject: "[%{team} - %{project}] Sebuah perihal telah dibatalkan
-        dari Anda"
+      assign_task_subject: "[%{team} - %{project}] Sebuah tugas telah diberikan kepada Anda"
+      unassign_task_subject: "[%{team} - %{project}] Sebuah tugas telah dibatalkan dari Anda"
+      assign_project_subject: "[%{team} - %{project}] Sebuah folder telah ditugaskan kepada Anda"
+      unassign_project_subject: "[%{team} - %{project}] Sebuah folder telah dibatalkan dari Anda"
+      assign_media_subject: "[%{team} - %{project}] Sebuah perihal telah ditugaskan kepada Anda"
+      unassign_media_subject: "[%{team} - %{project}] Sebuah perihal telah dibatalkan dari Anda"
       assign_project_title: Folder yang Ditugaskan
       unassign_project_title: Folder yang Dibatalkan
       assign_project_text: "%{author} menugaskan folder %{project} pada %{team}."
@@ -445,14 +391,11 @@ id:
       assign_task_title: Tugas yang Diberikan
       unassign_task_title: Tugas yang Dibatalkan
       assign_task_text: "%{author} memberikan tugas di dalam folder %{project} pada%{team}."
-      unassign_task_text: "%{author} membatalkan sebuah tugas dalam folder %{project}
-        pada %{team}."
+      unassign_task_text: "%{author} membatalkan sebuah tugas dalam folder %{project} pada %{team}."
       assign_media_title: Perihal yang Ditugaskan
       unassign_media_title: Perihal yang Dibatalkan
-      assign_media_text: "%{author} menugaskan sebuah perihal dalam folder %{project}
-        pada %{team}."
-      unassign_media_text: "%{author} membatalkan sebuah perihal dalam folder %{project}
-        pada %{team}."
+      assign_media_text: "%{author} menugaskan sebuah perihal dalam folder %{project} pada %{team}."
+      unassign_media_text: "%{author} membatalkan sebuah perihal dalam folder %{project} pada %{team}."
       assign_log: "%{author} menugaskan %{model} pada %{username}"
       unassign_log: "%{author} membatalkan %{model} dari %{username}"
       assign_by: Ditugaskan oleh
@@ -465,18 +408,13 @@ id:
       rejected_subject: Permintaan Anda untuk bergabung %{team} tidak disetujui
       approved_subject: Selamat datang di ruang kerja %{team}
       request_title: Permintaan untuk bergabung ke ruang kerja %{team}
-      request_text: "%{name} (%{email}) ingin bergabung dengan ruang kerja %{team}
-        pada%{app_name}. Anda dapat memproses permintaan ini dengan mengunjungi %{url}."
+      request_text: "%{name} (%{email}) ingin bergabung dengan ruang kerja %{team} pada%{app_name}. Anda dapat memproses permintaan ini dengan mengunjungi %{url}."
       approved_title: Selamat datang di ruang kerja %{team}
-      approved_text: Permintaan Anda untuk bergabung  ke ruang kerja %{team} pada
-        %{app_name} telah disetujui. Sekarang Anda dapat pergi ke %{url} dan mulai
-        berkontribusi.
+      approved_text: Permintaan Anda untuk bergabung  ke ruang kerja %{team} pada %{app_name} telah disetujui. Sekarang Anda dapat pergi ke %{url} dan mulai berkontribusi.
       rejected_title: Permintaan Ditolak
-      rejected_text: Maaf, permintaan Anda untuk bergabung ke ruang kerja %{team}pada
-        %{app_name} tidak disetujui.
+      rejected_text: Maaf, permintaan Anda untuk bergabung ke ruang kerja %{team}pada %{app_name} tidak disetujui.
   mail_security:
-    device_subject: 'Peringatan keamanan: Percobaan masuk ke %{app_name} dari %{browser}
-      pada %{platform}'
+    device_subject: 'Peringatan keamanan: Percobaan masuk ke %{app_name} dari %{browser} pada %{platform}'
     ip_subject: 'Peringatan keamanan: Percobaan masuk baru atau tidak biasa dari %{app_name}'
     failed_subject: 'Peringatan keamanan: Percobaan masuk ke %{app_name} gagal'
     ip: Anda telah masuk dari %{location}
@@ -484,20 +422,15 @@ id:
     devise_name: "%{browser} pada %{platform}"
     failed: Percobaan masuk gagal telah terdeteksi
     password_text: segera atur ulang kata sandi.
-    device_text: Sepertinya akun Anda baru saja masuk ke %{app_name} dari perangkat
-      baru. Jika ini bukan Anda, Anda harus %{change_password}
-    ip_text: Sepertinya akun Anda baru saja masuk ke %{app_name} Anda dari lokasi
-      baru. Jika ini bukan Anda, Anda harus %{change_password}
-    failed_text: Beberapa kali percobaan telah dilakukan untuk masuk ke akun %{app_name}
-      Anda. Jika ini memang Anda, Anda dapat secara aman mengabaikan pesan ini. Jika
-      bukan, maka Anda harus %{change_password}
+    device_text: Sepertinya akun Anda baru saja masuk ke %{app_name} dari perangkat baru. Jika ini bukan Anda, Anda harus %{change_password}
+    ip_text: Sepertinya akun Anda baru saja masuk ke %{app_name} Anda dari lokasi baru. Jika ini bukan Anda, Anda harus %{change_password}
+    failed_text: Beberapa kali percobaan telah dilakukan untuk masuk ke akun %{app_name} Anda. Jika ini memang Anda, Anda dapat secara aman mengabaikan pesan ini. Jika bukan, maka Anda harus %{change_password}
     time_h: Waktu
     device_h: Perangkat
     location_h: Lokasi
     location_disclaimer: "* Lokasi diperkirakan berdasarkan alamat IP asal."
     ip_h: Alamat IP
-    privacy: "%{manage} notifikasi surel Anda • Pelajari lebih lanjut mengenai %{privacy}
-      kami"
+    privacy: "%{manage} notifikasi surel Anda • Pelajari lebih lanjut mengenai %{privacy} kami"
     privacy_text: Kebijakan Privasi
     manage_text: Kelola
     privace_manage_plain: Kelola notifikasi surel anda
@@ -505,63 +438,47 @@ id:
   archive_keep_backup: Penyimpanan Video
   archive_pender_archive: Tangkapan layar
   archive_archive_org: Archive.org
-  workflow_status_is_not_valid: 'Status salah: ''%{status}'' (seharusnya berupa satu
-    dari %{valid})'
-  workflow_status_permission_error: Maaf, anda tidak diizinkan untuk mengubah status
-    ini.
-  blank_default_status_for_custom_verification_status: Mohon sediakan nilai bawaan
-    untuk status verifikasi kustom
-  blank_active_status_for_custom_verification_status: Mohon sediakan nilai yang aktif
-    untuk status verifikasi kustom
-  bot_name_exists_for_this_team: Sudah ada bot dengan nama tersebut di dalam ruang
-    kerja ini
+  workflow_status_is_not_valid: 'Status salah: ''%{status}'' (seharusnya berupa satu dari %{valid})'
+  workflow_status_permission_error: Maaf, anda tidak diizinkan untuk mengubah status ini.
+  blank_default_status_for_custom_verification_status: Mohon sediakan nilai bawaan untuk status verifikasi kustom
+  blank_active_status_for_custom_verification_status: Mohon sediakan nilai yang aktif untuk status verifikasi kustom
+  bot_name_exists_for_this_team: Sudah ada bot dengan nama tersebut di dalam ruang kerja ini
   bot_team_id_doesnt_exist: Maaf, tidak ada ruang kerja dengan pengenal yang disediakan
-  bot_team_id_mandatory_to_create: Maaf, Anda perlu memilih sebuah ruang kerja untuk
-    membuat bot
-  bot_not_approved_for_installation: Maaf, bot ini tidak disetujui sehingga tidak
-    dapat dipasang
-  could_not_save_related_bot_data: Maaf, tidak dapat menambah bot ke dalam ruang kerja
-    ini
-  bot_cant_add_response_to_task: Maaf, bot tidak dapat menjawab tugas secara langsung
-    - silakan kirimkan saran jawaban sebagai gantinya
+  bot_team_id_mandatory_to_create: Maaf, Anda perlu memilih sebuah ruang kerja untuk membuat bot
+  bot_not_approved_for_installation: Maaf, bot ini tidak disetujui sehingga tidak dapat dipasang
+  only_admins_can_approve_or_list_bots: Maaf, hanya administrator sistem yang dapat menyetujui atau mendaftar bot
+  could_not_save_related_bot_data: Maaf, tidak dapat menambah bot ke dalam ruang kerja ini
+  bot_cant_add_response_to_task: Maaf, bot tidak dapat menjawab tugas secara langsung - silakan kirimkan saran jawaban sebagai gantinya
   bot_cant_add_review_to_task: Maaf, bot tidak dapat meninjau sebuah tugas
-  task_suggestion_invalid_value: Saran tugas salah. Menunggu sebuah obyek JSON dengan
-    atribut `saran` (nilai sesungguhnya yang disalin ke jawaban dari tugas saat diterima)
-    dan `komentar` (ditampilkan kepada pengguna).
+  task_suggestion_invalid_value: Saran tugas salah. Menunggu sebuah obyek JSON dengan atribut `saran` (nilai sesungguhnya yang disalin ke jawaban dari tugas saat diterima) dan `komentar` (ditampilkan kepada pengguna).
   tag_text_id_not_found: Label tidak ditemukan
   annotation_type_language_label: Bahasa
   smooch_bot_message_confirmed: |-
-    Terima kasih. Permintaan Anda telah ditambahkan ke dalam antrian verifikasi kami.
+      Terima kasih. Permintaan Anda telah ditambahkan ke dalam antrian verifikasi kami.
 
-    Kami akan mencoba untuk mengirimkan Anda laporan dalam 24 jam, namun mohon dicatat bahwa kami tidak dapat merespons setiap permintaan.
-  smooch_bot_message_unconfirmed: Karena Anda tidak membalas dengan angka 1, kami
-    tidak akan memproses permintaan Anda lebih lanjut. Terima kasih.
-  smooch_bot_message_type_unsupported: Maaf, kami tidak mendukung jenis pesan seperti
-    ini.
-  smooch_bot_message_size_unsupported: Maaf, kami tidak mendukung berkas yang lebih
-    besar dari %{max_size}.
+      Kami akan mencoba untuk mengirimkan Anda laporan dalam 24 jam, namun mohon dicatat bahwa kami tidak dapat merespons setiap permintaan.
+  smooch_bot_message_unconfirmed: Karena Anda tidak membalas dengan angka 1, kami tidak akan memproses permintaan Anda lebih lanjut. Terima kasih.
+  smooch_bot_message_type_unsupported: Maaf, kami tidak mendukung jenis pesan seperti ini.
+  smooch_bot_message_size_unsupported: Maaf, kami tidak mendukung berkas yang lebih besar dari %{max_size}.
   smooch_bot_result: |-
-    [Laporan Verifikasi] Perihal yang Anda bagikan kepada kami telah ditandai sebagai *%{status}*.
+      [Laporan Verifikasi] Perihal yang Anda bagikan kepada kami telah ditandai sebagai *%{status}*.
 
-    Berikut langkah yang kami ambil untuk menentukannya: %{url}
+      Berikut langkah yang kami ambil untuk menentukannya: %{url}
   smooch_bot_ask_for_confirmation: |-
-    Terima kasih telah mengirimkan permintaan ini. Apakah Anda ingin kami memverifikasi kontennya?
+      Terima kasih telah mengirimkan permintaan ini. Apakah Anda ingin kami memverifikasi kontennya?
 
-    Jika ya, *mohon balas dengan angka 1*. Respons lainnya akan mengakhiri percakapan kita.
+      Jika ya, *mohon balas dengan angka 1*. Respons lainnya akan mengakhiri percakapan kita.
   smooch_bot_ask_for_tos: |-
-    Terima kasih telah menjangkau Check Message!
+      Terima kasih telah menjangkau Check Message!
 
-    Anda dapat menggunakan layanan ini untuk melakukan permintaan verifikasi, pengecekan fakta, dan investigasi dari berita-berita dan informasi. Check Message tersedia untuk Anda di bawah Persyaratan Layanan: %{tos}. Dengan terus menggunakan layanan ini, *Anda setuju untuk terikat pada persyaratan tersebut*. Anda dapat membatalkan penggunaan Check Message jika tidak setuju.
-  smooch_bot_window_closing: Jumlah permintaan pada saluran ini sangat tinggi, dan
-    kami belum dapat menyelesaikan persoalan Anda. Terima kasih untuk kesabaran Anda.
+      Anda dapat menggunakan layanan ini untuk melakukan permintaan verifikasi, pengecekan fakta, dan investigasi dari berita-berita dan informasi. Check Message tersedia untuk Anda di bawah Persyaratan Layanan: %{tos}. Dengan terus menggunakan layanan ini, *Anda setuju untuk terikat pada persyaratan tersebut*. Anda dapat membatalkan penggunaan Check Message jika tidak setuju.
+  smooch_bot_window_closing: Jumlah permintaan pada saluran ini sangat tinggi, dan kami belum dapat menyelesaikan persoalan Anda. Terima kasih untuk kesabaran Anda.
   smooch_bot_not_final: |-
-    [Laporan Verifikasi - KOREKSI] Pesan yang Anda bagikan kepada kami telah ditandai secara keliru sebagai *%{status}*.
+      [Laporan Verifikasi - KOREKSI] Pesan yang Anda bagikan kepada kami telah ditandai secara keliru sebagai *%{status}*.
 
-    Hal tersebut sedang dalam antrian untuk verifikasi lebih lanjut.
-  smooch_bot_disabled: Terima kasih telah mengirimkan pesan ini. Kami tidak dapat
-    mengirimkan kembali laporan verifikasi apapun, karena proyek ini sudah tidak aktif.
-  smooch_bot_result_changed: "❗️Pengecekan fakta yang kami kirimkan kepada Anda telah
-    *diperbarui* dengan informasi baru"
+      Hal tersebut sedang dalam antrian untuk verifikasi lebih lanjut.
+  smooch_bot_disabled: Terima kasih telah mengirimkan pesan ini. Kami tidak dapat mengirimkan kembali laporan verifikasi apapun, karena proyek ini sudah tidak aktif.
+  smooch_bot_result_changed: "❗️Pengecekan fakta yang kami kirimkan kepada Anda telah *diperbarui* dengan informasi baru"
   permissions_info:
     roles:
       admin:
@@ -569,8 +486,7 @@ id:
       editor:
         description: Penyunting mengelola ruang kerja dan folder-folder.
       collaborator:
-        description: Kolaborator dapat menambahkan informasi baru untuk memverifikasi.
-          Mereka seringkali bagian dari masyarakat umum.
+        description: Kolaborator dapat menambahkan informasi baru untuk memverifikasi. Mereka seringkali bagian dari masyarakat umum.
     permissions:
       sections:
         project_management:
@@ -616,15 +532,10 @@ id:
   team_import:
     invalid_google_spreadsheet_url: URL lembar kerja salah %{spreadsheet_url}
     not_found_google_spreadsheet_url: Lembar kerja tidak ditemukan pada %{spreadsheet_url}
-    cannot_authenticate_with_the_credentials: Tidak dapat mengautentikasi Google Drive
-      dengan kredensial saat ini. Mohon hubungi tim dukungan untuk memberitahukan
-      kejadian ini.
-    team_not_present: Ruang kerja saat ini tidak dapat ditemukan saat impor data.
-      Mohon beri tahu tim dukungan tentang kejadian ini.
-    user_not_present: Pengguna saat ini tidak ditemukan saat impor data. Mohon beri
-      tahu tim dukungan tentang kejadian ini.
-    user_not_authorized: Maaf, Anda tidak diizinkan untuk mengimpor data ke dalam
-      ruang kerja ini.
+    cannot_authenticate_with_the_credentials: Tidak dapat mengautentikasi Google Drive dengan kredensial saat ini. Mohon hubungi tim dukungan untuk memberitahukan kejadian ini.
+    team_not_present: Ruang kerja saat ini tidak dapat ditemukan saat impor data. Mohon beri tahu tim dukungan tentang kejadian ini.
+    user_not_present: Pengguna saat ini tidak ditemukan saat impor data. Mohon beri tahu tim dukungan tentang kejadian ini.
+    user_not_authorized: Maaf, Anda tidak diizinkan untuk mengimpor data ke dalam ruang kerja ini.
     invalid_project: Folder %{project} salah
     invalid_user: Pengarang %{user} salah
     invalid_status: Status %{status} salah
@@ -633,8 +544,7 @@ id:
     blank_project: Bidang folder tidak boleh kosong
     invalid_annotator: Pencatat %{user} salah
     invalid_assignee: Penerima tugas %{user} salah
-  cant_mutate_inactive_object: Maaf, sedang ada pekerjaan tertunda untuk perihal ini,
-    sehingga Anda tidak dapat mengubahnya sekarang. Mohon coba lagi nanti.
+  cant_mutate_inactive_object: Maaf, sedang ada pekerjaan tertunda untuk perihal ini, sehingga Anda tidak dapat mengubahnya sekarang. Mohon coba lagi nanti.
   embed_expand_all: Lebarkan semua
   embed_collapse_all: Tutup semua
   embed_tasks: Tugas
@@ -647,17 +557,16 @@ id:
   smooch_requests_desc: Paling banyak diminta
   bot_request_url_invalid: URL bot salah
   smooch_facebook_success: |
-    Sukses!
-    Tipline Anda sekarang terhubung dengan Facebook Messenger.
-    Pesan yang diterima oleh Halaman Facebook ini akan ditangani oleh tipline.
-    Mohon muat ulang halaman pengaturan tipline Anda untuk melihat pengubahan baru.
+      Sukses!
+      Tipline Anda sekarang terhubung dengan Facebook Messenger.
+      Pesan yang diterima oleh Halaman Facebook ini akan ditangani oleh tipline.
+      Mohon muat ulang halaman pengaturan tipline Anda untuk melihat pengubahan baru.
   smooch_twitter_success: |
-    Sukses!
-    Tipline Anda sekarang terhubung dengan Twitter.
-    Semua pesan yang diterima oleh profil Twitter ini akan ditangani oleh tipline.
-    Mohon muat ulang halaman pengaturan tipline Anda untuk melihat pengubahan baru.
-  must_select_exactly_one_facebook_page: Silakan pilih salah satu halaman Facebook
-    yang Anda ingin integrasikan dengan Tipline.
+      Sukses!
+      Tipline Anda sekarang terhubung dengan Twitter.
+      Semua pesan yang diterima oleh profil Twitter ini akan ditangani oleh tipline.
+      Mohon muat ulang halaman pengaturan tipline Anda untuk melihat pengubahan baru.
+  must_select_exactly_one_facebook_page: Silakan pilih salah satu halaman Facebook yang Anda ingin integrasikan dengan Tipline.
   invalid_task_answer: Format jawaban dari tugas salah
   team_rule_name: Nama unik yang dapat mengidentifikasi apa yang aturan ini lakukan
   team_rule_project_ids: Terapkan pada folder
@@ -667,8 +576,7 @@ id:
   team_rule_conditions: Jika
   team_rule_condition: Jika
   team_rule_condition_definition: Pilih kondisi
-  team_rule_has_less_than_x_words: Permintaan teks mengandung kurang dari (atau sama
-    dengan) kata-kata berikut
+  team_rule_has_less_than_x_words: Permintaan teks mengandung kurang dari (atau sama dengan) kata-kata berikut
   team_rule_title_matches_regexp: Judul perihal cocok dengan ekspresi reguler ini
   team_rule_request_matches_regexp: Permintaan cocok dengan ekspresi reguler ini
   team_rule_type_is: Tipe perihal adalah
@@ -676,12 +584,9 @@ id:
   team_rule_type_is_link: Tautan
   team_rule_type_is_uploadedimage: Gambar
   team_rule_type_is_uploadedvideo: Video
-  team_rule_contains_keyword: Permintaan mengandung satu atau lebih dari kata kunci
-    berikut
-  team_rule_title_contains_keyword: Konten mengandung satu atau lebih dari kata kunci
-    berikut
-  team_rule_extracted_text_contains_keyword: Teks yang diekstraksi mengandung kata
-    kunci
+  team_rule_contains_keyword: Permintaan mengandung satu atau lebih dari kata kunci berikut
+  team_rule_title_contains_keyword: Konten mengandung satu atau lebih dari kata kunci berikut
+  team_rule_extracted_text_contains_keyword: Teks yang diekstraksi mengandung kata kunci
   team_rule_select_type: Pilih tipe
   team_rule_select_language: Pilih bahasa
   team_rule_select_user: Pilih seorang kolaborator
@@ -698,8 +603,7 @@ id:
   team_rule_send_to_trash: Pindahkan ke Tong Sampah
   team_rule_move_to_project: Pindahkan perihal ke folder
   team_rule_copy_to_project: Tambah perihal ke folder
-  team_rule_ban_submitter: Tolak pengirim (pesan mereka yang akan datang tidak akan
-    muncul di Check)
+  team_rule_ban_submitter: Tolak pengirim (pesan mereka yang akan datang tidak akan muncul di Check)
   team_rule_all_items: Semua perihal
   team_rule_send_message_to_user: Kirim pesan ke pengguna
   team_rule_action_value: Ketik pesan di sini
@@ -723,10 +627,8 @@ id:
   team_rule_item_is_read: Perihal dibaca
   team_rule_field_from_fieldset_tasks_value_is: Tugas dengan jawaban spesifik
   team_rule_field_from_fieldset_metadata_value_is: Anotasi dengan nilai spesifik
-  team_rule_field_from_fieldset_tasks_value_contains_keyword: Jawaban tugas mengandung
-    kata kunci
-  team_rule_field_from_fieldset_metadata_value_contains_keyword: Nilai anotasi mengandung
-    kata kunci
+  team_rule_field_from_fieldset_tasks_value_contains_keyword: Jawaban tugas mengandung kata kunci
+  team_rule_field_from_fieldset_metadata_value_contains_keyword: Nilai anotasi mengandung kata kunci
   team_rule_select_field_metadata: Pilih anotasi
   team_rule_select_field_value_metadata: Pilih nilai
   team_rule_select_field_tasks: Pilih tugas
@@ -749,32 +651,23 @@ id:
   flag_likelihood_4: Mungkin
   flag_likelihood_5: Tinggi (konten akan terdeteksi lebih banyak)
   flag_likelihood_7: Panduan
-  relationship_not_same_team: Perihal terkait harus berada di dalam ruang kerja yang
-    sama
+  relationship_not_same_team: Perihal terkait harus berada di dalam ruang kerja yang sama
+  item_cant_be_related_to_itself: "Perihal tidak dapat dikaitkan dengan dirinya sendiri"
   target_is_published: Target seharusnya tidak memiliki laporan yang diterbitkan
   similar_item_exists: Maaf, perihal ini sudah ditambahkan sebagai perihal yang mirip.
-  bulk_operation_limit_error: Maaf, jumlah maksimal perihal yang dapat diproses saat
-    bersamaan adalah %{limit}
-  must_provide_fallback_when_deleting_status_in_use: Status ini sedang digunakan,
-    sehingga Anda harus menyertakan status fallback jika Anda ingin menghapusnya
-  embed_no_content_yet: Laporan sedang dibuat. Proses ini memakan waktu beberapa menit.
-    Mohon perbarui halaman ini.
+  bulk_operation_limit_error: Maaf, jumlah maksimal perihal yang dapat diproses saat bersamaan adalah %{limit}
+  must_provide_fallback_when_deleting_status_in_use: Status ini sedang digunakan, sehingga Anda harus menyertakan status fallback jika Anda ingin menghapusnya
+  embed_no_content_yet: Laporan sedang dibuat. Proses ini memakan waktu beberapa menit. Mohon perbarui halaman ini.
   language_format_invalid: Format bahasa salah. Menunggu kode ISO 639-1.
-  languages_format_invalid: Format bahasa salah. Menunggu daftar dari kode-kode ISO
-    639-1.
-  cant_change_status_if_item_is_published: Maaf, Anda tidak dapat mengubah status
-    ketika laporan diterbitkan
+  languages_format_invalid: Format bahasa salah. Menunggu daftar dari kode-kode ISO 639-1.
+  cant_change_status_if_item_is_published: Maaf, Anda tidak dapat mengubah status ketika laporan diterbitkan
   fetch_bot_service_unsupported: Layanan tidak didukung
   task_options_must_be_array: Pilihan tugas harus berupa daftar
   fieldset_not_defined_by_team: Fieldset harus didukung oleh ruang kerja
-  cant_change_field_type_or_options_when_answered: Jenis bidang tidak dapat diubah
-    karena telah terisi jawaban
-  replace_by_media_in_the_same_team: Maaf, Anda hanya dapat mengganti perihal ini
-    dengan perihal lain dari dalam ruang kerja yang sama
-  replace_blank_media_only: Maaf, namun sekarang Anda hanya dapat mengganti perihal
-    yang kosong
-  cant_preview_rss_feed: Maaf, Anda tidak memiliki izin untuk melakukan pratinjau
-    pada umpan RSS.
+  cant_change_field_type_or_options_when_answered: Jenis bidang tidak dapat diubah karena telah terisi jawaban
+  replace_by_media_in_the_same_team: Maaf, Anda hanya dapat mengganti perihal ini dengan perihal lain dari dalam ruang kerja yang sama
+  replace_blank_media_only: Maaf, namun sekarang Anda hanya dapat mengganti perihal yang kosong
+  cant_preview_rss_feed: Maaf, Anda tidak memiliki izin untuk melakukan pratinjau pada umpan RSS.
   list_column_demand: Permintaan
   list_column_share_count: Dibagikan di FB
   list_column_reaction_count: Reaksi di FB
@@ -791,60 +684,48 @@ id:
   list_column_published_by: Laporan diterbitkan oleh
   list_column_fact_check_published_on: Pengecekan fakta diterbitkan pada
   list_column_related_count: Terkait
+  list_column_suggestions_count: Saran
   list_column_folder: Folder
   list_column_creator_name: Dibuat oleh
   list_column_fact_check_title: Pengecekan fakta
   list_column_team_name: Ruang kerja
   list_column_sources_as_sentence: Sumber
   go_back_to_check: Kembali ke Check
-  project_cant_have_children_if_has_parent: Folder ini berada di dalam folder lain,
-    sehingga tidak dapat membuat folder turunan di dalamnya.
-  project_group_must_be_under_same_team: Koleksi tersebut harus berada di bawah ruang
-    kerja yang sama
+  project_cant_have_children_if_has_parent: Folder ini berada di dalam folder lain, sehingga tidak dapat membuat folder turunan di dalamnya.
+  project_group_must_be_under_same_team: Koleksi tersebut harus berada di bawah ruang kerja yang sama
   unique_default_folder_per_team: Ruang kerja harus memiliki hanya satu folder bawaan
-  center_is_not_part_of_another_cluster: Pusat klaster ini tidak dapat menjadi bagian
-    dari klaster lain
+  center_is_not_part_of_another_cluster: Pusat klaster ini tidak dapat menjadi bagian dari klaster lain
   smooch_bot_message_subscribed: |-
-    Anda saat ini sedang berlangganan ke buletin kami.
+      Anda saat ini sedang berlangganan ke buletin kami.
 
-    Ketik 0 untuk menuju ke menu utama
+      Ketik 0 untuk menuju ke menu utama
   smooch_bot_message_unsubscribed: |-
-    Anda saat ini sedang tidak berlangganan ke buletin kami.
+      Anda saat ini sedang tidak berlangganan ke buletin kami.
 
-    Ketik 0 untuk menuju ke menu utama.
+      Ketik 0 untuk menuju ke menu utama.
   subscribe: Berlangganan
   unsubscribe: Brhenti brlangganan
-  smooch_message_subscription_header_subscribed: Anda saat ini sedang berlangganan
-    ke buletin kami.
-  smooch_message_subscription_header_unsubscribed: Anda saat ini sedang tidak berlangganan
-    ke buletin kami.
+  smooch_message_subscription_header_subscribed: Anda saat ini sedang berlangganan ke buletin kami.
+  smooch_message_subscription_header_unsubscribed: Anda saat ini sedang tidak berlangganan ke buletin kami.
   smooch_bot_message_newsletter_fallback: |-
-    Halo! Berikut fakta mingguan Anda.
+      Halo! Berikut fakta mingguan Anda.
 
-    Buletin ini diterbitkan di %{platform} oleh %{team} pada %{date}:
+      Buletin ini diterbitkan di %{platform} oleh %{team} pada %{date}:
 
-    %{content}
+      %{content}
 
-    Untuk berhenti menerima buletin ini, ketik "%{unsubscribe}".
+      Untuk berhenti menerima buletin ini, ketik "%{unsubscribe}".
+  send_every_must_be_a_list_of_days_of_the_week: harus berupa daftar hari dalam seminggu.
+  send_on_must_be_in_the_future: tidak bisa ke masa lalu.
   info:
     messages:
-      sent_to_trash_by_rule: '"%{item_title}" telah dibuang ke tong sampah oleh aturan
-        otomasi.'
-      moved_to_project_by_rule: '"%{item_title}" dipindahkan ke folder "[%{list_name}](%{list_link})"
-        oleh aturan otomasi.'
-      banned_submitter_by_rule: Pemohon dari "%{item_title}" telah dilarang oleh aturan
-        otomasi.
-      copied_to_project_by_rule: '"%{item_title}" telah disalin ke dalam folder "[%{list_name}](%{list_link})"
-        oleh aturan otomasi.'
-      related_to_confirmed_similar: '"%{item_title}" telah dikonfirmasi mirip dengan
-        "%{similar_item_title}".'
-      related_to_suggested_similar: '"%{item_title}" telah disarankan mirip dengan
-        "%{similar_item_title}".'
-      sent_message_to_requestors_on_status_change: Sebuah pembaruan dengan status
-        "%{status}" telah dikirimkan ke %{requestors_count} pemohon.
-      tagged_by_rule: '"%{item_title}" telah ditandai sebagai "%{tag}" oleh aturan
-        otomasi.'
-      moved_to_private_folder: '"%{item_title}" telah dipindahkan ke folder yang tidak
-        dapat Anda akses.'
-      add_warning_cover_by_rule: Menambahkan sampul peringatan ke perihal sensitif
-        "%{item_title}"
+      sent_to_trash_by_rule: '"%{item_title}" telah dibuang ke tong sampah oleh aturan otomasi.'
+      moved_to_project_by_rule: '"%{item_title}" dipindahkan ke folder "[%{list_name}](%{list_link})" oleh aturan otomasi.'
+      banned_submitter_by_rule: Pemohon dari "%{item_title}" telah dilarang oleh aturan otomasi.
+      copied_to_project_by_rule: '"%{item_title}" telah disalin ke dalam folder "[%{list_name}](%{list_link})" oleh aturan otomasi.'
+      related_to_confirmed_similar: '"%{item_title}" telah dikonfirmasi mirip dengan "%{similar_item_title}".'
+      related_to_suggested_similar: '"%{item_title}" telah disarankan mirip dengan "%{similar_item_title}".'
+      sent_message_to_requestors_on_status_change: Sebuah pembaruan dengan status "%{status}" telah dikirimkan ke %{requestors_count} pemohon.
+      tagged_by_rule: '"%{item_title}" telah ditandai sebagai "%{tag}" oleh aturan otomasi.'
+      moved_to_private_folder: '"%{item_title}" telah dipindahkan ke folder yang tidak dapat Anda akses.'
+      add_warning_cover_by_rule: Menambahkan sampul peringatan ke perihal sensitif "%{item_title}"

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,4 +1,3 @@
----
 pt:
   statuses:
     ids:
@@ -25,7 +24,7 @@ pt:
         label: Em andamento
         description: O trabalho começou, mas nenhuma tradução ainda foi feita
       not_true:
-        label: Falso
+        label: 'Falso'
         description: 'Conclusão: o conteúdo do item é falso'
       verified:
         label: Verificado
@@ -76,36 +75,27 @@ pt:
     messages:
       invalid_password: Senha inválida
       invalid_qrcode: Código de validação inválido
-      extension_white_list_error: 'Não pode ter o tipo %{extension}, tipos permitidos:
-        %{allowed_types}'
-      invalid_size: Deve ter entre %{min_width} x %{min_height} e %{max_width} x %{max_height}
-        pixels
-      mini_magick_processing_error: 'Desculpe, não conseguimos processar a imagem.
-        O erro foi: %{e}'
+      extension_white_list_error: 'não pode ser do tipo %{extension}, os tipos permitidos são: %{allowed_types}'
+      invalid_size: Deve ter entre %{min_width} x %{min_height} e %{max_width} x %{max_height} pixels
+      mini_magick_processing_error: 'Desculpe, não conseguimos processar a imagem. O erro foi: %{e}'
       annotation_mandatory_fields: Por favor, preencha todos os campos obrigatórios
       annotation_type_does_not_exist: não existe
       invalid_attribution: Atribuição inválida
-      must_resolve_required_tasks_first: As tarefas obrigatórias devem ser resolvidas
-        primeiro
+      must_resolve_required_tasks_first: As tarefas obrigatórias devem ser resolvidas primeiro
       image_too_large: Desculpe, não oferecemos suporte a imagens maiores que %{max_size}.
       video_too_large: Desculpe, não oferecemos suporte a vídeos maiores que %{max_size}.
       audio_too_large: Desculpe, não oferecemos suporte a áudios maiores que %{max_size}.
-      pender_conflict: Este link já está sendo processado. Por favor, tente novamente
-        em alguns segundos.
+      pender_conflict: Este link já está sendo processado. Por favor, tente novamente em alguns segundos.
       pender_url_invalid: Este link é inválido.
       pender_url_unsafe: Este link não é seguro.
-      pender_could_not_parse: Não foi possível analisar este link. Por favor, contate
-        %{support_email} se o erro persistir.
-      invalid_format_for_languages: Formato de idioma inválido. O formato esperado
-        é `['en', 'ar', …]`
-      invalid_project_media_channel_value: Desculpe, não há suporte para este valor
-        do canal.
-      invalid_project_media_channel_update: Desculpe, não possível atualizar o valor
-        do canal
-      invalid_project_media_archived_value: Desculpe, não há suporte para o valor
-        arquivado
-      invalid_fact_check_language_value: Desculpe, não há suporte para o valor do
-        idioma
+      pender_could_not_parse: Não foi possível analisar este link. Por favor, contate %{support_email} se o erro persistir.
+      invalid_format_for_languages: Formato de idioma inválido. O formato esperado é `['en', 'ar', …]`
+      invalid_project_media_channel_value: Desculpe, não há suporte para este valor do canal.
+      invalid_project_media_channel_update: Desculpe, não possível atualizar o valor do canal
+      invalid_project_media_archived_value: Desculpe, não há suporte para o valor arquivado
+      invalid_fact_check_language_value: Desculpe, não há suporte para o valor do idioma
+      fact_check_empty_title_and_summary: Desculpe, você deve preencher o título ou o resumo
+      invalid_feed_saved_search_value: deve pertencer a um espaço de trabalho que faz parte deste feed
   activerecord:
     models:
       link: Link
@@ -166,17 +156,12 @@ pt:
   slack_webhook_format_wrong: Webhook do Slack inválido. O formato esperado é `https://hooks.slack.com/services/XXXXX/XXXXXXXXXX`
   slug_is_reserved: é reservado
   invalid_media_item: Este item é inválido
-  invalid_default_status_for_custom_verification_status: O identificador padrão de
-    status é  inválido
-  invalid_active_status_for_custom_verification_status: O identificador de status
-    ativo é inválido
+  invalid_default_status_for_custom_verification_status: O identificador padrão de status é  inválido
+  invalid_active_status_for_custom_verification_status: O identificador de status ativo é inválido
   invalid_label_for_custom_verification_status: O título de status é obrigatório
-  invalid_id_for_custom_verification_status: O identificador de status é obrigatório
-    e aceita apenas letras, números, hifens e sublinhados
-  invalid_statuses_format_for_custom_verification_status: 'Status de verificação personalizada
-    inválido. Esperando entradas válidas para: etiqueta, identificador, descrição
-    e estilo.'
-  mail_account_confirmation: 'Confirmação de conta no %{app_name} '
+  invalid_id_for_custom_verification_status: O identificador de status é obrigatório e aceita apenas letras, números, hifens e sublinhados
+  invalid_statuses_format_for_custom_verification_status: 'Status de verificação personalizada inválido. Esperando entradas válidas para: etiqueta, identificador, descrição e estilo.'
+  mail_account_confirmation: "Confirmação de conta no %{app_name} "
   slack:
     fields:
       assigned: Atribuída a
@@ -191,8 +176,7 @@ pt:
       project_media: Item
       attribution: Respondida por
     messages:
-      analysis_verification_status_status_changed: "%{user} modificou seu status para:
-        %{value}"
+      analysis_verification_status_status_changed: "%{user} modificou seu status para: %{value}"
       analysis_title_changed: "%{user} modificou o título da análise para: %{value}"
       analysis_content_changed: "%{user} modificou o conteúdo da análise para: %{value}"
       tasks_create: "%{user} adicionou uma tarefa: %{title}"
@@ -203,40 +187,29 @@ pt:
       metadata_edit: "%{user} editou o campo de metadados %{title}"
       metadata_answer_create: "%{user} definiu valor de metadados %{title}: %{answer}"
       metadata_answer_edit: "%{user} editou o valor de metadados %{title}: %{answer}"
-      project_media_comment: "%{user} (%{role} em %{team}) adicionou uma nota a um(a)
-        %{parent_type}"
+      project_media_comment: "%{user} (%{role} em %{team}) adicionou uma nota a um(a) %{parent_type}"
       project_media_create: "%{user} (%{role} em %{team}) enviou um novo item"
-      project_media_create_related: "%{user} (%{role} em %{team}) adicionou um(a)
-        %{type} relacionado(a)"
+      project_media_create_related: "%{user} (%{role} em %{team}) adicionou um(a) %{type} relacionado(a)"
       project_media_update: "%{user} (%{role} em %{team}) atualizou um item"
       project_media_move_to: "%{user} (%{role} de %{team}) moveu um item para %{project}"
-      project_media_added_to_list: "%{user} (%{role} em %{team}) adicionou um item
-        à pasta %{list_name}"
-      project_media_status: "%{user} (%{role} em %{team}) modificou o status de %{workflow}
-        de um(a) %{type}"
+      project_media_added_to_list: "%{user} (%{role} em %{team}) adicionou um item à pasta %{list_name}"
+      project_media_status: "%{user} (%{role} em %{team}) modificou o status de %{workflow} de um(a) %{type}"
       project_media_assign: "%{user} (%{role} em %{team}) atribuiu um(a) %{type}"
-      project_media_unassign: "%{user} (%{role} em %{team}) removeu a atribuição de
-        um(a) %{type}"
-      project_source_comment: "%{user} (%{role} em %{team}) adicionou uma nota a um(a)
-        %{parent_type}"
+      project_media_unassign: "%{user} (%{role} em %{team}) removeu a atribuição de um(a) %{type}"
+      project_source_comment: "%{user} (%{role} em %{team}) adicionou uma nota a um(a) %{parent_type}"
       project_source_create: "%{user} (%{role} em %{team}) adicionou um(a) %{type}"
       project_source_update: "%{user} (%{role} em %{team}) editou um(a) %{type}"
       project_create: "%{user} (%{role} em %{team}) criou uma pasta"
       project_assign: "%{user} (%{role} em %{team}) atribuiu uma pasta"
-      project_unassign: "%{user} (%{role} em %{team}) removeu a atribuição de uma
-        pasta"
+      project_unassign: "%{user} (%{role} em %{team}) removeu a atribuição de uma pasta"
       user_member: "%{user} começou a participar do espaço de trabalho %{team}"
-      user_requested: "%{user} enviou solicitação para participar do espaço de trabalho
-        %{team}"
+      user_requested: "%{user} enviou solicitação para participar do espaço de trabalho %{team}"
       user_invited: "%{user} foi convidado(a) a participar do espaço de trabalho %{team}"
       user_banned: "%{user} foi banido(a) do espaço de trabalho %{team}"
   mail_view_welcome: Bem-vindo/bem-vinda ao %{app_name}
-  mail_view_register: 'Você está a somente um passo de usar o %{app_name}! Por favor,
-    confirme o seu endereço de e-mail clicando neste link:'
+  mail_view_register: 'Você está a somente um passo de usar o %{app_name}! Por favor, confirme o seu endereço de e-mail clicando neste link:'
   mail_confirm_button: Confirmar minha conta
-  slack_restricted_join_to_members: Lamentamos, mas você não pode integrar %{team_name},
-    porque o acesso está restrito aos integrantes do(s) espaço(s) de trabalho %{teams}
-    do Slack.
+  slack_restricted_join_to_members: Lamentamos, mas você não pode integrar %{team_name}, porque o acesso está restrito aos integrantes do(s) espaço(s) de trabalho %{teams} do Slack.
   admin:
     actions:
       send_reset_password_email:
@@ -249,12 +222,10 @@ pt:
         menu: Duplicar o espaço de trabalho
         done: duplicado
         are_you_sure_you_want_to_copy_team:
-          html: Tem certeza que deseja duplicar o espaço de trabalho <strong>%{team}</strong>?
-            Todos os dados relacionados também serão copiados.
+          html: Tem certeza que deseja duplicar o espaço de trabalho <strong>%{team}</strong>? Todos os dados relacionados também serão copiados.
         the_team_is_being_copied: Duplicação do espaço de trabalho em andamento
         url_when_ready:
-          html: Quando pronto, o espaço de trabalho duplicado estará disponível em
-            <strong>%{copy_url}</strong>
+          html: Quando pronto, o espaço de trabalho duplicado estará disponível em <strong>%{copy_url}</strong>
     flash:
       delete_team_scheduled: O espaço de trabalho %{team} está sendo excluído
   email_not_found: E-mail não encontrado
@@ -266,13 +237,10 @@ pt:
       task: "%d de %B de %Y às %H:%M [TZ] (%z UTC)"
       email: "%d de %B de %Y às %p%I:%M  (%Z)"
   oembed_disclaimer_undetermined: Esse item ainda não foi verificado por %{team}
-  oembed_disclaimer_in_progress: Esse item está sendo verificado por %{team} desde
-    %{date}
-  oembed_disclaimer_verified: Esse item foi marcado como verificado por %{team} em
-    %{date}
+  oembed_disclaimer_in_progress: Esse item está sendo verificado por %{team} desde %{date}
+  oembed_disclaimer_verified: Esse item foi marcado como verificado por %{team} em %{date}
   oembed_disclaimer_false: Esse item foi considerado falso por %{team} em %{date}
-  oembed_disclaimer_not_applicable: Nenhuma conclusão foi obtida sobre esse item por
-    %{team} em %{date}
+  oembed_disclaimer_not_applicable: Nenhuma conclusão foi obtida sobre esse item por %{team} em %{date}
   oembed_source_date: "%{date} no %{provider}"
   role_editor: editor(a)
   role_admin: admin
@@ -281,11 +249,11 @@ pt:
   role_: admin de sistemas
   oembed_credit: Adicionado por %{user} (%{role}) %{date}
   oembed_notes_count:
-    one: Uma nota
+    one: "Uma nota"
     many: "%{count} notas"
     other: "%{count} notas"
   oembed_completed_tasks_count:
-    one: Uma tarefa concluída
+    one: "Uma tarefa concluída"
     many: "%{count} tarefas concluídas"
     other: "%{count} tarefas concluídas"
   oembed_verification_tasks: Tarefas
@@ -294,35 +262,28 @@ pt:
   oembed_expand_all: Expandir tudo
   oembed_collapse_all: Recolher tudo
   oembed_resolved_tasks_count:
-    one: Uma tarefa resolvida
+    one: "Uma tarefa resolvida"
     many: "%{count} tarefas resolvidas"
     other: "%{count} tarefas resolvidas"
   oembed_notes: Notas
   duplicate_source: Esta fonte já existe
-  geolocation_invalid_value: Localização inválida. Esperando uma estrutura GeoJSON
-    válida (http://geojson.org/)
+  geolocation_invalid_value: Localização inválida. Esperando uma estrutura GeoJSON válida (http://geojson.org/)
   url_invalid_value: A URL enviada é inválida
   datetime_invalid_date: Data inválida
-  error_team_archived: Desculpe, não é possível adicionar uma pasta a um espaço de
-    trabalho que esteja na lixeira
-  error_project_archived: Desculpe, não é possível adicionar um item a uma pasta que
-    esteja na lixeira
-  error_team_archived_for_source: 'Desculpe, não é possível adicionar uma fonte a
-    um espaço de trabalho que esteja na lixeira '
+  error_team_archived: Desculpe, não é possível adicionar uma pasta a um espaço de trabalho que esteja na lixeira
+  error_project_archived: Desculpe, não é possível adicionar um item a uma pasta que esteja na lixeira
+  error_team_archived_for_source: 'Desculpe, não é possível adicionar uma fonte a um espaço de trabalho que esteja na lixeira '
   permission_error: Desculpe, você não tem permissão para realizar esta operação
-  error_annotated_archived: Desculpe, não é possível adicionar uma nota a um item
-    na lixeira
-  only_super_admin_can_do_this: Desculpe, apenas admins do sistema podem efetuar esta
-    modificação
+  error_annotated_archived: Desculpe, não é possível adicionar uma nota a um item na lixeira
+  only_super_admin_can_do_this: Desculpe, apenas admins do sistema podem efetuar esta modificação
   cant_change_custom_statuses: |-
-    Desculpe, não é possível modificar as definições de status porque alguns deles desapareceriam. Esses identificadores de status: %{statuses} estão sendo usados pelos itens seguintes:
-    %{urls} %{others_amount}
+      Desculpe, não é possível modificar as definições de status porque alguns deles desapareceriam. Esses identificadores de status: %{statuses} estão sendo usados pelos itens seguintes:
+      %{urls} %{others_amount}
   account_exists: Esta conta já existe
   media_exists: Esse item já existe
   source_exists: Essa fonte já existe
   email_exists: já está em uso
-  banned_user: Desculpe, sua conta foi banida do %{app_name}. Por favor, entre em
-    contato com a equipe de suporte se você achar que isso é um erro.
+  banned_user: Desculpe, sua conta foi banida do %{app_name}. Por favor, entre em contato com a equipe de suporte se você achar que isso é um erro.
   devise:
     mailer:
       reset_password_instructions:
@@ -332,21 +293,18 @@ pt:
         action: Redefinir sua senha
         expiry: Esta solicitação irá expirar em %{expire} hours.
         instruction_1: Clique aqui para fazer uma nova solicitação.
-        instruction_2: Se você não tiver feito essa solicitação ou estiver com dificuldades
-          para redefinir sua senha, por favor, entre em contato com %{support_email}.
+        instruction_2: Se você não tiver feito essa solicitação ou estiver com dificuldades para redefinir sua senha, por favor, entre em contato com %{support_email}.
       invitation_instructions:
         subject: "%{user} convidou você a participar do espaço de trabalho %{team}"
         hello: Olá %{name}
         someone_invited_you_default:
-          html: "%{name} convidou você a participar do espaço de trabalho %{team}
-            como %{role}."
+          html: "%{name} convidou você a participar do espaço de trabalho %{team} como %{role}."
         someone_invited_you_custom:
-          html: "%{name} convidou você a participar do espaço de trabalho %{team}
-            como %{role}, dizendo:"
+          html: "%{name} convidou você a participar do espaço de trabalho %{team} como %{role}, dizendo:"
         accept: Aceitar convite
         accept_until: Este convite expirará em %{due_date}.
         ignore: Se você não quiser aceitar o convite, ignore este e-mail.
-        app_team: 'Espaço de trabalho do %{app} '
+        app_team: "Espaço de trabalho do %{app} "
     failure:
       unconfirmed: Por favor, consulte seu e-mail para verificar sua conta.
   user_invitation:
@@ -355,8 +313,7 @@ pt:
     team_found: Espaço de trabalho não encontrado.
     invalid: Código de convite inválido.
     no_invitation: Não há convite para o espaço de trabalho %{name}
-  error_user_is_not_a_team_member: Desculpe, você pode atribuir tarefas somente a
-    membros desse espaço de trabalho
+  error_user_is_not_a_team_member: Desculpe, você pode atribuir tarefas somente a membros desse espaço de trabalho
   error_login_with_exists_account: Desculpe, outra pessoa já está usando esta conta
   error_login_2fa: Por favor, complete seu login fornecendo um código de autenticação.
   error_record_not_found: "%{type} #%{id} não encontrado(a)."
@@ -370,55 +327,48 @@ pt:
     register:
       subject: Nova conta para você no %{app_name}
       header_text: |-
-        Você se registrou  no %{app_name} com sucesso!
-        <br>
-        Para fazer login no site, siga este link: %{url}. Insira este endereço de e-mail e esta senha: %{password}
+          Você se registrou  no %{app_name} com sucesso!
+          <br>
+          Para fazer login no site, siga este link: %{url}. Insira este endereço de e-mail e esta senha: %{password}
       login_button: Login no %{app_name}
       footer_text: Agradecemos-lhe por se registrar. Tenha um ótimo dia!
     duplicated:
       subject: Seu método de login no %{app_name}
       header_title: Duplicar conta
       one_email: |-
-        <p>Este é apenas um lembrete para ajudar a garantir que você faça login no %{app_name}.</p>
-        <p>O que aconteceu: você tentou se registrar no %{app_name} com uma conta %{user_provider} associada ao e-mail %{user_email}.
-        Esse endereço de e-mail já está associado a uma conta %{duplicate_provider} no %{app_name}.</p>
-        <p>O que fazer agora: Faça login com a sua conta %{duplicate_provider}.</p>
-        <p>Assim, você vai se conectar com a conta que estava usando antes.
-        Se você precisar de mais ajuda, por favor, envie um e-mail para %{support_email}.</p>
+          <p>Este é apenas um lembrete para ajudar a garantir que você faça login no %{app_name}.</p>
+          <p>O que aconteceu: você tentou se registrar no %{app_name} com uma conta %{user_provider} associada ao e-mail %{user_email}.
+          Esse endereço de e-mail já está associado a uma conta %{duplicate_provider} no %{app_name}.</p>
+          <p>O que fazer agora: Faça login com a sua conta %{duplicate_provider}.</p>
+          <p>Assim, você vai se conectar com a conta que estava usando antes.
+          Se você precisar de mais ajuda, por favor, envie um e-mail para %{support_email}.</p>
       both_emails: |-
-        <p>Este é apenas um lembrete para ajudar a garantir que você faça login no  %{app_name}.</p>
-        <p>O que aconteceu: você tentou criar uma nova conta no %{app_name} usando um e-mail, mas essa conta já existe.</p>
-        <p>Tente fazer login com seu e-mail e senha em vez de criar uma nova conta.</p>
-        <p>Assim, você vai se conectar com a conta que estava usando antes. Se você precisar de mais ajuda, por favor, envie um e-mail para %{support_email}.</p>
+          <p>Este é apenas um lembrete para ajudar a garantir que você faça login no  %{app_name}.</p>
+          <p>O que aconteceu: você tentou criar uma nova conta no %{app_name} usando um e-mail, mas essa conta já existe.</p>
+          <p>Tente fazer login com seu e-mail e senha em vez de criar uma nova conta.</p>
+          <p>Assim, você vai se conectar com a conta que estava usando antes. Se você precisar de mais ajuda, por favor, envie um e-mail para %{support_email}.</p>
       email: e-mail
     invitation:
       title: Novo Convite
     delete_user:
       subject: "[%{team}] Um(a) usuário(a) foi excluído(a)"
       header_title: O(a) usuário(a) foi excluído(a)
-      header_text: Uma conta de usuário foi excluída e seu conteúdo foi reatribuído
-        ao/à usuário(a) %{anonymous} %{id}
+      header_text: Uma conta de usuário foi excluída e seu conteúdo foi reatribuído ao/à usuário(a) %{anonymous} %{id}
       anonymous: anônimo(a)
     admin_mailer:
-      team_download_subject: "[%{team}] A cópia dos dados do espaço de trabalho está
-        pronta para download"
+      team_download_subject: "[%{team}] A cópia dos dados do espaço de trabalho está pronta para download"
       team_dump_title: Dados do Espaço de Trabalho
       types:
         dump: cópia de dados
         csv: relatório
         images: arquivo de imagem
-      team_dump_text: 'Você solicitou uma cópia dos dados do espaço de trabalho %{team}
-        - aqui está um link para baixá-la: %{link}'
+      team_dump_text: 'Você solicitou uma cópia dos dados do espaço de trabalho %{team} - aqui está um link para baixá-la: %{link}'
       team_dump_button: Baixar dados do espaço de trabalho
-      decompress_text: O %{type} será baixado em um arquivo comprimido e criptografado.
-        Para descomprimi-lo, por favor, use a senha %{password}.
+      decompress_text: O %{type} será baixado em um arquivo comprimido e criptografado. Para descomprimi-lo, por favor, use a senha %{password}.
       expire_note: Lembre que esse link irá expirar em %{days} dias.
       team_import_subject: A importação dos seus dados foi concluída
       team_import_title: Importação de Dados
-      team_import_text: "<p>A importação dos seus dados no %{app_name} foi concluída.
-        Você pode conferir em %{worksheet_url} para revisar o status de cada item
-        importado.</p> <p>Lembre que você pode reiniciar a importação depois de corrigir
-        os erros relatados - os itens previamente importados não serão duplicados.</p>"
+      team_import_text: "<p>A importação dos seus dados no %{app_name} foi concluída. Você pode conferir em %{worksheet_url} para revisar o status de cada item importado.</p> <p>Lembre que você pode reiniciar a importação depois de corrigir os erros relatados - os itens previamente importados não serão duplicados.</p>"
     task_resolved:
       subject: "[%{team} - %{project}] A tarefa foi respondida"
       header_title: A tarefa foi respondida
@@ -430,37 +380,30 @@ pt:
       label: Item
       subject: "[%{team} - %{project}] O status de um item foi marcado como %{status}"
       header_title: O status do item foi atualizado
-      header_text: " %{author} atualizou o status de um item na pasta %{project} em
-        %{team}."
+      header_text: " %{author} atualizou o status de um item na pasta %{project} em %{team}."
       section_title: Marcado como %{status}.
       added_to: Adicionado ao %{app_name}
       update_h: Última Atualização
       tasks_h: Tarefas Concluídas
     assignment:
       assign_task_subject: "[%{team} - %{project}] Uma tarefa foi atribuída a você"
-      unassign_task_subject: "[%{team} - %{project}] A atribuição de uma tarefa a
-        você foi removida"
+      unassign_task_subject: "[%{team} - %{project}] A atribuição de uma tarefa a você foi removida"
       assign_project_subject: "[%{team} - %{project}] Uma pasta foi atribuída a você"
-      unassign_project_subject: "[%{team} - %{project}] A atribuição de uma pasta
-        foi removida de você"
+      unassign_project_subject: "[%{team} - %{project}] A atribuição de uma pasta foi removida de você"
       assign_media_subject: "[%{team} - %{project}] Um item foi atribuído a você"
-      unassign_media_subject: "[%{team} - %{project}] A atribuição de um item a você
-        foi removida"
+      unassign_media_subject: "[%{team} - %{project}] A atribuição de um item a você foi removida"
       assign_project_title: Pasta atribuída
       unassign_project_title: A atribuição da pasta foi removida
       assign_project_text: "%{author} atribuiu a pasta %{project} em %{team}."
-      unassign_project_text: "%{author} removeu a atribuição da pasta %{project} em
-        %{team}."
+      unassign_project_text: "%{author} removeu a atribuição da pasta %{project} em %{team}."
       assign_task_title: Tarefa atribuída
       unassign_task_title: A atribuição da tarefa foi removida
       assign_task_text: "%{author} atribuiu uma tarefa na pasta %{project} em %{team}."
-      unassign_task_text: "%{author} removeu a atribuição de uma tarefa na pasta %{project}
-        em %{team}."
+      unassign_task_text: "%{author} removeu a atribuição de uma tarefa na pasta %{project} em %{team}."
       assign_media_title: Item atribuído
       unassign_media_title: A atribuição do item foi removida
       assign_media_text: "%{author} atribuiu um item na pasta %{project} em %{team}."
-      unassign_media_text: "%{author} removeu a atribuição de um item na pasta %{project}
-        em %{team}."
+      unassign_media_text: "%{author} removeu a atribuição de um item na pasta %{project} em %{team}."
       assign_log: " %{author} atribuiu um(a) %{model} a %{username}"
       unassign_log: " %{author} removeu a atribuição de %{model} de %{username}"
       assign_by: Atribuídos por
@@ -473,17 +416,13 @@ pt:
       rejected_subject: Sua solicitação para participar de %{team} não foi aprovada
       approved_subject: Boas-vindas ao espaço de trabalho %{team}
       request_title: Solicitação para participar do espaço de trabalho %{team}
-      request_text: "%{name} (%{email}) gostaria de participar do espaço de trabalho
-        %{team} no %{app_name}. Você pode tratar essa solicitação visitando %{url}."
+      request_text: "%{name} (%{email}) gostaria de participar do espaço de trabalho %{team} no %{app_name}. Você pode tratar essa solicitação visitando %{url}."
       approved_title: Boas-vindas ao espaço de trabalho %{team}
-      approved_text: Sua solicitação para participar do espaço de trabalho %{team}
-        no %{app_name} foi aprovada! Agora você pode ir para %{url} e começar a contribuir.
+      approved_text: Sua solicitação para participar do espaço de trabalho %{team} no %{app_name} foi aprovada! Agora você pode ir para %{url} e começar a contribuir.
       rejected_title: Solicitação rejeitada
-      rejected_text: Desculpe, mas sua solicitação para participar do espaço de trabalho
-        %{team} no %{app_name} não foi aprovada.
+      rejected_text: Desculpe, mas sua solicitação para participar do espaço de trabalho %{team} no %{app_name} não foi aprovada.
   mail_security:
-    device_subject: 'Alerta de segurança: Novo login no %{app_name} pelo %{browser}
-      em %{platform}'
+    device_subject: 'Alerta de segurança: Novo login no %{app_name} pelo %{browser} em %{platform}'
     ip_subject: 'Alerta de segurança: Login novo ou incomum no %{app_name}'
     failed_subject: 'Alerta de segurança: Tentativas malsucedidas de login no %{app_name} '
     ip: Você se conectou de %{location}
@@ -491,13 +430,9 @@ pt:
     devise_name: "%{browser} em %{platform}"
     failed: 'Foram detectadas tentativas malsucedidas de login '
     password_text: redefina sua senha imediatamente.
-    device_text: Parece que você recentemente entrou em sua conta no %{app_name} a
-      partir de um novo dispositivo. Se não for o caso, você deveria %{change_password}
-    ip_text: Parece que você recentemente entrou na sua conta no %{app_name} a partir
-      de uma nova localização. Se não for o caso, você deveria %{change_password}
-    failed_text: Parece que foram feitas múltiplas tentativas de login em sua conta
-      no %{app_name}. Se tiver sido você, você pode, sem problemas de segurança, desconsiderar
-      este e-mail. Caso contrário, você deveria %{change_password}
+    device_text: Parece que você recentemente entrou em sua conta no %{app_name} a partir de um novo dispositivo. Se não for o caso, você deveria %{change_password}
+    ip_text: Parece que você recentemente entrou na sua conta no %{app_name} a partir de uma nova localização. Se não for o caso, você deveria %{change_password}
+    failed_text: Parece que foram feitas múltiplas tentativas de login em sua conta no %{app_name}. Se tiver sido você, você pode, sem problemas de segurança, desconsiderar este e-mail. Caso contrário, você deveria %{change_password}
     time_h: Horário
     device_h: Aparelho
     location_h: Localização
@@ -511,63 +446,43 @@ pt:
   archive_keep_backup: Video Vault
   archive_pender_archive: Captura de tela
   archive_archive_org: Archive.org
-  workflow_status_is_not_valid: 'Status inválido: ''%{status}'' (deveria ser um de
-    %{valid})'
-  workflow_status_permission_error: Desculpe, você não tem permissão para mudar este
-    status.
-  blank_default_status_for_custom_verification_status: Por favor, forneça um valor
-    padrão para os status de verificação personalizada
-  blank_active_status_for_custom_verification_status: Por favor, forneça um valor
-    ativo para os status de verificação personalizada
-  bot_name_exists_for_this_team: Já existe um bot com o nome fornecido nesse espaço
-    de trabalho
-  bot_team_id_doesnt_exist: Desculpe, não há espaço de trabalho com o identificador
-    fornecido
-  bot_team_id_mandatory_to_create: Desculpe, você precisa escolher um espaço de trabalho
-    para criar um bot
-  bot_not_approved_for_installation: Desculpe, este bot não foi aprovado e por isso
-    não pode ser instalado
-  could_not_save_related_bot_data: Desculpe, não foi possível adicionar o bot a esse
-    espaço de trabalho
-  bot_cant_add_response_to_task: Desculpe, um bot não pode responder a uma tarefa
-    diretamente - por favor, adicione uma sugestão de resposta
+  workflow_status_is_not_valid: 'Status inválido: ''%{status}'' (deveria ser um de %{valid})'
+  workflow_status_permission_error: Desculpe, você não tem permissão para mudar este status.
+  blank_default_status_for_custom_verification_status: Por favor, forneça um valor padrão para os status de verificação personalizada
+  blank_active_status_for_custom_verification_status: Por favor, forneça um valor ativo para os status de verificação personalizada
+  bot_name_exists_for_this_team: Já existe um bot com o nome fornecido nesse espaço de trabalho
+  bot_team_id_doesnt_exist: Desculpe, não há espaço de trabalho com o identificador fornecido
+  bot_team_id_mandatory_to_create: Desculpe, você precisa escolher um espaço de trabalho para criar um bot
+  bot_not_approved_for_installation: Desculpe, este bot não foi aprovado e por isso não pode ser instalado
+  only_admins_can_approve_or_list_bots: Desculpe, apenas admins do sistema podem aprovar ou listar bots
+  could_not_save_related_bot_data: Desculpe, não foi possível adicionar o bot a esse espaço de trabalho
+  bot_cant_add_response_to_task: Desculpe, um bot não pode responder a uma tarefa diretamente - por favor, adicione uma sugestão de resposta
   bot_cant_add_review_to_task: Desculpe, um bot não pode avaliar uma tarefa
-  task_suggestion_invalid_value: Sugestão de tarefa inválida. Espera-se um objeto
-    JSON com atributos `suggestion` (o valor real que é copiado para a resposta de
-    tarefa quando aceita) e `comment` (exibido aos(às) usuário(a)s).
+  task_suggestion_invalid_value: Sugestão de tarefa inválida. Espera-se um objeto JSON com atributos `suggestion` (o valor real que é copiado para a resposta de tarefa quando aceita) e `comment` (exibido aos(às) usuário(a)s).
   tag_text_id_not_found: Tag não encontrada
   annotation_type_language_label: Idioma
-  smooch_bot_message_confirmed: Agradecemos a você. Sua solicitação foi adicionada
-    à nossa fila de verificação. Vamos tentar enviar um relatório nas próximas 24
-    horas, mas, por favor, note que não podemos responder a todas as mensagens.
-  smooch_bot_message_unconfirmed: Como você não respondeu com 1, nós interromperemos
-    o tratamento da sua solicitação. Agradecemos.
-  smooch_bot_message_type_unsupported: Desculpe, nós não oferecemos suporte a este
-    tipo de mensagem.
-  smooch_bot_message_size_unsupported: Desculpe, não oferecemos suporte a arquivos
-    maiores que %{max_size}.
+  smooch_bot_message_confirmed: |-
+      Agradecemos a você. Sua solicitação foi adicionada à nossa fila de verificação. Vamos tentar enviar um relatório nas próximas 24 horas, mas, por favor, note que não podemos responder a todas as mensagens.
+  smooch_bot_message_unconfirmed: Como você não respondeu com 1, nós interromperemos o tratamento da sua solicitação. Agradecemos.
+  smooch_bot_message_type_unsupported: Desculpe, nós não oferecemos suporte a este tipo de mensagem.
+  smooch_bot_message_size_unsupported: Desculpe, não oferecemos suporte a arquivos maiores que %{max_size}.
   smooch_bot_result: |-
-    [Relatório de Verificação] A mensagem que você compartilhou conosco está marcada como *%{status}*.
+      [Relatório de Verificação] A mensagem que você compartilhou conosco está marcada como *%{status}*.
 
-    Aqui estão os nossos passos para estabelecer esse status: %{url}
+      Aqui estão os nossos passos para estabelecer esse status: %{url}
   smooch_bot_ask_for_confirmation: |-
-    Agradecemos pelo envio desta solicitação. Você gostaria de verificar o conteúdo dela?
+      Agradecemos pelo envio desta solicitação. Você gostaria de verificar o conteúdo dela?
 
-    Para verificar, *por favor, responda com 1*. Qualquer outra resposta encerrará nossa conversa.
+      Para verificar, *por favor, responda com 1*. Qualquer outra resposta encerrará nossa conversa.
   smooch_bot_ask_for_tos: |-
-    Agradecemos a você por entrar em contato com a Check Message!
+      Agradecemos a você por entrar em contato com a Check Message!
 
-    Você pode usar este serviço para solicitar verificações, verificações de fatos e investigações de notícias e informações. Check Message é fornecida a você sob estes Termos de Serviço: %{tos}. Ao continuar a usar este serviço, *você concorda em cumprir estes termos*. Caso não concorde, você deve parar de usar a Check Message.
-  smooch_bot_window_closing: O volume de solicitações neste canal é muito alto, e
-    ainda não conseguimos responder ao seu pedido ainda. Agradecemos a você pela sua
-    paciência.
-  smooch_bot_not_final: "[Relatório de Verificação - CORREÇÃO] A mensagem que você
-    compartilhou conosco foi incorretamente marcada como *%{status}*. Ela ainda está
-    em nossa fila para verificação complementar."
-  smooch_bot_disabled: Agradecemos a você por enviar esta mensagem. Não é possível
-    enviar relatórios de verificação, porque este projeto não está mais ativo.
-  smooch_bot_result_changed: "❗️A verificação que lhe enviamos foi *atualizada* com
-    novas informações"
+      Você pode usar este serviço para solicitar verificações, verificações de fatos e investigações de notícias e informações. Check Message é fornecida a você sob estes Termos de Serviço: %{tos}. Ao continuar a usar este serviço, *você concorda em cumprir estes termos*. Caso não concorde, você deve parar de usar a Check Message.
+  smooch_bot_window_closing: O volume de solicitações neste canal é muito alto, e ainda não conseguimos responder ao seu pedido ainda. Agradecemos a você pela sua paciência.
+  smooch_bot_not_final: |-
+      [Relatório de Verificação - CORREÇÃO] A mensagem que você compartilhou conosco foi incorretamente marcada como *%{status}*. Ela ainda está em nossa fila para verificação complementar.
+  smooch_bot_disabled: Agradecemos a você por enviar esta mensagem. Não é possível enviar relatórios de verificação, porque este projeto não está mais ativo.
+  smooch_bot_result_changed: "❗️A verificação que lhe enviamos foi *atualizada* com novas informações"
   permissions_info:
     roles:
       admin:
@@ -575,8 +490,7 @@ pt:
       editor:
         description: Editores(as) gerenciam o espaço de trabalho e as pastas.
       collaborator:
-        description: O(A) colaborador(a) pode adicionar novas informações a serem
-          verificadas. Geralmente são pessoas do público.
+        description: O(A) colaborador(a) pode adicionar novas informações a serem verificadas. Geralmente são pessoas do público.
     permissions:
       sections:
         project_management:
@@ -622,15 +536,10 @@ pt:
   team_import:
     invalid_google_spreadsheet_url: A URL da planilha %{spreadsheet_url} é inválida
     not_found_google_spreadsheet_url: A planilha não foi encontrada em %{spreadsheet_url}
-    cannot_authenticate_with_the_credentials: Impossível se conectar ao Google Drive
-      com as credenciais atuais. Por favor, entre em contato com a equipe de suporte
-      para notificá-los sobre esse incidente.
-    team_not_present: O espaço de trabalho atual não foi encontrado durante a importação
-      de dados. Por favor, notifique a equipe de suporte sobre este incidente.
-    user_not_present: Usuário(a) atual não encontrado(a) durante a importação de dados.
-      Por favor, notifique a equipe de suporte sobre este incidente.
-    user_not_authorized: Desculpe, você não tem permissão para importar dados para
-      esse espaço de trabalho.
+    cannot_authenticate_with_the_credentials: Impossível se conectar ao Google Drive com as credenciais atuais. Por favor, entre em contato com a equipe de suporte para notificá-los sobre esse incidente.
+    team_not_present: O espaço de trabalho atual não foi encontrado durante a importação de dados. Por favor, notifique a equipe de suporte sobre este incidente.
+    user_not_present: Usuário(a) atual não encontrado(a) durante a importação de dados. Por favor, notifique a equipe de suporte sobre este incidente.
+    user_not_authorized: Desculpe, você não tem permissão para importar dados para esse espaço de trabalho.
     invalid_project: A pasta %{project} é inválida
     invalid_user: O(A) autor(a) %{user} é inválido(a)
     invalid_status: O status %{status} é inválido
@@ -639,8 +548,7 @@ pt:
     blank_project: O campo "pasta" é inválido
     invalid_annotator: O(A) anotador(a) %{user} é inválido(a)
     invalid_assignee: A pessoa à qual a tarefa foi atribuída, %{user}, é inválida
-  cant_mutate_inactive_object: Desculpe, há uma operação pendente para este item,
-    então você não pode alterá-lo agora. Por favor, tente novamente mais tarde.
+  cant_mutate_inactive_object: Desculpe, há uma operação pendente para este item, então você não pode alterá-lo agora. Por favor, tente novamente mais tarde.
   embed_expand_all: Expandir tudo
   embed_collapse_all: Recolher tudo
   embed_tasks: Tarefas
@@ -653,29 +561,26 @@ pt:
   smooch_requests_desc: Mais solicitados
   bot_request_url_invalid: A URL do bot é inválida
   smooch_facebook_success: |
-    Sucesso!
-    Sua Tipline agora está conectada ao Facebook Messenger.
-    Todas as mensagens recebidas por esta página do Facebook será gerenciada pela Tipline.
-    Por favor, recarregue a página de configurações da sua Tipline para ver as novas mudanças.
+      Sucesso!
+      Sua Tipline agora está conectada ao Facebook Messenger.
+      Todas as mensagens recebidas por esta página do Facebook será gerenciada pela Tipline.
+      Por favor, recarregue a página de configurações da sua Tipline para ver as novas mudanças.
   smooch_twitter_success: |
-    Sucesso!
-    Sua Tipline agora está conectada ao Twitter.
-    Todas as mensagens recebidas por este perfil do Twitter será gerenciada pela Tipline.
-    Por favor, recarregue a página de configurações da sua Tipline para ver as novas mudanças.
-  must_select_exactly_one_facebook_page: Por favor, selecione a página exata do Facebook
-    que você deseja integrar com a Tipline.
+      Sucesso!
+      Sua Tipline agora está conectada ao Twitter.
+      Todas as mensagens recebidas por este perfil do Twitter será gerenciada pela Tipline.
+      Por favor, recarregue a página de configurações da sua Tipline para ver as novas mudanças.
+  must_select_exactly_one_facebook_page: Por favor, selecione a página exata do Facebook que você deseja integrar com a Tipline.
   invalid_task_answer: Formato de resposta de tarefa inválido
   team_rule_name: Um nome exclusivo que identifica o que esta regra faz
   team_rule_project_ids: Aplicar à pasta
   team_rule_destination: Selecionar pasta de destino
-  team_rule_names_invalid: Os nomes de regras não podem ficar em branco e devem ser
-    únicos
+  team_rule_names_invalid: Os nomes de regras não podem ficar em branco e devem ser únicos
   team_rules: Regras
   team_rule_conditions: Se
   team_rule_condition: Se
   team_rule_condition_definition: Selecionar condição
-  team_rule_has_less_than_x_words: A solicitação contém menos que (ou exatamente)
-    o seguinte número de palavras
+  team_rule_has_less_than_x_words: A solicitação contém menos que (ou exatamente) o seguinte número de palavras
   team_rule_title_matches_regexp: O título do item coincide com esta expressão regular
   team_rule_request_matches_regexp: A solicitação coincide com esta expressão regular
   team_rule_type_is: O tipo do item é
@@ -702,8 +607,7 @@ pt:
   team_rule_send_to_trash: Mover para a Lixeira
   team_rule_move_to_project: Mover item para a pasta
   team_rule_copy_to_project: Adicionar item à pasta
-  team_rule_ban_submitter: Banir remetente (as futuras mensagens não aparecerão no
-    Check)
+  team_rule_ban_submitter: Banir remetente (as futuras mensagens não aparecerão no Check)
   team_rule_all_items: Todos os itens
   team_rule_send_message_to_user: Enviar mensagem para essa pessoa
   team_rule_action_value: Digite a mensagem aqui
@@ -727,10 +631,8 @@ pt:
   team_rule_item_is_read: O item foi lido
   team_rule_field_from_fieldset_tasks_value_is: A tarefa tem uma resposta específica
   team_rule_field_from_fieldset_metadata_value_is: As anotações têm um valor específico
-  team_rule_field_from_fieldset_tasks_value_contains_keyword: A resposta da tarefa
-    contém a palavra-chave
-  team_rule_field_from_fieldset_metadata_value_contains_keyword: O valor da anotação
-    contém palavra-chave
+  team_rule_field_from_fieldset_tasks_value_contains_keyword: A resposta da tarefa contém a palavra-chave
+  team_rule_field_from_fieldset_metadata_value_contains_keyword: O valor da anotação contém palavra-chave
   team_rule_select_field_metadata: Selecionar anotação
   team_rule_select_field_value_metadata: Selecionar valor
   team_rule_select_field_tasks: Selecionar tarefa
@@ -753,33 +655,23 @@ pt:
   flag_likelihood_4: Provável
   flag_likelihood_5: Alto (mais conteúdo será detectado)
   flag_likelihood_7: Manual
-  relationship_not_same_team: Itens relacionados devem existir no mesmo espaço de
-    trabalho
+  relationship_not_same_team: Itens relacionados devem existir no mesmo espaço de trabalho
+  item_cant_be_related_to_itself: "O item não pode ser relacionado a si mesmo"
   target_is_published: O alvo não deve ter um relatório publicado
   similar_item_exists: Desculpe, este item já foi adicionado como um item semelhante.
-  bulk_operation_limit_error: Desculpe, o número máximo de itens a serem processados
-    de uma só vez é %{limit}
-  must_provide_fallback_when_deleting_status_in_use: Esse status está sendo usado,
-    portanto, você deve fornecer um outro status se desejar excluí-lo
-  embed_no_content_yet: O relatório está sendo gerado. Esse processo pode demorar
-    alguns minutos. Por favor, atualize esta página.
-  language_format_invalid: Formato de idioma inválido. O formato esperado é um código
-    ISO 639-1.
-  languages_format_invalid: Formato de idiomas inválido. O formato esperado é uma
-    lista de códigos ISO 639-1.
-  cant_change_status_if_item_is_published: Desculpe, você não pode alterar o status
-    durante a publicação do relatório
+  bulk_operation_limit_error: Desculpe, o número máximo de itens a serem processados de uma só vez é %{limit}
+  must_provide_fallback_when_deleting_status_in_use: Esse status está sendo usado, portanto, você deve fornecer um outro status se desejar excluí-lo
+  embed_no_content_yet: O relatório está sendo gerado. Esse processo pode demorar alguns minutos. Por favor, atualize esta página.
+  language_format_invalid: Formato de idioma inválido. O formato esperado é um código ISO 639-1.
+  languages_format_invalid: Formato de idiomas inválido. O formato esperado é uma lista de códigos ISO 639-1.
+  cant_change_status_if_item_is_published: Desculpe, você não pode alterar o status durante a publicação do relatório
   fetch_bot_service_unsupported: O serviço não possui suporte
   task_options_must_be_array: As opções de tarefas devem ser uma lista
   fieldset_not_defined_by_team: Fieldset deve ter suporte do espaço de trabalho
-  cant_change_field_type_or_options_when_answered: O tipo de campo não pode ser alterado
-    porque as respostas já foram preenchidas
-  replace_by_media_in_the_same_team: Desculpe, você só pode substituir este item por
-    outro do mesmo espaço de trabalho
-  replace_blank_media_only: Desculpe, mas, por enquanto, você só pode substituir itens
-    em branco
-  cant_preview_rss_feed: Desculpe, você não tem permissão para pré-visualizar um feed
-    RSS.
+  cant_change_field_type_or_options_when_answered: O tipo de campo não pode ser alterado porque as respostas já foram preenchidas
+  replace_by_media_in_the_same_team: Desculpe, você só pode substituir este item por outro do mesmo espaço de trabalho
+  replace_blank_media_only: Desculpe, mas, por enquanto, você só pode substituir itens em branco
+  cant_preview_rss_feed: Desculpe, você não tem permissão para pré-visualizar um feed RSS.
   list_column_demand: Solicitações
   list_column_share_count: Compartilhamentos do Facebook
   list_column_reaction_count: Reações no Facebook
@@ -796,60 +688,47 @@ pt:
   list_column_published_by: Relatório publicado por
   list_column_fact_check_published_on: Verificação de fatos publicada em
   list_column_related_count: Relacionado
+  list_column_suggestions_count: Sugestões
   list_column_folder: Pasta
   list_column_creator_name: Criado por
   list_column_fact_check_title: Verificação de fatos
   list_column_team_name: Espaço de trabalho
   list_column_sources_as_sentence: Fonte
   go_back_to_check: Voltar ao Check
-  project_cant_have_children_if_has_parent: Esta pasta possui uma pasta ascendente,
-    por isso não pode ter uma pasta descendente
-  project_group_must_be_under_same_team: A coleção deve estar sob o mesmo espaço de
-    trabalho
-  unique_default_folder_per_team: O espaço de trabalho deve possuir apenas uma pasta
-    padrão
-  center_is_not_part_of_another_cluster: O núcleo deste conjunto não pode fazer parte
-    de outro conjunto
+  project_cant_have_children_if_has_parent: Esta pasta possui uma pasta ascendente, por isso não pode ter uma pasta descendente
+  project_group_must_be_under_same_team: A coleção deve estar sob o mesmo espaço de trabalho
+  unique_default_folder_per_team: O espaço de trabalho deve possuir apenas uma pasta padrão
+  center_is_not_part_of_another_cluster: O núcleo deste conjunto não pode fazer parte de outro conjunto
   smooch_bot_message_subscribed: |-
-    Atualmente, você está inscrito(a) em nosso boletim informativo.
+      Atualmente, você está inscrito(a) em nosso boletim informativo.
 
-    Digite 0 para ir para o menu principal.
+      Digite 0 para ir para o menu principal.
   smooch_bot_message_unsubscribed: |-
-    Atualmente, você não está inscrito(a) em nosso boletim informativo.
+      Atualmente, você não está inscrito(a) em nosso boletim informativo.
 
-    Digite 0 para ir para o menu principal.
+      Digite 0 para ir para o menu principal.
   subscribe: Inscrever-se
   unsubscribe: Desinscrever-se
-  smooch_message_subscription_header_subscribed: Atualmente, você está inscrito(a)
-    em nosso boletim informativo.
-  smooch_message_subscription_header_unsubscribed: Atualmente, você não está inscrito(a)
-    em nosso boletim informativo.
+  smooch_message_subscription_header_subscribed: Atualmente, você está inscrito(a) em nosso boletim informativo.
+  smooch_message_subscription_header_unsubscribed: Atualmente, você não está inscrito(a) em nosso boletim informativo.
   smooch_bot_message_newsletter_fallback: |-
-    Olá! Aqui estão os fatos da semana. Este boletim foi publicado
-    no %{platform} pelo %{team} em %{date}:
+      Olá! Aqui estão os fatos da semana. Este boletim foi publicado
+      no %{platform} pelo %{team} em %{date}:
 
-    %{content}
+      %{content}
 
-    Para deixar de receber este boletim, digite "%{unsubscribe}".
+      Para deixar de receber este boletim, digite "%{unsubscribe}".
+  send_every_must_be_a_list_of_days_of_the_week: deve ser uma lista de dias da semana.
+  send_on_must_be_in_the_future: não pode estar no passado.
   info:
     messages:
-      sent_to_trash_by_rule: O item "%{item_title}" foi enviado para a lixeira, seguindo
-        uma regra automática.
-      moved_to_project_by_rule: O item "%{item_title}" foi movido para a pasta "[%{list_name}](%{list_link})",
-        seguindo uma regra automática.
-      banned_submitter_by_rule: O(A) solicitante do item "%{item_title}" foi banido(a),
-        seguindo uma regra automática.
-      copied_to_project_by_rule: O item "%{item_title}" foi copiado para a pasta "[%{list_name}](%{list_link})",
-        seguindo uma regra automática.
-      related_to_confirmed_similar: O item "%{item_title}" foi confirmado como semelhante
-        ao item "%{similar_item_title}".
-      related_to_suggested_similar: O item "%{item_title}" foi sugerido como semelhante
-        ao item "%{similar_item_title}".
-      sent_message_to_requestors_on_status_change: Uma atualização com o status "%{status}"
-        foi enviada para %{requestors_count} solicitantes.
-      tagged_by_rule: O item "%{item_title}" foi marcado como "%{tag}", seguindo uma
-        regra automática.
-      moved_to_private_folder: O item "%{item_title}" foi movido para uma pasta à
-        qual você não possui acesso.
-      add_warning_cover_by_rule: Uma capa com aviso de conteúdo foi adicionada ao
-        item sensível "%{item_title}"
+      sent_to_trash_by_rule: 'O item "%{item_title}" foi enviado para a lixeira, seguindo uma regra automática.'
+      moved_to_project_by_rule: 'O item "%{item_title}" foi movido para a pasta "[%{list_name}](%{list_link})", seguindo uma regra automática.'
+      banned_submitter_by_rule: O(A) solicitante do item "%{item_title}" foi banido(a), seguindo uma regra automática.
+      copied_to_project_by_rule: 'O item "%{item_title}" foi copiado para a pasta "[%{list_name}](%{list_link})", seguindo uma regra automática.'
+      related_to_confirmed_similar: 'O item "%{item_title}" foi confirmado como semelhante ao item "%{similar_item_title}".'
+      related_to_suggested_similar: 'O item "%{item_title}" foi sugerido como semelhante ao item "%{similar_item_title}".'
+      sent_message_to_requestors_on_status_change: Uma atualização com o status "%{status}" foi enviada para %{requestors_count} solicitantes.
+      tagged_by_rule: 'O item "%{item_title}" foi marcado como "%{tag}", seguindo uma regra automática.'
+      moved_to_private_folder: 'O item "%{item_title}" foi movido para uma pasta à qual você não possui acesso.'
+      add_warning_cover_by_rule: Uma capa com aviso de conteúdo foi adicionada ao item sensível "%{item_title}"

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -1,4 +1,3 @@
----
 ro:
   statuses:
     ids:
@@ -25,7 +24,7 @@ ro:
         label: În lucru
         description: Lucrul a început, însă traduceri încă nu s-au făcut
       not_true:
-        label: Fals
+        label: 'Fals'
         description: 'Concluzia: conținutul elementului este fals'
       verified:
         label: Verificat
@@ -74,27 +73,19 @@ ro:
     messages:
       invalid_password: Parolă nevalidă
       invalid_qrcode: Cod de validare nevalid
-      extension_white_list_error: 'nu poate fi de tip %{extension}, tipuri permise:
-        %{allowed_types}'
-      invalid_size: trebuie să fie între %{min_width}x%{min_height} și %{max_width}x%{max_height}
-        pixeli
-      mini_magick_processing_error: 'Ne pare rău, nu am reușit să prelucrăm imaginea.
-        Eroare: %{e}'
+      invalid_size: trebuie să fie între %{min_width}x%{min_height} și %{max_width}x%{max_height} pixeli
+      mini_magick_processing_error: 'Ne pare rău, nu am reușit să prelucrăm imaginea. Eroare: %{e}'
       annotation_mandatory_fields: Vă rugăm să setați toate câmpurile obligatorii
       annotation_type_does_not_exist: nu există
       invalid_attribution: Atribuire nevalidă
       must_resolve_required_tasks_first: Trebuie rezolvate mai întâi sarcinile necesare
       image_too_large: Ne pare rău, nu oferim suport pentru imagini mai mari de %{max_size}.
-      video_too_large: Ne pare rău, nu oferim suport pentru videoclipuri mai mari
-        de %{max_size}.
-      audio_too_large: Ne pare rău, nu oferim suport pentru fișiere audio mai mari
-        de %{max_size}.
-      pender_conflict: Acest link este deja analizat sintactic. Vă rugăm să încercați
-        din nou în câteva secunde.
+      video_too_large: Ne pare rău, nu oferim suport pentru videoclipuri mai mari de %{max_size}.
+      audio_too_large: Ne pare rău, nu oferim suport pentru fișiere audio mai mari de %{max_size}.
+      pender_conflict: Acest link este deja analizat sintactic. Vă rugăm să încercați din nou în câteva secunde.
       pender_url_invalid: Acest link este nevalid.
       pender_url_unsafe: Acest link este nesigur.
-      invalid_format_for_languages: Format nevalid al limbilor. Se aștepta formatul
-        `['en', 'ar', …]`
+      invalid_format_for_languages: Format nevalid al limbilor. Se aștepta formatul `['en', 'ar', …]`
   activerecord:
     models:
       link: Link
@@ -151,21 +142,15 @@ ro:
           one: este prea scurt (minimul este de 1 caracter)
           few: este prea scurt (minimul este de %{count} caractere)
           other: este prea scurt (minimul este de %{count} de caractere)
-  slack_webhook_format_wrong: Webhookul Slack nu este valid, formatul trebuie să fie
-    `https://hooks.slack.com/services/XXXXX/XXXXXXXXXX`
+  slack_webhook_format_wrong: Webhookul Slack nu este valid, formatul trebuie să fie `https://hooks.slack.com/services/XXXXX/XXXXXXXXXX`
   slug_is_reserved: este rezervat
   invalid_media_item: Elementul este nevalid
-  invalid_default_status_for_custom_verification_status: Identificatorul de stare
-    implicit nu este valid
-  invalid_active_status_for_custom_verification_status: Identificatorul de stare activ
-    nu este valid
+  invalid_default_status_for_custom_verification_status: Identificatorul de stare implicit nu este valid
+  invalid_active_status_for_custom_verification_status: Identificatorul de stare activ nu este valid
   invalid_label_for_custom_verification_status: Eticheta privind starea este obligatorie
-  invalid_id_for_custom_verification_status: Identificatorul de stare este obligatoriu
-    și trebuie să conțină doar litere mici, cifre, cratime și caractere de subliniere
-  invalid_statuses_format_for_custom_verification_status: 'Stări nevalide de verificare
-    personalizată. Se așteaptă intrări valide pentru: etichetă, identificator, descriere
-    și stil.'
-  mail_account_confirmation: Confirmarea contului %{app_name}
+  invalid_id_for_custom_verification_status: Identificatorul de stare este obligatoriu și trebuie să conțină doar litere mici, cifre, cratime și caractere de subliniere
+  invalid_statuses_format_for_custom_verification_status: 'Stări nevalide de verificare personalizată. Se așteaptă intrări valide pentru: etichetă, identificator, descriere și stil.'
+  mail_account_confirmation: "Confirmarea contului %{app_name}"
   slack:
     fields:
       assigned: Atribuit lui
@@ -179,8 +164,7 @@ ro:
       project_media: Element
       attribution: Răspuns dat de
     messages:
-      analysis_verification_status_status_changed: "%{user} și-a schimbat starea în:
-        %{value}"
+      analysis_verification_status_status_changed: "%{user} și-a schimbat starea în: %{value}"
       analysis_title_changed: "%{user} a schimbat titlul analizei în: %{value}"
       analysis_content_changed: "%{user} a modificat conținutul analizei în: %{value}"
       tasks_create: "%{user} a adăugat o sarcină: %{title}"
@@ -193,11 +177,9 @@ ro:
       metadata_answer_edit: "%{user} a editat valoarea metadatelor %{title}: %{answer}"
       project_media_comment: "%{user} (%{role} în %{team}) a adăugat o notă la %{parent_type}"
       project_media_create: "%{user} (%{role} din %{team}) a adăugat un element nou"
-      project_media_create_related: "%{user} (%{role} în %{team}) a adăugat %{type}
-        asociat"
+      project_media_create_related: "%{user} (%{role} în %{team}) a adăugat %{type} asociat"
       project_media_update: "%{user} (%{role} din %{team}) a actualizat un element"
-      project_media_status: "%{user} (%{role} în %{team}) a modificat starea %{workflow}
-        pentru %{type}"
+      project_media_status: "%{user} (%{role} în %{team}) a modificat starea %{workflow} pentru %{type}"
       project_media_assign: "%{user} (%{role} în %{team}) a desemnat %{type}"
       project_media_unassign: "%{user} (%{role} în %{team}) a transferat %{type}"
       project_source_comment: "%{user} (%{role} în %{team}) a adăugat o notă la %{parent_type}"
@@ -208,11 +190,9 @@ ro:
       user_invited: "%{user} a fost invitat(ă) să se alăture spațiului de lucru %{team}"
       user_banned: "%{user} a fost interzis în spațiul de lucru %{team}"
   mail_view_welcome: Bun venit în %{app_name}
-  mail_view_register: 'Sunteți la un pas de a folosi %{app_name}! Confirmați adresa
-    de e-mail, făcând click pe următorul link:'
+  mail_view_register: 'Sunteți la un pas de a folosi %{app_name}! Confirmați adresa de e-mail, făcând click pe următorul link:'
   mail_confirm_button: Confirmă contul meu
-  slack_restricted_join_to_members: Ne pare rău, nu vă puteți alătura %{team_name}
-    deoarece este rezervată membrilor spațiilor de lucru din Slack %{teams}.
+  slack_restricted_join_to_members: Ne pare rău, nu vă puteți alătura %{team_name} deoarece este rezervată membrilor spațiilor de lucru din Slack %{teams}.
   admin:
     actions:
       send_reset_password_email:
@@ -225,8 +205,7 @@ ro:
         menu: Duplică spațiul de lucru
         done: duplicat
         are_you_sure_you_want_to_copy_team:
-          html: Sigur doriți să duplicați spațiul de lucru <strong>%{team}</strong>?
-            Vor fi copiate toate datele aferente.
+          html: Sigur doriți să duplicați spațiul de lucru <strong>%{team}</strong>? Vor fi copiate toate datele aferente.
         the_team_is_being_copied: Duplicare spațiu de lucru în curs
         url_when_ready:
           html: Când va fi gata, spațiul de lucru duplicat va fi disponibil la <strong>%{copy_url}</strong>
@@ -242,12 +221,9 @@ ro:
       email: "%B %d, %Y %I:%M %p %Z"
   oembed_disclaimer_undetermined: Acest element nu a fost verificat de %{team}
   oembed_disclaimer_in_progress: Acest element este verificat de %{team} de la %{date}
-  oembed_disclaimer_verified: Acest element a fost determinat ca verificat de %{team}
-    la %{date}
-  oembed_disclaimer_false: Acest element a fost determinat ca fiind fals de %{team}
-    la %{date}
-  oembed_disclaimer_not_applicable: "%{team} nu a putut ajunge la nicio concluzie
-    privind acest element la %{date}"
+  oembed_disclaimer_verified: Acest element a fost determinat ca verificat de %{team} la %{date}
+  oembed_disclaimer_false: Acest element a fost determinat ca fiind fals de %{team} la %{date}
+  oembed_disclaimer_not_applicable: '%{team} nu a putut ajunge la nicio concluzie privind acest element la %{date}'
   oembed_source_date: "%{date} pe %{provider}"
   role_editor: redactor
   role_admin: admin
@@ -256,11 +232,11 @@ ro:
   role_: administrator de sistem
   oembed_credit: Adăugat de %{user} (%{role}) %{date}
   oembed_notes_count:
-    one: O notă
+    one: "O notă"
     few: "%{count} note"
     other: "%{count} de note"
   oembed_completed_tasks_count:
-    one: O sarcină completă
+    one: "O sarcină completă"
     few: "%{count} sarcini completate"
     other: "%{count} de sarcini realizate"
   oembed_verification_tasks: Sarcini
@@ -269,66 +245,56 @@ ro:
   oembed_expand_all: Extindeți totul
   oembed_collapse_all: Restrângeți totul
   oembed_resolved_tasks_count:
-    one: O sarcină rezolvată
+    one: "O sarcină rezolvată"
     few: "%{count} sarcini rezolvate"
     other: "%{count} de sarcini rezolvate"
   oembed_notes: Note
   duplicate_source: Sursa există deja
-  geolocation_invalid_value: Locație nevalidă. Se așteaptă o structură GeoJSON validă
-    (http://geojson.org/)
+  geolocation_invalid_value: Locație nevalidă. Se așteaptă o structură GeoJSON validă (http://geojson.org/)
   datetime_invalid_date: Dată nevalidă
-  error_team_archived_for_source: Ne pare rău, nu puteți adăuga surse în spații de
-    lucru șterse
+  error_team_archived_for_source: Ne pare rău, nu puteți adăuga surse în spații de lucru șterse
   permission_error: Ne pare rău, nu aveți permisiunea de a efectua această operațiune
   error_annotated_archived: Ne pare rău, nu puteți adăuga note la elemente șterse
-  only_super_admin_can_do_this: Ne pare rău, doar administratorul de sistem poate
-    efectua această modificare
+  only_super_admin_can_do_this: Ne pare rău, doar administratorul de sistem poate efectua această modificare
   cant_change_custom_statuses: |-
-    Ne pare rău, nu puteți modifica definițiile statuturilor pentru că unele statuturi s-ar putea pierde. Acești identificatori de statut: %{statuses} sunt folosiți în elementele ce urmează:
-    %{urls} %{others_amount}
+      Ne pare rău, nu puteți modifica definițiile statuturilor pentru că unele statuturi s-ar putea pierde. Acești identificatori de statut: %{statuses} sunt folosiți în elementele ce urmează:
+      %{urls} %{others_amount}
   account_exists: Acest cont există deja
   media_exists: Acest element există deja
   source_exists: Această sursă există deja
   email_exists: a fost deja luat
-  banned_user: Ne pare rău, contul Dvs a fost interzis pentru %{app_name}. Contactați
-    echipa de suport dacă credeți că s-a produs o eroare.
+  banned_user: Ne pare rău, contul Dvs a fost interzis pentru %{app_name}. Contactați echipa de suport dacă credeți că s-a produs o eroare.
   devise:
     mailer:
       reset_password_instructions:
-        subject: 'Instrucțiuni de resetare a parolei pentru %{app_name} '
+        subject: "Instrucțiuni de resetare a parolei pentru %{app_name} "
         header_title: Solicitarea de resetare a parolei
         header_text: Am recepționat solicitarea dvs de a vă reseta parola pentru %{app_name}.
         action: Resetați parola
         expiry: Solicitarea dată va expira peste %{expire} ore.
         instruction_1: Click aici pentru a face o solicitare nouă.
-        instruction_2: Dacă nu ați făcut această solicitare sau aveți dificultăți
-          încercând să vă resetați parola, vă rugăm să ne contactați la %{support_email}.
+        instruction_2: Dacă nu ați făcut această solicitare sau aveți dificultăți încercând să vă resetați parola, vă rugăm să ne contactați la %{support_email}.
       invitation_instructions:
         subject: "%{user} v-a invitat să vă alăturați spațiului de lucru %{team}"
         hello: Salut %{name}
         someone_invited_you_default:
-          html: "%{name} v-a invitat să vă alăturați spațiului de lucru %{team} în
-            calitate de %{role}."
+          html: "%{name} v-a invitat să vă alăturați spațiului de lucru %{team} în calitate de %{role}."
         someone_invited_you_custom:
-          html: "%{name} v-a invitat să vă alăturați spațiului de lucru %{team} în
-            calitate de %{role} și a spus:"
+          html: "%{name} v-a invitat să vă alăturați spațiului de lucru %{team} în calitate de %{role} și a spus:"
         accept: Acceptă invitația
         accept_until: Invitația dată va expira pe %{due_date}.
         ignore: Dacă nu doriți să acceptați invitația, ignorați acest email.
-        app_team: Spațiu de lucru %{app}
+        app_team: "Spațiu de lucru %{app}"
     failure:
       unconfirmed: Vă rugăm să vă accesați emailul pentru a verifica contul Dvs.
   user_invitation:
     team_found: Spațiul de lucru nu a fost găsit.
     invalid: Cod de invitare nevalid.
     no_invitation: Nu există nicio invitație pentru spațiul de lucru %{name}
-  error_user_is_not_a_team_member: Ne pare rău, puteți aloca doar membrilor acestui
-    spațiu de lucru.
-  error_login_with_exists_account: Ne pare rău, acest cont este deja folosit de alt
-    utilizator
-  error_login_2fa: Vă rugăm să finalizați autentificarea prin introducerea codului
-    de autentificare.
-  error_record_not_found: 'Nu a fost găsit %{type} #%{id}'
+  error_user_is_not_a_team_member: Ne pare rău, puteți aloca doar membrilor acestui spațiu de lucru.
+  error_login_with_exists_account: Ne pare rău, acest cont este deja folosit de alt utilizator
+  error_login_2fa: Vă rugăm să finalizați autentificarea prin introducerea codului de autentificare.
+  error_record_not_found: "Nu a fost găsit %{type} #%{id}"
   mails_notifications:
     greeting: Salut, %{username},
     greeting_anonymous: Salut!
@@ -338,53 +304,46 @@ ro:
     register:
       subject: Un nou cont pentru dvs pe %{app_name}
       header_text: |-
-        V-ați înregistrat cu succes pe %{app_name}!
-        <br>
-        Pentru autentificare pe site, urmați acest link: %{url}. Introduceți această adresă de e-mail și această parolă: %{password}
+          V-ați înregistrat cu succes pe %{app_name}!
+          <br>
+          Pentru autentificare pe site, urmați acest link: %{url}. Introduceți această adresă de e-mail și această parolă: %{password}
       login_button: Conectare la %{app_name}
       footer_text: Vă mulțumim pentru că v-ați alăturăt și vă urăm o zi reușită!
     duplicated:
       subject: Metoda dvs. de conectare pentru %{app_name}
       header_title: Dublează contul
       one_email: |-
-        <p>Salut, este doar o notificare prietenoasă pentru asigurarea faptului că ați reușit să vă conectați la %{app_name}.</p> <p>Ce s-a întâmplat: Ați încercat să vă conectați la %{app_name} cu un cont pe %{user_provider} legat de %{user_email}.
-        Însă, această adresă de e-mail este deja asociată cu un cont pe%{duplicate_provider} în %{app_name}.</p>
-        <p>Ce trebuie făcut: Conectați-vă cu %{duplicate_provider}.</p>
-        <p>În acest caz vă veți conecta cu ajutorul contului folosit anterior.
-        Dacă aveți nevoie de ajutor suplimentar, scrieți un mesaj la adresa de e-mail %{support_email}.</p>
+          <p>Salut, este doar o notificare prietenoasă pentru asigurarea faptului că ați reușit să vă conectați la %{app_name}.</p> <p>Ce s-a întâmplat: Ați încercat să vă conectați la %{app_name} cu un cont pe %{user_provider} legat de %{user_email}.
+          Însă, această adresă de e-mail este deja asociată cu un cont pe%{duplicate_provider} în %{app_name}.</p>
+          <p>Ce trebuie făcut: Conectați-vă cu %{duplicate_provider}.</p>
+          <p>În acest caz vă veți conecta cu ajutorul contului folosit anterior.
+          Dacă aveți nevoie de ajutor suplimentar, scrieți un mesaj la adresa de e-mail %{support_email}.</p>
       both_emails: |-
-        <p>Este doar o notificare prietenoasă pentru asigurarea faptului că ați reușit să vă conectați la %{app_name}.</p> <p>Ce s-a întâmplat: Ați încercat să creați un nou cont bazat pe e-mail pe %{app_name}, însă acest cont deja există.</p>
-        <p>Încercați să vă conectați cu adresa de e-mail și parola dvs în loc să creați un cont nou.</p>
-        <p>Vă veți conecta la contul folosit anterior. Dacă aveți nevoie de ajutor suplimentar, scrieți un mesaj la adresa de e-mail %{support_email}.</p>
+          <p>Este doar o notificare prietenoasă pentru asigurarea faptului că ați reușit să vă conectați la %{app_name}.</p> <p>Ce s-a întâmplat: Ați încercat să creați un nou cont bazat pe e-mail pe %{app_name}, însă acest cont deja există.</p>
+          <p>Încercați să vă conectați cu adresa de e-mail și parola dvs în loc să creați un cont nou.</p>
+          <p>Vă veți conecta la contul folosit anterior. Dacă aveți nevoie de ajutor suplimentar, scrieți un mesaj la adresa de e-mail %{support_email}.</p>
       email: email
     invitation:
       title: Invitație nouă
     delete_user:
       subject: "[%{team}] A fost șters un utilizator"
       header_title: Utilizatorul a fost șters
-      header_text: Un cont de utilizator a fost șters și conținutul acestuia a fost
-        desemnat utilizatorului anonim %{anonymous}  %{id}
+      header_text: Un cont de utilizator a fost șters și conținutul acestuia a fost desemnat utilizatorului anonim %{anonymous}  %{id}
       anonymous: anonim
     admin_mailer:
-      team_download_subject: "[%{team}] Instantaneul cu datele spațiului de lucru
-        este gata pentru descărcare"
+      team_download_subject: "[%{team}] Instantaneul cu datele spațiului de lucru este gata pentru descărcare"
       team_dump_title: Datele spațiului de lucru
       types:
         dump: instantaneu de date
         csv: raport
         images: arhiva de imagini
-      team_dump_text: 'Ați solicitat un instantaneu cu datele spațiului de lucru %{team}
-        - acesta este linkul pentru descărcare: %{link}'
+      team_dump_text: 'Ați solicitat un instantaneu cu datele spațiului de lucru %{team} - acesta este linkul pentru descărcare: %{link}'
       team_dump_button: Descarcă datele spațiului de lucru
-      decompress_text: " %{type} va fi descărcat sub forma unui fișier comprimat,
-        criptat. Pentru a decomprima fișierul introduceți parola: %{password}."
+      decompress_text: ' %{type} va fi descărcat sub forma unui fișier comprimat, criptat. Pentru a decomprima fișierul introduceți parola: %{password}.'
       expire_note: Atenție! Acest link va expira peste %{days} zile.
       team_import_subject: Importul de date s-a finalizat
       team_import_title: Import de date
-      team_import_text: "<p>Activitatea dvs de import de date în %{app_name} s-a finalizat.
-        Puteți accesa %{worksheet_url} pentru a vedea starea fiecărui element ce urma
-        să fie importat.</p> <p>Atenție! Puteți porni importul repetat după ce corectați
-        erorile raportate acolo - elementele importate anterior nu vor fi dublate.</p>"
+      team_import_text: "<p>Activitatea dvs de import de date în %{app_name} s-a finalizat. Puteți accesa %{worksheet_url} pentru a vedea starea fiecărui element ce urma să fie importat.</p> <p>Atenție! Puteți porni importul repetat după ce corectați erorile raportate acolo - elementele importate anterior nu vor fi dublate.</p>"
     task_resolved:
       subject: "[%{team} - %{project}] Sarcină rezolvată"
       header_title: Sarcină rezolvată
@@ -401,11 +360,9 @@ ro:
       tasks_h: Sarcină finalizată
     assignment:
       assign_task_subject: "[%{team} - %{project}] V-a fost desemnată o sarcină"
-      unassign_task_subject: "[%{team} - %{project}] O sarcină a fost transferată
-        de la Dvs"
+      unassign_task_subject: "[%{team} - %{project}] O sarcină a fost transferată de la Dvs"
       assign_media_subject: "[%{team} - %{project}] Vi s-a alocat un element"
-      unassign_media_subject: "[%{team} - %{project}] Vi s-a anulat alocarea unui
-        element"
+      unassign_media_subject: "[%{team} - %{project}] Vi s-a anulat alocarea unui element"
       assign_task_title: Sarcină desemnată
       unassign_task_title: Sarcină transferată
       assign_media_title: Element alocat
@@ -418,41 +375,30 @@ ro:
       subject: Cerere pentru a intra în spațiul de lucru %{team}
       team_page: pagina spațiului de lucru
       team_button: Mergi la pagina spațiului de lucru
-      rejected_subject: Solicitarea Dvs de a se alătura echipei %{team} nu a fost
-        aprobată
+      rejected_subject: Solicitarea Dvs de a se alătura echipei %{team} nu a fost aprobată
       approved_subject: Bun venit în spațiul de lucru %{team}
       request_title: Cerere pentru a intra în spațiul de lucru %{team}
-      request_text: "%{name} (%{email}) vrea să se alăture spațiului de lucru %{team}
-        de pe %{app_name}. Puteți prelucra această cerere intrând pe %{url}."
+      request_text: "%{name} (%{email}) vrea să se alăture spațiului de lucru %{team} de pe %{app_name}. Puteți prelucra această cerere intrând pe %{url}."
       approved_title: Bun venit în spațiul de lucru %{team}
-      approved_text: Cererea dvs. de a intra în spațiul de lucru %{team} de pe %{app_name}
-        a fost aprobată. Puteți merge acum la %{url} și să începeți să contribuiți.
+      approved_text: Cererea dvs. de a intra în spațiul de lucru %{team} de pe %{app_name} a fost aprobată. Puteți merge acum la %{url} și să începeți să contribuiți.
       rejected_title: Solicitarea respinsă
-      rejected_text: Ne pare rău, cererea dvs. de a intra în spațiul de lucru %{team}
-        de pe %{app_name} nu a fost aprobată.
+      rejected_text: Ne pare rău, cererea dvs. de a intra în spațiul de lucru %{team} de pe %{app_name} nu a fost aprobată.
   mail_security:
-    device_subject: 'Avertizare de securitate: Conectare nouă la %{app_name} din %{browser}
-      pe %{platform}'
+    device_subject: 'Avertizare de securitate: Conectare nouă la %{app_name} din %{browser} pe %{platform}'
     ip_subject: 'Avertizare de securitate: Conectare nouă sau neobișnuită la %{app_name} '
-    failed_subject: 'Avertizare de securitate: Încercări ieșuate de a se conecta la
-      %{app_name}'
+    failed_subject: 'Avertizare de securitate: Încercări ieșuate de a se conecta la %{app_name}'
     ip: V-ați conectat din %{location}
     device: V-ați conectat de pe %{browser} pe %{platform}
     devise_name: "%{browser} pe %{platform}"
     failed: Au fost identificate încercări de conectare ieșuate
     password_text: resetează parola imediat.
-    device_text: Se pare că v-ați conectat recent la contul Dvs %{app_name} de pe
-      un dispozitiv nou. Dacă nu erați Dvs, ar fi bine să %{change_password}
-    ip_text: Se pare că v-ați conectat recent la contul Dvs %{app_name} dintr-o locație
-      nouă. Dacă nu erați Dvs, ar fi bine să %{change_password}
-    failed_text: Se pare că s-au făcut mai multe încercări de conectare la contul
-      Dvs %{app_name}. Dacă erați Dvs, puteți să ignorați acest mesaj liniștit. Dacă
-      nu erați Dvs, ar fi bine să %{change_password}
+    device_text: Se pare că v-ați conectat recent la contul Dvs %{app_name} de pe un dispozitiv nou. Dacă nu erați Dvs, ar fi bine să %{change_password}
+    ip_text: Se pare că v-ați conectat recent la contul Dvs %{app_name} dintr-o locație nouă. Dacă nu erați Dvs, ar fi bine să %{change_password}
+    failed_text: Se pare că s-au făcut mai multe încercări de conectare la contul Dvs %{app_name}. Dacă erați Dvs, puteți să ignorați acest mesaj liniștit. Dacă nu erați Dvs, ar fi bine să %{change_password}
     time_h: Ora
     device_h: Dispozitiv
     location_h: Locația
-    location_disclaimer: "* Locația a fost stabilită aproximativ, în baza adresei
-      IP de origine."
+    location_disclaimer: "* Locația a fost stabilită aproximativ, în baza adresei IP de origine."
     ip_h: Adresa IP
     privacy: "%{manage} notificările prin email • Aflați mai multe despre %{privacy}"
     privacy_text: Politica de confidențialitate
@@ -462,71 +408,50 @@ ro:
   archive_keep_backup: Video Vault
   archive_pender_archive: Captură de ecran
   archive_archive_org: Archive.org
-  workflow_status_is_not_valid: 'Stare nevalidă: ''%{status}'' (trebuie să fie una
-    din%{valid})'
-  workflow_status_permission_error: Ne pare rău, nu aveți permisiunea de a modifica
-    această stare
-  blank_default_status_for_custom_verification_status: Vă rugăm să introduceți o valoare
-    implicită pentru stările personalizate de verificare
-  blank_active_status_for_custom_verification_status: Vă rugăm să introduceți o valoare
-    activă pentru stările personalizate de verificare
-  bot_name_exists_for_this_team: Există deja un robot în acest spațiu de lucru cu
-    denumirea dată
-  bot_team_id_doesnt_exist: Ne pare rău, nu există niciun spațiu de lucru cu identificatorul
-    dat
-  bot_team_id_mandatory_to_create: Ne pare rău, trebuie să alegeți un spațiu de lucru
-    ca să puteți crea un robot
-  bot_not_approved_for_installation: Ne pare rău, acest robot nu a fost aprobat, deci
-    nu poate fi instalat
-  could_not_save_related_bot_data: Ne pare rău, nu am putut adăuga robotul în acest
-    spațiu de lucru
-  bot_cant_add_response_to_task: Ne pare rău, un robot nu poate răspunde la o sarcină
-    direct - rugăm să transmiteți o sugestie de răspuns în loc
+  workflow_status_is_not_valid: 'Stare nevalidă: ''%{status}'' (trebuie să fie una din%{valid})'
+  workflow_status_permission_error: Ne pare rău, nu aveți permisiunea de a modifica această stare
+  blank_default_status_for_custom_verification_status: Vă rugăm să introduceți o valoare implicită pentru stările personalizate de verificare
+  blank_active_status_for_custom_verification_status: Vă rugăm să introduceți o valoare activă pentru stările personalizate de verificare
+  bot_name_exists_for_this_team: Există deja un robot în acest spațiu de lucru cu denumirea dată
+  bot_team_id_doesnt_exist: Ne pare rău, nu există niciun spațiu de lucru cu identificatorul dat
+  bot_team_id_mandatory_to_create: Ne pare rău, trebuie să alegeți un spațiu de lucru ca să puteți crea un robot
+  bot_not_approved_for_installation: Ne pare rău, acest robot nu a fost aprobat, deci nu poate fi instalat
+  could_not_save_related_bot_data: Ne pare rău, nu am putut adăuga robotul în acest spațiu de lucru
+  bot_cant_add_response_to_task: Ne pare rău, un robot nu poate răspunde la o sarcină direct - rugăm să transmiteți o sugestie de răspuns în loc
   bot_cant_add_review_to_task: Ne pare rău, un robot nu poate analiza o sarcină
-  task_suggestion_invalid_value: Sugestie nevalidă de sarcină. Se așteaptă un obiect
-    JSON cu atributele `suggestion` (valoarea reală copiată în răspunsul sarcinii
-    la acceptare) și `comment` (afișat utilizatorilor).
+  task_suggestion_invalid_value: Sugestie nevalidă de sarcină. Se așteaptă un obiect JSON cu atributele `suggestion` (valoarea reală copiată în răspunsul sarcinii la acceptare) și `comment` (afișat utilizatorilor).
   tag_text_id_not_found: Etichetă negăsită
   annotation_type_language_label: Limba
   smooch_bot_message_confirmed: |-
-    Vă mulțumim. Solicitarea Dvs a fost adăugată în rândul nostru pentru verificare.
+      Vă mulțumim. Solicitarea Dvs a fost adăugată în rândul nostru pentru verificare.
 
-    Vom încerca să vă oferim un raport în decurs de 24 de ore, însă, atenționăm că nu putem da răspuns la fiecare solicitare.
-  smooch_bot_message_unconfirmed: Deoarece nu ați răspuns cu 1, nu vom procesa mesajul
-    dvs în continuare. Mulțumim.
-  smooch_bot_message_type_unsupported: Ne pare rău, nu oferim suport pentru acest
-    tip de mesaj.
-  smooch_bot_message_size_unsupported: Ne pare rău, nu oferim suport pentru fișiere
-    mai mari de %{max_size}.
+      Vom încerca să vă oferim un raport în decurs de 24 de ore, însă, atenționăm că nu putem da răspuns la fiecare solicitare.
+  smooch_bot_message_unconfirmed: Deoarece nu ați răspuns cu 1, nu vom procesa mesajul dvs în continuare. Mulțumim.
+  smooch_bot_message_type_unsupported: Ne pare rău, nu oferim suport pentru acest tip de mesaj.
+  smooch_bot_message_size_unsupported: Ne pare rău, nu oferim suport pentru fișiere mai mari de %{max_size}.
   smooch_bot_result: |-
-    [Verification Report] Mesajul, pe care l-ați partajat cu noi, este marcat *%{status}*.
+      [Verification Report] Mesajul, pe care l-ați partajat cu noi, este marcat *%{status}*.
 
-    Iată care sunt pașii, pe care le-am făcut pentru a determina acest lucru: %{url}
+      Iată care sunt pașii, pe care le-am făcut pentru a determina acest lucru: %{url}
   smooch_bot_ask_for_confirmation: |-
-    Vă mulțumim pentru că ați transmis această solicitare. Doriți ca noi să verificăm conținutul acesteia?
+      Vă mulțumim pentru că ați transmis această solicitare. Doriți ca noi să verificăm conținutul acesteia?
 
-    Pentru a spune da, *vă rugăm să răspundeți cu 1*. Orice alt răspuns va pune sfârșit conversației noastre.
+      Pentru a spune da, *vă rugăm să răspundeți cu 1*. Orice alt răspuns va pune sfârșit conversației noastre.
   smooch_bot_ask_for_tos: |-
-    Vă mulțumim că ați contactat Check Message!
+      Vă mulțumim că ați contactat Check Message!
 
-    Puteți folosi acest serviciu pentru a solicita verificări de fapte, investigații de știri și informații. Check Message vă este oferit în baza acestor Termeni de utilizare a serviciului: %{tos}. Prin continuarea utilizării serviciului, *sunteți de acord să vă obligați la acești termeni*. Dacă nu sunteți de acord, trebuie să încetați să mai folosiți Check Message.
-  smooch_bot_window_closing: Numărul de solicitări transmise prin acest canal este
-    foarte mare și deocamdată nu am reușit să soluționăm solicitarea dvs. Vă mulțumim
-    pentru că aveți răbdare.
-  smooch_bot_not_final: "[Raport de verificare - CORECTARE] Mesajul transmis de Dvs
-    a fost marcat greșit ca fiind *%{status}*. Este încă în coada de așteptare pentru
-    verificări ulterioare."
-  smooch_bot_disabled: Vă mulțumim că ați trimis acest mesaj. Nu putem să vă transmitem
-    rapoarte de verificare deoarece acest proiect nu mai este activ.
-  smooch_bot_result_changed: "❗️Raportul de verificare a faptelor pe care vi l-am
-    transmis a fost *actualizat* cu informații noi"
+      Puteți folosi acest serviciu pentru a solicita verificări de fapte, investigații de știri și informații. Check Message vă este oferit în baza acestor Termeni de utilizare a serviciului: %{tos}. Prin continuarea utilizării serviciului, *sunteți de acord să vă obligați la acești termeni*. Dacă nu sunteți de acord, trebuie să încetați să mai folosiți Check Message.
+  smooch_bot_window_closing: Numărul de solicitări transmise prin acest canal este foarte mare și deocamdată nu am reușit să soluționăm solicitarea dvs. Vă mulțumim pentru că aveți răbdare.
+  smooch_bot_not_final: |-
+      [Raport de verificare - CORECTARE] Mesajul transmis de Dvs a fost marcat greșit ca fiind *%{status}*. Este încă în coada de așteptare pentru verificări ulterioare.
+  smooch_bot_disabled: Vă mulțumim că ați trimis acest mesaj. Nu putem să vă transmitem rapoarte de verificare deoarece acest proiect nu mai este activ.
+  smooch_bot_result_changed: "❗️Raportul de verificare a faptelor pe care vi l-am transmis a fost *actualizat* cu informații noi"
   permissions_info:
     roles:
       admin:
         description: Administratorii controlează spațiul de lucru.
       collaborator:
-        description: Colaboratorii pot adăuga informații noi de verificat. Sunt adesea
-          persoane din publicul larg.
+        description: Colaboratorii pot adăuga informații noi de verificat. Sunt adesea persoane din publicul larg.
     permissions:
       sections:
         item_page_management:
@@ -557,32 +482,24 @@ ro:
             edit_tasks: Creează și editează sarcini în spațiul de lucru
             roles: Editează rolurile din spațiul de lucru
             third_party: Adaugă integrare a terților
-            invite_admin: Invită, aprobă și elimină administratori ai spațiului de
-              lucru
+            invite_admin: Invită, aprobă și elimină administratori ai spațiului de lucru
             invite_members: Invită, aprobă și elimină membri ai spațiului de lucru
   team_clone:
     user_not_authorized: Ne pare rău, nu aveți permisiunea să duplicați această echipă.
   team_import:
-    invalid_google_spreadsheet_url: URL %{spreadsheet_url} pentru tabel electronic
-      nu este valid
+    invalid_google_spreadsheet_url: URL %{spreadsheet_url} pentru tabel electronic nu este valid
     not_found_google_spreadsheet_url: Tabelul electronic nu a fost găsit pe %{spreadsheet_url}
-    cannot_authenticate_with_the_credentials: Nu puteți accesa Google Drive cu acest
-      nume de utilizator și parolă. Vă rygăm să contactați echipa de suport pentru
-      a-i informa despre acest incident.
-    team_not_present: Spațiul de lucru curent nu a fost găsit la importul de date.
-      Vă rugăm să notificați echipa de suport cu privire la acest incident.
-    user_not_present: În timpul importului de date utilizatorul actual nu a fost găsit.
-      Vă rugăm să informați echipa de suport despre acest incident.
-    user_not_authorized: Ne pare rău, nu aveți dreptu să importați date în acest spațiu
-      de lucru.
+    cannot_authenticate_with_the_credentials: Nu puteți accesa Google Drive cu acest nume de utilizator și parolă. Vă rygăm să contactați echipa de suport pentru a-i informa despre acest incident.
+    team_not_present: Spațiul de lucru curent nu a fost găsit la importul de date. Vă rugăm să notificați echipa de suport cu privire la acest incident.
+    user_not_present: În timpul importului de date utilizatorul actual nu a fost găsit. Vă rugăm să informați echipa de suport despre acest incident.
+    user_not_authorized: Ne pare rău, nu aveți dreptu să importați date în acest spațiu de lucru.
     invalid_user: Autorul %{user} nu este valid
     invalid_status: Starea %{status} nu este validă
     blank_user: Câmp gol de autor nevalid
     blank_annotator: Câmp gol de adnotator nevalid
     invalid_annotator: Adnotator nevalid %{user}
     invalid_assignee: Destinatar al desemnării nevalid %{user}
-  cant_mutate_inactive_object: Ne pare rău, pentru acest element există o operațiune
-    în așteptare, deci nu îl puteți modifica acum. Încercați din nou mai târziu.
+  cant_mutate_inactive_object: Ne pare rău, pentru acest element există o operațiune în așteptare, deci nu îl puteți modifica acum. Încercați din nou mai târziu.
   embed_expand_all: Extindeți totul
   embed_collapse_all: Restrângeți totul
   embed_tasks: Sarcini
@@ -594,28 +511,23 @@ ro:
   smooch_requests_asc: Cel mai puțin solicitat
   smooch_requests_desc: Cel mai solicitat
   bot_request_url_invalid: URL robot nevalid
-  must_select_exactly_one_facebook_page: Selectați exact pagina Facebook pe care vreți
-    să o integrați cu linia de ponturi.
+  must_select_exactly_one_facebook_page: Selectați exact pagina Facebook pe care vreți să o integrați cu linia de ponturi.
   invalid_task_answer: Format nevalid de răspuns la sarcină
   team_rule_name: O denumire unică ce identifică ce face această regulă
-  team_rule_names_invalid: Denumirile regulilor nu pot fi goale și trebuie să fie
-    unice
+  team_rule_names_invalid: Denumirile regulilor nu pot fi goale și trebuie să fie unice
   team_rules: Reguli
   team_rule_conditions: Dacă
   team_rule_condition: Dacă
   team_rule_condition_definition: Selectați condiția
-  team_rule_has_less_than_x_words: Cererea de text conține mai puțin de (sau exact)
-    următorul număr de cuvinte
-  team_rule_title_matches_regexp: Titlul elementului se potrivește cu această expresie
-    regulată
+  team_rule_has_less_than_x_words: Cererea de text conține mai puțin de (sau exact) următorul număr de cuvinte
+  team_rule_title_matches_regexp: Titlul elementului se potrivește cu această expresie regulată
   team_rule_request_matches_regexp: Cererea se potrivește cu această expresie regulată
   team_rule_type_is: Tipul de element este
   team_rule_type_is_claim: Text
   team_rule_type_is_link: Link
   team_rule_type_is_uploadedimage: Imagine
   team_rule_type_is_uploadedvideo: Video
-  team_rule_contains_keyword: Cererea conține unul sau mai multe dintre următoarele
-    cuvinte-cheie
+  team_rule_contains_keyword: Cererea conține unul sau mai multe dintre următoarele cuvinte-cheie
   team_rule_select_type: Selectați tipul
   team_rule_select_language: Selectați limba
   team_rule_select_user: Alegeți un colaborator
@@ -629,8 +541,7 @@ ro:
   team_rule_actions: Atunci
   team_rule_action: Atunci
   team_rule_action_definition: Selectați acțiunea
-  team_rule_ban_submitter: Pune interdicție expeditorului (mesajele viitoare de la
-    el/ea nu vor mai apărea în Check)
+  team_rule_ban_submitter: Pune interdicție expeditorului (mesajele viitoare de la el/ea nu vor mai apărea în Check)
   team_rule_all_items: Toate elementele
   team_rule_send_message_to_user: Trimite un mesaj utilizatorului
   team_rule_action_value: Scrieți mesajul aici
@@ -652,8 +563,7 @@ ro:
   team_rule_item_user_is: Elementul a fost creat de
   team_rule_item_is_read: Elementul este citit
   team_rule_field_from_fieldset_tasks_value_is: Sarcina are un răspuns specific
-  team_rule_field_from_fieldset_tasks_value_contains_keyword: Răspunsul la sarcină
-    conține cuvântul-cheie
+  team_rule_field_from_fieldset_tasks_value_contains_keyword: Răspunsul la sarcină conține cuvântul-cheie
   team_rule_select_field_value_metadata: Selectează valoarea
   team_rule_select_field_tasks: Selectează sarcina
   team_rule_select_field_value_tasks: Selectează răspunsul
@@ -668,28 +578,19 @@ ro:
   flag_likelihood_0: Necunoscut
   flag_likelihood_2: Improbabil
   flag_likelihood_4: Probabil
-  relationship_not_same_team: În același spațiu de lucru trebuie să existe elemente
-    corelate
-  bulk_operation_limit_error: Ne pare rău, numărul maxim de elemente care pot fi prelucrate
-    simultan este de %{limit}
-  must_provide_fallback_when_deleting_status_in_use: Această stare este deja folosită,
-    trebuie să furnizați o stare alternativă dacă doriți să o ștergeți.
-  embed_no_content_yet: Raport în curs de generare. Poate dura câteva minute. Vă rugăm
-    să împrospătați pagina.
+  relationship_not_same_team: În același spațiu de lucru trebuie să existe elemente corelate
+  bulk_operation_limit_error: Ne pare rău, numărul maxim de elemente care pot fi prelucrate simultan este de %{limit}
+  must_provide_fallback_when_deleting_status_in_use: Această stare este deja folosită, trebuie să furnizați o stare alternativă dacă doriți să o ștergeți.
+  embed_no_content_yet: Raport în curs de generare. Poate dura câteva minute. Vă rugăm să împrospătați pagina.
   language_format_invalid: Format nevalid al limbii. Se așteaptă un cod ISO 639-1.
-  languages_format_invalid: Format nevalid al limbilor. Se așteaptă o listă de coduri
-    ISO 639-1.
-  cant_change_status_if_item_is_published: Ne pare rău, nu puteți modifica starea
-    cât timp raportul este publicat
+  languages_format_invalid: Format nevalid al limbilor. Se așteaptă o listă de coduri ISO 639-1.
+  cant_change_status_if_item_is_published: Ne pare rău, nu puteți modifica starea cât timp raportul este publicat
   fetch_bot_service_unsupported: Serviciul nu are suport
   task_options_must_be_array: Opțiunile sarcinii trebuie să fie într-o listă
-  fieldset_not_defined_by_team: Setul de câmpuri trebuie să aibă suport în spațiul
-    de lucru
-  replace_by_media_in_the_same_team: Ne pare rău, puteți înlocui acest element numai
-    cu altul din același spațiu de lucru
+  fieldset_not_defined_by_team: Setul de câmpuri trebuie să aibă suport în spațiul de lucru
+  replace_by_media_in_the_same_team: Ne pare rău, puteți înlocui acest element numai cu altul din același spațiu de lucru
   replace_blank_media_only: Ne pare rău, dar puteți înlocui numai elemente goale deocamdată
-  cant_preview_rss_feed: Ne pare rău, nu ai permisiunea de previzualizare ca flux
-    RSS.
+  cant_preview_rss_feed: Ne pare rău, nu ai permisiunea de previzualizare ca flux RSS.
   list_column_demand: Cereri
   list_column_share_count: Partajări FB
   list_column_reaction_count: Reacții FB
@@ -711,11 +612,7 @@ ro:
   unsubscribe: Anulați abonarea
   info:
     messages:
-      sent_to_trash_by_rule: "„%{item_title}” a fost pus la coșul de gunoi de o regulă
-        automată."
-      banned_submitter_by_rule: Cererea de la „%{item_title}” a fost interzisă de
-        o regulă automată.
-      related_to_confirmed_similar: "„%{item_title}” a fost confirmat ca similar cu
-        „%{similar_item_title}”."
-      related_to_suggested_similar: "„%{item_title}” a fost sugerat ca similar cu
-        „%{similar_item_title}”."
+      sent_to_trash_by_rule: '„%{item_title}” a fost pus la coșul de gunoi de o regulă automată.'
+      banned_submitter_by_rule: Cererea de la „%{item_title}” a fost interzisă de o regulă automată.
+      related_to_confirmed_similar: '„%{item_title}” a fost confirmat ca similar cu „%{similar_item_title}”.'
+      related_to_suggested_similar: '„%{item_title}” a fost sugerat ca similar cu „%{similar_item_title}”.'

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,4 +1,3 @@
----
 ru:
   statuses:
     ids:
@@ -25,7 +24,7 @@ ru:
         label: В работе
         description: Работа начата, но перевод пока отсутствует
       not_true:
-        label: Неправда
+        label: 'Неправда'
         description: 'Заключение: не соответствует действительности'
       verified:
         label: Подтверждено
@@ -74,25 +73,19 @@ ru:
     messages:
       invalid_password: Неверный пароль
       invalid_qrcode: Неверный код подтверждения
-      extension_white_list_error: 'файлы %{extension} не разрешены; разрешённые форматы:
-        %{allowed_types}'
       invalid_size: должен быть между %{min_width}x%{min_height} и %{max_width}x%{max_height}
-      mini_magick_processing_error: 'Извините, не удалось обработать изображение.
-        Ошибка: %{e}'
+      mini_magick_processing_error: 'Извините, не удалось обработать изображение. Ошибка: %{e}'
       annotation_mandatory_fields: Пожалуйста, заполните все обязательные поля
       annotation_type_does_not_exist: не существует
       invalid_attribution: Неверное авторство
-      must_resolve_required_tasks_first: Необходимо указать ответы на все обязательные
-        вопросы
+      must_resolve_required_tasks_first: Необходимо указать ответы на все обязательные вопросы
       image_too_large: Извините, мы не поддерживаем изображения больше %{max_size}.
       video_too_large: Извините, мы не поддерживаем видео больше %{max_size}.
       audio_too_large: Извините, мы не поддерживаем аудио-файлы больше %{max_size}.
-      pender_conflict: Эта ссылка уже находится в обработке. Попробуйте еще раз через
-        пару секунд.
+      pender_conflict: Эта ссылка уже находится в обработке. Попробуйте еще раз через пару секунд.
       pender_url_invalid: Некорректная ссылка.
       pender_url_unsafe: Небезопасная ссылка.
-      invalid_format_for_languages: 'Неверный формат для указания языков. Пример:
-        `[''en'', ''ar'', …]`'
+      invalid_format_for_languages: 'Неверный формат для указания языков. Пример: `[''en'', ''ar'', …]`'
   activerecord:
     models:
       link: Ссылка
@@ -144,25 +137,20 @@ ru:
               slug_format: только буквы, цифры и дефисы
       messages:
         record_invalid: "%{errors}"
-        improbable_phone: "— неправильный номер"
+        improbable_phone: — неправильный номер
         too_short:
           one: 'не подходит по длине (минимум: 1 символ)'
           few: 'не подходит по длине (минимум: %{count} символов)'
           many: 'не подходит по длине (минимум: %{count} символов)'
           other: 'не подходит по длине (минимум: %{count} символов)'
-  slack_webhook_format_wrong: 'Неверный адрес webhook для Slack: адрес должен иметь
-    формат `https://hooks.slack.com/services/XXXXX/XXXXXXXXXX`.'
+  slack_webhook_format_wrong: 'Неверный адрес webhook для Slack: адрес должен иметь формат `https://hooks.slack.com/services/XXXXX/XXXXXXXXXX`.'
   slug_is_reserved: зарезервирован
   invalid_media_item: Извините, этот формат не поддерживается
-  invalid_default_status_for_custom_verification_status: Неверный идентификатор статуса
-    по умолчанию
-  invalid_active_status_for_custom_verification_status: Неверный идентификатор активного
-    статуса
+  invalid_default_status_for_custom_verification_status: Неверный идентификатор статуса по умолчанию
+  invalid_active_status_for_custom_verification_status: Неверный идентификатор активного статуса
   invalid_label_for_custom_verification_status: Название статуса обязательно
-  invalid_id_for_custom_verification_status: Идентификатор статуса обязателен; он
-    может содержать строчные латинские буквы, цифры, дефисы и подчеркивания
-  invalid_statuses_format_for_custom_verification_status: Дополнительные статусы должны
-    иметь название, идентификатор, описание и стиль.
+  invalid_id_for_custom_verification_status: Идентификатор статуса обязателен; он может содержать строчные латинские буквы, цифры, дефисы и подчеркивания
+  invalid_statuses_format_for_custom_verification_status: 'Дополнительные статусы должны иметь название, идентификатор, описание и стиль.'
   mail_account_confirmation: "%{app_name}: подтверждение e-mail адреса"
   slack:
     fields:
@@ -172,51 +160,40 @@ ru:
       status: Статус
       status_previous: Предыдущий статус
       related_to: Относится к
-      view_button: "%{type} в %{app}"
+      view_button: '%{type} в %{app}'
       project_source: Источник
       project_media: Материал
       attribution: Ответ от
     messages:
-      analysis_verification_status_status_changed: 'Изменён статус: %{value} (%{user})'
-      analysis_title_changed: 'Изменён заголовок анализа: %{value} (%{user})'
-      analysis_content_changed: 'Изменён контент анализа: %{value} (%{user})'
-      tasks_create: 'Добавлен вопрос: %{title} (%{user})'
-      tasks_edit: 'Отредактирован вопрос: %{title} (%{user})'
-      tasks_answer_create: 'На вопрос «%{title}» получен ответ: %{answer} (%{user})'
-      tasks_answer_edit: 'Отредактирован ответ на вопрос «%{title}»: %{answer} (%{user})'
-      metadata_create: 'Добавлено поле для метаданных: %{title} (%{user})'
-      metadata_edit: 'Отредактировано поле для метаданных: %{title} (%{user})'
-      metadata_answer_create: 'Задано значение для метаданных «%{title}»: %{answer}
-        (%{user})'
-      metadata_answer_edit: 'Обновлено значение для метаданных «%{title}»: %{answer}
-        (%{user})'
-      project_media_comment: Добавлена заметка к материалу «%{parent_type}» (%{user},
-        %{role} группы %{team})
+      analysis_verification_status_status_changed: "Изменён статус: %{value} (%{user})"
+      analysis_title_changed: "Изменён заголовок анализа: %{value} (%{user})"
+      analysis_content_changed: "Изменён контент анализа: %{value} (%{user})"
+      tasks_create: "Добавлен вопрос: %{title} (%{user})"
+      tasks_edit: "Отредактирован вопрос: %{title} (%{user})"
+      tasks_answer_create: "На вопрос «%{title}» получен ответ: %{answer} (%{user})"
+      tasks_answer_edit: "Отредактирован ответ на вопрос «%{title}»: %{answer} (%{user})"
+      metadata_create: "Добавлено поле для метаданных: %{title} (%{user})"
+      metadata_edit: "Отредактировано поле для метаданных: %{title} (%{user})"
+      metadata_answer_create: "Задано значение для метаданных «%{title}»: %{answer} (%{user})"
+      metadata_answer_edit: "Обновлено значение для метаданных «%{title}»: %{answer} (%{user})"
+      project_media_comment: "Добавлена заметка к материалу «%{parent_type}» (%{user}, %{role} группы %{team})"
       project_media_create: "%{user} (%{role} группы %{team}) загрузил(а) новый материал"
-      project_media_create_related: Добавлен связанный материал «%{type}» (%{user},
-        %{role} группы %{team})
+      project_media_create_related: "Добавлен связанный материал «%{type}» (%{user}, %{role} группы %{team})"
       project_media_update: "%{user} (%{role} группы %{team}) обновил(а) материал"
-      project_media_status: Изменён статус «%{workflow}» материала «%{type}» (%{user},
-        %{role} группы %{team})
-      project_media_assign: Назначен материал «%{type}» (%{user}, %{role} группы %{team})
-      project_media_unassign: Снято назначение материала «%{type}» (%{user}, %{role}
-        группы %{team})
-      project_source_comment: Добавлена заметка к источнику «%{parent_type}» (%{user},
-        %{role} группы %{team})
-      project_source_create: Добавлен источник «%{type}» (%{user}, %{role} группы
-        %{team})
-      project_source_update: Отредактирован источник «%{type}» (%{user}, %{role} группы
-        %{team})
-      user_member: 'Новый участник проекта %{team}: %{user} '
-      user_requested: 'Новый запрос на вступление в проект %{team}: %{user}'
-      user_invited: 'Новое приглашение в проект %{team}: %{user}'
-      user_banned: 'Новый бан в проекте %{team}: %{user}'
+      project_media_status: "Изменён статус «%{workflow}» материала «%{type}» (%{user}, %{role} группы %{team})"
+      project_media_assign: "Назначен материал «%{type}» (%{user}, %{role} группы %{team})"
+      project_media_unassign: "Снято назначение материала «%{type}» (%{user}, %{role} группы %{team})"
+      project_source_comment: "Добавлена заметка к источнику «%{parent_type}» (%{user}, %{role} группы %{team})"
+      project_source_create: "Добавлен источник «%{type}» (%{user}, %{role} группы %{team})"
+      project_source_update: "Отредактирован источник «%{type}» (%{user}, %{role} группы %{team})"
+      user_member: "Новый участник проекта %{team}: %{user} "
+      user_requested: "Новый запрос на вступление в проект %{team}: %{user}"
+      user_invited: "Новое приглашение в проект %{team}: %{user}"
+      user_banned: "Новый бан в проекте %{team}: %{user}"
   mail_view_welcome: Добро пожаловать в %{app_name}
-  mail_view_register: 'Вы уже совсем близко к тому, чтобы начать пользоваться %{app_name}!
-    Пожалуйста, перейдите по ссылке, чтобы подтвердить свой e-mail адрес:'
+  mail_view_register: 'Вы уже совсем близко к тому, чтобы начать пользоваться %{app_name}! Пожалуйста, перейдите по ссылке, чтобы подтвердить свой e-mail адрес:'
   mail_confirm_button: Подтвердить мой аккаунт
-  slack_restricted_join_to_members: К сожалению, группа %{team_name} доступна только
-    членам воркспейса %{teams} в Slack.
+  slack_restricted_join_to_members: К сожалению, группа %{team_name} доступна только членам воркспейса %{teams} в Slack.
   admin:
     actions:
       send_reset_password_email:
@@ -229,12 +206,10 @@ ru:
         menu: Клонировать проект
         done: скопировано
         are_you_sure_you_want_to_copy_team:
-          html: Вы уверены, что хотите клонировать проект <strong>%{team}</strong>?
-            Вместе с проектом будут скопированы все связанные данные.
+          html: Вы уверены, что хотите клонировать проект <strong>%{team}</strong>? Вместе с проектом будут скопированы все связанные данные.
         the_team_is_being_copied: Идёт клонирование проекта
         url_when_ready:
-          html: 'Когда копия проекта будет готова, она станет доступна по ссылке:
-            <strong>%{copy_url}</strong>'
+          html: 'Когда копия проекта будет готова, она станет доступна по ссылке: <strong>%{copy_url}</strong>'
     flash:
       delete_team_scheduled: Проект %{team} удаляется
   email_not_found: Email не найден
@@ -249,88 +224,79 @@ ru:
   oembed_disclaimer_in_progress: Проверка достоверности начата %{date} (%{team})
   oembed_disclaimer_verified: Достоверность подтверждена %{date} (%{team})
   oembed_disclaimer_false: Опровергнуто %{date} (%{team})
-  oembed_disclaimer_not_applicable: Не удалось проверить достоверность на %{date}
-    (%{team})
+  oembed_disclaimer_not_applicable: Не удалось проверить достоверность на %{date} (%{team})
   oembed_source_date: "%{date} в %{provider}"
   role_editor: редактор
   role_none: нет роли
   role_: суперадминистратор
   oembed_credit: 'Добавлено: %{user} (%{role}), %{date}'
   oembed_notes_count:
-    one: Одна заметка
-    few: 'Заметок: %{count}'
-    many: 'Заметок: %{count}'
-    other: 'Заметок: %{count}'
+    one: "Одна заметка"
+    few: "Заметок: %{count}"
+    many: "Заметок: %{count}"
+    other: "Заметок: %{count}"
   oembed_completed_tasks_count:
-    one: Один закрытый вопрос
-    few: 'Закрытых вопросов: %{count}'
-    many: 'Закрытых вопросов: %{count}'
-    other: 'Закрытых вопросов: %{count}'
+    one: "Один закрытый вопрос"
+    few: "Закрытых вопросов: %{count}"
+    many: "Закрытых вопросов: %{count}"
+    other: "Закрытых вопросов: %{count}"
   oembed_verification_tasks: Вопросы
   oembed_tasks: Вопросы
   oembed_translations: Переводы
   oembed_expand_all: Раскрыть всё
   oembed_collapse_all: Свернуть всё
   oembed_resolved_tasks_count:
-    one: Один вопрос с ответом
-    few: 'Вопросов с ответами: %{count}'
-    many: 'Вопросов с ответами: %{count}'
-    other: 'Вопросов с ответами: %{count}'
+    one: "Один вопрос с ответом"
+    few: "Вопросов с ответами: %{count}"
+    many: "Вопросов с ответами: %{count}"
+    other: "Вопросов с ответами: %{count}"
   oembed_notes: Заметки
   duplicate_source: Источник уже существует
-  geolocation_invalid_value: Неверная локация. Локация должна содержать корректный
-    GeoJSON (http://geojson.org/)
+  geolocation_invalid_value: Неверная локация. Локация должна содержать корректный GeoJSON (http://geojson.org/)
   datetime_invalid_date: Неверная дата
-  error_team_archived_for_source: Нельзя добавить источник в проект, который находится
-    в корзине
+  error_team_archived_for_source: Нельзя добавить источник в проект, который находится в корзине
   permission_error: Извините, вам не разрешена данная операция
-  error_annotated_archived: Извините, нельзя добавить заметку к материалу, который
-    находится в корзине
-  only_super_admin_can_do_this: Извините, только суперадминистраторы могут менять
-    эти настройки
+  error_annotated_archived: Извините, нельзя добавить заметку к материалу, который находится в корзине
+  only_super_admin_can_do_this: Извините, только суперадминистраторы могут менять эти настройки
   cant_change_custom_statuses: |-
-    Извините, нельзя отредактировать дополнительные статусы, поскольку они уже назначены. Статусы %{statuses} используются в следующих материалах:
-    %{urls} %{others_amount}
+      Извините, нельзя отредактировать дополнительные статусы, поскольку они уже назначены. Статусы %{statuses} используются в следующих материалах:
+      %{urls} %{others_amount}
   account_exists: Такой аккаунт уже существует
   media_exists: Такой материал уже существует
   source_exists: Такой источник уже существует
   email_exists: уже используется
-  banned_user: Извините, вам был закрыт доступ к %{app_name}. Пожалуйста, свяжитесь
-    с технической поддержкой, если вы считаете, что произошла ошибка.
+  banned_user: Извините, вам был закрыт доступ к %{app_name}. Пожалуйста, свяжитесь с технической поддержкой, если вы считаете, что произошла ошибка.
   devise:
     mailer:
       reset_password_instructions:
-        subject: Инструкции по сбросу пароля %{app_name}
+        subject: "Инструкции по сбросу пароля %{app_name}"
         header_title: Запрос сброса пароля
         header_text: Мы получили ваш запрос на сброс пароля для %{app_name}.
         action: Сбросить пароль
         expiry: Запрос истекает через %{expire} часов.
         instruction_1: Нажмите здесь, чтобы запросить сброс пароля.
-        instruction_2: Если вы не запрашивали сброс пароля или у вас не получается
-          сбросить свой пароль, пожалуйста, напишите нам на адрес %{support_email}.
+        instruction_2: Если вы не запрашивали сброс пароля или у вас не получается сбросить свой пароль, пожалуйста, напишите нам на адрес %{support_email}.
       invitation_instructions:
         subject: "%{user} пригласил(а) вас вступить в проект %{team}"
         hello: Здравствуйте, %{name}!
         someone_invited_you_default:
           html: "%{name} пригласил(а) вас вступить в проект %{team} как %{role}."
         someone_invited_you_custom:
-          html: "%{name} пригласил(а) вас вступить в группу %{team} как %{role} и
-            оставил(а) сообщение:"
+          html: "%{name} пригласил(а) вас вступить в группу %{team} как %{role} и оставил(а) сообщение:"
         accept: Принять приглашение
         accept_until: Приглашение истекает %{due_date}.
         ignore: Если вы не хотите принять приглашение, просто проигнорируйте это письмо.
-        app_team: 'Проект %{app} '
+        app_team: "Проект %{app} "
     failure:
       unconfirmed: Пожалуйста, проверьте e-mail, чтобы подтвердить аккаунт.
   user_invitation:
     team_found: Проект не найден.
     invalid: Неверный код приглашения.
     no_invitation: Вы не приглашены в проект %{name}
-  error_user_is_not_a_team_member: Извините, вы можете назначать задачи только участникам
-    этого проекта
+  error_user_is_not_a_team_member: Извините, вы можете назначать задачи только участникам этого проекта
   error_login_with_exists_account: Извините, этот аккаунт уже подключен другим пользователем
   error_login_2fa: Для завершения входа введите, пожалуйста, код аутентификации.
-  error_record_not_found: 'Не найдено: %{type} #%{id}'
+  error_record_not_found: "Не найдено: %{type} #%{id}"
   mails_notifications:
     greeting: Здравствуйте, %{username}!
     greeting_anonymous: Здравствуйте!
@@ -340,37 +306,25 @@ ru:
     register:
       subject: Новый аккаунт в %{app_name}
       header_text: |-
-        Вы успешно зарегистрировались в %{app_name}!
-        <br>
-        Чтобы начать работу, нажмите на ссылку: %{url}. Введите ваш email и этот пароль: %{password}
+          Вы успешно зарегистрировались в %{app_name}!
+          <br>
+          Чтобы начать работу, нажмите на ссылку: %{url}. Введите ваш email и этот пароль: %{password}
       login_button: Войти в %{app_name}
       footer_text: Спасибо, что присоединились к нам, и добро пожаловать!
     duplicated:
       subject: Ваш способ входа в %{app_name}
       header_title: Клонировать аккаунт
-      one_email: "<p>Здравствуйте! При вашей попытке входа в %{app_name} произошла
-        небольшая ошибка.</p> <p>Что произошло: вы попытались войти в %{app_name}
-        через аккаунт в %{user_provider}, привязанный к адресу %{user_email}, но этот
-        адрес уже используется в %{app_name} для входа через %{duplicate_provider}.</p>
-        <p>Что делать: выберите вход через %{duplicate_provider}, чтобы войти в свой
-        аккаунт.</p> <p>Вы попадёте в аккаунт, которым пользовались раньше. Если проблема
-        повторяется или что-то не работает так, как должно, свяжитесь с нами по адресу
-        %{support_email}.</p>"
-      both_emails: "<p>Здравствуйте! При вашей попытке входа в %{app_name} произошла
-        небольшая ошибка.</p> <p>Что произошло: вы попытались создать новый аккаунт
-        в %{app_name}, но аккаунт с таким адресом e-mail уже существует.</p> <p>Попробуйте
-        войти с вашим e-mail и паролем вместо того, чтобы регистрировать новый аккаунт.
-        Если вы не помните пароль, воспользуйтесь функцией восстановления.</p> <p>Если
-        проблема повторяется или что-то не работает так, как должно, свяжитесь с нами
-        по адресу %{support_email}.</p>"
+      one_email: |-
+          <p>Здравствуйте! При вашей попытке входа в %{app_name} произошла небольшая ошибка.</p> <p>Что произошло: вы попытались войти в %{app_name} через аккаунт в %{user_provider}, привязанный к адресу %{user_email}, но этот адрес уже используется в %{app_name} для входа через %{duplicate_provider}.</p> <p>Что делать: выберите вход через %{duplicate_provider}, чтобы войти в свой аккаунт.</p> <p>Вы попадёте в аккаунт, которым пользовались раньше. Если проблема повторяется или что-то не работает так, как должно, свяжитесь с нами по адресу %{support_email}.</p>
+      both_emails: |-
+          <p>Здравствуйте! При вашей попытке входа в %{app_name} произошла небольшая ошибка.</p> <p>Что произошло: вы попытались создать новый аккаунт в %{app_name}, но аккаунт с таким адресом e-mail уже существует.</p> <p>Попробуйте войти с вашим e-mail и паролем вместо того, чтобы регистрировать новый аккаунт. Если вы не помните пароль, воспользуйтесь функцией восстановления.</p> <p>Если проблема повторяется или что-то не работает так, как должно, свяжитесь с нами по адресу %{support_email}.</p>
       email: e-mail
     invitation:
       title: Новое приглашение
     delete_user:
       subject: "[%{team}] Пользователь был удалён"
       header_title: Пользователь удалён
-      header_text: Аккаунт пользователя был удалён, и все материалы были переназначены
-        (%{anonymous} пользователь %{id})
+      header_text: Аккаунт пользователя был удалён, и все материалы были переназначены (%{anonymous} пользователь %{id})
       anonymous: анонимный
     admin_mailer:
       team_download_subject: "[%{team}] Архив проекта готов для скачивания"
@@ -379,20 +333,13 @@ ru:
         dump: архив данных
         csv: отчёт
         images: архив изображений
-      team_dump_text: 'Вы запросили архив всех данных по проекту %{team} — вот ссылка
-        для его скачивания: %{link}'
+      team_dump_text: 'Вы запросили архив всех данных по проекту %{team} — вот ссылка для его скачивания: %{link}'
       team_dump_button: Скачать архив проекта
-      decompress_text: "%{type} будет скачан как защищённый паролем архив. Чтобы распаковать
-        его, используйте пароль %{password}."
-      expire_note: Пожалуйста, обратите внимание, что эта ссылка перестанет действовать
-        через %{days} дней.
+      decompress_text: '%{type} будет скачан как защищённый паролем архив. Чтобы распаковать его, используйте пароль %{password}.'
+      expire_note: Пожалуйста, обратите внимание, что эта ссылка перестанет действовать через %{days} дней.
       team_import_subject: Импорт данных завершён
       team_import_title: Импорт данных
-      team_import_text: "<p>Ваш запрос на импорт данных в %{app_name} выполнен. Чтобы
-        проверить детальное состояние импорта по всем элементам, перейдите по ссылке:
-        %{worksheet_url}.</p> <p>При наличии ошибок, вы можете исправить их и перезапустить
-        импорт — элементы, которые уже были успешно импортированы, дублированы не
-        будут.</p>"
+      team_import_text: "<p>Ваш запрос на импорт данных в %{app_name} выполнен. Чтобы проверить детальное состояние импорта по всем элементам, перейдите по ссылке: %{worksheet_url}.</p> <p>При наличии ошибок, вы можете исправить их и перезапустить импорт — элементы, которые уже были успешно импортированы, дублированы не будут.</p>"
     task_resolved:
       subject: "[%{team} - %{project}] Получен ответ на вопрос"
       header_title: Получен ответ на вопрос
@@ -416,9 +363,8 @@ ru:
       unassign_task_title: Задача снята
       assign_media_title: Материал назначен
       unassign_media_title: Материал снят
-      assign_log: Назначен элемент «%{model}» на пользователя %{username} (%{author}).
-      unassign_log: Снято назначение элемента «%{model}» с пользователя %{username}
-        (%{author}).
+      assign_log: "Назначен элемент «%{model}» на пользователя %{username} (%{author})."
+      unassign_log: "Снято назначение элемента «%{model}» с пользователя %{username} (%{author})."
       assign_by: Назначил(а)
       unassign_by: Снял(а)
     request_to_join:
@@ -428,14 +374,11 @@ ru:
       rejected_subject: Ваш запрос на вступление в %{team} не был одобрен
       approved_subject: Добро пожаловать в проект %{team}
       request_title: Запрос на вступление в проект %{team}
-      request_text: "%{name} (%{email}) хочет стать участником проекта %{team} в %{app_name}.
-        Вы можете посмотреть детали запроса по ссылке: %{url}."
+      request_text: "%{name} (%{email}) хочет стать участником проекта %{team} в %{app_name}. Вы можете посмотреть детали запроса по ссылке: %{url}."
       approved_title: Добро пожаловать в проект %{team}
-      approved_text: Ваш запрос на участие в проекте %{team} в %{app_name} был одобрен.
-        Теперь вы можете перейти по ссылке — %{url} — и начать работу.
+      approved_text: Ваш запрос на участие в проекте %{team} в %{app_name} был одобрен. Теперь вы можете перейти по ссылке — %{url} — и начать работу.
       rejected_title: Запрос отклонён
-      rejected_text: Извините, но ваш запрос на участие в проекте %{team} в %{app_name}
-        не был одобрен.
+      rejected_text: Извините, но ваш запрос на участие в проекте %{team} в %{app_name} не был одобрен.
   mail_security:
     device_subject: 'Внимание: Новый вход в %{app_name} через %{browser} на %{platform}'
     ip_subject: 'Внимание: Нетипичный вход в %{app_name}'
@@ -445,13 +388,9 @@ ru:
     devise_name: "%{browser} на %{platform}"
     failed: Обнаружены неудачные попытки входа
     password_text: немедленно сбросить пароль.
-    device_text: Кажется, вы недавно выполнили вход в %{app_name} с нового устройства.
-      Если это были не вы, вам нужно %{change_password}
-    ip_text: Кажется, вы недавно выполнили вход в %{app_name} из нового места. Если
-      это были не вы, вам нужно %{change_password}
-    failed_text: Кажется, было выполнено несколько попыток входа в ваш аккаунт %{app_name}
-      подряд. Если это были вы, можно проигнорировать это предупреждение. Если нет,
-      вам нужно %{change_password}
+    device_text: Кажется, вы недавно выполнили вход в %{app_name} с нового устройства. Если это были не вы, вам нужно %{change_password}
+    ip_text: Кажется, вы недавно выполнили вход в %{app_name} из нового места. Если это были не вы, вам нужно %{change_password}
+    failed_text: Кажется, было выполнено несколько попыток входа в ваш аккаунт %{app_name} подряд. Если это были вы, можно проигнорировать это предупреждение. Если нет, вам нужно %{change_password}
     time_h: Время
     device_h: Устройство
     location_h: Местонахождение
@@ -465,59 +404,46 @@ ru:
   archive_keep_backup: Сохранённые видео
   archive_pender_archive: Скриншот
   archive_archive_org: Archive.org
-  workflow_status_is_not_valid: 'Неверный статус: ''%{status}'' (должен быть одним
-    из списка: %{valid})'
+  workflow_status_is_not_valid: 'Неверный статус: ''%{status}'' (должен быть одним из списка: %{valid})'
   workflow_status_permission_error: Извините, вы не можете изменить этот статус.
-  blank_default_status_for_custom_verification_status: Пожалуйста, задайте значение
-    «по умолчанию» для дополнительных статусов
-  blank_active_status_for_custom_verification_status: Пожалуйста, задайте значение
-    «активный» для дополнительных статусов
+  blank_default_status_for_custom_verification_status: Пожалуйста, задайте значение «по умолчанию» для дополнительных статусов
+  blank_active_status_for_custom_verification_status: Пожалуйста, задайте значение «активный» для дополнительных статусов
   bot_name_exists_for_this_team: В этом проекте уже есть бот с таким именем
   bot_team_id_doesnt_exist: Извините, проекта с таким идентификатором не существует
-  bot_team_id_mandatory_to_create: Извините, нужно выбрать проект, чтобы добавить
-    бота
-  bot_not_approved_for_installation: Извините, этот бот не был одобрен, поэтому не
-    может быть добавлен
+  bot_team_id_mandatory_to_create: Извините, нужно выбрать проект, чтобы добавить бота
+  bot_not_approved_for_installation: Извините, этот бот не был одобрен, поэтому не может быть добавлен
   could_not_save_related_bot_data: Извините, не удалось добавить бота в этот проект
-  bot_cant_add_response_to_task: Извините, бот не может отвечать на вопросы — вместо
-    этого можно предложить ответ
+  bot_cant_add_response_to_task: Извините, бот не может отвечать на вопросы — вместо этого можно предложить ответ
   bot_cant_add_review_to_task: Извините, бот не может обрабатывать вопросы
-  task_suggestion_invalid_value: Неверный предлагаемый ответ. Корректный формат —
-    объект JSON с ключами `suggestion` (ответ на вопрос, публикуемый при принятии
-    предложения) и `comment` (показывается пользователям)
+  task_suggestion_invalid_value: Неверный предлагаемый ответ. Корректный формат — объект JSON с ключами `suggestion` (ответ на вопрос, публикуемый при принятии предложения) и `comment` (показывается пользователям)
   tag_text_id_not_found: Тег не найден
   annotation_type_language_label: Язык
   smooch_bot_message_confirmed: |-
-    Спасибо. Ваш запрос был добавлен в очередь на верификацию.
+      Спасибо. Ваш запрос был добавлен в очередь на верификацию.
 
-    Мы постараемся отправить вам отчёт в течение 24 часов, но, к сожалению, не всегда можем ответить на каждый запрос.
-  smooch_bot_message_unconfirmed: Поскольку вы не ответили «1», запрос будет отменён.
-    Спасибо.
-  smooch_bot_message_type_unsupported: Извините, мы не поддерживаем данный формат
-    сообщения.
+      Мы постараемся отправить вам отчёт в течение 24 часов, но, к сожалению, не всегда можем ответить на каждый запрос.
+  smooch_bot_message_unconfirmed: Поскольку вы не ответили «1», запрос будет отменён. Спасибо.
+  smooch_bot_message_type_unsupported: Извините, мы не поддерживаем данный формат сообщения.
   smooch_bot_message_size_unsupported: Извините, мы не поддерживаем файлы больше %{max_size}.
   smooch_bot_result: |-
-    [Отчёт о верификации] Материал, который вы нам отправили, получил отметку «*%{status}*».
+      [Отчёт о верификации] Материал, который вы нам отправили, получил отметку «*%{status}*».
 
-    Вы можете ознакомиться со всеми шагами, предпринятыми для верификации, по ссылке: %{url}
+      Вы можете ознакомиться со всеми шагами, предпринятыми для верификации, по ссылке: %{url}
   smooch_bot_ask_for_confirmation: |-
-    Спасибо за ваш запрос. Вы хотели бы, чтобы мы подтвердили достоверность данных материалов?
+      Спасибо за ваш запрос. Вы хотели бы, чтобы мы подтвердили достоверность данных материалов?
 
-    Если да, *отправьте 1*. Любой другой ответ завершит беседу.
+      Если да, *отправьте 1*. Любой другой ответ завершит беседу.
   smooch_bot_ask_for_tos: |-
-    Спасибо, что обратились в Check Message!
+      Спасибо, что обратились в Check Message!
 
-    Этот сервис предназначен для того, чтобы запрашивать факт-чекинг, подтверждение достоверности и расследование новостей и другой информации. Для Check Message действуют следующие Условия Использования: %{tos}. Используя сервис, *вы соглашаетесь на эти условия*. Если вы не согласны с условиями, вы должны прекратить использование сервиса.
-  smooch_bot_window_closing: В настоящее время нам поступает очень много запросов,
-    и ваш всё ещё находится в очереди. Спасибо за ваше терпение.
+      Этот сервис предназначен для того, чтобы запрашивать факт-чекинг, подтверждение достоверности и расследование новостей и другой информации. Для Check Message действуют следующие Условия Использования: %{tos}. Используя сервис, *вы соглашаетесь на эти условия*. Если вы не согласны с условиями, вы должны прекратить использование сервиса.
+  smooch_bot_window_closing: В настоящее время нам поступает очень много запросов, и ваш всё ещё находится в очереди. Спасибо за ваше терпение.
   smooch_bot_not_final: |-
-    [Отчёт о верификации — ИЗМЕНЕНИЕ] Сообщение, которое вы нам отправили, было некорректно отмечено как «*%{status}*».
+      [Отчёт о верификации — ИЗМЕНЕНИЕ] Сообщение, которое вы нам отправили, было некорректно отмечено как «*%{status}*».
 
-    Сообщение возвращено в очередь и ожидает верификации.
-  smooch_bot_disabled: Спасибо за ваше сообщение. К сожалению, мы не сможем провести
-    верификацию, поскольку этот проект больше не активен.
-  smooch_bot_result_changed: "❗️Отчёт о верификации, который мы вам отправили, был
-    *обновлён*"
+      Сообщение возвращено в очередь и ожидает верификации.
+  smooch_bot_disabled: Спасибо за ваше сообщение. К сожалению, мы не сможем провести верификацию, поскольку этот проект больше не активен.
+  smooch_bot_result_changed: "❗️Отчёт о верификации, который мы вам отправили, был *обновлён*"
   permissions_info:
     permissions:
       sections:
@@ -553,12 +479,9 @@ ru:
   team_import:
     invalid_google_spreadsheet_url: 'Неверный URL таблицы: %{spreadsheet_url}'
     not_found_google_spreadsheet_url: 'Таблица не найдена: %{spreadsheet_url}'
-    cannot_authenticate_with_the_credentials: Не удалось авторизоваться в Google Drive
-      с указанными данными. Пожалуйста, свяжитесь со службой поддержки.
-    team_not_present: 'Выбранный проект не найден при импорте данных. Пожалуйста,
-      свяжитесь со службой поддержки. '
-    user_not_present: Выбранный пользователь не найден при импорте данных. Пожалуйста,
-      свяжитесь со службой поддержки.
+    cannot_authenticate_with_the_credentials: Не удалось авторизоваться в Google Drive с указанными данными. Пожалуйста, свяжитесь со службой поддержки.
+    team_not_present: 'Выбранный проект не найден при импорте данных. Пожалуйста, свяжитесь со службой поддержки. '
+    user_not_present: Выбранный пользователь не найден при импорте данных. Пожалуйста, свяжитесь со службой поддержки.
     user_not_authorized: Извините, вы не можете импортировать данные в этот проект.
     invalid_user: Неверный пользователь %{user}
     invalid_status: Неверный статус %{status}
@@ -566,8 +489,7 @@ ru:
     blank_annotator: Не указан аннотатор
     invalid_annotator: Неверный аннотатор %{user}
     invalid_assignee: Неверный пользователь %{user}
-  cant_mutate_inactive_object: Этот материал находится в обработке и не может быть
-    изменён в настоящий момент. Пожалуйста, попробуйте позже.
+  cant_mutate_inactive_object: Этот материал находится в обработке и не может быть изменён в настоящий момент. Пожалуйста, попробуйте позже.
   embed_expand_all: Раскрыть всё
   embed_collapse_all: Свернуть всё
   embed_tasks: Вопросы
@@ -581,14 +503,12 @@ ru:
   bot_request_url_invalid: Неверный URL бота
   invalid_task_answer: Неверный формат ответа на вопрос
   team_rule_name: Уникальное название для правила
-  team_rule_names_invalid: Названия правил должны быть уникальными и не могут быть
-    пустыми
+  team_rule_names_invalid: Названия правил должны быть уникальными и не могут быть пустыми
   team_rules: Правила
   team_rule_conditions: Если
   team_rule_condition: Если
   team_rule_condition_definition: Выберите условие
-  team_rule_title_matches_regexp: Заголовок материала совпадает с данным регулярным
-    выражением
+  team_rule_title_matches_regexp: Заголовок материала совпадает с данным регулярным выражением
   team_rule_request_matches_regexp: Запрос совпадает с данным регулярным выражением
   team_rule_type_is: Тип материала совпадает с указанным
   team_rule_type_is_claim: Текст
@@ -609,8 +529,7 @@ ru:
   team_rule_actions: Тогда
   team_rule_action: Тогда
   team_rule_action_definition: Выберите действие
-  team_rule_ban_submitter: Забанить добавившего (их сообщения больше не будут появляться
-    в Check)
+  team_rule_ban_submitter: Забанить добавившего (их сообщения больше не будут появляться в Check)
   team_rule_all_items: Все материалы
   team_rule_send_message_to_user: Отправить сообщение пользователю
   team_rule_action_value: Введите сообщение
@@ -632,8 +551,7 @@ ru:
   team_rule_item_user_is: Материал был создан данным автором
   team_rule_item_is_read: Материал прочитан
   team_rule_field_from_fieldset_tasks_value_is: На вопрос есть конкретный ответ
-  team_rule_field_from_fieldset_tasks_value_contains_keyword: Ответ содержит ключевое
-    слово
+  team_rule_field_from_fieldset_tasks_value_contains_keyword: Ответ содержит ключевое слово
   team_rule_select_field_value_metadata: Выберите значение
   team_rule_select_field_tasks: Выберите вопрос
   team_rule_select_field_value_tasks: Выберите ответ
@@ -649,25 +567,17 @@ ru:
   flag_likelihood_2: Маловероятно
   flag_likelihood_4: Вероятно
   relationship_not_same_team: Связанные материалы должны находиться в одном проекте
-  bulk_operation_limit_error: 'Извините, достигнуто максимальное количество материалов,
-    обрабатываемых за раз: %{limit}'
-  must_provide_fallback_when_deleting_status_in_use: Этот статус используется в проекте,
-    поэтому, если вы хотите удалить его, нужно указать альтернативный вариант
-  embed_no_content_yet: Отчёт находится в процессе создания. Это может занять несколько
-    минут. Пожалуйста, обновите страницу чуть позже.
-  language_format_invalid: Неверное обозначение языка. Язык должен быть указан кодом
-    ISO 639-1.
-  languages_format_invalid: Неверные обозначения языков. Языки должны указываться
-    кодами ISO 639-1.
-  cant_change_status_if_item_is_published: Извините, вы не можете изменить статус,
-    когда отчёт уже опубликован
+  bulk_operation_limit_error: 'Извините, достигнуто максимальное количество материалов, обрабатываемых за раз: %{limit}'
+  must_provide_fallback_when_deleting_status_in_use: Этот статус используется в проекте, поэтому, если вы хотите удалить его, нужно указать альтернативный вариант
+  embed_no_content_yet: Отчёт находится в процессе создания. Это может занять несколько минут. Пожалуйста, обновите страницу чуть позже.
+  language_format_invalid: Неверное обозначение языка. Язык должен быть указан кодом ISO 639-1.
+  languages_format_invalid: Неверные обозначения языков. Языки должны указываться кодами ISO 639-1.
+  cant_change_status_if_item_is_published: Извините, вы не можете изменить статус, когда отчёт уже опубликован
   fetch_bot_service_unsupported: Сервис не поддерживается
   task_options_must_be_array: Параметры вопроса должны быть отформатированы списком
   fieldset_not_defined_by_team: Набор полей должен поддерживаться проектом
-  replace_by_media_in_the_same_team: Извините, этот материал можно заменять только
-    другими материалами из того же проекта
-  replace_blank_media_only: Извините, в данный момент можно заменять только пустые
-    материалы
+  replace_by_media_in_the_same_team: Извините, этот материал можно заменять только другими материалами из того же проекта
+  replace_blank_media_only: Извините, в данный момент можно заменять только пустые материалы
   cant_preview_rss_feed: Извините, у вас нет доступа к предпросмотру RSS-ленты.
   list_column_demand: Запросы
   list_column_share_count: Репосты FB

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -1,4 +1,3 @@
----
 sw:
   statuses:
     ids:
@@ -25,7 +24,7 @@ sw:
         label: Inaendelea
         description: Kazi imeanza, lakini hakuna tafsiri yoyote iliyofanywa
       not_true:
-        label: Uongo
+        label: 'Uongo'
         description: 'Hitimisho: maudhui ya kitu ni ya uongo'
       verified:
         label: Imethibitishwa
@@ -76,25 +75,19 @@ sw:
     messages:
       invalid_password: Nenosiri batili
       invalid_qrcode: Nambari batili ya kuthibitisha
-      extension_white_list_error: 'haiwezi kuwa na aina %{extension}, aina zinazokubaliwa:
-        %{allowed_types}'
       invalid_size: lazima iwe kati ya %{min_width}x%{min_height} na piseli%{max_width}x%{max_height}
-      mini_magick_processing_error: 'Samahani, hatukuweza kuchakata picha. Hilitafu
-        ilikuwa: %{e}'
+      mini_magick_processing_error: 'Samahani, hatukuweza kuchakata picha. Hilitafu ilikuwa: %{e}'
       annotation_mandatory_fields: Tafadhali seti nyuga zote za lazima
       annotation_type_does_not_exist: Haipo
       invalid_attribution: uhusishwaji batili
-      must_resolve_required_tasks_first: Kazi zinazohitajika ni lazima zisuluhishwe
-        kwanza
+      must_resolve_required_tasks_first: Kazi zinazohitajika ni lazima zisuluhishwe kwanza
       image_too_large: Samahani, hatukubali picha kubwa zaidi ya %{max_size}.
       video_too_large: Samahani, hatukubali video kubwa zaidi ya %{max_size}.
       audio_too_large: Samahani, hatukubali faili za sauti zenye ukubwa zaidi ya %{max_size}
-      pender_conflict: Kiungo hiki tayari kinachambuliwa. Tafadhali jaribu tena ndani
-        ya sekunde chache
+      pender_conflict: Kiungo hiki tayari kinachambuliwa. Tafadhali jaribu tena ndani ya sekunde chache
       pender_url_invalid: Kiungo hiki ni batili.
       pender_url_unsafe: Kiungo hiki sio salama.
-      invalid_format_for_languages: 'Muundo batili wa lugha. Inatarajia muundo ''["en'',
-        ''ar'', ...]'' '
+      invalid_format_for_languages: 'Muundo batili wa lugha. Inatarajia muundo ''["en'', ''ar'', ...]'' '
   activerecord:
     models:
       link: Kiungo
@@ -153,16 +146,12 @@ sw:
   slack_webhook_format_wrong: Kiungo batili cha Slack. Inatarajia muundo 'https://hooks.slack.com/services/XXXXX/XXXXXXXXXX'
   slug_is_reserved: Imetengewa
   invalid_media_item: Kitu ni batili
-  invalid_default_status_for_custom_verification_status: Hali msingi ya kutambulisha
-    ni batili
-  invalid_active_status_for_custom_verification_status: Utambulisho wa hali ya shughuli
-    ni batili
+  invalid_default_status_for_custom_verification_status: Hali msingi ya kutambulisha ni batili
+  invalid_active_status_for_custom_verification_status: Utambulisho wa hali ya shughuli ni batili
   invalid_label_for_custom_verification_status: Lebo ya hali ni lazima
-  invalid_id_for_custom_verification_status: Utambulisho wa hali ni lazima na unapaswa
-    kuwa na herufi ndogo pekee, nambari, deshi, na vistari chini
-  invalid_statuses_format_for_custom_verification_status: 'Kaida batili ya uthibitishaji
-    hali. Inatarajia maingizo halali kwa: lebo, kitambulisho, maelezo na mtindo.'
-  mail_account_confirmation: Uthibitisho wa akaunti ya %{app_name}
+  invalid_id_for_custom_verification_status: Utambulisho wa hali ni lazima na unapaswa kuwa na herufi ndogo pekee, nambari, deshi, na vistari chini
+  invalid_statuses_format_for_custom_verification_status: 'Kaida batili ya uthibitishaji hali. Inatarajia maingizo halali kwa: lebo, kitambulisho, maelezo na mtindo.'
+  mail_account_confirmation: "Uthibitisho wa akaunti ya %{app_name}"
   slack:
     fields:
       assigned: Imepangiwa
@@ -176,8 +165,7 @@ sw:
       project_media: Kitu
       attribution: Imejibiwa na
     messages:
-      analysis_verification_status_status_changed: "%{user}alibadilisha hadhi kuwa:
-        %{value}"
+      analysis_verification_status_status_changed: "%{user}alibadilisha hadhi kuwa: %{value}"
       analysis_title_changed: "%{user}alibadilisha kichwa cha uchambuzi kuwa: %{value}"
       analysis_content_changed: "%{user} alibadilisha maudhui ya uchambuzi kuwa: %{value}"
       tasks_create: "%{user} aliongeza kazi:%{title}"
@@ -188,19 +176,14 @@ sw:
       metadata_edit: "%{user} alibadilisha sehemu ya metadata %{title}"
       metadata_answer_create: "%{user} weka thamani ya metadata %{title}: %{answer}"
       metadata_answer_edit: "%{user} alibadilisha thamani ya metadata %{title}:%{answer}"
-      project_media_comment: "%{user} (%{role} kwa %{team}) ameongeza kidokezo kwa
-        %{parent_type}"
-      project_media_create: "%{user} (%{role} katika %{team}) iliwasilisha kipengee
-        kipya"
-      project_media_create_related: "%{user} (%{role} kwa %{team}) ameongeza inayohusiana
-        %{type}"
+      project_media_comment: "%{user} (%{role} kwa %{team}) ameongeza kidokezo kwa %{parent_type}"
+      project_media_create: "%{user} (%{role} katika %{team}) iliwasilisha kipengee kipya"
+      project_media_create_related: "%{user} (%{role} kwa %{team}) ameongeza inayohusiana %{type}"
       project_media_update: "%{user}( %{role} katika %{team} ) ilisasisha kipengee"
-      project_media_status: "%{user} (%{role} kwa %{team}) amebadilisha %{workflow}
-        hali ya %{type}"
+      project_media_status: "%{user} (%{role} kwa %{team}) amebadilisha %{workflow} hali ya %{type}"
       project_media_assign: "%{user} (%{role} kwa %{team}) amepangia %{type}"
       project_media_unassign: "%{user} (%{role} kwa %{team}) amepangua %{type}"
-      project_source_comment: "%{user} (%{role} kwa %{team}) ameongeza kidokezo kwa
-        %{parent_type}"
+      project_source_comment: "%{user} (%{role} kwa %{team}) ameongeza kidokezo kwa %{parent_type}"
       project_source_create: "%{user} (%{role} kwa %{team}) ameongeza %{type}"
       project_source_update: "%{user} (%{role} kwa %{team}) amehariri %{type}"
       user_member: "%{user} amejiunga na ulingo wa kazi %{team}"
@@ -208,11 +191,9 @@ sw:
       user_invited: "%{user} ameaalikwa kujiunga na ulingo wa kazi %{team}"
       user_banned: "%{user} alipigwa marufuku kwenye ulingo wa kazi %{team}"
   mail_view_welcome: Welcome %{app_name}
-  mail_view_register: 'Imesalia hatua moja tu uweze kutumia %{app_name}! Tafadhali
-    thibitisha barua pepe yako kwa kubonyeza kiungo kifwatacho:'
+  mail_view_register: 'Imesalia hatua moja tu uweze kutumia %{app_name}! Tafadhali thibitisha barua pepe yako kwa kubonyeza kiungo kifwatacho:'
   mail_confirm_button: Thibitisha akaunti
-  slack_restricted_join_to_members: 'Samahani, huwezi kujiunga na %{team_name} kwa
-    sababu imezuiliwa kwa wanachama wa ulingo wa kazi wa Slack %{teams}. '
+  slack_restricted_join_to_members: 'Samahani, huwezi kujiunga na %{team_name} kwa sababu imezuiliwa kwa wanachama wa ulingo wa kazi wa Slack %{teams}. '
   admin:
     actions:
       send_reset_password_email:
@@ -225,8 +206,7 @@ sw:
         menu: Ulingo wa kazi uliorudiwa
         done: Imenakiliwa
         are_you_sure_you_want_to_copy_team:
-          html: Je! Una uhakika ungependa kunakili ulingo wa kazi <strong>%{team}</strong>?
-            Takwimu zote zinazohusiana zitanakiliwa pia.
+          html: Je! Una uhakika ungependa kunakili ulingo wa kazi <strong>%{team}</strong>? Takwimu zote zinazohusiana zitanakiliwa pia.
         the_team_is_being_copied: Nakili ya ulingo wa kazi inaendelea
         url_when_ready:
           html: Iwapo tayari, nakala ya ulingo wa kazi itapatikana kwa <strong>%{copy_url}</strong>
@@ -242,49 +222,44 @@ sw:
       email: "%B %d, %Y %I:%M  %p %Z"
   oembed_disclaimer_undetermined: Kitu hiki hakijathibitishwa na %{team}
   oembed_disclaimer_in_progress: Kitu hiki kinathibitishwa na %{team} kutokea %{date}
-  oembed_disclaimer_verified: Kitu hiki kimedhamiriwa kuthibitishwa na %{team} mnamo
-    %{date}
+  oembed_disclaimer_verified: Kitu hiki kimedhamiriwa kuthibitishwa na %{team} mnamo %{date}
   oembed_disclaimer_false: Kitu hiki kimedhamiriwa kuwa uongo na %{team} mnamo %{date}
-  oembed_disclaimer_not_applicable: Hakuna hitimisho lililofikiwa kuhusu kitu hiki
-    na %{team} kufikia %{date}
+  oembed_disclaimer_not_applicable: Hakuna hitimisho lililofikiwa kuhusu kitu hiki na %{team} kufikia %{date}
   oembed_source_date: "%{date} mnamo %{provider}"
   role_editor: mhariri
   role_none: mwanachama
   role_: mtawalamfumo
   oembed_credit: Imeongezwa na %{user} (%{role}) %{date}
   oembed_notes_count:
-    one: 1 maelezo
-    other: 'Vidokezo %{count} '
+    one: "1 maelezo"
+    other: "Vidokezo %{count} "
   oembed_completed_tasks_count:
-    one: '1 kazi iliyomaliziwa '
-    other: Kazi %{count} zilizokamilishwa
+    one: "1 kazi iliyomaliziwa "
+    other: "Kazi %{count} zilizokamilishwa"
   oembed_verification_tasks: Kazi
   oembed_tasks: Kazi
   oembed_translations: Tafsiri
   oembed_expand_all: Tanua zote
   oembed_collapse_all: Kunja zote
   oembed_resolved_tasks_count:
-    one: 1 kazi zilizomalizwa
-    other: Kazi %{count} zilizokamilishwa
+    one: "1 kazi zilizomalizwa"
+    other: "Kazi %{count} zilizokamilishwa"
   oembed_notes: Maelezo
   duplicate_source: Chanzo tayari kipo
   geolocation_invalid_value: Mahali batili. Inatarajia muundo halali wa GeoJSON (http://geojson.org/)
   datetime_invalid_date: Tarehe batili
-  error_team_archived_for_source: Samahani,  huwezi kuongeza chanzo kwenye ulingo
-    wa kazi taka
+  error_team_archived_for_source: Samahani,  huwezi kuongeza chanzo kwenye ulingo wa kazi taka
   permission_error: Samahani hauruhusiwi kutekeleza kitendo hiki
   error_annotated_archived: Samahani, huwezi kuongeza kidokezo kwenye kitu taka
-  only_super_admin_can_do_this: Samahani, ni msimamizi mfumo tu anayeweza kufanya
-    badiliko hili
+  only_super_admin_can_do_this: Samahani, ni msimamizi mfumo tu anayeweza kufanya badiliko hili
   cant_change_custom_statuses: |-
-    Samahani, hauwezi kufanyia mabadiliko ufafanuzi wa hali kwa sababu hali zingine huenda zikapotea. Tambulisho za hali: %{statuses} zinatumiwa na vitu vifuatayo:
-    %{urls} %{others_amount}
+      Samahani, hauwezi kufanyia mabadiliko ufafanuzi wa hali kwa sababu hali zingine huenda zikapotea. Tambulisho za hali: %{statuses} zinatumiwa na vitu vifuatayo:
+      %{urls} %{others_amount}
   account_exists: Akaunti hii tayari ipo
   media_exists: Kitu hiki tayari kipo
   source_exists: Chanzo hiki tayari kipo
   email_exists: tayari imechukuliwa
-  banned_user: Samahani, akaunti yako imepigwa marufuku kwenye %{app_name}. Tafadhali
-    wasiliana na timu ya msaada iwapo unadhani kuwa hili ni kosa.
+  banned_user: Samahani, akaunti yako imepigwa marufuku kwenye %{app_name}. Tafadhali wasiliana na timu ya msaada iwapo unadhani kuwa hili ni kosa.
   devise:
     mailer:
       reset_password_instructions:
@@ -294,8 +269,7 @@ sw:
         action: Badilisha nenosiri
         expiry: Ombi hili litaisha muda ndani ya masaa %{expire}.
         instruction_1: Bonyeza kufanya ombi lingine.
-        instruction_2: Iwapo haukufanya ombi hili, au unapata ugumu kubadilisha nenosiri
-          lako, tafadhali wasiliana nasi kwa %{support_email}.
+        instruction_2: Iwapo haukufanya ombi hili, au unapata ugumu kubadilisha nenosiri lako, tafadhali wasiliana nasi kwa %{support_email}.
       invitation_instructions:
         subject: "%{user} amekualika kujiunga na ulingo wa kazi %{team}"
         hello: Habari %{name}
@@ -313,10 +287,8 @@ sw:
     team_found: Ulingo wa kazi haupatikani.
     invalid: Nambari batili ya mwaliko.
     no_invitation: Hakuna mialiko iliyopo kwenye ulingo huu wa kazi %{name}
-  error_user_is_not_a_team_member: Samahani, unaweza kupangia tu wanachama wa ulingo
-    huu wa kazi
-  error_login_with_exists_account: Samahani, kuna mtumiaji mwingine anayetumia akaunti
-    hii
+  error_user_is_not_a_team_member: Samahani, unaweza kupangia tu wanachama wa ulingo huu wa kazi
+  error_login_with_exists_account: Samahani, kuna mtumiaji mwingine anayetumia akaunti hii
   error_login_2fa: Tafadhali kamilisha kuingia kwako kwa kutoa nambari ya uthibitisho.
   error_record_not_found: "%{type} # %{id} haijapatikana"
   mails_notifications:
@@ -328,56 +300,48 @@ sw:
     register:
       subject: Akaunti yako mpya kwa %{app_name}
       header_text: |-
-        Umefanikiwa kujiunga na %{app_name}!
-        <br>
-        Ili kuingia kwenye wavuti, fuata kiungo hiki: %{url}. Ingiza anwani hii ya barua pepe na nenosiri hili: %{password}
+          Umefanikiwa kujiunga na %{app_name}!
+          <br>
+          Ili kuingia kwenye wavuti, fuata kiungo hiki: %{url}. Ingiza anwani hii ya barua pepe na nenosiri hili: %{password}
       login_button: Ingia kwa %{app_name}
       footer_text: Asante sana kwa kujiunga, kuwa na siku njema
     duplicated:
       subject: Mtindo wako wa kuingia wa %{app_name}
       header_title: Akaunti iliyojirudia
       one_email: |-
-        <p>Huu ni ukumbusho wa kirafiki tu utakakusaidia kuweza kuingia kwenye %{app_name}.</p>
-        <p>Nini kilichotokea: Ulijaribu kuingia kwa %{app_name} na %{user_provider} -  akaunti inayohusishwa na %{user_email}.
-        Lakini anwani hii ya barua pepe tayari imehusishwa na akaunti inayohusishwa na%{duplicate_provider}. akaunti inayohusishwa na %{app_name}</p>
-        <p>Utakachofanya sasa, ingia na %{duplicate_provider}.</p>
-        <p>Kisha utaingia kwenye akaunti uliyokuwa unatumia awali.
-        Ukihitaji msaada zaidi, tafadhali tuma barua pepe kwa %{support_email}.</p>
+          <p>Huu ni ukumbusho wa kirafiki tu utakakusaidia kuweza kuingia kwenye %{app_name}.</p>
+          <p>Nini kilichotokea: Ulijaribu kuingia kwa %{app_name} na %{user_provider} -  akaunti inayohusishwa na %{user_email}.
+          Lakini anwani hii ya barua pepe tayari imehusishwa na akaunti inayohusishwa na%{duplicate_provider}. akaunti inayohusishwa na %{app_name}</p>
+          <p>Utakachofanya sasa, ingia na %{duplicate_provider}.</p>
+          <p>Kisha utaingia kwenye akaunti uliyokuwa unatumia awali.
+          Ukihitaji msaada zaidi, tafadhali tuma barua pepe kwa %{support_email}.</p>
       both_emails: |-
-        <p>Huu ni ukumbusho wa kirafiki tu utakaokusaidia kuweza kuingia kwenye %{app_name}.</p>
-        <p>Nini kilichotokea: Ulijaribu kuunda barua pepe mpya inayohusishwa na %{app_name}, lakini akaunti hii tayari ipo.</p>
-        <p>Jaribu kuingia na barua pepe na nenosiri, badala ya kuunda akaunti mpya.</p>
-        <p>Kisha utaingia na akaunti uliyokuwa unatumia awali. Iwapo unahitaji msaada zaidi, tafadhali tuma barua pepe kwa %{support_email}.</p>
+          <p>Huu ni ukumbusho wa kirafiki tu utakaokusaidia kuweza kuingia kwenye %{app_name}.</p>
+          <p>Nini kilichotokea: Ulijaribu kuunda barua pepe mpya inayohusishwa na %{app_name}, lakini akaunti hii tayari ipo.</p>
+          <p>Jaribu kuingia na barua pepe na nenosiri, badala ya kuunda akaunti mpya.</p>
+          <p>Kisha utaingia na akaunti uliyokuwa unatumia awali. Iwapo unahitaji msaada zaidi, tafadhali tuma barua pepe kwa %{support_email}.</p>
       email: Barua pepe
     invitation:
       title: Mwaliko mpya
     delete_user:
       subject: "[%{team}] Mtumiaji amefutwa"
       header_title: Mtumiaji amefutwa
-      header_text: Akaunti ya mtumiaji imefutwa na yaliyomo kupangiwa tena kwa %{anonymous}
-        mtumiaji %{id}
+      header_text: Akaunti ya mtumiaji imefutwa na yaliyomo kupangiwa tena kwa %{anonymous} mtumiaji %{id}
       anonymous: Asiyejulikana
     admin_mailer:
-      team_download_subject: "[%{team}] Picha ya data ya ulingo wa kazi ipo tayari
-        kupakuliwa"
+      team_download_subject: "[%{team}] Picha ya data ya ulingo wa kazi ipo tayari kupakuliwa"
       team_dump_title: Data za ulingo wa kazi
       types:
         dump: Picha za data
         csv: Ripoti
         images: Jalada
-      team_dump_text: 'Umeomba picha ya data ya ulingo wa kazi %{team} - kiungo cha
-        kupakua hiki hapa: %{link}'
+      team_dump_text: 'Umeomba picha ya data ya ulingo wa kazi %{team} - kiungo cha kupakua hiki hapa: %{link}'
       team_dump_button: Pakua data za ulingo wa kazi
-      decompress_text: "%{type} itapakua kama iliyogandamizwa, faili ya msimbo fiche.
-        Kuioandoa kwenye gandamizo, tafadhali tumia nenosiri %{password}."
-      expire_note: Tafadhali zingatia kuwa kiungo hiki kitaisha muda ndani ya siku
-        %{days}.
+      decompress_text: '%{type} itapakua kama iliyogandamizwa, faili ya msimbo fiche. Kuioandoa kwenye gandamizo, tafadhali tumia nenosiri %{password}.'
+      expire_note: Tafadhali zingatia kuwa kiungo hiki kitaisha muda ndani ya siku %{days}.
       team_import_subject: Uagizaji wako wa data  umekamilika
       team_import_title: Uagizaji data
-      team_import_text: "<p>Data zako za kazi zilizoagizwa hadi %{app_name} zimekamilika.
-        Unaweza kuangalia %{worksheet_url} kuhakiki hali ya kila kitu kitakachoagizwa.</p>
-        <p>Zingatia ya kuwa unaweza kuanzisha tena uagizaji baada ya kurekebisha hitilafu
-        zinazoripotiwa pale - vitu vilivyoagizwa awali havitarudiwa.</p>"
+      team_import_text: "<p>Data zako za kazi zilizoagizwa hadi %{app_name} zimekamilika. Unaweza kuangalia %{worksheet_url} kuhakiki hali ya kila kitu kitakachoagizwa.</p> <p>Zingatia ya kuwa unaweza kuanzisha tena uagizaji baada ya kurekebisha hitilafu zinazoripotiwa pale - vitu vilivyoagizwa awali havitarudiwa.</p>"
     task_resolved:
       subject: "[%{team} - %{project}] Tazi Imejibiwa"
       header_title: Kazi imejibiwa
@@ -412,17 +376,13 @@ sw:
       rejected_subject: Ombi lako la kujiunga na %{team} halikukubaliwa
       approved_subject: Karibu kwa ulingo wa kazi %{team}
       request_title: 'Omba kujiunga na ulingo wa %{team} '
-      request_text: "%{name} (%{email}) anataka kujiiunga na ulingo wa kazi %{team}
-        kwa %{app_name}. Unaweza kuchakata ombi hili kwa kutembelea %{url}."
+      request_text: "%{name} (%{email}) anataka kujiiunga na ulingo wa kazi %{team} kwa %{app_name}. Unaweza kuchakata ombi hili kwa kutembelea %{url}."
       approved_title: Karibu kwa ulingo wa kazi %{team}
-      approved_text: 'Ombi lako la kijiunga na ulingo wa kazi %{team} kwa %{app_name}
-        lilikubaliwa. Unaweza kwenda kwa %{url} na uanze kuchangia. '
+      approved_text: 'Ombi lako la kijiunga na ulingo wa kazi %{team} kwa %{app_name} lilikubaliwa. Unaweza kwenda kwa %{url} na uanze kuchangia. '
       rejected_title: Ombi limekataliwa
-      rejected_text: Samahani, ombi lako la kujiunga na ulingo wa kazi %{team} kwa
-        %{app_name} halikukubaliwa.
+      rejected_text: Samahani, ombi lako la kujiunga na ulingo wa kazi %{team} kwa %{app_name} halikukubaliwa.
   mail_security:
-    device_subject: 'Tahadhari ya usalama: Uingiaji mpya kwa %{app_name} kutoka kwa
-      %{browser} kwa %{platform}'
+    device_subject: 'Tahadhari ya usalama: Uingiaji mpya kwa %{app_name} kutoka kwa %{browser} kwa %{platform}'
     ip_subject: 'Tahadhari ya usalama: Uingiaji mpya au usio wa kawaida %{app_name}'
     failed_subject: 'Tahadhari ya usalama: Majaribio yaliyofeli ya kuingia kwa %{app_name}'
     ip: Umeingia kutoka %{location}
@@ -430,13 +390,9 @@ sw:
     devise_name: "%{browser} kwa %{platform}"
     failed: Majaribio ya kuingia yaliyofeli yamegunduliwa
     password_text: Badilisha nenosiri lako mara moja.
-    device_text: Inaonekana kana kwamba uliingia kwa akaunti yako ya %{app_name} kutoka
-      kwa kifaa kipya. Iwapo sio wewe, unapaswa %{change_password}
-    ip_text: Inaonekana kana kwamba uliingia kwa akaunti yako %{app_name} kutoka eneo
-      jipya. Iwapo sio wewe, unapaswa %{change_password}
-    failed_text: Inaonekana kana kwamba majaribio mengi ya kuingia kwa akaunti yako
-      ya %{app_name} yalifanywa. Iwapo ni wewe, basi puuza barua pepe hii. Iwapo sio
-      wewe, basi unapaswa %{change_password}
+    device_text: Inaonekana kana kwamba uliingia kwa akaunti yako ya %{app_name} kutoka kwa kifaa kipya. Iwapo sio wewe, unapaswa %{change_password}
+    ip_text: Inaonekana kana kwamba uliingia kwa akaunti yako %{app_name} kutoka eneo jipya. Iwapo sio wewe, unapaswa %{change_password}
+    failed_text: Inaonekana kana kwamba majaribio mengi ya kuingia kwa akaunti yako ya %{app_name} yalifanywa. Iwapo ni wewe, basi puuza barua pepe hii. Iwapo sio wewe, basi unapaswa %{change_password}
     time_h: Saa
     device_h: KIfaa
     location_h: Eneo
@@ -450,61 +406,46 @@ sw:
   archive_keep_backup: Video ya maelezo
   archive_pender_archive: Kielezo skrini
   archive_archive_org: Archive.org
-  workflow_status_is_not_valid: 'Hali batili: ''%{status}'' (inapaswa kuwa moja ya
-    %{valid})'
+  workflow_status_is_not_valid: 'Hali batili: ''%{status}'' (inapaswa kuwa moja ya %{valid})'
   workflow_status_permission_error: Samahani, hauruhusiwi kubadilisha hali hii.
-  blank_default_status_for_custom_verification_status: Tafadhali toa nambari msingi
-    kwa uhakiki kaida wa hali.
-  blank_active_status_for_custom_verification_status: Tafadhali toa nambari hai kwa
-    uhakiki kaida wa hali.
-  bot_name_exists_for_this_team: Tayari kuna boti yenye jina lililotolewa kwenye ulingo
-    huu wa kazi
+  blank_default_status_for_custom_verification_status: Tafadhali toa nambari msingi kwa uhakiki kaida wa hali.
+  blank_active_status_for_custom_verification_status: Tafadhali toa nambari hai kwa uhakiki kaida wa hali.
+  bot_name_exists_for_this_team: Tayari kuna boti yenye jina lililotolewa kwenye ulingo huu wa kazi
   bot_team_id_doesnt_exist: 'Samahani, hakuna ulingo wa kazi wenye utambulisho uliotolewa. '
-  bot_team_id_mandatory_to_create: Samahani, unahitaji kuchagua ulingo wa kazi ili
-    uweze kuunda boti.
-  bot_not_approved_for_installation: Samahani, boti hii haukuweza kukubaliwa kwa hivyo
-    haiwezi kusakinishwa
-  could_not_save_related_bot_data: Samahani, boti haikuweza kuongezwa kwenye ulingo
-    huu wa kazi
-  bot_cant_add_response_to_task: Samahani, boti haiwezi kujibu kazi moja kwa moja-tafadhali
-    tuma pendekezo la jibu badala yake.
+  bot_team_id_mandatory_to_create: Samahani, unahitaji kuchagua ulingo wa kazi ili uweze kuunda boti.
+  bot_not_approved_for_installation: Samahani, boti hii haukuweza kukubaliwa kwa hivyo haiwezi kusakinishwa
+  could_not_save_related_bot_data: Samahani, boti haikuweza kuongezwa kwenye ulingo huu wa kazi
+  bot_cant_add_response_to_task: Samahani, boti haiwezi kujibu kazi moja kwa moja-tafadhali tuma pendekezo la jibu badala yake.
   bot_cant_add_review_to_task: Samahani, boti haiwezi kuhakiki kazi
-  task_suggestion_invalid_value: Pendekezo batili la kazi. Inatarajia kitu cha JSON
-    kilicho na sifa `pendekezo` (thamani halisi inayonakiliwa kwa jibu la kazi wakati
-    inapokubaliwa) na `maoni` (yanayoonyeshwa kwa watumiaji).
+  task_suggestion_invalid_value: Pendekezo batili la kazi. Inatarajia kitu cha JSON kilicho na sifa `pendekezo` (thamani halisi inayonakiliwa kwa jibu la kazi wakati inapokubaliwa) na `maoni` (yanayoonyeshwa kwa watumiaji).
   tag_text_id_not_found: Tagi haipatikani
   annotation_type_language_label: Lugha
   smooch_bot_message_confirmed: |-
-    Asante. Ombi lako limeongezwa kwenye foleni yetu ya uthibitishaji.
+      Asante. Ombi lako limeongezwa kwenye foleni yetu ya uthibitishaji.
 
-    Tutajaribu kukutumia ripoti ndani ya masaa 24, lakini tafadhali zingatia kuwa hatuwezi kujibu kila ombi.
-  smooch_bot_message_unconfirmed: Kwa vile haukujibu na 1, hatutaweza kulishughulikia
-    ombi lako. Asante.
+      Tutajaribu kukutumia ripoti ndani ya masaa 24, lakini tafadhali zingatia kuwa hatuwezi kujibu kila ombi.
+  smooch_bot_message_unconfirmed: Kwa vile haukujibu na 1, hatutaweza kulishughulikia ombi lako. Asante.
   smooch_bot_message_type_unsupported: Samahani, hatuhimili aina ya ujumbe huu.
-  smooch_bot_message_size_unsupported: Samahani, hatuhimili faili zenye ukubwa zaidi
-    ya %{max_size}.
+  smooch_bot_message_size_unsupported: Samahani, hatuhimili faili zenye ukubwa zaidi ya %{max_size}.
   smooch_bot_result: |-
-    [Ripoti ya uthibitisho] Kitu ulichoshirilki nasi kimealamishwa *%{status}*.
+      [Ripoti ya uthibitisho] Kitu ulichoshirilki nasi kimealamishwa *%{status}*.
 
-    Hizi ndizo hatua tulizochukua kuamua hili: %{url}
+      Hizi ndizo hatua tulizochukua kuamua hili: %{url}
   smooch_bot_ask_for_confirmation: |-
-    Asante sana kwa kutuma ombi hili. Ungetaka tuthibitishe maudhui yake?
+      Asante sana kwa kutuma ombi hili. Ungetaka tuthibitishe maudhui yake?
 
-    Kukubali, *tafadhali jibu na 1*. Jibu lingine lolote litasitisha mazungumzo yetu.
+      Kukubali, *tafadhali jibu na 1*. Jibu lingine lolote litasitisha mazungumzo yetu.
   smooch_bot_ask_for_tos: |-
-    Asante kwa kutufikia kupitia Check Message!
+      Asante kwa kutufikia kupitia Check Message!
 
-    Unaweza kutumia huduma kuomba uthibitishaji, kutathmini ukweli, na kuchunguza habari au taarifa. Check Message inatolewa kwako chini ya Masharti haya ya Huduma: %{tos}. Kwa kuendelea kutumia huduma hiii, *unakubaliana na masharti haya*. Unapaswa kusitisha kuendelea kutumia Check Message iwapo haukubaliani nayo.
-  smooch_bot_window_closing: Kimo cha maombi kwenye mkondo huu kipo juu, na bado hatujaweza
-    kulisuluhisha ombi lako. Asante kwa uvumilivu wako.
+      Unaweza kutumia huduma kuomba uthibitishaji, kutathmini ukweli, na kuchunguza habari au taarifa. Check Message inatolewa kwako chini ya Masharti haya ya Huduma: %{tos}. Kwa kuendelea kutumia huduma hiii, *unakubaliana na masharti haya*. Unapaswa kusitisha kuendelea kutumia Check Message iwapo haukubaliani nayo.
+  smooch_bot_window_closing: Kimo cha maombi kwenye mkondo huu kipo juu, na bado hatujaweza kulisuluhisha ombi lako. Asante kwa uvumilivu wako.
   smooch_bot_not_final: |-
-    [Ripoti ya uthibitisho- MAREKEBISHO] Ujumbe ulioshiriki ulialamishwa kimakosa kama *%{status}*.
+      [Ripoti ya uthibitisho- MAREKEBISHO] Ujumbe ulioshiriki ulialamishwa kimakosa kama *%{status}*.
 
-    Bado upo kwenye foleni kwa uthibitishaji zaidi.
-  smooch_bot_disabled: Asante sana kwa kutuma ujumbe huu. Hatuwezi kutuma ripoti ya
-    kuthibitisha, kwa sababu mradi huu umesitisha shughuli.
-  smooch_bot_result_changed: "❗️Tathmini ukweli tuliyokutumia *imesasishwa* na maelezo
-    mapya"
+      Bado upo kwenye foleni kwa uthibitishaji zaidi.
+  smooch_bot_disabled: Asante sana kwa kutuma ujumbe huu. Hatuwezi kutuma ripoti ya kuthibitisha, kwa sababu mradi huu umesitisha shughuli.
+  smooch_bot_result_changed: "❗️Tathmini ukweli tuliyokutumia *imesasishwa* na maelezo mapya"
   permissions_info:
     permissions:
       sections:
@@ -542,13 +483,9 @@ sw:
   team_import:
     invalid_google_spreadsheet_url: KISARA batili cha lahajedwali %{spreadsheet_url}
     not_found_google_spreadsheet_url: Lahajedwali haijapatikana kwa %{spreadsheet_url}
-    cannot_authenticate_with_the_credentials: Haiwezi kuhalisisha Google Drive na
-      hati tambulishi zilizopo. Tafadhali wasiliana na timu ya msaadai kuwajulisha
-      kuhusu tukio hili.
-    team_not_present: Ulingo wa sasa wa kazi haukuweza kupatikana wakati wa uagizaji
-      data. Tafadhali ijulishe timu ya msaada kuhusu tukio hili.
-    user_not_present: Mtumiaji wa sasa hakuweza kupatikana wakati wa uagizaji data.
-      Tafadhali ijulishe timu ya msaada kuhusu tukio hili.
+    cannot_authenticate_with_the_credentials: Haiwezi kuhalisisha Google Drive na hati tambulishi zilizopo. Tafadhali wasiliana na timu ya msaadai kuwajulisha kuhusu tukio hili.
+    team_not_present: Ulingo wa sasa wa kazi haukuweza kupatikana wakati wa uagizaji data. Tafadhali ijulishe timu ya msaada kuhusu tukio hili.
+    user_not_present: Mtumiaji wa sasa hakuweza kupatikana wakati wa uagizaji data. Tafadhali ijulishe timu ya msaada kuhusu tukio hili.
     user_not_authorized: Samahani, hauruhusiwi kuleta data kwenye ulingo huu wa kazi.
     invalid_user: Mwandishi batili %{user}
     invalid_status: Hali batili %{status}
@@ -556,8 +493,7 @@ sw:
     blank_annotator: 'Uga batili tupu wa ufafanuzi '
     invalid_annotator: Mfafanuzi batili %{user}
     invalid_assignee: Mpangiwaji batili %{user}
-  cant_mutate_inactive_object: Samahani, kuna shughuli inayosubiri kwa kipengele hiki,
-    kwa hivyo hauwezi kukibadili sasa. Tafadhali Jaribu tena baadaye.
+  cant_mutate_inactive_object: Samahani, kuna shughuli inayosubiri kwa kipengele hiki, kwa hivyo hauwezi kukibadili sasa. Tafadhali Jaribu tena baadaye.
   embed_expand_all: Tanua zote
   embed_collapse_all: Kunja zote
   embed_tasks: Kazi
@@ -576,8 +512,7 @@ sw:
   team_rule_conditions: Iwapo
   team_rule_condition: Iwapo
   team_rule_condition_definition: Chagua hali
-  team_rule_has_less_than_x_words: Ombi la maandishi lina chini ya (au haswa) idadi
-    ifuatayo ya maneno
+  team_rule_has_less_than_x_words: Ombi la maandishi lina chini ya (au haswa) idadi ifuatayo ya maneno
   team_rule_title_matches_regexp: Kichwa cha kipengee kinawiana na usemi huu wa kawaida
   team_rule_request_matches_regexp: Ombi linawiana na usemi huu wa kawaida
   team_rule_type_is: Aina ya kipengee ni
@@ -599,8 +534,7 @@ sw:
   team_rule_actions: Basi
   team_rule_action: Basi
   team_rule_action_definition: Chagua hatua
-  team_rule_ban_submitter: Mpige marufuku mtumaji (jumbe zao za siku za usoni hazitaonekana
-    katika Check)
+  team_rule_ban_submitter: Mpige marufuku mtumaji (jumbe zao za siku za usoni hazitaonekana katika Check)
   team_rule_all_items: Vitu vyote
   team_rule_send_message_to_user: Tuma ujumbe kwa mtumiaji
   team_rule_action_value: Andika ujumbe hapa
@@ -622,8 +556,7 @@ sw:
   team_rule_item_user_is: Kitu kiliundwa na
   team_rule_item_is_read: Kitu kimesomwa
   team_rule_field_from_fieldset_tasks_value_is: Kazi ina jibu fulani
-  team_rule_field_from_fieldset_tasks_value_contains_keyword: Jibu la kazi lina neno
-    kuu
+  team_rule_field_from_fieldset_tasks_value_contains_keyword: Jibu la kazi lina neno kuu
   team_rule_select_field_value_metadata: Chagua thamani
   team_rule_select_field_tasks: Chagua kazi
   team_rule_select_field_value_tasks: Chagua jibu
@@ -638,27 +571,18 @@ sw:
   flag_likelihood_0: Isiyojulikana
   flag_likelihood_2: Haiwezekani
   flag_likelihood_4: Uwezekano
-  relationship_not_same_team: Vitu vinavyohusiana lazima viwe kwenye ulingo mmoja
-    wa kazi
-  bulk_operation_limit_error: Samahani, kiwango cha juu cha vitu vitakavyochakatwa
-    mara moja ni %{limit}
-  must_provide_fallback_when_deleting_status_in_use: Hali hii inatumika, kwa hivyo
-    itakulazimu kutoa hali ya kurejelea iwapo unataka kuifuta.
-  embed_no_content_yet: Ripoti inatolewa. Mchakato huu unaweza kuchukua dakika chache.
-    Tafadhali pakia tena ukurasa huu.
+  relationship_not_same_team: Vitu vinavyohusiana lazima viwe kwenye ulingo mmoja wa kazi
+  bulk_operation_limit_error: Samahani, kiwango cha juu cha vitu vitakavyochakatwa mara moja ni %{limit}
+  must_provide_fallback_when_deleting_status_in_use: Hali hii inatumika, kwa hivyo itakulazimu kutoa hali ya kurejelea iwapo unataka kuifuta.
+  embed_no_content_yet: Ripoti inatolewa. Mchakato huu unaweza kuchukua dakika chache. Tafadhali pakia tena ukurasa huu.
   language_format_invalid: Muundo batili wa lugha. Inatarajia nambari ya ISO 639-1.
-  languages_format_invalid: Muundo batili wa lugha. Inatarajia orodha ya nambari za
-    ISO 639-1.
-  cant_change_status_if_item_is_published: Samahani, hauwezi kubadilisha hali wakati
-    ripoti inachapishwa.
+  languages_format_invalid: Muundo batili wa lugha. Inatarajia orodha ya nambari za ISO 639-1.
+  cant_change_status_if_item_is_published: Samahani, hauwezi kubadilisha hali wakati ripoti inachapishwa.
   fetch_bot_service_unsupported: Huduma haihimiliwi
   task_options_must_be_array: Chaguo za kazi lazima ziwe zenye orodha
-  fieldset_not_defined_by_team: Mpangilio wa uga unapaswa kuhimiliwa na ulingo wa
-    kazi
-  replace_by_media_in_the_same_team: Samahani, unaweza tu kubadilisha kipengee hiki
-    na kipengee kingine kutoka kwenye ulingo mmoja wa kazi
-  replace_blank_media_only: Samahani, ila kwa sasa unaweza tu kubadilisha vitu vilivyo
-    tupu
+  fieldset_not_defined_by_team: Mpangilio wa uga unapaswa kuhimiliwa na ulingo wa kazi
+  replace_by_media_in_the_same_team: Samahani, unaweza tu kubadilisha kipengee hiki na kipengee kingine kutoka kwenye ulingo mmoja wa kazi
+  replace_blank_media_only: Samahani, ila kwa sasa unaweza tu kubadilisha vitu vilivyo tupu
   cant_preview_rss_feed: Samahani, huna ruhusa ya kukagua mlisho wa RSS.
   list_column_demand: Maombi
   list_column_share_count: Shiriki za FB

--- a/lib/tasks/transifex.rake
+++ b/lib/tasks/transifex.rake
@@ -5,16 +5,6 @@ TRANSIFEX_TIPLINES_PROJECT_SLUG = 'check-tiplines'
 
 namespace :transifex do
 
-  # Login on Transifex
-
-  task login: :environment do
-    Transifex.configure do |c|
-      c.client_login = CheckConfig.get('transifex_user')
-      c.client_secret = CheckConfig.get('transifex_password')
-    end
-    puts "Logged in as #{CheckConfig.get('transifex_user')} on Transifex."
-  end
-
   # Get the supported languages on Transifex and update config/application.rb accordingly
 
   task languages: [:environment, :login] do
@@ -30,27 +20,6 @@ namespace :transifex do
     apprb.puts apprb_contents.gsub(/config\.i18n\.available_locales = \[[^\]]*\] # #{disclaimer}/, "config.i18n.available_locales = #{langs.to_json} # #{disclaimer}")
     apprb.close
     puts "Set languages #{langs.join(', ')} on #{apprb_path}."
-  end
-
-  # Download translations from Transifex - api resource
-
-  task download: [:environment, :languages, :login] do
-    project = Transifex::Project.new(TRANSIFEX_CHECKUI_PROJECT_SLUG)
-    resource_slugs = project.resources.fetch.select{ |r| r['slug'] =~ /^api/ }.collect{ |r| r['slug'] }
-    @langs_ui.each do |lang|
-      yaml = {}
-      yaml[lang] = {}
-      resource_slugs.each do |slug|
-        resource = project.resource(slug)
-        translations = YAML.load(resource.translation(lang).fetch['content'])
-        yaml[lang].merge!(translations[lang])
-      end
-      path = File.join(Rails.root, 'config', 'locales', "#{lang}.yml")
-      file = File.open(path, 'w+')
-      file.puts yaml.to_yaml
-      file.close
-      puts "Downloaded translations from Transifex and saved as #{path}."
-    end
   end
 
   # Download translations from Transifex - tipline resource
@@ -90,37 +59,5 @@ namespace :transifex do
     file.close
 
     puts "Updated #{path} with localizable strings found on code."
-  end
-
-  # Update or create the resource on Transifex
-
-  task upload: [:environment, :login] do
-    project = Transifex::Project.new(TRANSIFEX_CHECKUI_PROJECT_SLUG)
-    resource = nil
-
-    begin
-      resource = project.resource('api')
-      resource.fetch
-      yaml = { 'en' => {} }
-      YAML.load(File.read(File.join(Rails.root, 'config', 'locales', 'en.yml')))['en'].each do |key, value|
-        yaml['en'][key] = value unless key =~ /^custom_message_/
-      end
-      resource.content.update(i18n_type: 'YML', content: yaml.to_yaml)
-    rescue Transifex::TransifexError => e
-      if e.message == 'Not Found'
-        params = { slug: 'api', name: 'API', i18n_type: 'YML', content: File.read(File.join(Rails.root, 'config', 'locales', 'en.yml')) }
-        options = { trad_from_file: true }
-        project.resources.create(params, options)
-        resource = project.resource('api')
-      else
-        raise e
-      end
-    end
-
-    puts "Uploaded strings to Transifex."
-  end
-
-  task localize: [:environment, :login, :languages, :download, :parse, :upload] do
-    puts "Localizing the application using Transifex."
   end
 end


### PR DESCRIPTION
## Description

This commits make Dockerfile install the new Transifex CLI client that supports their current API and includes translation files freshly downloaded with it and deprecate rake tasks previously used a transifex gem to connect with Transifex.

References: CV2-3319

## How has this been tested?

Downloaded and Uploaded strings with new cli client from within the container

## Things to pay attention to during code review

The formatting on yml files changed due to the new client, but the result should be the same anyway.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

