### PR TITLE
Fixing: Media headers should work for non-WhatsApp tiplines.

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -614,7 +614,7 @@ class Team < ApplicationRecord
     tbi = TeamBotInstallation.where(team_id: self.id, user_id: BotUser.smooch_user&.id.to_i).last
     unless tbi.nil?
       ['none', 'image', 'video', 'audio', 'link_preview'].each do |header_type|
-        mapped_header_type = TiplineNewsletter::HEADER_TYPE_MAPPING[header_type]
+        mapped_header_type = TiplineNewsletter::WHATSAPP_HEADER_TYPE_MAPPING[header_type]
         if !tbi.send("get_smooch_template_name_for_newsletter_#{mapped_header_type}_no_articles").blank? &&
            !tbi.send("get_smooch_template_name_for_newsletter_#{mapped_header_type}_one_articles").blank? &&
            !tbi.send("get_smooch_template_name_for_newsletter_#{mapped_header_type}_two_articles").blank? &&

--- a/app/models/tipline_resource.rb
+++ b/app/models/tipline_resource.rb
@@ -14,9 +14,7 @@ class TiplineResource < ApplicationRecord
     message = []
     message << "*#{self.title.strip}*" unless self.title.strip.blank?
     message << self.content unless self.content.blank?
-    if self.content_type == 'static'
-      # FIXME: Handle static content
-    elsif self.content_type == 'rss' && !self.rss_feed_url.blank?
+    if self.content_type == 'rss' && !self.rss_feed_url.blank?
       message << Rails.cache.fetch("tipline_resource:rss_feed:#{Digest::MD5.hexdigest(self.rss_feed_url)}:#{self.number_of_articles}", expires_in: 15.minutes, skip_nil: true) do
         rss_feed = RssFeed.new(self.rss_feed_url)
         rss_feed.get_articles(self.number_of_articles).join("\n\n")

--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -40,7 +40,7 @@ class TiplineNewsletterWorker
         RequestStore.store[:smooch_bot_platform] = ts.platform
         Bot::Smooch.get_installation('team_bot_installation_id', tbi.id) { |i| i.id == tbi.id }
 
-        response = Bot::Smooch.send_message_to_user(ts.uid, newsletter.format_as_template_message)
+        response = (ts.platform == 'WhatsApp' ? Bot::Smooch.send_message_to_user(ts.uid, newsletter.format_as_template_message) : Bot::Smooch.send_message_to_user(ts.uid, *newsletter.format_as_tipline_message))
 
         if response.code.to_i < 400
           log team_id, language, "Newsletter sent to subscriber ##{ts.id}, response: (#{response.code}) #{response.body.inspect}"

--- a/test/workers/tipline_newsletter_worker_test.rb
+++ b/test/workers/tipline_newsletter_worker_test.rb
@@ -82,4 +82,11 @@ class TiplineNewsletterWorkerTest < ActiveSupport::TestCase
     TiplineNewsletter.any_instance.stubs(:content_has_changed?).raises(RssFeed::RssLoadError)
     assert_equal 0, TiplineNewsletterWorker.new.perform(@team.id, 'en')
   end
+
+  test "should send newsletter for non-WhatsApp subscription" do
+    create_tipline_subscription team_id: @team.id, platform: 'Telegram'
+    assert_nothing_raised do
+      TiplineNewsletterWorker.perform_async(@team.id, 'en')
+    end
+  end
 end


### PR DESCRIPTION
## Description

Only WhatsApp requires template messages. The fix here is to use the regular message type when sending newsletters to non-WhatsApp subscribers.

Fixes CV2.3646.

## How has this been tested?

I added a unit test for this case.

## Things to pay attention to during code review

Nothing in particular. I renamed a constant for clarity and also removed two lines of code not related to this fix but not required anymore.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

