### PR TITLE
Updating copy for tipline bot message.

### DIFF
--- a/db/migrate/20230906160303_update_copy_for_smooch_bot_message.rb
+++ b/db/migrate/20230906160303_update_copy_for_smooch_bot_message.rb
@@ -1,0 +1,13 @@
+class UpdateCopyForSmoochBotMessage < ActiveRecord::Migration[6.1]
+  def change
+    tb = BotUser.smooch_user
+    unless tb.nil?
+      settings = tb.get_settings.clone || []
+      i = settings.find_index{ |s| s['name'] == 'smooch_disabled' }
+      settings[i]['label'] = 'Pause the bot'
+      settings[i]['description'] = 'When paused, the bot will send the "Inactive bot" message to any user interacting with the tipline. No other messages will be sent. The tipline will not be deactivated.'
+      tb.set_settings(settings)
+      tb.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_08_25_234109) do
+ActiveRecord::Schema.define(version: 2023_09_06_160303) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Reference: CV2-3628.

## Description

Updating copy for tipline bot message.

Reference: CV2-3628.

## How has this been tested?

Go to the tipline settings tab. Under "Pause the bot" checkbox, the description should read: "When paused, the bot will send the "Inactive bot" message to any user interacting with the tipline. No other messages will be sent. The tipline will not be deactivated.".

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

