### PR TITLE
Should shorten URLs in newsletter introduction only if the workspace setting on

### DIFF
--- a/app/models/tipline_newsletter.rb
+++ b/app/models/tipline_newsletter.rb
@@ -164,7 +164,7 @@ class TiplineNewsletter < ApplicationRecord
       file_url = self.header_media_url
       file_type = HEADER_TYPE_MAPPING[self.header_type]
     end
-    introduction = UrlRewriter.shorten_and_utmize_urls(self.introduction, self.team.get_outgoing_urls_utm_code, self)
+    introduction = self.team.get_shorten_outgoing_urls ? UrlRewriter.shorten_and_utmize_urls(self.introduction, self.team.get_outgoing_urls_utm_code, self) : self.introduction
     params = [date, introduction, self.articles].flatten.reject{ |param| param.blank? }
     preview_url = (self.header_type == 'link_preview')
     Bot::Smooch.format_template_message(self.whatsapp_template_name, params, file_url, self.build_content, self.language, file_type, preview_url)

--- a/test/models/concerns/smooch_capi_test.rb
+++ b/test/models/concerns/smooch_capi_test.rb
@@ -214,4 +214,8 @@ class SmoochCapiTest < ActiveSupport::TestCase
     request = OpenStruct.new(params: { 'token' => '654321', 'entry' => [{ 'id' => '654321' }] })
     assert !Bot::Smooch.valid_capi_request?(request)
   end
+
+  test 'should return empty string if Cloud API payload is not supported' do
+    assert_equal '', Bot::Smooch.get_capi_message_text(nil)
+  end
 end


### PR DESCRIPTION
## Description

Should shorten URLs in newsletter introduction only if the workspace setting on.

Fixes CV2-3502.

## How has this been tested?

![Captura de tela de 2023-07-21 17-47-50](https://github.com/meedan/check-api/assets/117518/a97e977e-9797-4c29-8477-5e792c9bc962)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

