### PR TITLE
Ignore some events from WhatsApp Cloud API which are not relevant.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -23,7 +23,7 @@ checks:
       threshold: 4
   return-statements:
     config:
-      threshold: 4
+      threshold: 5
 plugins:
   fixme:
     enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -224,7 +224,7 @@ Metrics/CyclomaticComplexity:
                  A complexity metric that is strongly correlated to the number
                  of test cases needed to validate a method.
   Enabled: true
-  Max: 11
+  Max: 12
 
 Metrics/LineLength:
   Description: 'Limit lines to 80 characters.'

--- a/app/controllers/api/v1/webhooks_controller.rb
+++ b/app/controllers/api/v1/webhooks_controller.rb
@@ -13,6 +13,9 @@ module Api
           render_error('Bot not found', 'ID_NOT_FOUND', 404) and return
         end
         bot = bot_name_to_class[params[:name].to_sym]
+        if bot.should_ignore_request?(request)
+          render_success('ignored') and return
+        end
         unless bot.valid_request?(request)
           render_error('Invalid request', 'UNKNOWN') and return
         end

--- a/app/controllers/api/v1/webhooks_controller.rb
+++ b/app/controllers/api/v1/webhooks_controller.rb
@@ -13,7 +13,7 @@ module Api
           render_error('Bot not found', 'ID_NOT_FOUND', 404) and return
         end
         bot = bot_name_to_class[params[:name].to_sym]
-        if bot.should_ignore_request?(request)
+        if bot.respond_to?(:should_ignore_request?) && bot.should_ignore_request?(request)
           render_success('ignored') and return
         end
         unless bot.valid_request?(request)

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -255,6 +255,10 @@ class Bot::Smooch < BotUser
     self.valid_zendesk_request?(request) || self.valid_turnio_request?(request) || self.valid_capi_request?(request)
   end
 
+  def self.should_ignore_request?(request)
+    self.should_ignore_capi_request?(request)
+  end
+
   def self.config
     RequestStore.store[:smooch_bot_settings]
   end

--- a/app/models/bot_user.rb
+++ b/app/models/bot_user.rb
@@ -332,6 +332,10 @@ class BotUser < User
     begin Module.const_defined?("Bot::#{self.identifier.camelize}") rescue false end
   end
 
+  def should_ignore_request?
+    false
+  end
+
   protected
 
   def confirmation_required?

--- a/app/models/concerns/smooch_capi.rb
+++ b/app/models/concerns/smooch_capi.rb
@@ -4,6 +4,11 @@ module SmoochCapi
   extend ActiveSupport::Concern
 
   module ClassMethods
+    def should_ignore_capi_request?(request)
+      event = request.params.dig('entry', 0, 'changes', 0, 'value', 'statuses', 0, 'status').to_s
+      ['read', 'sent'].include?(event)
+    end
+
     def valid_capi_request?(request)
       valid = false
       if request.params['hub.mode'] == 'subscribe'

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -196,4 +196,40 @@ class WebhooksControllerTest < ActionController::TestCase
     assert_match /not found/, response.body
     assert_equal 13, JSON.parse(response.body)['errors'].first['code']
   end
+
+  test "should ignore some WhatsApp Cloud API requests" do
+    payload = {
+      object: 'whatsapp_business_account',
+      entry: [
+        {
+          id: '123456',
+          changes: [
+            {
+              value: {
+                messaging_product: 'whatsapp',
+                metadata: {
+                  display_phone_number: '123456',
+                  phone_number_id: '123456'
+                },
+                statuses: [
+                  {
+                    id: 'wamid.123456==',
+                    status: 'read',
+                    timestamp: '1689633253',
+                    recipient_id: "654321"
+                  }
+                ]
+              },
+              field: 'messages'
+            }
+          ]
+        }
+      ]
+    }
+
+    post :index, params: { name: :smooch }.merge(payload), body: payload
+
+    assert_equal '200', response.code
+    assert_match /ignored/, response.body
+  end
 end

--- a/test/models/bot_user_2_test.rb
+++ b/test/models/bot_user_2_test.rb
@@ -110,4 +110,9 @@ class BotUser2Test < ActiveSupport::TestCase
     b = create_team_bot team_author_id: t.id, set_approved: true, set_events: [{ event: 'create_project_media', graphql: nil }]
     BotUser.notify_bots('create_project_media', t.id, 'ProjectMedia', pm.id, b)
   end
+
+  test "should not ignore requests by default" do
+    b = create_team_bot
+    assert !b.should_ignore_request?
+  end
 end


### PR DESCRIPTION
## Description

First, allow core bots to ignore requests. By default, it's false, so no requests are ignored.

For WhatsApp Cloud API, ignore events of type "read" and "sent", since we just react to "delivered".

Reference: CV2-3453.

## How has this been tested?

I added a functional test for this case.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

