### PR TITLE
Fallback to Smooch API when can't get phone number from local database

### DIFF
--- a/lib/tasks/migrate/20230608215010_migrate_tipline_subscriptions.rake
+++ b/lib/tasks/migrate/20230608215010_migrate_tipline_subscriptions.rake
@@ -14,12 +14,35 @@ namespace :check do
       i = 0
       errors = 0
       migrated = 0
+      skipped = 0
+      already_migrated = 0
       TiplineSubscription.where(team: team).find_each do |subscription|
         i += 1
         begin
           old_uid = subscription.uid
-          user_data = JSON.parse(DynamicAnnotation::Field.where(field_name: 'smooch_user_id', value: old_uid).last.annotation.load.get_field_value('smooch_user_data'))
-          user_phone = user_data.dig('raw', 'clients', 0, 'externalId').gsub(/[^0-9]/, '')
+          if subscription.uid =~ /#{tipline_phone}:/
+            puts "[#{Time.now}] [#{i}/#{n}] Already migrated subscription with ID #{subscription.id}"
+            already_migrated += 1
+            next
+          end
+          if subscription.platform != 'WhatsApp'
+            puts "[#{Time.now}] [#{i}/#{n}] Skipped subscription with ID #{subscription.id} because it's not WhatsApp (it's #{subscription.platform})"
+            skipped += 1
+            next
+          end
+          user_data = nil
+          user_phone = nil
+          # Try to find a phone number from our database
+          begin
+            user_data = JSON.parse(DynamicAnnotation::Field.where(field_name: 'smooch_user_id', value: old_uid).last.annotation.load.get_field_value('smooch_user_data'))
+            user_phone = user_data.dig('raw', 'clients', 0, 'externalId').gsub(/[^0-9]/, '')
+          # If not found, try to get it from Smooch API
+          rescue
+            tbi = TeamBotInstallation.where(team_id: subscription.team_id, user_id: BotUser.smooch_user.id).last
+            Bot::Smooch.get_installation { |i| i.id == tbi.id }
+            user_data = Bot::Smooch.zendesk_api_get_user_data(old_uid)
+            user_phone = user_data.dig('clients', 0, 'externalId').gsub(/[^0-9]/, '')
+          end
           new_uid = "#{tipline_phone}:#{user_phone}"
           subscription.uid = new_uid
           subscription.save!
@@ -31,7 +54,7 @@ namespace :check do
         end
       end
       finish = Time.now.to_i
-      puts "Done in #{finish - start} seconds. Migrated: #{migrated}. Errors: #{errors}"
+      puts "Done in #{finish - start} seconds. Migrated: #{migrated}. Already migrated: #{already_migrated}. Errors: #{errors}. Skipped: #{skipped}."
     end
   end
 end


### PR DESCRIPTION
## Description

Fallback to Smooch API when can't get phone number from local database when migrating from Smooch to CAPI.

Also:

* Skip subscriptions that were already migrated
* Skip subscriptions that are not from WhatsApp

Reference: CV2-3400.

## How has this been tested?

I executed the rake task manually locally, where I have a Smooch tipline.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

