### PR TITLE
Do not crash when calculating number of items in a list that has an invalid team task filter

### DIFF
--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -488,8 +488,8 @@ class CheckSearch
 
   def team_tasks_conditions
     conditions = []
-    return conditions unless @options.has_key?('team_tasks') && @options['team_tasks'].class.name == 'Array'
-    @options['team_tasks'].delete_if{ |tt| tt['response'].blank? }
+    return conditions unless @options['team_tasks'].class.name == 'Array'
+    @options['team_tasks'].delete_if{ |tt| tt['response'].blank? || tt['id'].blank? }
     @options['team_tasks'].each do |tt|
       must_c = []
       must_c << { term: { "task_responses.team_task_id": tt['id'] } } if tt.has_key?('id')

--- a/test/models/saved_search_test.rb
+++ b/test/models/saved_search_test.rb
@@ -44,4 +44,11 @@ class SavedSearchTest < ActiveSupport::TestCase
     ss = create_saved_search
     assert_equal 0, ss.items_count
   end
+
+  test "should not crash if filter is invalid" do
+    ss = create_saved_search filters: { team_tasks: [{ id: '', task_type: 'single_choice', response: 'NO_VALUE' }] }
+    assert_nothing_raised do
+      assert_equal 0, ss.items_count
+    end
+  end
 end


### PR DESCRIPTION
## Description

I noticed it happening on live only for duplicated workspaces. When a list has a team task filter that doesn't have a valid ID, an exception would happen. I was able to reproduce that exception in a unit test.

The fix was to discard the team task filter if the ID is blank.

Fixes CV2-3742.

## How has this been tested?

TDD. I was able to implement a unit test that reproduced the issue.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

