### PR TITLE
CV2-3556: fix the way we store tag data in PG

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -735,11 +735,10 @@ class Bot::Smooch < BotUser
   def self.add_hashtags(text, pm)
     hashtags = Twitter::TwitterText::Extractor.extract_hashtags(text)
     return nil if hashtags.blank?
-
     # Only add team tags.
     TagText.where("team_id = ? AND text IN (?)", pm.team_id, hashtags).each do |tag|
       unless pm.annotations('tag').map(&:tag_text).include?(tag.text)
-        Tag.create!(tag: tag, annotator: pm.user, annotated: pm)
+        Tag.create!(tag: tag.id, annotator: pm.user, annotated: pm)
       end
     end
   end

--- a/test/models/bot/smooch_test.rb
+++ b/test/models/bot/smooch_test.rb
@@ -204,8 +204,8 @@ class Bot::SmoochTest < ActiveSupport::TestCase
       }
     ]
 
-    create_tag_text text: 'teamtag', team_id: @team.id
-    create_tag_text text: 'montag', team_id: @team.id
+    tt_teamtag = create_tag_text text: 'teamtag', team_id: @team.id
+    tt_montag = create_tag_text text: 'montag', team_id: @team.id
 
     assert_difference 'ProjectMedia.count', 7 do
       assert_difference 'Annotation.where(annotation_type: "smooch").count', 22 do
@@ -254,7 +254,8 @@ class Bot::SmoochTest < ActiveSupport::TestCase
 
     pms = ProjectMedia.order("id desc").limit(5).reverse
     assert_equal 1, pms[4].annotations.where(annotation_type: 'tag').count
-    assert_equal 'teamtag', pms[4].annotations.where(annotation_type: 'tag').last.load.data[:tag].text
+    data = pms[4].annotations.where(annotation_type: 'tag').last.load.data
+    assert_equal [{'tag' => tt_teamtag.id}], [data]
     assert_equal 2, pms[3].annotations.where(annotation_type: 'tag').count
   end
 


### PR DESCRIPTION
## Description

Fix the way we store tag data in PG by storing the TagText id only instead of the object

References: CV2-3556

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

