### PR TITLE
Do not crash when sending report if tipline `send_message_to_user` returns `null`.

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -917,16 +917,16 @@ class Bot::Smooch < BotUser
       if report.report_design_field_value('use_introduction')
         introduction = report.report_design_introduction(data, lang)
         smooch_intro_response = self.send_message_to_user(uid, introduction)
-        Rails.logger.info "[Smooch Bot] Sent report introduction to user #{uid} for item with ID #{pm.id}, response was: #{smooch_intro_response.body}"
+        Rails.logger.info "[Smooch Bot] Sent report introduction to user #{uid} for item with ID #{pm.id}, response was: #{smooch_intro_response&.body}"
         sleep 1
       end
       if report.report_design_field_value('use_text_message')
         workflow = self.get_workflow(lang)
         last_smooch_response = self.send_final_messages_to_user(uid, report.report_design_text(lang), workflow, lang)
-        Rails.logger.info "[Smooch Bot] Sent text report to user #{uid} for item with ID #{pm.id}, response was: #{last_smooch_response.body}"
+        Rails.logger.info "[Smooch Bot] Sent text report to user #{uid} for item with ID #{pm.id}, response was: #{last_smooch_response&.body}"
       elsif report.report_design_field_value('use_visual_card')
         last_smooch_response = self.send_message_to_user(uid, '', { 'type' => 'image', 'mediaUrl' => report.report_design_image_url })
-        Rails.logger.info "[Smooch Bot] Sent report visual card to user #{uid} for item with ID #{pm.id}, response was: #{last_smooch_response.body}"
+        Rails.logger.info "[Smooch Bot] Sent report visual card to user #{uid} for item with ID #{pm.id}, response was: #{last_smooch_response&.body}"
       end
       self.save_smooch_response(last_smooch_response, parent, data['received'], fallback_template, lang)
     end


### PR DESCRIPTION
## Description

Do not crash when sending report if tipline `send_message_to_user` returns `null`, which is a valid scenario. For example, for the WhatsApp Cloud API, it can return `null` if text is blank (for a text message) or if the account ID can't be validated from the destination user UID. So, this commit is to just be safe for that case. The information will be in the log anyway (the failing line is a logging line).

Fixes: CV2-3576.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

