### PR TITLE
Fixing PostgreSQL syntax error when bulk-importing versions with quotes

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,6 +76,6 @@ Rails.application.configure do
   # Disable PaperTrail by default on tests
   # https://github.com/paper-trail-gem/paper_trail#7-testing
   config.after_initialize do
-    PaperTrail.enabled = ENV['PAPERTRAIL_ENABLED'] || false
+    PaperTrail.enabled = true # ENV['PAPERTRAIL_ENABLED'] || false
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -76,6 +76,6 @@ Rails.application.configure do
   # Disable PaperTrail by default on tests
   # https://github.com/paper-trail-gem/paper_trail#7-testing
   config.after_initialize do
-    PaperTrail.enabled = true # ENV['PAPERTRAIL_ENABLED'] || false
+    PaperTrail.enabled = ENV['PAPERTRAIL_ENABLED'] || false
   end
 end

--- a/config/initializers/active_record_extensions.rb
+++ b/config/initializers/active_record_extensions.rb
@@ -40,9 +40,9 @@ module ActiveRecordExtensions
       sql = "INSERT INTO #{table_name} #{columns_sql} VALUES "
       sql_values = []
       versions.each do |version|
-        sql_values << "(#{version.values.map{|v| "'#{v}'"}.join(", ")})"
+        sql_values << "(#{version.values.map{ |v| ActiveRecord::Base.connection.quote(v) }.join(', ')})"
       end
-      sql += sql_values.join(", ")
+      sql += sql_values.join(', ')
       ActiveRecord::Base.connection.execute(ActiveRecord::Base.send(:sanitize_sql_for_assignment, sql, table_name))
     end
   end

--- a/test/models/version_test.rb
+++ b/test/models/version_test.rb
@@ -226,4 +226,31 @@ class VersionTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should sanitize content before bulk-importing" do
+    t = create_team
+    versions = [{
+      item_type: 'Team',
+      item_id: t.id,
+      event: 'update',
+      whodunnit: nil,
+      object: t.to_json,
+      object_changes: {
+        updated_at: [t.updated_at, Time.now],
+        settings: { description: "DK Shivakumar was seen drunk in today’s 'Mekedatu" }.to_yaml,
+      }.to_json,
+      created_at: Time.now,
+      meta: {}.to_json,
+      event_type: 'update_team',
+      object_after: t.to_json,
+      associated_id: t.id,
+      associated_type: 'Team',
+      team_id: t.id
+    }]
+    assert_nothing_raised do
+      assert_difference "Version.from_partition(#{t.id}).count" do
+        Team.bulk_import_versions(versions, t.id)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

This was reported by Sentry. I was able to reproduce in a unit test. The solution is to replace the manual adding of single quotes by calling `ActiveRecord::Base.connection.quote`.

Fixes: CV2-2910.

## How has this been tested?

TDD. I added a unit test that was able to reproduce the exact same error as Sentry.

## Things to pay attention to during code review

Can it have impact in other bulk-insert version operations? In order to be sure, I added a commit to enable PaperTrail for all tests (this commit is not going to be merged).

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

