### PR TITLE
CV2-3650: Improve NLU option selection

### DIFF
--- a/app/lib/smooch_nlu.rb
+++ b/app/lib/smooch_nlu.rb
@@ -58,10 +58,10 @@ class SmoochNlu
         i = 0
         workflow.fetch("smooch_state_#{menu}",{}).fetch('smooch_menu_options', []).each do |option|
           output[language][menu] << {
-            index: i,
-            title: option.dig('smooch_menu_option_label'),
-            keywords: option.dig('smooch_menu_option_nlu_keywords').to_a,
-            id: option.dig('smooch_menu_option_id'),
+            'index' => i,
+            'title' => option.dig('smooch_menu_option_label'),
+            'keywords' => option.dig('smooch_menu_option_nlu_keywords').to_a,
+            'id' => option.dig('smooch_menu_option_id'),
           }
           i += 1
         end

--- a/app/lib/smooch_nlu.rb
+++ b/app/lib/smooch_nlu.rb
@@ -40,12 +40,14 @@ class SmoochNlu
   def self.menu_option_from_message(message, options)
     # FIXME: Raise exception if not in a tipline context (so, if Bot::Smooch.config is nil)
     option = nil
+    team_slug = Team.find(Bot::Smooch.config['team_id']).slug
+    params = nil
+    response = nil
     if Bot::Smooch.config.to_h['nlu_menus_enabled'] && !options.nil?
       # FIXME: In the future we could consider menus across all languages when options is nil
       # FIXME: No need to call Alegre if it's an exact match to one of the keywords
       # FIXME: No need to call Alegre if message has no word characters
       # FIXME: Handle error responses from Alegre
-      team_slug = Team.find(Bot::Smooch.config['team_id']).slug
       params = {
         text: message,
         models: ALEGRE_MODELS_AND_THRESHOLDS.keys,
@@ -71,18 +73,18 @@ class SmoochNlu
       end
 
       # FIXME: Deal with ties (i.e., where two options have an equal count)
-
-      log = {
-        version: "0.1", # Update if schema changes
-        datetime: DateTime.current,
-        team_slug: team_slug,
-        user_query: message,
-        alegre_query: params,
-        alegre_response: response,
-        selected_option: option
-      }
-      Rails.logger.info("[Smooch NLU] [Menu Option From Message] #{log.to_json}")
     end
+    # In all cases log for analysis
+    log = {
+      version: "0.1", # Update if schema changes
+      datetime: DateTime.current,
+      team_slug: team_slug,
+      user_query: message,
+      alegre_query: params,
+      alegre_response: response,
+      selected_option: option
+    }
+    Rails.logger.info("[Smooch NLU] [Menu Option From Message] #{log.to_json}")
     option
   end
 

--- a/app/lib/smooch_nlu.rb
+++ b/app/lib/smooch_nlu.rb
@@ -67,7 +67,7 @@ class SmoochNlu
     nil
   end
 
-  def self.menu_option_from_message(message, options)
+  def self.menu_option_from_message(message, language, options)
     # FIXME: Raise exception if not in a tipline context (so, if Bot::Smooch.config is nil)
     option = nil
     team_slug = Team.find(Bot::Smooch.config['team_id']).slug
@@ -85,6 +85,7 @@ class SmoochNlu
         context: {
           context: ALEGRE_CONTEXT_KEY,
           team: team_slug,
+          language: language,
         }
       }
       response = Bot::Alegre.request_api('get', '/text/similarity/', params)
@@ -135,12 +136,13 @@ class SmoochNlu
     Digest::MD5.hexdigest([ALEGRE_CONTEXT_KEY, @team_slug, menu, menu_option_id, keyword].join(':'))
   end
 
-  def common_params_for_alegre(menu, menu_option_id, keyword)
+  def common_params_for_alegre(menu, language, menu_option_id, keyword)
     {
       doc_id: alegre_doc_id(menu, menu_option_id, keyword),
       context: {
         context: ALEGRE_CONTEXT_KEY,
         team: @team_slug,
+        language: language,
         menu: menu,
         menu_option_id: menu_option_id
       }
@@ -161,11 +163,11 @@ class SmoochNlu
     if operation == 'add' && !keywords.include?(keyword)
       keywords << keyword
       alegre_operation = 'post'
-      alegre_params = common_params_for_alegre(menu, menu_option_id, keyword).merge({ text: keyword, models: ALEGRE_MODELS_AND_THRESHOLDS.keys })
+      alegre_params = common_params_for_alegre(menu, language, menu_option_id, keyword).merge({ text: keyword, models: ALEGRE_MODELS_AND_THRESHOLDS.keys })
     elsif operation == 'remove'
       keywords -= [keyword]
       alegre_operation = 'delete'
-      alegre_params = common_params_for_alegre(menu, menu_option_id, keyword).merge({ quiet: true })
+      alegre_params = common_params_for_alegre(menu, language, menu_option_id, keyword).merge({ quiet: true })
     end
     workflow["smooch_state_#{menu}"]['smooch_menu_options'][menu_option_index]['smooch_menu_option_nlu_keywords'] = keywords
     @smooch_bot_installation.save!

--- a/app/lib/smooch_nlu.rb
+++ b/app/lib/smooch_nlu.rb
@@ -37,6 +37,36 @@ class SmoochNlu
     update_keywords(language, menu, menu_option_index, keyword, 'remove')
   end
 
+  def list_keywords(languages = nil, menus = nil)
+    if languages.nil?
+      languages = @smooch_bot_installation.get_smooch_workflows.map { |w| w['smooch_workflow_language'] }
+    elsif languages.is_a? String
+      languages = [languages]
+    end
+    if menus.nil?
+      menus = ['main', 'secondary']
+    elsif menus.is_a? String
+      menus = [menus]
+    end
+
+    languages.each do |language|
+      puts("------------\n#{language}\n------------")
+      workflow = @smooch_bot_installation.get_smooch_workflows.find { |w| w['smooch_workflow_language'] == language }
+      menus.each do |menu|
+        puts("--- #{menu} ---")
+        i = 0
+        workflow.fetch("smooch_state_#{menu}",{}).fetch('smooch_menu_options', []).each do |option|
+          keywords = option.dig('smooch_menu_option_nlu_keywords').to_a
+          title = option.dig('smooch_menu_option_label')
+          pp i, title, keywords, option.dig('smooch_menu_option_id')
+          puts("\n")
+          i += 1
+        end
+      end
+    end
+    nil
+  end
+
   def self.menu_option_from_message(message, options)
     # FIXME: Raise exception if not in a tipline context (so, if Bot::Smooch.config is nil)
     option = nil

--- a/app/lib/smooch_nlu.rb
+++ b/app/lib/smooch_nlu.rb
@@ -49,22 +49,25 @@ class SmoochNlu
       menus = [menus]
     end
 
+    output = {}
     languages.each do |language|
-      puts("------------\n#{language}\n------------")
+      output[language] = {}
       workflow = @smooch_bot_installation.get_smooch_workflows.find { |w| w['smooch_workflow_language'] == language }
       menus.each do |menu|
-        puts("--- #{menu} ---")
+        output[language][menu] = []
         i = 0
         workflow.fetch("smooch_state_#{menu}",{}).fetch('smooch_menu_options', []).each do |option|
-          keywords = option.dig('smooch_menu_option_nlu_keywords').to_a
-          title = option.dig('smooch_menu_option_label')
-          pp i, title, keywords, option.dig('smooch_menu_option_id')
-          puts("\n")
+          output[language][menu] << {
+            index: i,
+            title: option.dig('smooch_menu_option_label'),
+            keywords: option.dig('smooch_menu_option_nlu_keywords').to_a,
+            id: option.dig('smooch_menu_option_id'),
+          }
           i += 1
         end
       end
     end
-    nil
+    output
   end
 
   def self.menu_option_from_message(message, language, options)

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -562,7 +562,7 @@ class Bot::Smooch < BotUser
       end
     end
     # ...if nothing is matched, try using the NLU feature
-    option = SmoochNlu.menu_option_from_message(typed, options)
+    option = SmoochNlu.menu_option_from_message(typed, options) if state != 'query'
     unless option.nil?
       self.process_menu_option_value(option['smooch_menu_option_value'], option, message, language, workflow, app_id)
       return true

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -562,7 +562,7 @@ class Bot::Smooch < BotUser
       end
     end
     # ...if nothing is matched, try using the NLU feature
-    option = SmoochNlu.menu_option_from_message(typed, options) if state != 'query'
+    option = SmoochNlu.menu_option_from_message(typed, language, options) if state != 'query'
     unless option.nil?
       self.process_menu_option_value(option['smooch_menu_option_value'], option, message, language, workflow, app_id)
       return true

--- a/test/lib/smooch_nlu_test.rb
+++ b/test/lib/smooch_nlu_test.rb
@@ -74,14 +74,14 @@ class SmoochNluTest < ActiveSupport::TestCase
       }
     }
     # Since the demo team has only one language and menu all of the following are nearly the same
-    assert nlu.list_keywords('en', 'main') == expected_output
-    assert nlu.list_keywords('en', ['main']) == expected_output
+    assert_equal nlu.list_keywords('en', 'main'), expected_output
+    assert_equal nlu.list_keywords('en', ['main']), expected_output
 
     # These calls should include an empty secondary menu
     expected_output['en']['secondary'] = []
-    assert nlu.list_keywords() == expected_output
-    assert nlu.list_keywords('en') == expected_output
-    assert nlu.list_keywords(['en']) == expected_output
+    assert_equal nlu.list_keywords(), expected_output
+    assert_equal nlu.list_keywords('en'), expected_output
+    assert_equal nlu.list_keywords(['en']), expected_output
   end
 
   test 'should add keyword if it does not exist' do

--- a/test/lib/smooch_nlu_test.rb
+++ b/test/lib/smooch_nlu_test.rb
@@ -85,7 +85,7 @@ class SmoochNluTest < ActiveSupport::TestCase
     team = create_team_with_smooch_bot_installed
     SmoochNlu.new(team.slug).disable!
     Bot::Smooch.get_installation('smooch_id', 'test')
-    assert_nil SmoochNlu.menu_option_from_message('I want to subscribe to the newsletter', @menu_options)
+    assert_nil SmoochNlu.menu_option_from_message('I want to subscribe to the newsletter', 'en', @menu_options)
   end
 
   test 'should return a menu option if NLU is enabled' do
@@ -95,6 +95,6 @@ class SmoochNluTest < ActiveSupport::TestCase
     team = create_team_with_smooch_bot_installed
     SmoochNlu.new(team.slug).enable!
     Bot::Smooch.get_installation('smooch_id', 'test')
-    assert_not_nil SmoochNlu.menu_option_from_message('I want to subscribe to the newsletter', @menu_options)
+    assert_not_nil SmoochNlu.menu_option_from_message('I want to subscribe to the newsletter', 'en', @menu_options)
   end
 end


### PR DESCRIPTION
## Description

This branch makes a few improvements / tweaks to the NLU prototype.

1. It does not do an Alegre look up if options is nil. This occurs on the first message of a conversation, for example. In the future, we might want to consider all menu options across all workflows/languages, but the current fix simply doesn't return any option
2. It looks at all the Alegre results and chooses the menu option that has the highest scoring match and exists
This is a bug fix (otherwise we had issues where the top result was a menu option that didn't exist)  In the future we should consider a disambiguation menu for close options but for now I think this approach could work ok.
3. Log user intents in all cases, even when NLU is not enabled or options is nil
4. Add a method list_keywords to be used on the terminal to list out current keywords for a team/language/menu.
5. Add language to the context hash sent to Alegre  - **NOTE** this is a breaking change and requires existing keywords to be reindexed in Alegre
6. Disable NLU while in the query state (so, already waiting for more user search input)

References: CV2-3650

## How has this been tested?

Local testing and end-to-end with a local tipline installed on Telegram

## Things to pay attention to during code review

We now log all unmatched intents even when NLU is disabled (the default). This will increase our logs, but I've checked with @caiosba and confirmed we don't expect an undue performance hit. The advantage of logging all intents is to gain better data into what intents we should support going forward.
 
## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

