### PR TITLE
Feature/devops 466 remove GitHub token

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - feature/DEVOPS-466_remove-github-token
 
 deploy_qa:
   image: docker:latest
@@ -45,20 +46,18 @@ deploy_qa:
     - alias aws='docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION --rm amazon/aws-cli'
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/check-api/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/check-api/##' > env.qa.names
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-migration $NAME /qa/check-api/$NAME " >> qa-check-api-migration.env.args; done
-    - echo -n "-s qa-check-api-migration GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-migration.env.args
     - ecs update qa-check-api-migration --image qa-check-api-migration $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA --exclusive-env -e qa-check-api-migration APP check-api -e qa-check-api-migration DEPLOY_ENV qa -e qa-check-api-migration AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-check-api-migration.env.args`
     - taskArn=$(aws ecs run-task --cluster ecs-qa --task-definition qa-check-api-migration --query 'tasks[].taskArn' --output text)
     - echo "Migration task started - $taskArn"
     - aws ecs wait tasks-stopped --cluster ecs-qa --tasks $taskArn
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-c $NAME /qa/check-api/$NAME " >> qa-check-api-c.env.args; done
-    - echo -n "-s qa-check-api-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-c.env.args
     - ecs deploy ecs-qa qa-check-api --image qa-check-api-c $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e qa-check-api-c APP check-api -e qa-check-api-c DEPLOY_ENV qa -e qa-check-api-c AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-check-api-c.env.args`
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-background $NAME /qa/check-api/$NAME " >> qa-check-api-background.env.args; done
-    - echo -n "-s qa-check-api-background GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> qa-check-api-background.env.args
     - ecs deploy ecs-qa qa-check-api-background --image qa-check-api-background $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e qa-check-api-background APP check-api -e qa-check-api-background DEPLOY_ENV qa -e qa-check-api-background AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat qa-check-api-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - feature/DEVOPS-466_remove-github-token
 
 build_batch:
   image: docker:latest
@@ -123,18 +122,15 @@ deploy_live:
     - alias aws='docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION --rm amazon/aws-cli'
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/check-api/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/check-api/##' > env.live.names
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-migration $NAME /live/check-api/$NAME " >> live-check-api-migration.env.args; done
-    - echo -n "-s live-check-api-migration GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-check-api-migration.env.args
     - ecs update live-check-api-migration --image live-check-api-migration $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA --exclusive-env -e live-check-api-migration APP check-api -e live-check-api-migration DEPLOY_ENV live -e live-check-api-migration AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat live-check-api-migration.env.args`
     - taskArn=$(aws ecs run-task --cluster ecs-live --task-definition live-check-api-migration --query 'tasks[].taskArn' --output text)
     - echo "Migration task started - $taskArn"
     - aws ecs wait tasks-stopped --cluster ecs-live --tasks $taskArn
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-c $NAME /live/check-api/$NAME " >> live-check-api-c.env.args; done
-    - echo -n "-s live-check-api-c GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-check-api-c.env.args
     - python3 scripts/uptime-maintenance.py on
     - ecs deploy ecs-live  live-check-api --image live-check-api-c $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e live-check-api-c APP check-api -e live-check-api-c DEPLOY_ENV live -e live-check-api-c AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat live-check-api-c.env.args`
     - python3 scripts/uptime-maintenance.py off
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-background $NAME /live/check-api/$NAME " >> live-check-api-background.env.args; done
-    - echo -n "-s live-check-api-background GITHUB_TOKEN arn:aws:secretsmanager:eu-west-1:848416313321:secret:GithubToken-Plain-BUhwIw" >> live-check-api-background.env.args
     - ecs deploy ecs-live  live-check-api-background --image live-check-api-background $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA  --timeout 3600 --exclusive-env -e live-check-api-background APP check-api -e live-check-api-background DEPLOY_ENV live -e live-check-api-background AWS_REGION $AWS_DEFAULT_REGION --exclusive-secrets `cat live-check-api-background.env.args`
     - echo "new Image was deployed $ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA"
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,7 +22,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
-    - feature/DEVOPS-466_remove-github-token
 
 deploy_qa:
   image: docker:latest
@@ -57,7 +56,6 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
-    - feature/DEVOPS-466_remove-github-token
 
 build_batch:
   image: docker:latest

--- a/production/bin/run_command.sh
+++ b/production/bin/run_command.sh
@@ -4,8 +4,8 @@
 
 set -e
 
-if [[ -z ${GITHUB_TOKEN+x} || -z ${DEPLOY_ENV+x} ]]; then
-	echo "GITHUB_TOKEN, DEPLOY_ENV  must be in the environment. Exiting."
+if [[ -z ${DEPLOY_ENV+x} ]]; then
+	echo "DEPLOY_ENV must be in the environment. Exiting."
 	exit 1
 fi
 

--- a/production/bin/run_migration.sh
+++ b/production/bin/run_migration.sh
@@ -6,8 +6,8 @@ set -e
 
 DEPLOY_ENV=$1
 
-if [[ -z ${GITHUB_TOKEN+x} || -z ${DEPLOY_ENV+x} ]]; then
-	echo "GITHUB_TOKEN, DEPLOY_ENV  must be in the environment. Exiting."
+if [[ -z ${DEPLOY_ENV+x} ]]; then
+	echo "DEPLOY_ENV must be in the environment. Exiting."
 	exit 1
 fi
 


### PR DESCRIPTION
## Description

This change eliminates references to the deprecated GITHUB_TOKEN variable in ECS task definitions.

References: DEVOPS-466

## How has this been tested?

I tested a QA deployment from this branch to verify startup behavior. This included migration tasks.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [X] My changes generate no new warnings
