### PR TITLE
CV2-3469: add media_slug field to ProjectMediaType

### DIFF
--- a/app/graph/types/project_media_type.rb
+++ b/app/graph/types/project_media_type.rb
@@ -337,7 +337,7 @@ class ProjectMediaType < DefaultObject
     object.sources_count > 0
   end
 
-  field :similar_items,
-        ProjectMediaType.connection_type,
-        null: true
+  field :similar_items, ProjectMediaType.connection_type, null: true
+
+  field :media_slug, GraphQL::Types::String, null: true
 end

--- a/app/models/concerns/project_media_getters.rb
+++ b/app/models/concerns/project_media_getters.rb
@@ -152,6 +152,15 @@ module ProjectMediaGetters
     title.to_s
   end
 
+  def media_slug
+    title = ''
+    if self.user&.login == 'smooch'
+      analysis = self.analysis
+      title = [analysis['file_title'], analysis['title']].compact_blank.first
+    end
+    title
+  end
+
   def get_description
     return self.fact_check_summary if self.get_main_channel == CheckChannels::ChannelCodes::FETCH
     analysis_description = self.has_analysis_description? ? self.analysis_description : nil

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -11021,6 +11021,7 @@ type ProjectMedia implements Node {
   ): VersionConnection
   media: Media
   media_id: Int
+  media_slug: String
   oembed_metadata: String
   permissions: String
   picture: String

--- a/public/relay.json
+++ b/public/relay.json
@@ -58015,6 +58015,20 @@
               "deprecationReason": null
             },
             {
+              "name": "media_slug",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "oembed_metadata",
               "description": null,
               "args": [

--- a/test/models/project_media_5_test.rb
+++ b/test/models/project_media_5_test.rb
@@ -570,12 +570,20 @@ class ProjectMedia5Test < ActiveSupport::TestCase
     with_current_user_and_team(bot, team) do
       pm = create_project_media team: team, quote: random_string
       assert_equal "text-#{team.slug}-#{pm.id}", pm.title
+      # verify media_slug field
+      cd = create_claim_description project_media: pm, description: 'description_text'
+      assert_equal pm.get_title, cd.description
+      assert_equal "text-#{team.slug}-#{pm.id}", pm.media_slug
     end
     # test with non smooch user
     with_current_user_and_team(u, team) do
       quote = random_string
       pm = create_project_media team: team, quote: quote
       assert_equal quote, pm.title
+      # verify media_slug field
+      cd = create_claim_description project_media: pm, description: 'description_text'
+      assert_equal pm.get_title, cd.description
+      assert_empty pm.media_slug
     end
   end
 


### PR DESCRIPTION
## Description

Add a new field `media_slug` to `ProjectMediaType` to get the original title for tipline items so it'll return empty strings for other items.

References: CV2-3469

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

