### PR TITLE
Silently ignore duplicate errors when saving tipline messages

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -726,7 +726,7 @@ class Bot::Smooch < BotUser
     tm.payload = payload
     tm.team_id = team_id
     tm.skip_check_ability = true
-    tm.save!
+    tm.save_ignoring_duplicate!
   end
 
   def self.create_project_media_from_message(message)

--- a/app/models/tipline_message.rb
+++ b/app/models/tipline_message.rb
@@ -6,6 +6,14 @@ class TiplineMessage < ApplicationRecord
   validates_presence_of :team, :uid, :platform, :language, :direction, :sent_at, :payload, :state
   validates_inclusion_of :state, in: ['sent', 'received', 'delivered']
 
+  def save_ignoring_duplicate!
+    begin
+      self.save!
+    rescue ActiveRecord::RecordNotUnique
+      Rails.logger.info("[Smooch Bot] Not storing tipline message because it already exists. ID: #{self.external_id}. State: #{self.state}.")
+    end
+  end
+
   class << self
     def from_smooch_payload(msg, payload, event = nil, language = nil)
       msg = msg.with_indifferent_access

--- a/app/workers/smooch_tipline_message_worker.rb
+++ b/app/workers/smooch_tipline_message_worker.rb
@@ -27,7 +27,7 @@ class SmoochTiplineMessageWorker
     end
 
     tm = TiplineMessage.from_smooch_payload(message_json, payload_json, event, language)
-    tm.save
+    tm.save_ignoring_duplicate!
 
     User.current = nil
   end


### PR DESCRIPTION
## Description

Silently ignore duplicate errors when saving tipline messages. We don't need to raise an exception for a legit validation error. A duplication error happens when a tipline message has the same ID and state.

## How has this been tested?

I implemented a unit test for this.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- x ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

