### PR TITLE
CV2-3476 test for nil input to get_number_of_words

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -194,12 +194,12 @@ class Bot::Alegre < BotUser
 
   def self.get_number_of_words(text)
     # Get the number of space-separated words (Does not work with Chinese/Japanese)
-    space_separted_words = text.nil? ? 0 : text.gsub(/[^\p{L}\s]/u, '').strip.chomp.split(/\s+/).size
+    space_separted_words = text.to_s.gsub(/[^\p{L}\s]/u, '').strip.chomp.split(/\s+/).size
 
     # This removes URLs
     # Then it splits the text on any non unicode word boundary (works with Chinese, Japanese)
     # We then clean each word and remove any empty ones
-    unicode_words = text.gsub(/https?:\/\/\S+/u, '').scan(/(?u)\w+/).map{|w| w.gsub(/[^\p{L}\s]/u, '').strip.chomp}.reject{|w| w.length==0}
+    unicode_words = text.to_s.gsub(/https?:\/\/\S+/u, '').scan(/(?u)\w+/).map{|w| w.gsub(/[^\p{L}\s]/u, '').strip.chomp}.reject{|w| w.length==0}
     # For each word, we:
     # Get the number of Chinese characters. We'll assume two characters are like one word
     # Get the number of Japanese hiragana/katakana (kana) characters.

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -539,6 +539,8 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
     # All together - 10 words as below
     # '韓国語で'=>3, 'おいしい'=>1, 'は'=>1, '맛있는'=>1, 'です'=>1, 'Test'=>1, 'string'=>1
     assert_equal 9, Bot::Alegre.get_number_of_words('韓国語で「おいしい」は「맛있는」です。Test string!😊')
+    # Test for nil string
+    assert_equal 0, Bot::Alegre.get_number_of_words(nil)
   end
 
   test "should be able to request deletion from index for a media given specific field" do


### PR DESCRIPTION
## Description

We started using `get_number_of_words` in a new location and do not properly handle `nil` input that is possible there:
https://github.com/meedan/check-api/pull/1561/files#r1268906901

I've added a unit test to test for `nil` input to the function and fixed the function to return zero words for nil input. 

References: CV2-3476

## How has this been tested?

Implemented new unit test and verified the test failed. Then fixed the issue and verified the new test passed. 

## Things to pay attention to during code review

Who knew that `.to_s` was defined for the `nil` class in Ruby?!  Thanks for the pointer, @caiosba 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I have commented my code in hard-to-understand areas, if any
- [x] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

