### PR TITLE
Adding "signature" to fact-checks.

### DIFF
--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -193,6 +193,7 @@ module ProjectMediaCreators
         language: fact_check['language'],
         url: fact_check['url'],
         publish_report: !!fact_check['publish_report'],
+        signature: Digest::MD5.hexdigest([self.set_fact_check.to_json, self.team_id].join(':')),
         claim_description: cd,
         skip_check_ability: true
       })

--- a/db/migrate/20230718012453_add_signature_to_fact_checks.rb
+++ b/db/migrate/20230718012453_add_signature_to_fact_checks.rb
@@ -1,0 +1,6 @@
+class AddSignatureToFactChecks < ActiveRecord::Migration[6.1]
+  def change
+    add_column :fact_checks, :signature, :string
+    add_index :fact_checks, :signature, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_11_211928) do
+ActiveRecord::Schema.define(version: 2023_07_18_012453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -296,8 +296,10 @@ ActiveRecord::Schema.define(version: 2023_07_11_211928) do
     t.string "language", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "signature"
     t.index ["claim_description_id"], name: "index_fact_checks_on_claim_description_id", unique: true
     t.index ["language"], name: "index_fact_checks_on_language"
+    t.index ["signature"], name: "index_fact_checks_on_signature", unique: true
     t.index ["user_id"], name: "index_fact_checks_on_user_id"
   end
 

--- a/test/models/fact_check_test.rb
+++ b/test/models/fact_check_test.rb
@@ -291,4 +291,18 @@ class FactCheckTest < ActiveSupport::TestCase
     end
     assert_not_empty fc.reload.title
   end
+
+  test "should create many fact-checks without signature" do
+    assert_difference 'FactCheck.count', 2 do
+      create_fact_check signature: nil
+      create_fact_check signature: nil
+    end
+  end
+
+  test "should not create fact-checks with the same signature" do
+    create_fact_check signature: 'test'
+    assert_raises ActiveRecord::RecordNotUnique do
+      create_fact_check signature: 'test'
+    end
+  end
 end

--- a/test/models/project_media_6_test.rb
+++ b/test/models/project_media_6_test.rb
@@ -401,4 +401,19 @@ class ProjectMedia6Test < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should not create duplicated fact-check when creating an item" do
+    u = create_user is_admin: true
+    t = create_team
+    params = { title: 'Foo', summary: 'Bar', url: random_url, language: 'en' }
+    with_current_user_and_team(u, t) do
+      assert_nothing_raised do
+        create_project_media set_fact_check: params, set_claim_description: 'Test', team: t
+        create_project_media set_fact_check: params, set_claim_description: 'Test'
+      end
+      assert_raises ActiveRecord::RecordNotUnique do
+        create_project_media set_fact_check: params, set_claim_description: 'Test', team: t
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

When a fact-check is created through the `ProjectMedia` `set_fact_check` setter, be sure to generate a unique signature based on the fact-check fields and current team. This is to avoid duplicated fact-checks created through the API.

Fixes CV2-3447.

## How has this been tested?

A bunch of automated tests were implemented for all cases I could think of.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

