### PR TITLE
Changing configuration key name and default value for tipline submission shortcut

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -539,7 +539,7 @@ class Bot::Smooch < BotUser
   end
 
   def self.is_a_shortcut_for_submission?(state, message)
-    self.is_v2? && (state == 'main' || state == 'waiting_for_message') && (!message['mediaUrl'].blank? || ::Bot::Alegre.get_number_of_words(message['text'].to_s) > CheckConfig.get('min_number_of_words_for_tipline_shortcut', 3, :integer))
+    self.is_v2? && (state == 'main' || state == 'waiting_for_message') && (!message['mediaUrl'].blank? || ::Bot::Alegre.get_number_of_words(message['text'].to_s) > CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer))
   end
 
   def self.process_menu_option(message, state, app_id)

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -44,7 +44,7 @@ development: &default
   image_cluster_similarity_threshold: 0.9
   text_cluster_similarity_threshold: 0.9
   similarity_media_file_url_host: ''
-  min_number_of_words_for_tipline_shortcut: 3
+  min_number_of_words_for_tipline_submit_shortcut: 10
 
   # Localization
   #

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -784,7 +784,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     nlu.disable!
     reload_tipline_settings
     send_message 'Can I subscribe to the newsletter?'
-    assert_state 'ask_if_ready'
+    assert_state 'main'
 
     # Delete two keywords, so expect two calls to Alegre
     Bot::Alegre.expects(:request_api).with{ |x, y, _z| x == 'delete' && y == '/text/similarity/' }.twice


### PR DESCRIPTION
## Description

Changing configuration key name and default value for tipline submission shortcut

Reference: CV2-2326.

## How has this been tested?

Existing tests should cover this.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [x] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

