### PR TITLE
Changing `sendTiplineMessage` mutation so that it requires only one argument besides the message

### DIFF
--- a/app/graph/types/dynamic_annotation_field_type.rb
+++ b/app/graph/types/dynamic_annotation_field_type.rb
@@ -6,6 +6,7 @@ class DynamicAnnotationFieldType < DefaultObject
   field :dbid, GraphQL::Types::Int, null: true
   field :value_json, JsonStringType, null: true
   field :annotation, AnnotationType, null: true
+  field :annotation_id, GraphQL::Types::Int, null: true
   field :associated_graphql_id, GraphQL::Types::String, null: true
   field :smooch_user_slack_channel_url, GraphQL::Types::String, null: true
   field :smooch_user_external_identifier, GraphQL::Types::String, null: true

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -437,6 +437,11 @@ module SmoochMessages
       sm.reset
     end
 
+    def reply_to_request_with_custom_message(request, message)
+      data = JSON.parse(request.get_field_value('smooch_data'))
+      self.send_custom_message_to_user(request.annotated.team, data['authorId'], data['received'], message, data['language'])
+    end
+
     def send_custom_message_to_user(team, uid, timestamp, message, language)
       platform = self.get_user_platform(uid)
       RequestStore.store[:smooch_bot_platform] = platform

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -11967,10 +11967,8 @@ input SendInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
-  language: String!
+  inReplyToId: Int!
   message: String!
-  timestamp: Int!
-  uid: ID!
 }
 
 """

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -4576,6 +4576,7 @@ DynamicAnnotation::Field type
 """
 type DynamicAnnotationField implements Node {
   annotation: Annotation
+  annotation_id: Int
   associated_graphql_id: String
   created_at: String
   dbid: Int

--- a/public/relay.json
+++ b/public/relay.json
@@ -62794,39 +62794,7 @@
           "fields": null,
           "inputFields": [
             {
-              "name": "uid",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "ID",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "message",
-              "description": null,
-              "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "timestamp",
+              "name": "inReplyToId",
               "description": null,
               "type": {
                 "kind": "NON_NULL",
@@ -62842,7 +62810,7 @@
               "deprecationReason": null
             },
             {
-              "name": "language",
+              "name": "message",
               "description": null,
               "type": {
                 "kind": "NON_NULL",

--- a/public/relay.json
+++ b/public/relay.json
@@ -25855,6 +25855,20 @@
               "deprecationReason": null
             },
             {
+              "name": "annotation_id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "associated_graphql_id",
               "description": null,
               "args": [

--- a/test/controllers/graphql_controller_10_test.rb
+++ b/test/controllers/graphql_controller_10_test.rb
@@ -784,9 +784,11 @@ class GraphqlController10Test < ActionController::TestCase
     u = create_user
     t = create_team
     create_team_user user: u, team: t, role: 'editor'
+    pm = create_project_media team: t
+    a = create_dynamic_annotation annotation_type: 'smooch', set_fields: { smooch_data: { authorId: '123', language: 'en', received: Time.now.to_f }.to_json }.to_json, annotated: pm
     authenticate_with_user(u)
 
-    query = 'mutation { sendTiplineMessage(input: { clientMutationId: "1", uid: "123456", message: "Hello", language: "en", timestamp: 1695692221 }) { success } }'
+    query = "mutation { sendTiplineMessage(input: { clientMutationId: \"1\", message: \"Hello\", inReplyToId: #{a.id} }) { success } }"
     post :create, params: { query: query, team: t.slug }
 
     assert_response :success
@@ -797,9 +799,11 @@ class GraphqlController10Test < ActionController::TestCase
     Bot::Smooch.stubs(:send_message_to_user).returns(OpenStruct.new(code: 200)).never
     u = create_user
     t = create_team
+    pm = create_project_media team: t
+    a = create_dynamic_annotation annotation_type: 'smooch', set_fields: { smooch_data: { authorId: '123', language: 'en', received: Time.now.to_f }.to_json }.to_json, annotated: pm
     authenticate_with_user(u)
 
-    query = 'mutation { sendTiplineMessage(input: { clientMutationId: "1", uid: "123456", message: "Hello", language: "en", timestamp: 1695692221 }) { success } }'
+    query = "mutation { sendTiplineMessage(input: { clientMutationId: \"1\", message: \"Hello\", inReplyToId: #{a.id} }) { success } }"
     post :create, params: { query: query, team: t.slug }
 
     assert_response :success


### PR DESCRIPTION
## Description

For now the only use case is to allow custom messages to be sent in reply to previous user requests. So, this PR changes the `sendTiplineMessage` mutation... instead of requiring `uid`, `timestamp` and `language`, it just requires the ID of the request (`smooch` annotation).

References: CV2-3643 and CV2-3677.

## How has this been tested?

There are two automated tests that were updated.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

