### PR TITLE
Test should not make a real HTTP request

### DIFF
--- a/test/lib/lapis_webhook_test.rb
+++ b/test/lib/lapis_webhook_test.rb
@@ -3,7 +3,9 @@ require_relative '../../lib/lapis_webhook'
 
 class LapisWebhookTest < ActiveSupport::TestCase
   def setup
-    @lw = Lapis::Webhook.new('https://ca.ios.ba/', { foo: 'bar' }.to_json)
+    url = URI.join(random_url, '/webhook/')
+    WebMock.stub_request(:post, url).to_return(status: 200)
+    @lw = Lapis::Webhook.new(url, { foo: 'bar' }.to_json)
     super
   end
 


### PR DESCRIPTION
## Description

A unit test should not make a real HTTP request. So this PR replaces a real HTTP request by a mocked call.

## How has this been tested?

The commit itself is a test!

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

