### PR TITLE
CV2-3536: set recent_added as default sort in all cases

### DIFF
--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -10,8 +10,7 @@ class CheckSearch
     @options['operator'] ||= 'AND' # AND or OR
 
     # Set sort options
-    smooch_bot_installed = TeamBotInstallation.where(team_id: @options['team_id'], user_id: BotUser.smooch_user&.id).exists?
-    @options['sort'] ||= (smooch_bot_installed ? 'last_seen' : 'recent_added')
+    @options['sort'] ||= 'recent_added'
     @options['sort_type'] ||= 'desc'
 
     # Set show options

--- a/test/controllers/graphql_controller_2_test.rb
+++ b/test/controllers/graphql_controller_2_test.rb
@@ -155,7 +155,7 @@ class GraphqlController2Test < ActionController::TestCase
     post :create, params: { query: query, team: t.slug }
     assert_response :success
 
-    assert_queries(9, '=') do
+    assert_queries(7, '=') do
       query = 'query CheckSearch { search(query: "{}") { medias(first: 5) { edges { node { list_columns_values } } } } }'
       post :create, params: { query: query, team: t.slug }
       assert_response :success


### PR DESCRIPTION
## Description

Set `recent_added` as a default search in all cases.

References: CV2-3536

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

