### PR TITLE
CV2-3449 stop running known failed transactions

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -377,6 +377,8 @@ class Bot::Alegre < BotUser
       annotation.skip_check_ability = true
       annotation.save!
       completed = true
+    elsif result['job_status'] == 'DONE'
+      completed = true
     end
     self.delay_for(10.seconds, retry: 5).update_audio_transcription(annotation.id, attempts + 1) if !completed && attempts < 2000 # Maximum: ~5h of transcription
   end

--- a/test/models/bot/alegre_3_test.rb
+++ b/test/models/bot/alegre_3_test.rb
@@ -61,6 +61,76 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
     end
   end
 
+  test "should bypass untranscribable audio" do
+    json_schema = {
+      type: 'object',
+      required: ['job_name'],
+      properties: {
+        text: { type: 'string' },
+        job_name: { type: 'string' },
+        last_response: { type: 'object' }
+      }
+    }
+    create_annotation_type_and_fields('Transcription', {}, json_schema)
+    create_annotation_type_and_fields('Smooch', { 'Data' => ['JSON', true] })
+    Bot::Alegre.unstub(:request_api)
+    tbi = Bot::Alegre.get_alegre_tbi(@team.id)
+    tbi.set_transcription_similarity_enabled = false
+    tbi.save!
+    WebMock.stub_request(:post, 'http://alegre/text/langid/').to_return(body: { 'result' => { 'language' => 'es' }}.to_json)
+    stub_configs({ 'alegre_host' => 'http://alegre', 'alegre_token' => 'test' }) do
+      WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
+      WebMock.stub_request(:post, 'http://alegre/text/similarity/').to_return(body: 'success')
+      WebMock.stub_request(:delete, 'http://alegre/text/similarity/').to_return(body: {success: true}.to_json)
+      WebMock.stub_request(:get, 'http://alegre/text/similarity/').to_return(body: {success: true}.to_json)
+      WebMock.stub_request(:post, 'http://alegre/audio/similarity/').to_return(body: {
+        "success": true
+      }.to_json)
+      WebMock.stub_request(:get, 'http://alegre/audio/similarity/').to_return(body: {
+        "result": []
+      }.to_json)
+
+      media_file_url = 'https://example.com/test/data/rails.mp3'
+      s3_file_url = "s3://check-api-test/test/data/rails.mp3"
+      WebMock.stub_request(:get, media_file_url).to_return(body: File.new(File.join(Rails.root, 'test', 'data', 'rails.mp3')))
+      Bot::Alegre.stubs(:media_file_url).returns(media_file_url)
+
+      pm1 = create_project_media team: @pm.team, media: create_uploaded_audio(file: 'rails.mp3')
+      WebMock.stub_request(:post, 'http://alegre/audio/transcription/').with({
+        body: { url: s3_file_url, job_name: '0c481e87f2774b1bd41a0a70d9b70d11' }.to_json
+      }).to_return(body: { 'job_status' => 'IN_PROGRESS' }.to_json)
+      WebMock.stub_request(:get, 'http://alegre/audio/transcription/').with(
+        body: { job_name: '0c481e87f2774b1bd41a0a70d9b70d11' }
+      ).to_return(body: { 'job_status' => 'DONE' }.to_json)
+      # Verify with transcription_similarity_enabled = false
+      assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
+      a = pm1.annotations('transcription').last
+      assert_nil a
+      # Verify with transcription_similarity_enabled = true and duration less than transcription_maximum_duration
+      tbi.set_transcription_similarity_enabled = true
+      tbi.set_transcription_minimum_duration = 7
+      tbi.set_transcription_maximum_duration = 10
+      tbi.set_transcription_minimum_requests = 2
+      tbi.save!
+      assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
+      a = pm1.annotations('transcription').last
+      assert_nil a
+      # Verify that requests count less than transcription_minimum_requests
+      tbi.set_transcription_maximum_duration = 30
+      tbi.save!
+      assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
+      a = pm1.annotations('transcription').last
+      assert_nil a
+      # Audio item match all required conditions by verify transcription_minimum_requests count
+      RequestStore.store[:skip_cached_field_update] = false
+      create_dynamic_annotation annotation_type: 'smooch', annotated: pm1
+      create_dynamic_annotation annotation_type: 'smooch', annotated: pm1
+      assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
+      a = pm1.annotations('transcription').last
+      assert_equal "", a.data['text']
+    end
+  end
+
   test "should auto transcribe audio" do
     json_schema = {
       type: 'object',
@@ -127,6 +197,8 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
       create_dynamic_annotation annotation_type: 'smooch', annotated: pm1
       assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
       a = pm1.annotations('transcription').last
+      expected_last_response = {"job_status"=>"COMPLETED", "transcription"=>"Foo bar"}
+      assert_equal expected_last_response, a.data["last_response"]
       assert_equal 'Foo bar', a.data['text']
     end
   end


### PR DESCRIPTION
## Description

In some cases, audio transcription fails for known, unsolvable reasons. Namely, we know these to currently be (a) when an audio file is too short to contain audio, and (b) when a video file has no audio information attached. Currently, in check-api we keep trying again for any non-COMPLETED value response from the transcription controller. Instead, we should mark these cases as DONE to denote that they were not successfully COMPLETED, but also should not be re-enqueued.

References: CV2-3449, CV2-3448 (alegre work was completed in this ticket)

## How has this been tested?

Not directly tested yet - added automated test for what i expect to occur given this change

## Things to pay attention to during code review

The change in `alegre.rb` - I believe this is all that's needed to bypass triggering the job - @amoedoamorim would love to know what you think

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)
