### PR TITLE
New data point for tipline statistics: WhatsApp conversations.

### DIFF
--- a/app/models/monthly_team_statistic.rb
+++ b/app/models/monthly_team_statistic.rb
@@ -9,9 +9,10 @@ class MonthlyTeamStatistic < ApplicationRecord
   # Mapping of attributes to human-readable descriptions
   FIELD_MAPPINGS = {
     id: "ID",
-    platform_name: "Platform", # model method
-    language: "Language",
-    month: "Month", # model method
+    platform_name: 'Platform', # model method
+    language: 'Language',
+    month: 'Month', # model method
+    whatsapp_conversations: 'WhatsApp conversations',
     average_messages_per_day: 'Average messages per day',
     unique_users: 'Unique users',
     returning_users: 'Returning users',

--- a/db/migrate/20230809160826_add_whatsapp_conversations_to_monthly_team_statistic.rb
+++ b/db/migrate/20230809160826_add_whatsapp_conversations_to_monthly_team_statistic.rb
@@ -1,0 +1,5 @@
+class AddWhatsappConversationsToMonthlyTeamStatistic < ActiveRecord::Migration[6.1]
+  def change
+    add_column :monthly_team_statistics, :whatsapp_conversations, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_25_053637) do
+ActiveRecord::Schema.define(version: 2023_08_09_160826) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -389,6 +389,7 @@ ActiveRecord::Schema.define(version: 2023_07_25_053637) do
     t.datetime "updated_at", null: false
     t.integer "conversations_24hr"
     t.integer "newsletters_delivered"
+    t.integer "whatsapp_conversations"
     t.index ["team_id", "platform", "language", "start_date"], name: "index_monthly_stats_team_platform_language_start", unique: true
     t.index ["team_id"], name: "index_monthly_team_statistics_on_team_id"
   end

--- a/lib/check_statistics.rb
+++ b/lib/check_statistics.rb
@@ -77,7 +77,12 @@ module CheckStatistics
 
           # Only available for tiplines using WhatsApp Cloud API
           unless tbi&.get_capi_whatsapp_business_account_id.blank?
-            uri = URI("https://graph.facebook.com/v17.0/#{tbi.get_capi_whatsapp_business_account_id}?fields=conversation_analytics.start(#{from}).end(#{to}).granularity(DAILY).phone_numbers(#{tbi.get_capi_phone_number})&access_token=#{tbi.get_capi_permanent_token}")
+            uri = URI(URI.join('https://graph.facebook.com/v17.0/', tbi.get_capi_whatsapp_business_account_id.to_s))
+            params = {
+              fields: "conversation_analytics.start(#{from}).end(#{to}).granularity(DAILY).phone_numbers(#{tbi.get_capi_phone_number})",
+              access_token: tbi.get_capi_permanent_token
+            }
+            uri.query = Rack::Utils.build_query(params)
             http = Net::HTTP.new(uri.host, uri.port)
             http.use_ssl = true
             request = Net::HTTP::Get.new(uri.request_uri, 'Content-Type' => 'application/json')

--- a/test/lib/check_statistics_test.rb
+++ b/test/lib/check_statistics_test.rb
@@ -1,0 +1,77 @@
+require_relative '../test_helper'
+
+class CheckStatisticsTest < ActiveSupport::TestCase
+  def setup
+    Rails.cache.delete_matched("check_statistics:whatsapp_conversations:*")
+    WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
+    @team = create_team
+    bot = create_team_bot login: 'smooch', name: 'Smooch', set_approved: true
+    settings = {
+      capi_whatsapp_business_account_id: '123456',
+      capi_phone_number: '12345678',
+      capi_permanent_token: '654321'
+    }
+    create_team_bot_installation team_id: @team.id, user_id: bot.id, settings: settings
+    @from = Time.parse('2023-01-01').beginning_of_month.to_date
+    @to = Time.parse('2023-01-01').end_of_month.to_date
+    @url = 'https://graph.facebook.com/v17.0/123456?fields=conversation_analytics.start(1672531200).end(1675123200).granularity(DAILY).phone_numbers(12345678)&access_token=654321'
+  end
+
+  def teardown
+  end
+
+  test 'should calculate number of WhatsApp conversations' do
+    WebMock.stub_request(:get, @url).to_return(status: 200, body: {
+      conversation_analytics: {
+        data: [
+          {
+            data_points: [
+              {
+                start: 1688454000,
+                end: 1688540400,
+                conversation: 39,
+                cost: 0.8866
+              },
+              {
+                start: 1688281200,
+                end: 1688367600,
+                conversation: 19,
+                cost: 0
+              },
+              {
+                start: 1688367600,
+                end: 1688454000,
+                conversation: 1117,
+                cost: 68.465
+              },
+              {
+                start: 1688540400,
+                end: 1688626800,
+                conversation: 1101,
+                cost: 66.9023
+              },
+              {
+                start: 1688194800,
+                end: 1688281200,
+                conversation: 24,
+                cost: 0.1875
+              }
+            ]
+          }
+        ]
+      },
+      id: '123456'
+    }.to_json)
+    assert_equal 2300, CheckStatistics.number_of_whatsapp_conversations(@team.id, @from, @to)
+  end
+
+  test 'should not calculate number of WhatsApp conversations if WhatsApp Insights API returns an error' do
+    WebMock.stub_request(:get, @url).to_return(status: 400, body: { error: 'Error' }.to_json)
+    assert_nil CheckStatistics.number_of_whatsapp_conversations(@team.id, @from, @to)
+  end
+
+  test 'should not calculate number of WhatsApp conversations if there is no tipline' do
+    WebMock.stub_request(:get, @url).to_return(status: 400, body: { error: 'Error' }.to_json)
+    assert_nil CheckStatistics.number_of_whatsapp_conversations(create_team.id, @from, @to)
+  end
+end


### PR DESCRIPTION
## Description

* This pull request adds a new data point for the statistics that are collected for the tipline: WhatsApp conversations
* This data point is collected using WhatsApp Insights API, so it's available only for WhatsApp tiplines, specifically, the ones that use the WhatsApp Cloud API
* For other tiplines, this data point should return null
* This data point is not available per-language, so the value should be the same for all languages
* This data point is cached, so it doesn't require multiple API calls when collecting this value per language, since this value is the same as per bullet point above

Reference: CV2-2903.

## How has this been tested?

Unit tests were added.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

