### PR TITLE
Allow cached fields to have a custom expiration date.

### DIFF
--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -250,6 +250,7 @@ module ProjectMediaCachedFields
       start_as: proc { |_pm| '' },
       update_es: :cached_field_tags_as_sentence_es,
       recalculate: :recalculate_tags_as_sentence,
+      expires_in: 5.years,
       update_on: [
         {
           model: Tag,


### PR DESCRIPTION
## Description

Previously, all cached fields had the same expiration date, controlled by a global configuration key. This commit allows cached fields to define a custom expiration date by setting a `expires_in` key... when not defined, the global configuration is used.

This commit also uses this feature for the `ProjectMedia` `tags_as_sentence` cached field, by definiting a longer expiration date for it, since it's one of the most expensive fields.

Reference: CV2-3563.

## How has this been tested?

I implemented a unit test for it.

## Things to pay attention to during code review

We can set longer expiration dates for other fields later.

## Checklist

- [x ] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

