### PR TITLE
Tipline submission shortcuts

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -549,12 +549,7 @@ class Bot::Smooch < BotUser
     workflow = self.get_workflow(language)
     typed, new_state = self.get_typed_message(message, sm)
     state = new_state if new_state
-    if self.is_a_shortcut_for_submission?(sm.state, message)
-      self.bundle_message(message)
-      sm.go_to_ask_if_ready
-      self.send_message_for_state(uid, workflow, 'ask_if_ready', language)
-      return true
-    elsif self.should_send_tos?(state, typed)
+    if self.should_send_tos?(state, typed)
       sm.reset
       platform = self.get_platform_from_message(message)
       self.send_tos_to_user(workflow, uid, language, platform)
@@ -585,6 +580,13 @@ class Bot::Smooch < BotUser
         self.delay_for(1.seconds, { queue: 'smooch', retry: false }).bundle_messages(uid, message['_id'], app_id, 'resource_requests', resource)
         return true
       end
+    end
+    # Lastly, check if it's a submission shortcut
+    if self.is_a_shortcut_for_submission?(sm.state, message)
+      self.bundle_message(message)
+      sm.go_to_ask_if_ready
+      self.send_message_for_state(uid, workflow, 'ask_if_ready', language)
+      return true
     end
     self.bundle_message(message)
     return false

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -539,7 +539,7 @@ class Bot::Smooch < BotUser
   end
 
   def self.is_a_shortcut_for_submission?(state, message)
-    self.is_v2? && (state == 'main' || state == 'waiting_for_message') && (!message['mediaUrl'].blank? || ::Bot::Alegre.get_number_of_words(message['text'].to_s) > 3) # FIXME: Confirm this number
+    self.is_v2? && (state == 'main' || state == 'waiting_for_message') && (!message['mediaUrl'].blank? || ::Bot::Alegre.get_number_of_words(message['text'].to_s) > CheckConfig.get('min_number_of_words_for_tipline_shortcut', 3, :integer))
   end
 
   def self.process_menu_option(message, state, app_id)

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -589,7 +589,7 @@ class Bot::Smooch < BotUser
       return true
     end
     self.bundle_message(message)
-    return false
+    false
   end
 
   def self.user_received_report(message)

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -44,6 +44,7 @@ development: &default
   image_cluster_similarity_threshold: 0.9
   text_cluster_similarity_threshold: 0.9
   similarity_media_file_url_host: ''
+  min_number_of_words_for_tipline_shortcut: 3
 
   # Localization
   #

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -844,4 +844,14 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
       r.remove_keyword('who are you')
     end
   end
+
+  test 'should have shortcuts for submission' do
+    send_message 'This is message is so long that it is considered a media'
+    assert_state 'ask_if_ready'
+  end
+
+  test 'should not have shortcuts for submission' do
+    send_message 'Hello'
+    assert_state 'main'
+  end
 end

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -784,7 +784,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     nlu.disable!
     reload_tipline_settings
     send_message 'Can I subscribe to the newsletter?'
-    assert_state 'main'
+    assert_state 'ask_if_ready'
 
     # Delete two keywords, so expect two calls to Alegre
     Bot::Alegre.expects(:request_api).with{ |x, y, _z| x == 'delete' && y == '/text/similarity/' }.twice


### PR DESCRIPTION
## Description

When a tipline user sends a long text message or a file, jump right away into the "are you ready to submit" state.

Reference: CV2-2326.

## How has this been tested?

I added two new unit tests for this feature.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

