### PR TITLE
Block WhatsApp user if WhatsApp API reports a "pair rate limit hit" error

### DIFF
--- a/app/models/blocked_tipline_user.rb
+++ b/app/models/blocked_tipline_user.rb
@@ -1,0 +1,2 @@
+class BlockedTiplineUser < ApplicationRecord
+end

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -809,7 +809,9 @@ class Bot::Smooch < BotUser
 
   def self.block_user(uid)
     begin
-      BlockedTiplineUser.create!(uid: uid)
+      block = BlockedTiplineUser.new(uid: uid)
+      block.skip_check_ability = true
+      block.save!
       Rails.logger.info("[Smooch Bot] Blocked user #{uid}")
       Rails.cache.write("smooch:banned:#{uid}", Time.now.to_i)
     rescue ActiveRecord::RecordNotUnique

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -803,14 +803,37 @@ class Bot::Smooch < BotUser
   def self.ban_user(message)
     unless message.nil?
       uid = message['authorId']
-      Rails.logger.info("[Smooch Bot] Banned user #{uid}")
-      Rails.cache.write("smooch:banned:#{uid}", message.to_json)
+      self.block_user(uid)
     end
+  end
+
+  def self.block_user(uid)
+    begin
+      puts 'HERE 1'
+      BlockedTiplineUser.create!(uid: uid)
+      Rails.logger.info("[Smooch Bot] Blocked user #{uid}")
+      Rails.cache.write("smooch:banned:#{uid}", Time.now.to_i)
+    rescue ActiveRecord::RecordNotUnique
+      puts 'HERE 2'
+      # User already blocked
+    end
+  end
+
+  def self.unblock_user(uid)
+    puts 'HERE 3'
+    BlockedTiplineUser.where(uid: uid).last.destroy!
+    Rails.logger.info("[Smooch Bot] Unblocked user #{uid}")
+    Rails.cache.delete("smooch:banned:#{uid}")
+  end
+
+  def self.user_blocked?(uid)
+    puts 'HERE 4'
+    !uid.blank? && (!Rails.cache.read("smooch:banned:#{uid}").nil? || BlockedTiplineUser.where(uid: uid).exists?)
   end
 
   def self.user_banned?(payload)
     uid = payload.dig('appUser', '_id')
-    !uid.blank? && !Rails.cache.read("smooch:banned:#{uid}").nil?
+    self.user_blocked?(uid)
   end
 
   # Don't save as a ProjectMedia if it contains only menu options

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -809,25 +809,21 @@ class Bot::Smooch < BotUser
 
   def self.block_user(uid)
     begin
-      puts 'HERE 1'
       BlockedTiplineUser.create!(uid: uid)
       Rails.logger.info("[Smooch Bot] Blocked user #{uid}")
       Rails.cache.write("smooch:banned:#{uid}", Time.now.to_i)
     rescue ActiveRecord::RecordNotUnique
-      puts 'HERE 2'
       # User already blocked
     end
   end
 
   def self.unblock_user(uid)
-    puts 'HERE 3'
     BlockedTiplineUser.where(uid: uid).last.destroy!
     Rails.logger.info("[Smooch Bot] Unblocked user #{uid}")
     Rails.cache.delete("smooch:banned:#{uid}")
   end
 
   def self.user_blocked?(uid)
-    puts 'HERE 4'
     !uid.blank? && (!Rails.cache.read("smooch:banned:#{uid}").nil? || BlockedTiplineUser.where(uid: uid).exists?)
   end
 

--- a/app/models/concerns/smooch_blocking.rb
+++ b/app/models/concerns/smooch_blocking.rb
@@ -1,0 +1,46 @@
+require 'active_support/concern'
+
+module SmoochBlocking
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def ban_user(message)
+      unless message.nil?
+        uid = message['authorId']
+        self.block_user(uid)
+      end
+    end
+
+    def block_user_from_error_code(uid, error_code)
+      self.block_user(uid) if error_code == 131056 # Error of type "pair rate limit hit"
+    end
+
+    def block_user(uid)
+      begin
+        block = BlockedTiplineUser.new(uid: uid)
+        block.skip_check_ability = true
+        block.save!
+        Rails.logger.info("[Smooch Bot] Blocked user #{uid}")
+        Rails.cache.write("smooch:banned:#{uid}", Time.now.to_i)
+      rescue ActiveRecord::RecordNotUnique
+        # User already blocked
+        Rails.logger.info("[Smooch Bot] User #{uid} already blocked")
+      end
+    end
+
+    def unblock_user(uid)
+      BlockedTiplineUser.where(uid: uid).last.destroy!
+      Rails.logger.info("[Smooch Bot] Unblocked user #{uid}")
+      Rails.cache.delete("smooch:banned:#{uid}")
+    end
+
+    def user_blocked?(uid)
+      !uid.blank? && (!Rails.cache.read("smooch:banned:#{uid}").nil? || BlockedTiplineUser.where(uid: uid).exists?)
+    end
+
+    def user_banned?(payload)
+      uid = payload.dig('appUser', '_id')
+      self.user_blocked?(uid)
+    end
+  end
+end

--- a/app/models/concerns/smooch_capi.rb
+++ b/app/models/concerns/smooch_capi.rb
@@ -281,14 +281,17 @@ module SmoochCapi
       response = http.request(req)
       if response.code.to_i >= 400
         error_message = begin JSON.parse(response.body)['error']['message'] rescue response.body end
+        error_code = begin JSON.parse(response.body)['error']['code'] rescue nil end
         e = Bot::Smooch::CapiMessageDeliveryError.new(error_message)
-        self.block_user(uid) if JSON.parse(response.body).dig('error', 'code') == 131056 # Error of type "pair rate limit hit"
+        self.block_user(uid) if error_code == 131056 # Error of type "pair rate limit hit"
         CheckSentry.notify(e,
           uid: uid,
           type: payload.dig(:type),
           template_name: payload.dig(:template, :name),
           template_language: payload.dig(:template, :language, :code),
-          error: response.body
+          error: response.body,
+          error_message: error_message,
+          error_code: error_code
         )
       end
       response

--- a/app/models/concerns/smooch_capi.rb
+++ b/app/models/concerns/smooch_capi.rb
@@ -283,7 +283,7 @@ module SmoochCapi
         error_message = begin JSON.parse(response.body)['error']['message'] rescue response.body end
         error_code = begin JSON.parse(response.body)['error']['code'] rescue nil end
         e = Bot::Smooch::CapiMessageDeliveryError.new(error_message)
-        self.block_user(uid) if error_code == 131056 # Error of type "pair rate limit hit"
+        self.block_user_from_error_code(uid, error_code)
         CheckSentry.notify(e,
           uid: uid,
           type: payload.dig(:type),

--- a/app/models/concerns/smooch_capi.rb
+++ b/app/models/concerns/smooch_capi.rb
@@ -282,6 +282,7 @@ module SmoochCapi
       if response.code.to_i >= 400
         error_message = begin JSON.parse(response.body)['error']['message'] rescue response.body end
         e = Bot::Smooch::CapiMessageDeliveryError.new(error_message)
+        self.block_user(uid) if JSON.parse(response.body).dig('error', 'code') == 131056 # Error of type "pair rate limit hit"
         CheckSentry.notify(e,
           uid: uid,
           type: payload.dig(:type),

--- a/db/migrate/20231002202443_create_blocked_tipline_users.rb
+++ b/db/migrate/20231002202443_create_blocked_tipline_users.rb
@@ -1,0 +1,9 @@
+class CreateBlockedTiplineUsers < ActiveRecord::Migration[6.1]
+  def change
+    create_table :blocked_tipline_users do |t|
+      t.string :uid, null: false
+      t.timestamps
+    end
+    add_index :blocked_tipline_users, :uid, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_09_22_174044) do
+ActiveRecord::Schema.define(version: 2023_10_02_202443) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -193,6 +193,13 @@ ActiveRecord::Schema.define(version: 2023_09_22_174044) do
     t.index ["assigned_type"], name: "index_assignments_on_assigned_type"
     t.index ["assigner_id"], name: "index_assignments_on_assigner_id"
     t.index ["user_id"], name: "index_assignments_on_user_id"
+  end
+
+  create_table "blocked_tipline_users", force: :cascade do |t|
+    t.string "uid", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["uid"], name: "index_blocked_tipline_users_on_uid", unique: true
   end
 
   create_table "bounces", id: :serial, force: :cascade do |t|

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -1096,4 +1096,8 @@ module SampleData
     at = create_annotation_type annotation_type: 'task_response_free_text', label: 'Task Response Free Text'
     create_field_instance annotation_type_object: at, name: 'response_free_text', label: 'Response', field_type_object: text, optional: false
   end
+
+  def create_blocked_tipline_user(options = {})
+    BlockedTiplineUser.create!({ uid: random_string }.merge(options))
+  end
 end

--- a/test/models/blocked_tipline_user_test.rb
+++ b/test/models/blocked_tipline_user_test.rb
@@ -1,0 +1,33 @@
+require_relative '../test_helper'
+
+class BlockedTiplineUserTest < ActiveSupport::TestCase
+  def setup
+  end
+
+  def teardown
+  end
+
+  test 'should create blocked tipline user' do
+    assert_difference 'BlockedTiplineUser.count' do
+      create_blocked_tipline_user
+    end
+  end
+
+  test 'should not create blocked tipline user if UID is blank' do
+    assert_no_difference 'BlockedTiplineUser.count' do
+      assert_raises ActiveRecord::NotNullViolation do
+        create_blocked_tipline_user uid: nil
+      end
+    end
+  end
+
+  test 'should not block the same user more than once' do
+    uid = random_string
+    create_blocked_tipline_user uid: uid
+    assert_no_difference 'BlockedTiplineUser.count' do
+      assert_raises ActiveRecord::RecordNotUnique do
+        create_blocked_tipline_user uid: uid
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

If WhatsApp Cloud API reports an error of type "pair rate limit hit" when we try to send a message to a WhatsApp user, block that user automatically, so we don't need to answer them again.

It helps with SPAM and abuse.

Reference: CV2-3489.

## How has this been tested?

I added a unit test for this feature.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

