### PR TITLE
Fixing how Sentry is notified when an external bot can't be called.

### DIFF
--- a/app/models/bot_user.rb
+++ b/app/models/bot_user.rb
@@ -180,7 +180,7 @@ class BotUser < User
         begin
           response = http.request(request)
         rescue StandardError => e
-          CheckSentry.notify(ExternalBotRequestError.new('Could not send request to external bot'), { error: e, bot_id: self.id })
+          CheckSentry.notify(ExternalBotRequestError.new('Could not send request to external bot'), error: e, bot_id: self.id)
           return nil
         end
         # Log data with team_id only to avoid Encoding::CompatibilityError


### PR DESCRIPTION
## Description

Just fixing a syntax error.

Fixes CV2-3626.

## How has this been tested?

I was able to reproduce in Rails console but not in a test.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

