### PR TITLE
CV2-2256 refactor re-index nested field rake task

### DIFF
--- a/app/lib/check_cached_fields.rb
+++ b/app/lib/check_cached_fields.rb
@@ -132,14 +132,11 @@ module CheckCachedFields
           pg_field_name: options[:pg_field_name],
           recalculate: options[:recalculate],
         }
-        obj_info = {type: obj.class.name, id: obj.id}.to_json
-        self.delay_for(1.second).update_cached_field_bg(name, obj_info, ids, callback, index_options)
+        self.delay_for(1.second).update_cached_field_bg(name, obj, ids, callback, index_options)
       end
     end
 
-    def update_cached_field_bg(name, obj_info_json, ids, callback, options)
-      obj_info = JSON.parse(obj_info_json)
-      obj = obj_info['type'].constantize.where(id: obj_info['id']).last
+    def update_cached_field_bg(name, obj, ids, callback, options)
       recalculate = options[:recalculate]
       self.where(id: ids).each do |target|
         value = callback == :recalculate ? target.send(recalculate) : obj.send(callback, target)

--- a/app/lib/check_cached_fields.rb
+++ b/app/lib/check_cached_fields.rb
@@ -132,11 +132,14 @@ module CheckCachedFields
           pg_field_name: options[:pg_field_name],
           recalculate: options[:recalculate],
         }
-        self.delay_for(1.second).update_cached_field_bg(name, obj, ids, callback, index_options)
+        obj_info = {type: obj.class.name, id: obj.id}.to_json
+        self.delay_for(1.second).update_cached_field_bg(name, obj_info, ids, callback, index_options)
       end
     end
 
-    def update_cached_field_bg(name, obj, ids, callback, options)
+    def update_cached_field_bg(name, obj_info_json, ids, callback, options)
+      obj_info = JSON.parse(obj_info_json)
+      obj = obj_info['type'].constantize.where(id: obj_info['id']).last
       recalculate = options[:recalculate]
       self.where(id: ids).each do |target|
         value = callback == :recalculate ? target.send(recalculate) : obj.send(callback, target)


### PR DESCRIPTION
## Description

 - Refactor re-index nested field rake task to collect data using one query instead of iterate using single object.
so we collect either `comments`, `tags` or `requests` using one query to reduce the execution time
- Send object id to background job to update cached field instead of sending the whole object

References: CV2-2256

## How has this been tested?

re-run `bundle exec rails check:project_media:sync_es_nested_field['field:requests']` locally against live db and done in minutes instead of days 

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

