### PR TITLE
Make resolve method explicit for settings attributes

### DIFF
--- a/app/graph/types/feed_team_type.rb
+++ b/app/graph/types/feed_team_type.rb
@@ -11,6 +11,11 @@ class FeedTeamType < DefaultObject
   field :team_id, GraphQL::Types::Int, null: true
   field :feed_id, GraphQL::Types::Int, null: true
   field :shared, GraphQL::Types::Boolean, null: true
-  field :requests_filters, JsonStringType, method: :get_requests_filters, null: true
+  field :requests_filters, JsonStringType, null: true
+
+  def requests_filters
+    object.get_requests_filters
+  end
+
   field :saved_search, SavedSearchType, null: true
 end


### PR DESCRIPTION
## Description

Our settings attributes rely on hitting a Method Missing exception to create the getter method - e.g. get_requests_filters for requests_filters. As a result, we can't use the method: helper on GraphQL classes, because they raise an error before the method is programmatically created.

We can get around this by explicitly defining a resolve method and calling the getter method on the object by name.

I also did a search to make sure that we weren't using the method attribute to access getters in the rest of the code base. We weren't.

References:CV2-3597

## How has this been tested?

I haven't tested this or tried it locally - I don't have a local setup with shared feeds, wasn't sure of a good test, and am out of hours for the week but wanted to get this in quickly. I'm sorry!

## Things to pay attention to during code review

n/a

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

