### PR TITLE
A couple of small fixes for newsletters delivery.

### DIFF
--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -46,7 +46,7 @@ class TiplineNewsletterWorker
 
         if response.code.to_i < 400
           log team_id, language, "Newsletter sent to subscriber ##{ts.id}, response: (#{response.code}) #{response.body.inspect}"
-          Bot::Smooch.save_smooch_response(response, nil, Time.now.to_i, 'newsletter', language, {}, 7.days)
+          Bot::Smooch.save_smooch_response(response, nil, Time.now.to_i, 'newsletter', language, {}, 1.month)
           count += 1
         else
           log team_id, language, "Could not send newsletter to subscriber ##{ts.id}: (#{response.code}) #{response.body.inspect}"

--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -35,6 +35,7 @@ class TiplineNewsletterWorker
     count = 0
     log team_id, language, 'Preparing newsletter to be sent...'
     start = Time.now
+    total = 0
     TiplineSubscription.where(language: language, team_id: team_id).find_each do |ts|
       log team_id, language, "Sending newsletter to subscriber ##{ts.id}..."
       begin
@@ -45,7 +46,7 @@ class TiplineNewsletterWorker
 
         if response.code.to_i < 400
           log team_id, language, "Newsletter sent to subscriber ##{ts.id}, response: (#{response.code}) #{response.body.inspect}"
-          Bot::Smooch.save_smooch_response(response, nil, Time.now.to_i, 'newsletter', language, {}, 24.hours)
+          Bot::Smooch.save_smooch_response(response, nil, Time.now.to_i, 'newsletter', language, {}, 7.days)
           count += 1
         else
           log team_id, language, "Could not send newsletter to subscriber ##{ts.id}: (#{response.code}) #{response.body.inspect}"
@@ -53,6 +54,7 @@ class TiplineNewsletterWorker
       rescue StandardError => e
         log team_id, language, "Could not send newsletter to subscriber ##{ts.id} (exception): #{e.message}"
       end
+      total += 1
     end
     finish = Time.now
 
@@ -62,7 +64,7 @@ class TiplineNewsletterWorker
     # Save the last time this newsletter was sent
     newsletter.update_column(:last_sent_at, Time.now)
 
-    log team_id, language, "Newsletter sent to #{count} subscribers"
+    log team_id, language, "All newsletters sent to #{count} subscribers, from a total of #{total}"
 
     # Static newsletter is paused after sent
     newsletter.update_column(:enabled, false) if newsletter.content_type == 'static'


### PR DESCRIPTION
## Description

(1) Log total number of subscribers, not only the ones messaged successfully... this is just to make debugging easier.

(2) Cache delivery information for 7 days instead of 24 hours... this means that if the subscriber receives the newsletter 7 days after the delivery, we will know.

## How has this been tested?

Just tested manually. But existing automated tests should cover.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

