### PR TITLE
Strip spaces from URLs when validating URL annotation field.

### DIFF
--- a/config/initializers/field_validators.rb
+++ b/config/initializers/field_validators.rb
@@ -16,7 +16,7 @@ DynamicAnnotation::Field.class_eval do
     errormsg = I18n.t(:url_invalid_value)
     urls = self.value
     urls.each do |item|
-      url = URI.parse(item['url'])
+      url = URI.parse(item['url'].strip!)
       errors.add(:base, errormsg + ' ' + url.to_s) unless url.is_a?(URI::HTTP) && !url.host.nil?
     end
   end

--- a/test/models/dynamic_annotation/field_test.rb
+++ b/test/models/dynamic_annotation/field_test.rb
@@ -255,6 +255,16 @@ class DynamicAnnotation::FieldTest < ActiveSupport::TestCase
     end
   end
 
+  test "should remove leading and trailing spaces from URLs when validating URL fields" do
+    url = create_field_type field_type: 'url', label: 'URL'
+    create_field_instance name: 'url', field_type_object: url
+    f = nil
+    assert_nothing_raised do
+      f = create_field field_name: 'url', value: [{ 'url' => ' https://archive.org/web/  ' }]
+    end
+    assert_equal 'https://archive.org/web/', f.reload.value[0]['url']
+  end
+
   protected
 
   def create_geojson_field


### PR DESCRIPTION
## Description

Strip spaces from URLs when validating URL annotation field.

Fixes: CV2-3612.

## How has this been tested?

TDD. I implemented a unit test.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

