### PR TITLE
Ignore status changing permission check if previous value is not a string

### DIFF
--- a/app/models/workflow/concerns/dynamic_annotation_field_concern.rb
+++ b/app/models/workflow/concerns/dynamic_annotation_field_concern.rb
@@ -124,7 +124,9 @@ module Workflow
           if ::Workflow::Workflow.is_field_name_a_workflow?(self.field_name)
             options = self.workflow_options_and_roles
             value = self.value&.to_sym
-            old_value = self.previous_value&.to_sym
+            old_value = self.previous_value
+            return true unless old_value.is_a?(String)
+            old_value = old_value.to_sym
             self.previous_status = old_value
             user = User.current
 

--- a/test/models/dynamic_annotation/field_test.rb
+++ b/test/models/dynamic_annotation/field_test.rb
@@ -265,6 +265,21 @@ class DynamicAnnotation::FieldTest < ActiveSupport::TestCase
     assert_equal 'https://archive.org/web/', f.reload.value[0]['url']
   end
 
+  test "should ignore permission check for changing status if previous value is empty" do
+    create_verification_status_stuff
+    pm = create_project_media
+    a = create_dynamic_annotation annotation_type: 'verification_status', annotated: pm, set_fields: { verification_status_status: 'undetermined' }.to_json
+    assert_equal 'undetermined', pm.reload.last_status
+    f = a.get_field('verification_status_status')
+    f.update_column(:value, [])
+    f = DynamicAnnotation::Field.find(f.id)
+    assert_nothing_raised do
+      f.value = 'false'
+      f.save!
+    end
+    assert_equal 'false', pm.reload.last_status
+  end
+
   protected
 
   def create_geojson_field


### PR DESCRIPTION
## Description

Ignore status changing permission check if previous value is not a string. Fixes CV2-3764.

## How has this been tested?

TDD. I was able to reproduce the bug in a unit test.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

