### PR TITLE
Count number of items in a list.

### DIFF
--- a/app/graph/types/saved_search_type.rb
+++ b/app/graph/types/saved_search_type.rb
@@ -7,7 +7,7 @@ class SavedSearchType < DefaultObject
   field :title, GraphQL::Types::String, null: true
   field :team_id, GraphQL::Types::Int, null: true
   field :team, TeamType, null: true
-
+  field :items_count, GraphQL::Types::Int, null: true
   field :filters, GraphQL::Types::String, null: true
 
   def filters

--- a/app/models/saved_search.rb
+++ b/app/models/saved_search.rb
@@ -7,4 +7,8 @@ class SavedSearch < ApplicationRecord
   belongs_to :team, optional: true
   has_many :feeds, dependent: :nullify
   has_many :feed_teams, dependent: :nullify
+
+  def items_count
+    CheckSearch.new(self.filters.to_json, nil, self.team_id).number_of_results
+  end
 end

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -11829,6 +11829,7 @@ type SavedSearch implements Node {
   filters: String
   id: ID!
   is_part_of_feeds: Boolean
+  items_count: Int
   permissions: String
   team: Team
   team_id: Int

--- a/public/relay.json
+++ b/public/relay.json
@@ -62258,6 +62258,20 @@
               "deprecationReason": null
             },
             {
+              "name": "items_count",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "permissions",
               "description": null,
               "args": [

--- a/test/models/saved_search_test.rb
+++ b/test/models/saved_search_test.rb
@@ -3,7 +3,6 @@ require_relative '../test_helper'
 class SavedSearchTest < ActiveSupport::TestCase
   def setup
     require 'sidekiq/testing'
-    super
     SavedSearch.delete_all
   end
 
@@ -39,5 +38,10 @@ class SavedSearchTest < ActiveSupport::TestCase
   test "should serialize the filters" do
     ss = create_saved_search filters: { foo: 'bar'}
     assert_equal 'bar', ss.reload.filters['foo']
+  end
+
+  test "should count number of items" do
+    ss = create_saved_search
+    assert_equal 0, ss.items_count
   end
 end


### PR DESCRIPTION
## Description

* Adding a method `items_count` to `SavedSearch` that returns the number of items in a list
* Essentially, it runs an ElasticSearch query that returns the number of items that match the filters defined by the `SavedSearch` instance
* Exposed in GraphQL as field `items_count` for `SavedSearchType`

Reference: CV2-3419.

## How has this been tested?

Added a unit test for the new method.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

