### PR TITLE
Fixing video/audio tipline resources for tiplines hosted in Smooch.

### DIFF
--- a/app/models/concerns/smooch_resources.rb
+++ b/app/models/concerns/smooch_resources.rb
@@ -12,6 +12,7 @@ module SmoochResources
         if ['image', 'audio', 'video'].include?(resource.header_type)
           type = resource.header_type
           type = 'video' if type == 'audio' # Audio gets converted to video with a cover
+          type = 'file' if type == 'video' && RequestStore.store[:smooch_bot_provider] == 'ZENDESK' # Smooch doesn't support video
           self.send_message_to_user(uid, message, { 'type' => type, 'mediaUrl' => CheckS3.rewrite_url(resource.header_media_url) })
           sleep 2 # Wait a couple of seconds before sending the main menu
           self.send_message_for_state(uid, workflow, 'main', language)


### PR DESCRIPTION
## Description

Smooch doesn't support video. So we need to convert the type from "video" to "file" before calling the Smooch API.

Fixes CV2-3797.

## How has this been tested?

Since this touches an external service (the Smooch API), automated tests wouldn't help much here. So I tried it locally and works fine.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

