### PR TITLE
Don't pause the newsletter automatically when new content from RSS feed can't be loaded

### DIFF
--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -11,14 +11,12 @@ class TiplineNewsletterWorker
     # For RSS newsletter, if content hasn't changed or RSS can't be loaded, don't send the newsletter (actually, pause it)
     begin
       if newsletter.content_type == 'rss' && !newsletter.content_has_changed?
-        newsletter.enabled = false
         newsletter.last_delivery_error = 'CONTENT_HASNT_CHANGED'
         newsletter.save!
         log team_id, language, "RSS newsletter not sent because the content hasn't changed"
         return 0
       end
     rescue RssFeed::RssLoadError
-      newsletter.enabled = false
       newsletter.last_delivery_error = 'RSS_ERROR'
       newsletter.save!
       log team_id, language, "RSS newsletter not sent because RSS feed could not be loaded from #{newsletter.rss_feed_url}"


### PR DESCRIPTION
## Description

Don't pause the newsletter automatically when new content from RSS feed can't be loaded.

Reference: CV2-3370.

## How has this been tested?

Existing tests should cover.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

