### PR TITLE
CV2-3287: run migration against teams with activity in the last year

### DIFF
--- a/lib/tasks/migrate/20230730055732_migrate_from_folders_to_lists.rake
+++ b/lib/tasks/migrate/20230730055732_migrate_from_folders_to_lists.rake
@@ -49,12 +49,17 @@ namespace :check do
       condition = {}
       if slugs.blank?
         last_team_id = Rails.cache.read('check:migrate:migrate_from_folders_to_lists:team_id') || 0
+        # Collect teams with activity in the last year
+        last_year = Time.now - 1.years
+        team_ids = ProjectMedia.select('team_id').where('updated_at > ?', last_year).group('team_id').map(&:team_id).uniq
+        condition = { id: team_ids }
       else
         last_team_id = 0
         condition = { slug: slugs }
       end
       errors = []
       Team.where(condition).where('id > ?', last_team_id).find_each do |team|
+        puts "Processing team [#{team.slug}]"
         team_tags = team.tag_texts.map{ |tag| [tag.id.to_s, tag.text] }.to_h
         team.projects.where(is_default: false).find_each do |project|
           puts "Processing folder [#{team.slug} => #{project.title}(#{project.id})]\n"

--- a/lib/tasks/migrate/20230730055732_migrate_from_folders_to_lists.rake
+++ b/lib/tasks/migrate/20230730055732_migrate_from_folders_to_lists.rake
@@ -51,7 +51,7 @@ namespace :check do
         last_team_id = Rails.cache.read('check:migrate:migrate_from_folders_to_lists:team_id') || 0
         # Collect teams with activity in the last year
         last_year = Time.now - 1.years
-        team_ids = ProjectMedia.select('team_id').where('updated_at > ?', last_year).group('team_id').map(&:team_id).uniq
+        team_ids = ProjectMedia.select('team_id').where('created_at > ?', last_year).group('team_id').map(&:team_id).uniq
         condition = { id: team_ids }
       else
         last_team_id = 0


### PR DESCRIPTION
## Description

Limit folder migration to teams with activity in the last year.

References: CV2-3287

## How has this been tested?

I run the new query against live DB to make sure that I collect right teams.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

