### PR TITLE
Make sure that a default folder (project) can't be deleted.

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -24,8 +24,8 @@ class Project < ApplicationRecord
 
   before_validation :set_description_and_team_and_user, on: :create
   before_validation :generate_token, on: :create
-  before_destroy :ensure_its_not_default, prepend: true do
-    throw(:abort) if errors.present?
+  before_destroy :ensure_its_not_default, prepend: true do |p|
+    throw(:abort) if errors.present? && !p.is_being_copied
   end
 
   after_commit :send_slack_notification, on: [:create, :update]

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -24,6 +24,9 @@ class Project < ApplicationRecord
 
   before_validation :set_description_and_team_and_user, on: :create
   before_validation :generate_token, on: :create
+  before_destroy :ensure_its_not_default, prepend: true do
+    throw(:abort) if errors.present?
+  end
 
   after_commit :send_slack_notification, on: [:create, :update]
   after_update :update_elasticsearch_data, if: proc { |p| p.saved_change_to_team_id? }
@@ -325,5 +328,9 @@ class Project < ApplicationRecord
       default_folder = self.team.default_folder
       errors.add(:base, I18n.t(:unique_default_folder_per_team)) if self.id == default_folder.id
     end
+  end
+
+  def ensure_its_not_default
+    errors.add(:base, I18n.t(:cant_delete_default_folder)) if self.is_default?
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -804,6 +804,7 @@ en:
     To stop receiving this newsletter, type "%{unsubscribe}".
   send_every_must_be_a_list_of_days_of_the_week: must be a list of days of the week.
   send_on_must_be_in_the_future: can't be in the past.
+  cant_delete_default_folder: The default folder can't be deleted
   info:
     messages:
       sent_to_trash_by_rule: '"%{item_title}" has been sent to trash by an automation

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -442,6 +442,7 @@ module SampleData
     project.title = options[:title] || random_string
     project.description = options[:description] || random_string(40)
     project.user = options.has_key?(:user) ? options[:user] : create_user
+    project.is_default = options[:is_default] if options.has_key?(:is_default)
     file = 'rails.png'
     if options.has_key?(:lead_image)
       file = options[:lead_image]

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -627,12 +627,8 @@ class ProjectTest < ActiveSupport::TestCase
     p.save!
     assert_equal 1, t.projects.where(is_default: true).count
     default_folder = t.default_folder
-    u = create_user
-    tu = create_team_user team: t, user: u, role: 'admin'
-    with_current_user_and_team(u, t) do
-      assert_raise RuntimeError do
-        default_folder.destroy
-      end
+    assert_raises ActiveRecord::RecordNotDestroyed do
+      default_folder.destroy!
     end
   end
 

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -667,4 +667,21 @@ class ProjectTest < ActiveSupport::TestCase
     end
     RequestStore.store[:skip_cached_field_update] = true
   end
+
+  test "should not delete default folder" do
+    t = create_team
+    t.projects.delete_all
+    p = create_project is_default: false, team: t
+    assert_difference 'Project.count', -1 do
+      assert_nothing_raised do
+        p.destroy!
+      end
+    end
+    p = create_project is_default: true, team: t
+    assert_no_difference 'Project.count' do
+      assert_raises ActiveRecord::RecordNotDestroyed do
+        p.destroy!
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

Adding a validation to be sure that a default folder/project can't be deleted.

Fixes CV2-3554.

## How has this been tested?

I added a unit test for this case.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

