### PR TITLE
CV2-3454: handle unmatched for both source and target item

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -179,7 +179,7 @@ class Relationship < ApplicationRecord
   def set_unmatched_field(value)
     items = [self.target]
     count = 0
-    # unmatch source when there is no other targets assign to same source
+    # unmatch source when there is no other targets assigned to same source
     count = Relationship.where(source_id: self.source_id).where.not(target_id: self.target_id).count if value
     items << self.source if count == 0
     items.compact.each do |item|

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -177,11 +177,17 @@ class Relationship < ApplicationRecord
   end
 
   def set_unmatched_field(value)
-    target = self.target
-    unless target.nil?
-      target.unmatched = value
-      target.skip_check_ability = true
-      target.save!
+    items = [self.target]
+    count = 0
+    # unmatch source when there is no other targets assign to same source
+    count = Relationship.where(source_id: self.source_id).where.not(target_id: self.target_id).count if value
+    items << self.source if count == 0
+    items.compact.each do |item|
+      if item.unmatched != value
+        item.unmatched = value
+        item.skip_check_ability = true
+        item.save!
+      end
     end
   end
 

--- a/test/controllers/elastic_search_10_test.rb
+++ b/test/controllers/elastic_search_10_test.rb
@@ -407,13 +407,17 @@ class ElasticSearch10Test < ActionController::TestCase
     result = CheckSearch.new({ unmatched: [0, 1] }.to_json)
     assert_equal [source.id, target.id, target2.id], result.medias.map(&:id).sort
     result = CheckSearch.new({ unmatched: [0] }.to_json)
-    assert_equal [source.id], result.medias.map(&:id)
+    assert_empty result.medias.map(&:id)
     result = CheckSearch.new({ unmatched: [1] }.to_json)
-    assert_equal [target.id, target2.id], result.medias.map(&:id).sort
+    assert_equal [source.id, target.id, target2.id].sort, result.medias.map(&:id).sort
     # filter by unmatched (hit ES)
     result = CheckSearch.new({ keyword: 'target', unmatched: [1] }.to_json)
     assert_equal [target.id, target2.id], result.medias.map(&:id).sort
     result = CheckSearch.new({ keyword: 'target', unmatched: [0] }.to_json)
+    assert_empty result.medias.map(&:id)
+    result = CheckSearch.new({ keyword: 'source', unmatched: [1] }.to_json)
+    assert_equal [source.id], result.medias.map(&:id)
+    result = CheckSearch.new({ keyword: 'source', unmatched: [0] }.to_json)
     assert_empty result.medias.map(&:id)
     Team.current = nil
   end

--- a/test/models/project_media_test.rb
+++ b/test/models/project_media_test.rb
@@ -372,6 +372,7 @@ class ProjectMediaTest < ActiveSupport::TestCase
     assert !pm.is_suggested
     assert !pm.is_confirmed
     assert_equal 0, pm.reload.unmatched
+    assert_equal 0, main.reload.unmatched
     r = create_relationship source_id: main.id, target_id: pm.id, relationship_type: Relationship.suggested_type
     assert pm.is_suggested
     assert !pm.is_confirmed
@@ -385,8 +386,10 @@ class ProjectMediaTest < ActiveSupport::TestCase
     assert !pm.is_suggested
     assert !pm.is_confirmed
     assert_equal 1, pm.reload.unmatched
+    assert_equal 1, main.reload.unmatched
     r = create_relationship source_id: main.id, target_id: pm.id, relationship_type: Relationship.confirmed_type
     assert_equal 0, pm.reload.unmatched
+    assert_equal 0, main.reload.unmatched
   end
 
   test "should delete for ever trashed items" do

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -108,6 +108,7 @@ class RelationshipTest < ActiveSupport::TestCase
         r2 = create_relationship source_id: pm_s.id, target_id: pm_t2.id, relationship_type: Relationship.suggested_type
         r3 = create_relationship source_id: pm_s.id, target_id: pm_t3.id, relationship_type: Relationship.suggested_type
         # Verify unmatched
+        assert_equal 0, pm_s.reload.unmatched
         assert_equal 0, pm_t1.reload.unmatched
         assert_equal 0, pm_t2.reload.unmatched
         assert_equal 0, pm_t3.reload.unmatched
@@ -139,6 +140,7 @@ class RelationshipTest < ActiveSupport::TestCase
         assert_equal 1, pm_t1.reload.sources_count
         assert_equal pm_s.suggestions_count, es_s['suggestions_count']
         # Verify unmatched
+        assert_equal 0, pm_s.reload.unmatched
         assert_equal 0, pm_t1.reload.unmatched
         assert_equal 0, pm_t2.reload.unmatched
         assert_equal 0, pm_t3.reload.unmatched
@@ -172,9 +174,13 @@ class RelationshipTest < ActiveSupport::TestCase
         assert_equal 1, pm_t1.reload.unmatched
         assert_equal 1, pm_t2.reload.unmatched
         assert_equal 0, pm_t3.reload.unmatched
+        assert_equal 0, pm_s.reload.unmatched
         # Verify cached fields
         assert_not pm_t1.is_suggested
         assert_not pm_t1.is_suggested(true)
+        r3.destroy!
+        assert_equal 1, pm_t3.reload.unmatched
+        assert_equal 1, pm_s.reload.unmatched
       end
     end
   end


### PR DESCRIPTION
## Description

Update the `unmatched` field for both source and target items in relationships.
also updated rake task to fetch both items

References: CV2-3454

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

