### PR TITLE
Fixing two lines of code for Ruby 3.

### DIFF
--- a/app/models/tipline_newsletter.rb
+++ b/app/models/tipline_newsletter.rb
@@ -270,8 +270,8 @@ class TiplineNewsletter < ApplicationRecord
   def validate_header_file(max_size, allowed_types, message)
     size_in_mb = (self.header_file.file.size.to_f / (1000 * 1000))
     type = self.header_file.file.extension.downcase
-    errors.add(:base, I18n.t(message, { max_size: "#{max_size}MB" })) if size_in_mb > max_size.to_f
-    errors.add(:header_file, I18n.t('errors.messages.extension_white_list_error', { extension: type, allowed_types: allowed_types.join(', ') })) unless allowed_types.include?(type)
+    errors.add(:base, I18n.t(message, **{ max_size: "#{max_size}MB" })) if size_in_mb > max_size.to_f
+    errors.add(:header_file, I18n.t('errors.messages.extension_white_list_error', **{ extension: type, allowed_types: allowed_types.join(', ') })) unless allowed_types.include?(type)
   end
 
   def not_scheduled_for_the_past

--- a/test/models/tipline_newsletter_test.rb
+++ b/test/models/tipline_newsletter_test.rb
@@ -330,6 +330,24 @@ class TiplineNewsletterTest < ActiveSupport::TestCase
     end
   end
 
+  test 'should have a valid header file format' do
+    Sidekiq::Testing.inline! do
+      TiplineNewsletter.any_instance.stubs(:new_file_uploaded?).returns(true)
+      assert_raises ActiveRecord::RecordInvalid do
+        create_tipline_newsletter header_type: 'image', header_file: 'rails.mp4'
+      end
+    end
+  end
+
+  test 'should have a valid header file size' do
+    Sidekiq::Testing.inline! do
+      TiplineNewsletter.any_instance.stubs(:new_file_uploaded?).returns(true)
+      assert_raises ActiveRecord::RecordInvalid do
+        create_tipline_newsletter header_type: 'image', header_file: 'large-image.jpg'
+      end
+    end
+  end
+
   test 'should format RSS newsletter time as cron' do
     # Offset
     newsletter = TiplineNewsletter.new(


### PR DESCRIPTION
## Description

There are two lines of code that were not converted during the Ruby 3 upgrade because they were not covered by the tests. This commit adds tests to them and fixes them as well.

Fixes CV2-3617.

## How has this been tested?

TDD. I added unit tests before the fix.

## Checklist

- [x] I have performed a self-review of my own code
- [] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

