### PR TITLE
Do not reply to banned tipline user.

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -268,6 +268,7 @@ class Bot::Smooch < BotUser
     begin
       json = self.preprocess_message(body)
       JSON::Validator.validate!(SMOOCH_PAYLOAD_JSON_SCHEMA, json)
+      return false if self.user_banned?(json)
       case json['trigger']
       when 'capi:verification'
         'capi:verification'
@@ -748,6 +749,11 @@ class Bot::Smooch < BotUser
       Rails.logger.info("[Smooch Bot] Banned user #{uid}")
       Rails.cache.write("smooch:banned:#{uid}", message.to_json)
     end
+  end
+
+  def self.user_banned?(payload)
+    uid = payload.dig('appUser', '_id')
+    !uid.blank? && !Rails.cache.read("smooch:banned:#{uid}").nil?
   end
 
   # Don't save as a ProjectMedia if it contains only menu options


### PR DESCRIPTION
## Description

If a tipline user is banned, do not even try to process their message.

Reference: CV2-3455.

## How has this been tested?

An automated test was implemented.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

