### PR TITLE
The "body" of a response of an API call to Smooch with an empty message should be an object, not a string

### DIFF
--- a/app/models/concerns/smooch_zendesk.rb
+++ b/app/models/concerns/smooch_zendesk.rb
@@ -69,7 +69,7 @@ module SmoochZendesk
           }
         })
       end
-      return OpenStruct.new(body: 'Empty message', code: 400) if params['type'] == 'text' && params['text'].blank?
+      return OpenStruct.new(body: OpenStruct.new({ error: 'Empty message' }), code: 400) if params['type'] == 'text' && params['text'].blank?
       message_post_body = SmoochApi::MessagePost.new(params)
       response_body = nil
       response_code = 0

--- a/test/models/concerns/smooch_zendesk_test.rb
+++ b/test/models/concerns/smooch_zendesk_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative '../../test_helper'
 
 class FakeSmoochZendesk
   include SmoochZendesk
@@ -27,5 +27,10 @@ class SmoochZendeskTest < ActiveSupport::TestCase
     CheckSentry.expects(:notify).with(mock_error, has_entries(smooch_app_id: 'app-id', uid: 'phone-12345:123456', smooch_body: anything, errors: errors))
 
     FakeSmoochZendesk.zendesk_send_message_to_user('phone-12345:123456', 'fake text')
+  end
+
+  test "should return nil when it tries to get the ID of a message that was not sent because was blank" do
+    response = FakeSmoochZendesk.zendesk_send_message_to_user('abc123', '')
+    assert_nil Bot::Smooch.get_id_from_send_response(response)
   end
 end


### PR DESCRIPTION
## Description

In the method used to send a message to a tipline user on Smooch we return a custom object when the message is blank, since it's not valid. But that message must follow the same format as a response from Smooch API. So, the `body` must return an object, not a string.

Reproduced in a unit test, included in this PR, which passed after the fix.

Fixes: CV2-3516.

## How has this been tested?

TDD. I included a unit test.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

