### PR TITLE
Cv2 3397 add option more than in date range

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -8,11 +8,13 @@ module SearchHelper
   end
 
   def get_from_and_to_values(values, tz)
-    # condition_type = 'less_than', 'is_between'
+    # condition_type = 'less_than', 'more_than', 'is_between'
     condition_type = values.dig('condition') || 'is_between'
-    if condition_type == 'less_than'
+    from = nil
+    to = nil
+    if ['less_than', 'more_than'].include?(condition_type)
       period = values.dig('period').to_i
-      from_date = case values.dig('period_type').downcase
+      period_date = case values.dig('period_type').downcase
                   when 'd'
                     Time.now - period.day
                   when 'w'
@@ -22,8 +24,12 @@ module SearchHelper
                   when 'y'
                     Time.now - period.year
                   end
-      from = from_date.blank? ? nil : format_time_with_timezone(from_date.to_s, tz)
-      to = nil
+      condition_date = period_date.blank? ? nil : format_time_with_timezone(period_date.to_s, tz)
+      if condition_type == 'less_than'
+        from = condition_date
+      else
+        to = condition_date
+      end
     else
       from = format_time_with_timezone(values.dig('start_time'), tz)
       to = format_time_with_timezone(values.dig('end_time'), tz)


### PR DESCRIPTION
## Description

Add a new option `more than` for date range filter

References: CV2-3397

## How has this been tested?

Go to list page and select date range filter then you can find a new option `more than`.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

