### PR TITLE
Use "random" argument passed to GraphQL team query.

### DIFF
--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -79,12 +79,13 @@ class QueryType < BaseObject
     argument :random, GraphQL::Types::String, required: false
   end
 
-  def team(id: nil, slug: nil, _random: nil)
+  def team(id: nil, slug: nil, random: nil)
     tid = id.to_i
-    if !slug.blank?
+    unless slug.blank?
       team = Team.where(slug: slug).first
       tid = team.id unless team.nil?
     end
+    team.reload if random
     tid = Team.current&.id || User.current&.teams&.first&.id if tid === 0
     GraphqlCrudOperations.load_if_can(Team, tid.to_i, context)
   end


### PR DESCRIPTION
## Description

This is temporarily needed in order to bypass Relay compat cache. Shouldn't be needed once the client is completely migrated to Relay modern.

Fixes CV2-3775.

## How has this been tested?

Existing tests should cover this change.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

