### PR TITLE
Automatically install tipline in v2 when workspace is created.

### DIFF
--- a/app/models/concerns/smooch_team_bot_installation.rb
+++ b/app/models/concerns/smooch_team_bot_installation.rb
@@ -16,10 +16,14 @@ module SmoochTeamBotInstallation
         end
       end
 
-      # Save Twitter/Facebook token and authorization URL
       after_create do
         if self.bot_user&.identifier == 'smooch'
+          # Save Twitter/Facebook token and authorization URL
           self.reset_smooch_authorization_token
+
+          # Bump to v2
+          self.set_smooch_version = 'v2'
+
           self.save!
         end
       end

--- a/db/migrate/20230914152816_mark_tipline_bot_as_default.rb
+++ b/db/migrate/20230914152816_mark_tipline_bot_as_default.rb
@@ -1,0 +1,9 @@
+class MarkTiplineBotAsDefault < ActiveRecord::Migration[6.1]
+  def change
+    tb = BotUser.smooch_user
+    unless tb.nil?
+      tb.default = true
+      tb.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_06_160303) do
+ActiveRecord::Schema.define(version: 2023_09_14_152816) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -985,6 +985,7 @@ class ActiveSupport::TestCase
       })
     end
     @installation = create_team_bot_installation user_id: @bot.id, settings: @settings.merge(extra_settings), team_id: @team.id
+    @installation.set_smooch_version = 'v1' ; @installation.save!
     create_team_bot_installation user_id: @bot.id, settings: {}, team_id: create_team.id
     Bot::Smooch.get_installation('smooch_webhook_secret', 'test')
     @media_url = 'https://smooch.com/image/test.jpeg'


### PR DESCRIPTION
## Description

* Set `default` as `true` for the Smooch Bot, this way it's installed automatically for all new workspaces
* Bump to v2 automatically when Smooch Bot is installed

Refences: CV2-833 and CV2-3558.

## How has this been tested?

Existing tests should pass. When running the application, this can be tested this way:

* Create a new workspace
* Go to the "Tipline" tab: It should be installed and display the v2 settings UI

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

