### PR TITLE
CV2-3287: add rake task to migrate folders to list

### DIFF
--- a/lib/tasks/migrate/20230727094535_remove_add_item_slack_notification.rake
+++ b/lib/tasks/migrate/20230727094535_remove_add_item_slack_notification.rake
@@ -2,7 +2,7 @@ namespace :check do
   namespace :migrate do
     task remove_item_add_from_slack_notification: :environment do
       started = Time.now.to_i
-      last_team_id = 0 #Rails.cache.read('check:migrate:remove_item_add_from_slack_notification:team_id') || 0
+      last_team_id = Rails.cache.read('check:migrate:remove_item_add_from_slack_notification:team_id') || 0
       Team.where('id > ?', last_team_id).find_each do |team|
         print '.'
         slack_notifications = team.get_slack_notifications

--- a/lib/tasks/migrate/20230730055732_migrate_from_folders_to_lists.rake
+++ b/lib/tasks/migrate/20230730055732_migrate_from_folders_to_lists.rake
@@ -1,0 +1,75 @@
+namespace :check do
+  namespace :migrate do
+    # Migrate folder to list against all teams or specific one
+    # All teams: bundle exec rails check:migrate:migrate_from_folders_to_lists
+    # Specific team: bundle exec rails check:migrate:migrate_from_folders_to_lists['team_slug1,team_slug2,...']
+    task migrate_from_folders_to_lists: :environment do |_t, args|
+      started = Time.now.to_i
+      index_alias = CheckElasticSearchModel.get_index_alias
+      client = $repository.client
+      slugs = args.extras
+      condition = {}
+      if slugs.blank?
+        last_team_id = Rails.cache.read('check:migrate:migrate_from_folders_to_lists:team_id') || 0
+      else
+        last_team_id = 0
+        condition = { slug: slugs }
+      end
+      errors = []
+      Team.where(condition).where('id > ?', last_team_id).find_each do |team|
+        team_tags = team.tag_texts.map{ |tag| [tag.id.to_s, tag.text] }.to_h
+        team.projects.where(is_default: false).find_each do |project|
+          puts "Processing folder [#{team.slug} => #{project.title}(#{project.id})]\n"
+          tag_name = project.project_group_id.nil? ? project.title.strip : "(#{project.project_group.title.strip})(#{project.title.strip})"
+          # Create TagText if not exists
+          tag_text = TagText.where(text: tag_name, team_id: team.id).last
+          if tag_text.nil?
+            tag_text = TagText.new
+            tag_text.text = tag_name
+            tag_text.team_id = team.id
+            tag_text.save!
+            # Add new tag to team_tags array
+            team_tags[tag_text.id.to_s] = tag_text.text
+          end
+          project.project_medias.find_in_batches(:batch_size => 1000) do |pms|
+            print '.'
+            ids = pms.map(&:id)
+            # Tag existing items
+            inserts = []
+            ids.each {|pm_id| inserts << { annotated_type: 'ProjectMedia', annotated_id: pm_id, annotation_type: 'tag', data: { tag: tag_text.id } }.with_indifferent_access }
+            # Bulk-insert tags
+            result = Annotation.import inserts, validate: false, recursive: false, timestamps: true unless inserts.blank?
+            # delete cache to enforce creation on first hit
+            ids.each{ |pm_id| Rails.cache.delete("check_cached_field:ProjectMedia:#{pm_id.to_i}:tags_as_sentence") }
+            # Update ES
+            # Collect tags for each ProjectMedia item
+            pm_tags = Hash.new {|hash, key| hash[key] = [] }
+            Annotation.where(annotation_type: 'tag', annotated_type: 'ProjectMedia', annotated_id: ids).find_each do |tag|
+              pm_tags[tag.annotated_id] << { id: tag.id, tag: team_tags[tag.data["tag"].to_s] }
+            end
+            es_body = []
+            pm_tags.each do |pm_id, tags|
+              print '.'
+              doc_id = Base64.encode64("ProjectMedia/#{pm_id}")
+              fields = { 'tags' => tags }
+              es_body << { update: { _index: index_alias, _id: doc_id, retry_on_conflict: 3, data: { doc: fields } } }
+            end
+            client.bulk body: es_body unless es_body.blank?
+          end
+          # Update tags count
+          tag_text.update_column(:tags_count, tag_text.calculate_tags_count)
+          # Create a list with tag filter
+          ss = SavedSearch.new
+          ss.team = team
+          ss.title = project.title
+          ss.filters = { tags: [tag_name] }
+          begin ss.save! rescue errors << tag_name end
+        end
+        Rails.cache.write('check:migrate:migrate_from_folders_to_lists:team_id', team.id)
+      end
+      puts "Failed to create a list with tags: #{errors.inspect}" unless errors.blank?
+      minutes = ((Time.now.to_i - started) / 60).to_i
+      puts "[#{Time.now}] Done in #{minutes} minutes."
+    end
+  end
+end

--- a/lib/tasks/migrate/20230730055732_migrate_from_folders_to_lists.rake
+++ b/lib/tasks/migrate/20230730055732_migrate_from_folders_to_lists.rake
@@ -1,5 +1,23 @@
 namespace :check do
   namespace :migrate do
+    task fix_tags_with_invalid_data: :environment do
+      started = Time.now.to_i
+      Annotation.where(annotation_type: "tag", annotated_type: "ProjectMedia")
+      .find_in_batches(:batch_size => 1000) do |tags|
+        print '.'
+        tags.each do |tag|
+          tag_text = tag.data['tag']
+          if tag_text.class.name == 'TagText'
+            print '.'
+            data = { tag: tag_text.id }.with_indifferent_access
+            tag.update_columns(data: data)
+          end
+        end
+      end
+      minutes = ((Time.now.to_i - started) / 60).to_i
+      puts "[#{Time.now}] Done in #{minutes} minutes."
+    end
+
     # Migrate folder to list against all teams or specific one
     # All teams: bundle exec rails check:migrate:migrate_from_folders_to_lists
     # Specific team: bundle exec rails check:migrate:migrate_from_folders_to_lists['team_slug1,team_slug2,...']
@@ -20,7 +38,9 @@ namespace :check do
         team_tags = team.tag_texts.map{ |tag| [tag.id.to_s, tag.text] }.to_h
         team.projects.where(is_default: false).find_each do |project|
           puts "Processing folder [#{team.slug} => #{project.title}(#{project.id})]\n"
-          tag_name = project.project_group_id.nil? ? project.title.strip : "(#{project.project_group.title.strip})(#{project.title.strip})"
+          # Copy normalize_tag from TagText
+          p_title = project.title.strip.gsub(/^#/, '')
+          tag_name = project.project_group_id.nil? ? p_title : "(#{project.project_group.title.strip})(#{p_title})"
           # Create TagText if not exists
           tag_text = TagText.where(text: tag_name, team_id: team.id).last
           if tag_text.nil?
@@ -50,8 +70,11 @@ namespace :check do
             es_body = []
             pm_tags.each do |pm_id, tags|
               print '.'
+              # Set tags_as_sentence cached field
+              tags_as_sentence = tags.collect{|item| item[:tag]}.uniq.join(', ')
+              Rails.cache.write("check_cached_field:ProjectMedia:#{pm_id.to_i}:tags_as_sentence", tags_as_sentence)
               doc_id = Base64.encode64("ProjectMedia/#{pm_id}")
-              fields = { 'tags' => tags }
+              fields = { 'tags' => tags, 'tags_as_sentence' => tags_as_sentence.size }
               es_body << { update: { _index: index_alias, _id: doc_id, retry_on_conflict: 3, data: { doc: fields } } }
             end
             client.bulk body: es_body unless es_body.blank?


### PR DESCRIPTION
## Description

Rake task to migrate folders to list through the following steps:

1. Create a workspace tag with the {title} of the original folder.
2. Tag items related to project with tag in step 1 using bulk import
3. Delete cached field `tags_as_sentence` to enforce creation on first hit
4. Update ES with new item tags using bulk operation
5. Update tags count related to created tag in step 1
6. Create a list with the {title} of the original folder and set the filter of the list to ‘tag is {title}’

References: TICKET-ID, TICKET-ID, …

## How has this been tested?

After run the migration go to a workspace and check that each folder has a list with same name and tags filter.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

