### PR TITLE
CV2-3589 add language as a parameter for import_claim_reviews

### DIFF
--- a/app/models/bot/fetch.rb
+++ b/app/models/bot/fetch.rb
@@ -171,7 +171,9 @@ class Bot::Fetch < BotUser
           (from.to_i..to.to_i).step(step.days).each do |current_timestamp|
             from2 = Time.at(current_timestamp)
             to2 = from2 + step.days
-            Bot::Fetch.get_claim_reviews({ service: service_name, start_time: from2.strftime('%Y-%m-%d'), end_time: to2.strftime('%Y-%m-%d'), language: language}).each do |claim_review|
+            params = { service: service_name, start_time: from2.strftime('%Y-%m-%d'), end_time: to2.strftime('%Y-%m-%d'), language: language}
+            params[:language] = language if !language.nil?
+            Bot::Fetch.get_claim_reviews(params).each do |claim_review|
               next if !maximum.nil? && total >= maximum
               self.import_claim_review(claim_review, team.id, user.id, status_fallback, status_mapping, auto_publish_reports, force)
               total += 1

--- a/app/models/bot/fetch.rb
+++ b/app/models/bot/fetch.rb
@@ -94,7 +94,7 @@ class Bot::Fetch < BotUser
       end
     end
     previous_services.each { |previous_service| self.call_fetch_api(:delete, 'subscribe', { service: previous_service, url: self.webhook_url(team) }) }
-    Bot::Fetch::Import.delay_for(1.second, { queue: 'fetch', retry: 0 }).import_claim_reviews(installation.id) unless new_services.blank?
+    Bot::Fetch::Import.delay_for(1.second, { queue: 'fetch', retry: 0 }).import_claim_reviews(installation.id, language, false, nil) unless new_services.blank?
   end
 
   def self.is_service_supported?(service)
@@ -148,7 +148,7 @@ class Bot::Fetch < BotUser
   # Mandatory fields in the imported ClaimReview: claim_review_headline, claim_review_url, created_at and id
 
   class Import
-    def self.import_claim_reviews(installation_id, force = false, maximum = nil)
+    def self.import_claim_reviews(installation_id, language = nil, force = false, maximum = nil)
       installation = TeamBotInstallation.find(installation_id)
       RequestStore.store[:skip_notifications] = true
       RequestStore.store[:skip_cached_field_update] = false
@@ -171,7 +171,7 @@ class Bot::Fetch < BotUser
           (from.to_i..to.to_i).step(step.days).each do |current_timestamp|
             from2 = Time.at(current_timestamp)
             to2 = from2 + step.days
-            Bot::Fetch.get_claim_reviews({ service: service_name, start_time: from2.strftime('%Y-%m-%d'), end_time: to2.strftime('%Y-%m-%d')}).each do |claim_review|
+            Bot::Fetch.get_claim_reviews({ service: service_name, start_time: from2.strftime('%Y-%m-%d'), end_time: to2.strftime('%Y-%m-%d'), language: language}).each do |claim_review|
               next if !maximum.nil? && total >= maximum
               self.import_claim_review(claim_review, team.id, user.id, status_fallback, status_mapping, auto_publish_reports, force)
               total += 1

--- a/app/models/bot/fetch.rb
+++ b/app/models/bot/fetch.rb
@@ -171,7 +171,7 @@ class Bot::Fetch < BotUser
           (from.to_i..to.to_i).step(step.days).each do |current_timestamp|
             from2 = Time.at(current_timestamp)
             to2 = from2 + step.days
-            params = { service: service_name, start_time: from2.strftime('%Y-%m-%d'), end_time: to2.strftime('%Y-%m-%d'), language: language}
+            params = { service: service_name, start_time: from2.strftime('%Y-%m-%d'), end_time: to2.strftime('%Y-%m-%d')}
             params[:language] = language if !language.nil?
             Bot::Fetch.get_claim_reviews(params).each do |claim_review|
               next if !maximum.nil? && total >= maximum

--- a/lib/tasks/data/fetch.rake
+++ b/lib/tasks/data/fetch.rake
@@ -137,7 +137,8 @@ namespace :check do
         services.each { |service| Bot::Fetch.call_fetch_api(:delete, 'subscribe', { service: service, url: Bot::Fetch.webhook_url(team) }) }
         services.each { |service| Bot::Fetch.call_fetch_api(:post, 'subscribe', { service: service, url: Bot::Fetch.webhook_url(team) }) }
         tbi = TeamBotInstallation.where(user_id: BotUser.find_by_login('fetch').id, team_id: team.id).last.id
-        Bot::Fetch::Import.delay(retry: 0).import_claim_reviews(tbi, force)
+        #dont support languages here, its just going to get too messy via the rake syntax.
+        Bot::Fetch::Import.delay(retry: 0).import_claim_reviews(tbi, nil, force)
       end
     end
 
@@ -172,7 +173,7 @@ namespace :check do
       end
       Bot::Fetch.set_service(team.slug, services, 'undetermined', status_mapping)
       tbi = TeamBotInstallation.where(user_id: BotUser.find_by_login('fetch').id, team_id: team.id).last.id
-      Bot::Fetch::Import.import_claim_reviews(tbi, true, size)
+      Bot::Fetch::Import.import_claim_reviews(tbi, nil, true, size)
       puts "A sample of #{size} articles were imported from Fetch service(s) #{services.join(', ')} to https://checkmedia.org/#{team.slug}/imported-fact-checks."
     end
   end


### PR DESCRIPTION
## Description

Adds a language parameter to `import_claim_reviews`, and passes that along to fetch, which already supports it.

References: 3589

## How has this been tested?

I've tested the fetch side of this, and this update is simply a passthrough to allow for using that functionality.

## Things to pay attention to during code review

Nothing particularly exciting here.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

