### PR TITLE
CV2-3454: add rake task to migrate existing data

### DIFF
--- a/lib/tasks/migrate/20230725053637_add_unmatched_to_project_medias.rake
+++ b/lib/tasks/migrate/20230725053637_add_unmatched_to_project_medias.rake
@@ -4,11 +4,12 @@ namespace :check do
       started = Time.now.to_i
       last_team_id = Rails.cache.read('check:migrate:add_unmatched_to_project_media:team_id') || 0
       Team.where('id > ?', last_team_id).find_each do |team|
+        print '.'
         # Get rejected and detach items from version table
         Version.from_partition(team.id).where(event_type: 'destroy_relationship')
         .where("object LIKE '%confirmed_sibling%confirmed_sibling%' OR object LIKE '%suggested_sibling%suggested_sibling%'")
         .find_in_batches(:batch_size => 1000) do |versions|
-          pm_ids = versions.map(&:associated_id).uniq
+          pm_ids = versions.map(&:associated_id).uniq.compact
           # Get re-matched items (suggested or confirmed)
           target_ids = Relationship.where(target_id: pm_ids)
           .where('relationship_type = ? OR relationship_type = ?', Relationship.suggested_type.to_yaml, Relationship.confirmed_type.to_yaml)
@@ -16,6 +17,7 @@ namespace :check do
           # remove re-matched items to get the right list
           unmatched_ids = pm_ids - target_ids
           unless unmatched_ids.blank?
+            print '.'
             # Update PG
             ProjectMedia.where(id: unmatched_ids).update_all(unmatched: 1)
             # Update ES

--- a/lib/tasks/migrate/20230725053637_add_unmatched_to_project_medias.rake
+++ b/lib/tasks/migrate/20230725053637_add_unmatched_to_project_medias.rake
@@ -1,0 +1,34 @@
+namespace :check do
+  namespace :migrate do
+    task add_unmatched_to_project_media: :environment do
+      started = Time.now.to_i
+      last_team_id = Rails.cache.read('check:migrate:add_unmatched_to_project_media:team_id') || 0
+      Team.where('id > ?', last_team_id).find_each do |team|
+        Version.from_partition(team.id).where(event_type: 'destroy_relationship')
+        .where("object LIKE '%confirmed_sibling%confirmed_sibling%'")
+        .find_in_batches(:batch_size => 2500) do |versions|
+          pm_ids = versions.map(&:associated_id).uniq
+          target_ids = Relationship.where(target_id: pm_ids).where('relationship_type = ?', Relationship.confirmed_type.to_yaml).map(&:target_id)
+          unmatched_ids = pm_ids - target_ids
+          unless unmatched_ids.blank?
+            # Update PG
+            ProjectMedia.where(id: unmatched_ids).update_all(unmatched: 1)
+            # Update ES
+            options = {
+              index: CheckElasticSearchModel.get_index_alias,
+              conflicts: 'proceed',
+              body: {
+                script: { source: "ctx._source.unmatched = params.unmatched", params: { unmatched: 1 } },
+                query: { terms: { annotated_id: unmatched_ids } }
+              }
+            }
+            $repository.client.update_by_query options
+          end
+        end
+        Rails.cache.write('check:migrate:add_unmatched_to_project_media:team_id', team.id)
+      end
+      minutes = ((Time.now.to_i - started) / 60).to_i
+      puts "[#{Time.now}] Done in #{minutes} minutes."
+    end
+  end
+end


### PR DESCRIPTION
## Description

Add a rake task to migrate existing data to `unmatched` field.

1. Got detach items from versions table
2. Got re-matched items in step 1 and exclude them from final ids
3. Update final ids using PG & ES queries  

References: CV2-3454

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

