### PR TITLE
Cv2 3449 stop running known failed transcriptions

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,7 +23,7 @@ checks:
       threshold: 4
   return-statements:
     config:
-      threshold: 4
+      threshold: 5
 plugins:
   fixme:
     enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -224,7 +224,7 @@ Metrics/CyclomaticComplexity:
                  A complexity metric that is strongly correlated to the number
                  of test cases needed to validate a method.
   Enabled: true
-  Max: 11
+  Max: 12
 
 Metrics/LineLength:
   Description: 'Limit lines to 80 characters.'

--- a/app/controllers/api/v1/webhooks_controller.rb
+++ b/app/controllers/api/v1/webhooks_controller.rb
@@ -13,6 +13,9 @@ module Api
           render_error('Bot not found', 'ID_NOT_FOUND', 404) and return
         end
         bot = bot_name_to_class[params[:name].to_sym]
+        if bot.respond_to?(:should_ignore_request?) && bot.should_ignore_request?(request)
+          render_success('ignored') and return
+        end
         unless bot.valid_request?(request)
           render_error('Invalid request', 'UNKNOWN') and return
         end

--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -377,6 +377,8 @@ class Bot::Alegre < BotUser
       annotation.skip_check_ability = true
       annotation.save!
       completed = true
+    elsif result['job_status'] == 'DONE'
+      completed = true
     end
     self.delay_for(10.seconds, retry: 5).update_audio_transcription(annotation.id, attempts + 1) if !completed && attempts < 2000 # Maximum: ~5h of transcription
   end

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -268,6 +268,7 @@ class Bot::Smooch < BotUser
     begin
       json = self.preprocess_message(body)
       JSON::Validator.validate!(SMOOCH_PAYLOAD_JSON_SCHEMA, json)
+      return false if self.user_banned?(json)
       case json['trigger']
       when 'capi:verification'
         'capi:verification'
@@ -748,6 +749,11 @@ class Bot::Smooch < BotUser
       Rails.logger.info("[Smooch Bot] Banned user #{uid}")
       Rails.cache.write("smooch:banned:#{uid}", message.to_json)
     end
+  end
+
+  def self.user_banned?(payload)
+    uid = payload.dig('appUser', '_id')
+    !uid.blank? && !Rails.cache.read("smooch:banned:#{uid}").nil?
   end
 
   # Don't save as a ProjectMedia if it contains only menu options

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -255,6 +255,10 @@ class Bot::Smooch < BotUser
     self.valid_zendesk_request?(request) || self.valid_turnio_request?(request) || self.valid_capi_request?(request)
   end
 
+  def self.should_ignore_request?(request)
+    self.should_ignore_capi_request?(request)
+  end
+
   def self.config
     RequestStore.store[:smooch_bot_settings]
   end

--- a/app/models/bot_user.rb
+++ b/app/models/bot_user.rb
@@ -332,6 +332,10 @@ class BotUser < User
     begin Module.const_defined?("Bot::#{self.identifier.camelize}") rescue false end
   end
 
+  def should_ignore_request?
+    false
+  end
+
   protected
 
   def confirmation_required?

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -193,6 +193,7 @@ module ProjectMediaCreators
         language: fact_check['language'],
         url: fact_check['url'],
         publish_report: !!fact_check['publish_report'],
+        signature: Digest::MD5.hexdigest([self.set_fact_check.to_json, self.team_id].join(':')),
         claim_description: cd,
         skip_check_ability: true
       })

--- a/app/models/concerns/smooch_capi.rb
+++ b/app/models/concerns/smooch_capi.rb
@@ -4,6 +4,11 @@ module SmoochCapi
   extend ActiveSupport::Concern
 
   module ClassMethods
+    def should_ignore_capi_request?(request)
+      event = request.params.dig('entry', 0, 'changes', 0, 'value', 'statuses', 0, 'status').to_s
+      ['read', 'sent'].include?(event)
+    end
+
     def valid_capi_request?(request)
       valid = false
       if request.params['hub.mode'] == 'subscribe'

--- a/app/models/monthly_team_statistic.rb
+++ b/app/models/monthly_team_statistic.rb
@@ -23,10 +23,10 @@ class MonthlyTeamStatistic < ApplicationRecord
     unique_users_who_received_report: 'Unique users who received a report',
     formatted_median_response_time: 'Average (median) response time', # model method
     unique_newsletters_sent: 'Unique newsletters sent',
+    newsletters_delivered: 'Total newsletter received',
     new_newsletter_subscriptions: 'New newsletter subscriptions',
     newsletter_cancellations: 'Newsletter cancellations',
-    current_subscribers: 'Current subscribers',
-    newsletters_delivered: 'Newsletters delivered'
+    current_subscribers: 'Current subscribers'
   }.freeze
 
   def formatted_hash

--- a/db/migrate/20230718012453_add_signature_to_fact_checks.rb
+++ b/db/migrate/20230718012453_add_signature_to_fact_checks.rb
@@ -1,0 +1,6 @@
+class AddSignatureToFactChecks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :fact_checks, :signature, :string
+    add_index :fact_checks, :signature, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_11_211928) do
+ActiveRecord::Schema.define(version: 2023_07_18_012453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -296,8 +296,10 @@ ActiveRecord::Schema.define(version: 2023_07_11_211928) do
     t.string "language", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "signature"
     t.index ["claim_description_id"], name: "index_fact_checks_on_claim_description_id", unique: true
     t.index ["language"], name: "index_fact_checks_on_language"
+    t.index ["signature"], name: "index_fact_checks_on_signature", unique: true
     t.index ["user_id"], name: "index_fact_checks_on_user_id"
   end
 

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -196,4 +196,40 @@ class WebhooksControllerTest < ActionController::TestCase
     assert_match /not found/, response.body
     assert_equal 13, JSON.parse(response.body)['errors'].first['code']
   end
+
+  test "should ignore some WhatsApp Cloud API requests" do
+    payload = {
+      object: 'whatsapp_business_account',
+      entry: [
+        {
+          id: '123456',
+          changes: [
+            {
+              value: {
+                messaging_product: 'whatsapp',
+                metadata: {
+                  display_phone_number: '123456',
+                  phone_number_id: '123456'
+                },
+                statuses: [
+                  {
+                    id: 'wamid.123456==',
+                    status: 'read',
+                    timestamp: '1689633253',
+                    recipient_id: "654321"
+                  }
+                ]
+              },
+              field: 'messages'
+            }
+          ]
+        }
+      ]
+    }
+
+    post :index, params: { name: :smooch }.merge(payload), body: payload
+
+    assert_equal '200', response.code
+    assert_match /ignored/, response.body
+  end
 end

--- a/test/models/bot/alegre_3_test.rb
+++ b/test/models/bot/alegre_3_test.rb
@@ -61,6 +61,76 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
     end
   end
 
+  test "should bypass untranscribable audio" do
+    json_schema = {
+      type: 'object',
+      required: ['job_name'],
+      properties: {
+        text: { type: 'string' },
+        job_name: { type: 'string' },
+        last_response: { type: 'object' }
+      }
+    }
+    create_annotation_type_and_fields('Transcription', {}, json_schema)
+    create_annotation_type_and_fields('Smooch', { 'Data' => ['JSON', true] })
+    Bot::Alegre.unstub(:request_api)
+    tbi = Bot::Alegre.get_alegre_tbi(@team.id)
+    tbi.set_transcription_similarity_enabled = false
+    tbi.save!
+    WebMock.stub_request(:post, 'http://alegre/text/langid/').to_return(body: { 'result' => { 'language' => 'es' }}.to_json)
+    stub_configs({ 'alegre_host' => 'http://alegre', 'alegre_token' => 'test' }) do
+      WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
+      WebMock.stub_request(:post, 'http://alegre/text/similarity/').to_return(body: 'success')
+      WebMock.stub_request(:delete, 'http://alegre/text/similarity/').to_return(body: {success: true}.to_json)
+      WebMock.stub_request(:get, 'http://alegre/text/similarity/').to_return(body: {success: true}.to_json)
+      WebMock.stub_request(:post, 'http://alegre/audio/similarity/').to_return(body: {
+        "success": true
+      }.to_json)
+      WebMock.stub_request(:get, 'http://alegre/audio/similarity/').to_return(body: {
+        "result": []
+      }.to_json)
+
+      media_file_url = 'https://example.com/test/data/rails.mp3'
+      s3_file_url = "s3://check-api-test/test/data/rails.mp3"
+      WebMock.stub_request(:get, media_file_url).to_return(body: File.new(File.join(Rails.root, 'test', 'data', 'rails.mp3')))
+      Bot::Alegre.stubs(:media_file_url).returns(media_file_url)
+
+      pm1 = create_project_media team: @pm.team, media: create_uploaded_audio(file: 'rails.mp3')
+      WebMock.stub_request(:post, 'http://alegre/audio/transcription/').with({
+        body: { url: s3_file_url, job_name: '0c481e87f2774b1bd41a0a70d9b70d11' }.to_json
+      }).to_return(body: { 'job_status' => 'IN_PROGRESS' }.to_json)
+      WebMock.stub_request(:get, 'http://alegre/audio/transcription/').with(
+        body: { job_name: '0c481e87f2774b1bd41a0a70d9b70d11' }
+      ).to_return(body: { 'job_status' => 'DONE' }.to_json)
+      # Verify with transcription_similarity_enabled = false
+      assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
+      a = pm1.annotations('transcription').last
+      assert_nil a
+      # Verify with transcription_similarity_enabled = true and duration less than transcription_maximum_duration
+      tbi.set_transcription_similarity_enabled = true
+      tbi.set_transcription_minimum_duration = 7
+      tbi.set_transcription_maximum_duration = 10
+      tbi.set_transcription_minimum_requests = 2
+      tbi.save!
+      assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
+      a = pm1.annotations('transcription').last
+      assert_nil a
+      # Verify that requests count less than transcription_minimum_requests
+      tbi.set_transcription_maximum_duration = 30
+      tbi.save!
+      assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
+      a = pm1.annotations('transcription').last
+      assert_nil a
+      # Audio item match all required conditions by verify transcription_minimum_requests count
+      RequestStore.store[:skip_cached_field_update] = false
+      create_dynamic_annotation annotation_type: 'smooch', annotated: pm1
+      create_dynamic_annotation annotation_type: 'smooch', annotated: pm1
+      assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
+      a = pm1.annotations('transcription').last
+      assert_equal "", a.data['text']
+    end
+  end
+
   test "should auto transcribe audio" do
     json_schema = {
       type: 'object',
@@ -127,6 +197,8 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
       create_dynamic_annotation annotation_type: 'smooch', annotated: pm1
       assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
       a = pm1.annotations('transcription').last
+      expected_last_response = {"job_status"=>"COMPLETED", "transcription"=>"Foo bar"}
+      assert_equal expected_last_response, a.data["last_response"]
       assert_equal 'Foo bar', a.data['text']
     end
   end

--- a/test/models/bot_user_2_test.rb
+++ b/test/models/bot_user_2_test.rb
@@ -110,4 +110,9 @@ class BotUser2Test < ActiveSupport::TestCase
     b = create_team_bot team_author_id: t.id, set_approved: true, set_events: [{ event: 'create_project_media', graphql: nil }]
     BotUser.notify_bots('create_project_media', t.id, 'ProjectMedia', pm.id, b)
   end
+
+  test "should not ignore requests by default" do
+    b = create_team_bot
+    assert !b.should_ignore_request?
+  end
 end

--- a/test/models/fact_check_test.rb
+++ b/test/models/fact_check_test.rb
@@ -291,4 +291,18 @@ class FactCheckTest < ActiveSupport::TestCase
     end
     assert_not_empty fc.reload.title
   end
+
+  test "should create many fact-checks without signature" do
+    assert_difference 'FactCheck.count', 2 do
+      create_fact_check signature: nil
+      create_fact_check signature: nil
+    end
+  end
+
+  test "should not create fact-checks with the same signature" do
+    create_fact_check signature: 'test'
+    assert_raises ActiveRecord::RecordNotUnique do
+      create_fact_check signature: 'test'
+    end
+  end
 end

--- a/test/models/project_media_6_test.rb
+++ b/test/models/project_media_6_test.rb
@@ -401,4 +401,19 @@ class ProjectMedia6Test < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should not create duplicated fact-check when creating an item" do
+    u = create_user is_admin: true
+    t = create_team
+    params = { title: 'Foo', summary: 'Bar', url: random_url, language: 'en' }
+    with_current_user_and_team(u, t) do
+      assert_nothing_raised do
+        create_project_media set_fact_check: params, set_claim_description: 'Test', team: t
+        create_project_media set_fact_check: params, set_claim_description: 'Test'
+      end
+      assert_raises ActiveRecord::RecordNotUnique do
+        create_project_media set_fact_check: params, set_claim_description: 'Test', team: t
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

In some cases, audio transcription fails for known, unsolvable reasons. Namely, we know these to currently be (a) when an audio file is too short to contain audio, and (b) when a video file has no audio information attached. Currently, in check-api we keep trying again for any non-COMPLETED value response from the transcription controller. Instead, we should mark these cases as DONE to denote that they were not successfully COMPLETED, but also should not be re-enqueued.

References: CV2-3449, CV2-3448 (alegre work was completed in this ticket)

## How has this been tested?

Not directly tested yet - added automated test for what i expect to occur given this change

## Things to pay attention to during code review

The change in `alegre.rb` - I believe this is all that's needed to bypass triggering the job - @amoedoamorim would love to know what you think

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

