### PR TITLE
3718 – Update how we retry tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 - docker-compose -f docker-compose.yml -f docker-test.yml up -d
 - tail -f log/test.log &
 - until curl --silent -I -f --fail http://localhost:3000 ; do printf .; sleep 1; done
-- docker-compose exec -e TEST_RETRY_COUNT=3 api test/setup-parallel-env.sh
+- docker-compose exec api test/setup-parallel-env.sh
 - docker-compose exec api bundle exec rake assets:precompile
 - sleep 10
 - touch tmp/parallel_runtime_test.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,13 +44,13 @@ jobs:
   include:
     - stage: tests
       name: functional-tests
-      script: docker-compose exec -e TEST_RETRY_COUNT=3 PATTERN='models mailers integration workers lib contract' api test/run-tests.sh
+      script: docker-compose exec -e TEST_RETRY_COUNT=3 -e PATTERN='models mailers integration workers lib contract' api test/run-tests.sh
     - stage: tests
       name: unit-tests
-      script: docker-compose exec -e TEST_RETRY_COUNT=3 PATTERN='controllers contract' api test/run-tests.sh
+      script: docker-compose exec -e TEST_RETRY_COUNT=3 -e PATTERN='controllers contract' api test/run-tests.sh
     - stage: tests
       name: contract-tests
-      script: docker-compose exec -e TEST_RETRY_COUNT=3 PATTERN='controllers models mailers integration workers lib' api test/run-tests.sh
+      script: docker-compose exec -e TEST_RETRY_COUNT=3 -e PATTERN='controllers models mailers integration workers lib' api test/run-tests.sh
 notifications:
   slack:
     secure: dhqNhrJ0FVPnjtxa7R6k0s+1h/gMFNeK8zYJLZw+mK/FJ41K1u82Y8E6IDFbgNcKyAJ27ielvzGgWGSkDVltEnPR+ph15OMcy05TM9Pr2tWNusbDECOaEQgn4vGOq0shmiahE9tTOQpgc1TzhzIF9o1xgocah2PCLKiiH06kiiRlNZkaeQSJRFrXsPDDK8jIUtkLLUvFGQA6fq/lOh4tN6/N+K6+fo86wSxarkjv3d6h2flqvQqvqkbNpkv/UBC2Y1QACP+EX6uA0ySer8K5X6Q0Trrkjjacwvo5j74UVa+UYrBD+vr7Mgnr5aNFNId6M2nHd92ZiPM+6VDllCWsDLvJ2qFFy8cOO693EjrU7puaPp29+sptriIC71dk1oHSIEpPWwuaEZKzpwP4Swe322ne2th2VrjMhIye2Ru0519Lr2Dl4iTVV+hxoeVta3Nng23rUjrGoAbcw2FO1jmhANp8JWatv/V4PmlrS1/kYbiCfltWOMbKAD9f1EOTFnPCJsp3hPL238Ic+kvNJ8LM+ItNNR5cly+JPto6nSnMO8uhig9i78Mp2hVpnvrwhDLYntWEP2vcaNhP8oRys7X2iq5PRmsRwr9SyJReczd6i5gnvskXqKat6mNfPeGMBKSYof/1ve3Um0wEtwaYxvU5y/ZezFc3Kzzi6vt4P86j+mg=

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,13 +44,13 @@ jobs:
   include:
     - stage: tests
       name: functional-tests
-      script: docker-compose exec -e PATTERN='models mailers integration workers lib contract' api test/run-tests.sh
+      script: docker-compose exec -e TEST_RETRY_COUNT=3 PATTERN='models mailers integration workers lib contract' api test/run-tests.sh
     - stage: tests
       name: unit-tests
-      script: docker-compose exec -e PATTERN='controllers contract' api test/run-tests.sh
+      script: docker-compose exec -e TEST_RETRY_COUNT=3 PATTERN='controllers contract' api test/run-tests.sh
     - stage: tests
       name: contract-tests
-      script: docker-compose exec -e PATTERN='controllers models mailers integration workers lib' api test/run-tests.sh
+      script: docker-compose exec -e TEST_RETRY_COUNT=3 PATTERN='controllers models mailers integration workers lib' api test/run-tests.sh
 notifications:
   slack:
     secure: dhqNhrJ0FVPnjtxa7R6k0s+1h/gMFNeK8zYJLZw+mK/FJ41K1u82Y8E6IDFbgNcKyAJ27ielvzGgWGSkDVltEnPR+ph15OMcy05TM9Pr2tWNusbDECOaEQgn4vGOq0shmiahE9tTOQpgc1TzhzIF9o1xgocah2PCLKiiH06kiiRlNZkaeQSJRFrXsPDDK8jIUtkLLUvFGQA6fq/lOh4tN6/N+K6+fo86wSxarkjv3d6h2flqvQqvqkbNpkv/UBC2Y1QACP+EX6uA0ySer8K5X6Q0Trrkjjacwvo5j74UVa+UYrBD+vr7Mgnr5aNFNId6M2nHd92ZiPM+6VDllCWsDLvJ2qFFy8cOO693EjrU7puaPp29+sptriIC71dk1oHSIEpPWwuaEZKzpwP4Swe322ne2th2VrjMhIye2Ru0519Lr2Dl4iTVV+hxoeVta3Nng23rUjrGoAbcw2FO1jmhANp8JWatv/V4PmlrS1/kYbiCfltWOMbKAD9f1EOTFnPCJsp3hPL238Ic+kvNJ8LM+ItNNR5cly+JPto6nSnMO8uhig9i78Mp2hVpnvrwhDLYntWEP2vcaNhP8oRys7X2iq5PRmsRwr9SyJReczd6i5gnvskXqKat6mNfPeGMBKSYof/1ve3Um0wEtwaYxvU5y/ZezFc3Kzzi6vt4P86j+mg=

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 - docker-compose -f docker-compose.yml -f docker-test.yml up -d
 - tail -f log/test.log &
 - until curl --silent -I -f --fail http://localhost:3000 ; do printf .; sleep 1; done
-- docker-compose exec api test/setup-parallel-env.sh
+- docker-compose exec -e TEST_RETRY_COUNT=3 api test/setup-parallel-env.sh
 - docker-compose exec api bundle exec rake assets:precompile
 - sleep 10
 - touch tmp/parallel_runtime_test.log

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,7 +35,7 @@ require 'csv'
 
 Dir[Rails.root.join("test/support/**/*.rb")].each {|f| require f}
 
-Minitest::Retry.use!
+Minitest::Retry.use!(retry_count: ENV['TEST_RETRY_COUNT'].to_i || 0)
 TestDatabaseHelper.setup_database_partitions!
 
 class ActionController::TestCase


### PR DESCRIPTION
## Description

When running locally we might not want the tests to retry, to do this
we would need to comment out the retry line. We want to make this easier
on the developer

Converting the env variable to an integer because ENV[] on ruby returns a string
https://ruby-doc.org/core-3.0.0/ENV.html

Set TEST_RETRY_COUNT to 3 on Travis because we were using the default
before (which is 3)
https://www.rubydoc.info/gems/minitest-retry/

References: 3718

## How has this been tested?

Changed a test to make it fail.
Ran tests locally without setting TEST_RETRY_COUNT, test failed and didn't retry.
Set the env var inside the container (export TEST_RETRY_COUNT=3) and ran the tests again, it retried 3 times.

