### PR TITLE
CV2-3664 allow column fact check published at to be sortable

### DIFF
--- a/app/lib/check_elastic_search.rb
+++ b/app/lib/check_elastic_search.rb
@@ -22,7 +22,6 @@ module CheckElasticSearch
     ms.attributes[:parent_id] = self.id
     ms.attributes[:created_at] = self.created_at.utc
     ms.attributes[:updated_at] = self.updated_at.utc
-    ms.attributes[:media_published_at] = self.media_published_at
     ms.attributes[:source_id] = self.source_id
     # Intial nested objects with []
     ['comments', 'tags', 'task_responses', 'assigned_user_ids', 'requests'].each{ |f| ms.attributes[f] = [] }

--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -185,6 +185,7 @@ module ProjectMediaCachedFields
 
     cached_field :fact_check_published_on,
       start_as: 0,
+      update_es: true,
       recalculate: :recalculate_fact_check_published_on,
       update_on: [FACT_CHECK_EVENT]
 

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -421,9 +421,9 @@ class ProjectMedia < ApplicationRecord
     ms.attributes[:language] = self.get_dynamic_annotation('language')&.get_field_value('language')
     # set fields with integer value including cached fields
     fields_i = [
-      'archived', 'sources_count', 'linked_items_count', 'share_count',
-      'last_seen', 'demand', 'user_id', 'read', 'suggestions_count',
-      'related_count', 'reaction_count', 'comment_count', 'media_published_at', 'unmatched'
+      'archived', 'sources_count', 'linked_items_count', 'share_count','last_seen', 'demand', 'user_id',
+      'read', 'suggestions_count','related_count', 'reaction_count', 'comment_count', 'media_published_at',
+      'unmatched', 'fact_check_published_on'
     ]
     fields_i.each{ |f| ms.attributes[f] = self.send(f).to_i }
     # add more cached fields

--- a/app/repositories/media_search.rb
+++ b/app/repositories/media_search.rb
@@ -134,5 +134,7 @@ class MediaSearch
     indexes :unmatched, { type: 'long' }
 
     indexes :report_language, { type: 'keyword', normalizer: 'check' }
+
+    indexes :fact_check_published_on, { type: 'long' }
   end
 end

--- a/db/migrate/20230906054844_add_mapping_for_fact_check_published_on_field.rb
+++ b/db/migrate/20230906054844_add_mapping_for_fact_check_published_on_field.rb
@@ -1,0 +1,13 @@
+class AddMappingForFactCheckPublishedOnField < ActiveRecord::Migration[6.1]
+  def change
+    options = {
+      index: CheckElasticSearchModel.get_index_alias,
+      body: {
+        properties: {
+          fact_check_published_on: { type: 'long' },
+        }
+      }
+    }
+    $repository.client.indices.put_mapping options
+  end
+end

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -55,7 +55,8 @@ class CheckSearch
     'type_of_media' => 'type_of_media', 'title' => 'title_index', 'creator_name' => 'creator_name',
     'cluster_size' => 'cluster_size', 'cluster_first_item_at' => 'cluster_first_item_at',
     'cluster_last_item_at' => 'cluster_last_item_at', 'cluster_requests_count' => 'cluster_requests_count',
-    'cluster_published_reports_count' => 'cluster_published_reports_count', 'score' => '_score'
+    'cluster_published_reports_count' => 'cluster_published_reports_count', 'score' => '_score',
+    'fact_check_published_on' => 'fact_check_published_on'
   }
 
   def team_condition(team_id = nil)


### PR DESCRIPTION
## Description

1. Allow user to sort by fact-check published_at date.

References: CV2-3664

## How has this been tested?

1. Go to workspace settings=> columns
2. Show Fact-check published at column
3. Go to list page and try to sort by Fact-check published at column

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

