### PR TITLE
CV2-2256 more options for search language filter in check

### DIFF
--- a/app/models/annotations/dynamic.rb
+++ b/app/models/annotations/dynamic.rb
@@ -122,7 +122,7 @@ class Dynamic < ApplicationRecord
     handle_elasticsearch_response(op)
     handle_annotated_by(op)
     handle_extracted_text(op)
-    handle_report_published_at
+    handle_report_fields
   end
 
   def handle_elasticsearch_response(op)
@@ -148,14 +148,14 @@ class Dynamic < ApplicationRecord
     if self.annotated_type == 'ProjectMedia' && self.annotation_type == 'extracted_text'
       pm = self.annotated
       value = op == 'destroy' ? '' : self.data['text']
-      pm.update_elasticsearch_doc(['extracted_text'], { 'extracted_text' => value }, pm.id)
+      pm.update_elasticsearch_doc(['extracted_text'], { 'extracted_text' => value }, pm.id, true)
     end
   end
 
-  def handle_report_published_at
+  def handle_report_fields
     if self.annotated_type == 'ProjectMedia' && self.annotation_type == 'report_design'
-      data = { 'report_published_at' => self.data['last_published'] }
-      self.update_elasticsearch_doc(['report_published_at'], data, self.annotated_id)
+      data = { 'report_published_at' => self.data['last_published'], 'report_language' => self.report_design_field_value('language') }
+      self.update_elasticsearch_doc(data.keys, data, self.annotated_id, true)
     end
   end
 

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -197,7 +197,7 @@ module SmoochSearch
 
     def search_by_keywords_for_similar_published_fact_checks(words, after, team_ids, feed_id = nil, language = nil)
       filters = { keyword: words.join('+'), eslimit: 3 }
-      filters.merge!({ fc_languages: [language] }) if should_restrict_by_language?(team_ids)
+      filters.merge!({ fc_language: [language] }) if should_restrict_by_language?(team_ids)
       filters.merge!({ sort: 'score' }) if words.size > 1 # We still want to be able to return the latest fact-checks if a meaninful query is not passed
       feed_id.blank? ? filters.merge!({ report_status: ['published'] }) : filters.merge!({ feed_id: feed_id })
       filters.merge!({ range: { updated_at: { start_time: after.strftime('%Y-%m-%dT%H:%M:%S.%LZ') } } }) unless after.blank?

--- a/app/models/dynamic_annotation/field.rb
+++ b/app/models/dynamic_annotation/field.rb
@@ -130,6 +130,7 @@ class DynamicAnnotation::Field < ApplicationRecord
           'username' => self.value_json['name'],
           'identifier' => identifier&.gsub(/[[:space:]|-]/, ''),
           'content' => self.value_json['text'],
+          'language' => self.value_json['language'],
         }
         options = { op: op, pm_id: obj.id, nested_key: 'requests', keys: data.keys, data: data, skip_get_data: true }
         self.add_update_nested_obj(options)

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -490,6 +490,7 @@ class ProjectMedia < ApplicationRecord
         username: field.value_json['name'],
         identifier: identifier&.gsub(/[[:space:]|-]/, ''),
         content: field.value_json['text'],
+        language: field.value_json['language'],
       }
     end
     ms.attributes[:requests] = requests

--- a/app/repositories/media_search.rb
+++ b/app/repositories/media_search.rb
@@ -132,5 +132,7 @@ class MediaSearch
     indexes :source_name, { type: 'text', analyzer: 'check' }
 
     indexes :unmatched, { type: 'long' }
+
+    indexes :report_language, { type: 'keyword', normalizer: 'check' }
   end
 end

--- a/app/repositories/media_search.rb
+++ b/app/repositories/media_search.rb
@@ -55,6 +55,7 @@ class MediaSearch
         username: { type: 'text', analyzer: 'check'},
         identifier: { type: 'text', analyzer: 'check'},
         content: { type: 'text', analyzer: 'check'},
+        language: { type: 'keyword', normalizer: 'check' },
       }
     }
 

--- a/db/migrate/20230809103545_add_mapping_for_request_and_report_language.rb
+++ b/db/migrate/20230809103545_add_mapping_for_request_and_report_language.rb
@@ -1,4 +1,4 @@
-class AddMappingForRequestLanguage < ActiveRecord::Migration[6.1]
+class AddMappingForRequestAndReportLanguage < ActiveRecord::Migration[6.1]
   def change
     index_alias = CheckElasticSearchModel.get_index_alias
     client = $repository.client
@@ -6,6 +6,7 @@ class AddMappingForRequestLanguage < ActiveRecord::Migration[6.1]
       index: index_alias,
       body: {
         properties: {
+          report_language: { type: 'keyword', normalizer: 'check' },
           requests: {
             type: 'nested',
             properties: {

--- a/db/migrate/20230809103545_add_mapping_for_request_language.rb
+++ b/db/migrate/20230809103545_add_mapping_for_request_language.rb
@@ -1,0 +1,20 @@
+class AddMappingForRequestLanguage < ActiveRecord::Migration[6.1]
+  def change
+    index_alias = CheckElasticSearchModel.get_index_alias
+    client = $repository.client
+    options = {
+      index: index_alias,
+      body: {
+        properties: {
+          requests: {
+            type: 'nested',
+            properties: {
+              language: { type: 'keyword', normalizer: 'check' },
+            }
+          },
+        }
+      }
+    }
+    client.indices.put_mapping options
+  end
+end

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -109,7 +109,7 @@ class CheckSearch
     return [] unless !media_types_filter.blank? && index_exists?
     return @medias if @medias
     if should_hit_elasticsearch?
-      query = medias_build_search_query
+      query = medias_query
       result = medias_get_search_result(query)
       key = get_search_field
       @ids = result.collect{ |i| i[key] }.uniq
@@ -139,7 +139,7 @@ class CheckSearch
           }
         }
       }
-      response = $repository.search(query: self.medias_build_search_query, size: 0, aggs: aggs).raw_response
+      response = $repository.search(query: self.medias_query, size: 0, aggs: aggs).raw_response
       return response.dig('aggregations', 'total', 'value')
     end
     collection = collection.unscope(where: :id)
@@ -180,7 +180,7 @@ class CheckSearch
     pm = ProjectMedia.where(id: @options['id']).last
     return -1 if pm.nil?
     if should_hit_elasticsearch?
-      query = medias_build_search_query
+      query = medias_query
       conditions = query[:bool][:must]
       es_id = @options['es_id']
       offset_c = item_navigation_offset_condition(sort_type, sort_key)
@@ -238,7 +238,7 @@ class CheckSearch
     end
     core_conditions.merge!({ archived: @options['archived'] })
     core_conditions.merge!({ sources_count: 0 }) unless should_include_related_items?
-    build_search_range_filter(:pg, custom_conditions)
+    range_filter(:pg, custom_conditions)
     relation = ProjectMedia
     if @options['operator'].upcase == 'OR'
       custom_conditions.each do |key, value|
@@ -281,7 +281,7 @@ class CheckSearch
     field
   end
 
-  def medias_build_search_query(include_related_items = self.should_include_related_items?)
+  def medias_query(include_related_items = self.should_include_related_items?)
     core_conditions = []
     custom_conditions = []
     core_conditions << { terms: { get_search_field => @options['project_media_ids'] } } unless @options['project_media_ids'].blank?
@@ -292,25 +292,23 @@ class CheckSearch
     core_conditions << { term: { sources_count: 0 } } unless include_related_items
     core_conditions << { range: { cluster_size: { gt: 0 } } } if clusterized_feed_query?
     custom_conditions << { terms: { unmatched: @options['unmatched'] } } if @options.has_key?('unmatched')
-    custom_conditions.concat build_search_keyword_conditions
-    custom_conditions.concat build_search_tags_conditions
-    custom_conditions.concat build_search_report_status_conditions
-    custom_conditions.concat build_search_published_by_conditions
-    custom_conditions.concat build_search_annotated_by_conditions
-    custom_conditions.concat build_search_cluster_published_reports_conditions
-    custom_conditions.concat build_search_integer_terms_query('assigned_user_ids', 'assigned_to')
-    custom_conditions.concat build_search_integer_terms_query('channel', 'channels')
-    custom_conditions.concat build_search_integer_terms_query('source_id', 'sources')
-    custom_conditions.concat build_search_doc_conditions
-    custom_conditions.concat build_search_has_claim_conditions
-    custom_conditions.concat build_search_file_filter
-    custom_conditions.concat build_search_range_filter(:es)
-    custom_conditions.concat build_search_numeric_range_filter
-    language_conditions = build_search_language_conditions
-    check_search_concat_conditions(custom_conditions, language_conditions)
-    custom_conditions.concat build_search_fact_check_language_conditions
-    team_tasks_conditions = build_search_team_tasks_conditions
-    check_search_concat_conditions(custom_conditions, team_tasks_conditions)
+    custom_conditions.concat keyword_conditions
+    custom_conditions.concat tags_conditions
+    custom_conditions.concat report_status_conditions
+    custom_conditions.concat published_by_conditions
+    custom_conditions.concat annotated_by_conditions
+    custom_conditions.concat cluster_published_reports_conditions
+    custom_conditions.concat integer_terms_query('assigned_user_ids', 'assigned_to')
+    custom_conditions.concat integer_terms_query('channel', 'channels')
+    custom_conditions.concat integer_terms_query('source_id', 'sources')
+    custom_conditions.concat doc_conditions
+    custom_conditions.concat has_claim_conditions
+    custom_conditions.concat file_filter
+    custom_conditions.concat range_filter(:es)
+    custom_conditions.concat numeric_range_filter
+    custom_conditions.concat language_conditions
+    custom_conditions.concat fact_check_language_conditions
+    custom_conditions.concat team_tasks_conditions
     feed_conditions = build_feed_conditions
     conditions = []
     if @options['operator'].upcase == 'OR'
@@ -323,14 +321,10 @@ class CheckSearch
     { bool: { must: conditions.reject{ |c| c.blank? } } }
   end
 
-  def check_search_concat_conditions(base_condition, c)
-    base_condition.concat(c) unless c.blank?
-  end
-
   def medias_get_search_result(query)
     # use collapse to return uniq results
     collapse = { field: get_search_field }
-    sort = build_search_sort
+    sort = build_es_sort
     @options['es_id'] ? $repository.find([@options['es_id']]).compact : $repository.search(query: query, collapse: collapse, sort: sort, size: @options['eslimit'], from: @options['esoffset']).results
   end
 
@@ -387,12 +381,12 @@ class CheckSearch
     client.indices.exists? index: CheckElasticSearchModel.get_index_alias
   end
 
-  def build_search_keyword_conditions
+  def keyword_conditions
     return [] if @options["keyword"].blank? || @options["keyword"].class.name != 'String'
     set_keyword_fields
     keyword_c = []
     field_conditions = build_keyword_conditions_media_fields
-    check_search_concat_conditions(keyword_c, field_conditions)
+    keyword_c.concat field_conditions
     # Search in comments
     keyword_c << {
       nested: {
@@ -441,17 +435,17 @@ class CheckSearch
     @options['keyword_fields']['fields'].blank? || @options['keyword_fields']['fields'].include?(field)
   end
 
-  def build_search_language_conditions
+  def language_conditions
     return [] unless @options.has_key?('language')
     [{ terms: { language: @options['language'] } }]
   end
 
-  def build_search_fact_check_language_conditions
+  def fact_check_language_conditions
     return [] unless @options.has_key?('fc_languages')
     [{ terms: { fact_check_languages: @options['fc_languages'] } }]
   end
 
-  def build_search_has_claim_conditions
+  def has_claim_conditions
     conditions = []
     return conditions unless @options.has_key?('has_claim')
     if @options['has_claim'].include?('NO_VALUE')
@@ -462,14 +456,14 @@ class CheckSearch
     conditions
   end
 
-  def build_search_file_filter
+  def file_filter
     conditions = []
     return conditions unless @options.has_key?('file_type')
     ids = alegre_file_similar_items
     [{ terms: { annotated_id: ids } }]
   end
 
-  def build_search_team_tasks_conditions
+  def team_tasks_conditions
     conditions = []
     return conditions unless @options.has_key?('team_tasks') && @options['team_tasks'].class.name == 'Array'
     @options['team_tasks'].delete_if{ |tt| tt['response'].blank? }
@@ -512,7 +506,7 @@ class CheckSearch
     conditions
   end
 
-  def build_search_sort
+  def build_es_sort
     # As per spec, for now the team task sort should be just based on "has data" / "has no data"
     # Items without data appear first
     if @options['sort'] =~ /^task_value_[0-9]+$/
@@ -547,13 +541,13 @@ class CheckSearch
     end
   end
 
-  def build_search_tags_conditions
+  def tags_conditions
     return [] if @options["tags"].blank? || @options["tags"].class.name != 'Array'
     tags_c = search_tags_query(@options["tags"])
     [tags_c]
   end
 
-  def build_search_integer_terms_query(field, key)
+  def integer_terms_query(field, key)
     conditions = []
     return conditions unless @options[key].is_a?(Array)
     # Handle ANY_VALUE or ANY_VALUE
@@ -584,7 +578,7 @@ class CheckSearch
     end
   end
 
-  def build_search_report_status_conditions
+  def report_status_conditions
     return [] if @options['report_status'].blank? || !@options['report_status'].is_a?(Array)
     if clusterized_feed_query?
       conditions = []
@@ -605,12 +599,12 @@ class CheckSearch
     [{ terms: { report_status: statuses } }]
   end
 
-  def build_search_published_by_conditions
+  def published_by_conditions
     return [] if @options['published_by'].blank?
     [{ terms: { published_by: [@options['published_by']].flatten } }]
   end
 
-  def build_search_annotated_by_conditions
+  def annotated_by_conditions
     return [] if @options['annotated_by'].blank?
     if @options['annotated_by_operator'].to_s.downcase == 'and'
       and_c = []
@@ -621,12 +615,12 @@ class CheckSearch
     end
   end
 
-  def build_search_cluster_published_reports_conditions
+  def cluster_published_reports_conditions
     return [] if @options['cluster_published_reports'].blank?
     [{ terms: { cluster_published_reports: [@options['cluster_published_reports']].flatten } }]
   end
 
-  def build_search_doc_conditions
+  def doc_conditions
     doc_c = []
     unless @options['show'].blank?
       types_mapping = {
@@ -671,7 +665,7 @@ class CheckSearch
   end
 
   # range: {created_at: {start_time: <start_time>, end_time: <end_time>}, updated_at: {start_time: <start_time>, end_time: <end_time>}, timezone: 'GMT'}
-  def build_search_range_filter(type, filters = nil)
+  def range_filter(type, filters = nil)
     conditions = []
     return conditions unless @options.has_key?(:range)
     timezone = @options[:range].delete(:timezone) || @context_timezone
@@ -691,7 +685,7 @@ class CheckSearch
 
   # range_numeric: {field_name: {min: <minimum_number>}, max: <maximum_number> }
   # field_name should be one of the following: linked_items_count, suggestions_count, demand
-  def build_search_numeric_range_filter
+  def numeric_range_filter
     conditions = []
     return conditions if @options['range_numeric'].blank?
     @options['range_numeric'].each do |field, values|
@@ -731,7 +725,7 @@ class CheckSearch
     conditions = []
     @feed.get_team_filters.each do |filters|
       team_id = filters['team_id'].to_i
-      conditions << CheckSearch.new(filters.to_json, nil, team_id).medias_build_search_query
+      conditions << CheckSearch.new(filters.to_json, nil, team_id).medias_query
     end
     { bool: { should: conditions } }
   end

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -154,7 +154,7 @@ class CheckSearch
     end
     query_all_types = (MEDIA_TYPES.size == media_types_filter.size)
     filters_blank = true
-    ['tags', 'keyword', 'rules', 'language', 'fc_languages', 'team_tasks', 'assigned_to', 'report_status', 'range_numeric',
+    ['tags', 'keyword', 'rules', 'language', 'fc_language', 'request_language', 'team_tasks', 'assigned_to', 'report_status', 'range_numeric',
       'has_claim', 'cluster_teams', 'published_by', 'annotated_by', 'channels', 'cluster_published_reports'
     ].each do |filter|
       filters_blank = false unless @options[filter].blank?
@@ -271,7 +271,7 @@ class CheckSearch
   end
 
   def show_parent?
-    search_keys = ['verification_status', 'tags', 'rules', 'language', 'fc_languages', 'team_tasks', 'assigned_to', 'channels', 'report_status']
+    search_keys = ['verification_status', 'tags', 'rules', 'language', 'fc_language', 'request_language', 'team_tasks', 'assigned_to', 'channels', 'report_status']
     !@options['projects'].blank? && !@options['keyword'].blank? && (search_keys & @options.keys).blank?
   end
 
@@ -308,6 +308,7 @@ class CheckSearch
     custom_conditions.concat numeric_range_filter
     custom_conditions.concat language_conditions
     custom_conditions.concat fact_check_language_conditions
+    custom_conditions.concat request_language_conditions
     custom_conditions.concat team_tasks_conditions
     feed_conditions = build_feed_conditions
     conditions = []
@@ -441,8 +442,13 @@ class CheckSearch
   end
 
   def fact_check_language_conditions
-    return [] unless @options.has_key?('fc_languages')
-    [{ terms: { fact_check_languages: @options['fc_languages'] } }]
+    return [] unless @options.has_key?('fc_language')
+    [{ terms: { fact_check_languages: @options['fc_language'] } }]
+  end
+
+  def request_language_conditions
+    return [] unless @options.has_key?('request_language')
+    [{ nested: { path: 'requests', query: { terms: { 'requests.language': @options['request_language'] } } } }]
   end
 
   def has_claim_conditions

--- a/lib/tasks/data/project_media.rake
+++ b/lib/tasks/data/project_media.rake
@@ -85,6 +85,7 @@ namespace :check do
           username: field.value_json['name'],
           identifier: field.smooch_user_external_identifier.value&.gsub(/[[:space:]|-]/, ''),
           content: field.value_json['text'],
+          language: field.value_json['language'],
         }}
       end
     end

--- a/lib/tasks/migrate/20220214055345_add_mapping_for_report_fields.rake
+++ b/lib/tasks/migrate/20220214055345_add_mapping_for_report_fields.rake
@@ -25,5 +25,31 @@ namespace :check do
       minutes = ((Time.now.to_i - started) / 60).to_i
       puts "[#{Time.now}] Done in #{minutes} minutes."
     end
+
+    task index_report_language: :environment do
+      started = Time.now.to_i
+      index_alias = CheckElasticSearchModel.get_index_alias
+      client = $repository.client
+      last_team_id = Rails.cache.read('check:migrate:index_report_language:team_id') || 0
+      Team.where('id > ?', last_team_id).find_each do |team|
+        team.project_medias.find_in_batches(:batch_size => 2500) do |pms|
+          es_body = []
+          ids = pms.map(&:id)
+          Dynamic.where(annotated_id: ids, annotated_type: 'ProjectMedia', annotation_type: 'report_design')
+          .find_in_batches(:batch_size => 2500) do |annotations|
+            print '.'
+            annotations.each do |d|
+              doc_id = Base64.encode64("ProjectMedia/#{d.annotated_id}")
+              fields = { 'report_language' => d.report_design_field_value('language') }
+              es_body << { update: { _index: index_alias, _id: doc_id, retry_on_conflict: 3, data: { doc: fields } } }
+            end
+          end
+          client.bulk body: es_body unless es_body.blank?
+        end
+        Rails.cache.write('check:migrate:index_report_language:team_id', team.id)
+      end
+      minutes = ((Time.now.to_i - started) / 60).to_i
+      puts "[#{Time.now}] Done in #{minutes} minutes."
+    end
   end
 end

--- a/test/controllers/elastic_search_10_test.rb
+++ b/test/controllers/elastic_search_10_test.rb
@@ -131,11 +131,11 @@ class ElasticSearch10Test < ActionController::TestCase
       cd = create_claim_description project_media: pm4, disable_es_callbacks: false
       create_fact_check claim_description: cd, disable_es_callbacks: false
       sleep 2
-      results = CheckSearch.new({ fc_languages: ['en', 'fr'] }.to_json)
+      results = CheckSearch.new({ fc_language: ['en', 'fr'] }.to_json)
       assert_equal [pm.id, pm2.id, pm3.id], results.medias.map(&:id).sort
-      results = CheckSearch.new({ fc_languages: ['fr', 'und'] }.to_json)
+      results = CheckSearch.new({ fc_language: ['fr', 'und'] }.to_json)
       assert_equal [pm3.id, pm4.id], results.medias.map(&:id).sort
-      results = CheckSearch.new({ keyword: 'claim', fc_languages: ['en', 'fr'] }.to_json)
+      results = CheckSearch.new({ keyword: 'claim', fc_language: ['en', 'fr'] }.to_json)
       assert_equal [pm.id], results.medias.map(&:id)
     end
   end


### PR DESCRIPTION
## Description

- Add ES mapping for request language.
- Allow user to filter by request language
- Rename ES methods by remove `build_search_` prefix  (i.e change `build_search_keyword_conditions` to `keyword_conditions`)
- Add ES mapping for report language

References:  CV2-2256


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

