### PR TITLE
Fixing "PG::UntranslatableCharacter" error when storing some Pender data annotations

### DIFF
--- a/app/models/annotations/dynamic.rb
+++ b/app/models/annotations/dynamic.rb
@@ -98,6 +98,7 @@ class Dynamic < ApplicationRecord
     f.skip_check_ability = true
     f.disable_es_callbacks = self.disable_es_callbacks || value.blank?
     f.field_name = name
+    value.gsub!('\u0000', '') if value.is_a?(String) # Avoid PG::UntranslatableCharacter exception
     f.value = value
     f.annotation_id = self.id
     f

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -593,4 +593,14 @@ class MediaTest < ActiveSupport::TestCase
     l = create_valid_media
     assert_equal '', l.picture
   end
+
+  test "should sanitize link data before storing" do
+    pender_url = CheckConfig.get('pender_url_private') + '/api/medias'
+    url = random_url
+    response = { type: 'media', data: { url: url, type: 'item', title: "Foo \u0000 bar" } }
+    WebMock.stub_request(:get, pender_url).with({ query: { url: url } }).to_return(body: response.to_json)
+    assert_difference 'Link.count' do
+      create_media url: url
+    end
+  end
 end


### PR DESCRIPTION
## Description

PostgreSQL doesn't support null characters in a JSON column, so these characters need to be removed before storing.

Fixes CV2-3582.

## How has this been tested?

TDD. I added a unit test for this case.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

