### PR TITLE
CV2-3177: skip validation when newsletter enabled is false

### DIFF
--- a/test/controllers/graphql_controller_9_test.rb
+++ b/test/controllers/graphql_controller_9_test.rb
@@ -345,7 +345,7 @@ class GraphqlController9Test < ActionController::TestCase
   end
 
   test "should return tipline newsletter errors as an array" do
-    query = 'mutation create { createTiplineNewsletter(input: { clientMutationId: "1", content_type: "rss", language: "en", time: "10:00", send_every: ["holiday"], timezone: "America/Los_Angeles" }) { tipline_newsletter { id, time, send_on, enabled } } }'
+    query = 'mutation create { createTiplineNewsletter(input: { clientMutationId: "1", enabled: true, content_type: "rss", language: "en", time: "10:00", send_every: ["holiday"], timezone: "America/Los_Angeles" }) { tipline_newsletter { id, time, send_on, enabled } } }'
     assert_no_difference 'TiplineNewsletter.count' do
       post :create, params: { query: query, team: @t.slug }
     end

--- a/test/models/tipline_newsletter_test.rb
+++ b/test/models/tipline_newsletter_test.rb
@@ -34,6 +34,8 @@ class TiplineNewsletterTest < ActiveSupport::TestCase
 
   test 'should have introduction' do
     @newsletter.introduction = ''
+    assert @newsletter.valid?
+    @newsletter.enabled = 1
     assert_not @newsletter.valid?
   end
 
@@ -53,6 +55,7 @@ class TiplineNewsletterTest < ActiveSupport::TestCase
   end
 
   test 'should have between 0 and 3 articles' do
+    @newsletter.enabled = 1
     @newsletter.number_of_articles = 4
     assert_not @newsletter.valid?
     @newsletter.number_of_articles = 0
@@ -60,6 +63,7 @@ class TiplineNewsletterTest < ActiveSupport::TestCase
   end
 
   test 'should have a valid day' do
+    @newsletter.enabled = 1
     @newsletter.send_every = 'tuesday'
     assert_not @newsletter.valid?
     @newsletter.send_every = ['invalid_day']


### PR DESCRIPTION
## Description

Skip some validation when newsletter.enabled is 0.

References: CV2-3177

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

