### PR TITLE
CV2-3771: export published items without fact check to CSV file and copy reports to fact check

### DIFF
--- a/lib/tasks/migrate/20231003085827_unpublish_items_without_fact_check.rake
+++ b/lib/tasks/migrate/20231003085827_unpublish_items_without_fact_check.rake
@@ -1,12 +1,10 @@
 namespace :check do
   namespace :migrate do
-    task unpublish_items_without_fact_check: :environment do
+    task export_published_items_without_fact_check: :environment do
       started = Time.now.to_i
-      RequestStore.store[:skip_notifications] = true
-      last_team_id = Rails.cache.read('check:migrate:unpublish_items_without_fact_check:team_id') || 0
       log_items = []
-      failed_items = []
-      Team.where('id > ?', last_team_id).find_each do |team|
+      data_csv = []
+      Team.find_each do |team|
         print '.'
         total = 0
         team.project_medias.find_in_batches(:batch_size => 1000) do |pms|
@@ -24,28 +22,86 @@ namespace :check do
           # Get published items without fact checks
           diff = published_ids - fact_checks_ids
           unless diff.empty?
-            Dynamic.where(
-              annotation_type: "report_design",
-              annotated_type: "ProjectMedia",
-              annotated_id: diff
-            ).find_each do |a|
-              print '.'
-              new_data = a.data
-              new_data['state'] = 'unpublished'
-              a.data = new_data
-              begin a.save! rescue failed_items << a.id end
+            total += diff.length
+            ProjectMedia.where(id: diff).find_each do |pm|
+              data_csv << [team.name, pm.full_url, pm.media_published_at]
             end
-            total += diff.length 
           end
         end
-        unless total == 0
-          log_items << { team_slug: team.slug, total: total }  
-        end
-        Rails.cache.write('check:migrate:unpublish_items_without_fact_check:team_id', team.id)
+        log_items << { team_slug: team.slug, total: total } unless total == 0
       end
-      RequestStore.store[:skip_notifications] = false
-      puts "Logs data is: #{log_items.inspect}" if log_items.length > 0
-      puts "Failed items: #{failed_items.inspect}" if failed_items.length > 0
+      unless data_csv.empty?
+        # Export items to CSV
+        require 'csv'
+        file = "#{Rails.root}/public/list_published_reports_without_fact_check_#{Time.now.to_i}.csv"
+        headers = ["Workspace", "URL", "Published at"]
+        CSV.open(file, 'w', write_headers: true, headers: headers) do |writer|
+          data_csv.each do |d|
+            writer << d
+          end
+        end
+        puts "\nExported items to file:: #{file}"
+      end
+      puts "Logs data:: #{log_items.inspect}" if log_items.length > 0
+      minutes = ((Time.now.to_i - started) / 60).to_i
+      puts "[#{Time.now}] Done in #{minutes} minutes."
+    end
+
+    # Copy reports to fact check and used `check:migrate:reports_to_fact_checks` rake task as a reference
+    task set_fact_check_for_published_items: :environment do
+      started = Time.now.to_i
+      n = 0
+      last_team_id = Rails.cache.read('check:migrate:set_fact_check_for_published_items:team_id') || 0
+      Team.where('id > ?', last_team_id).find_each do |team|
+        print '.'
+        languages = team.get_languages || ['en']
+        team.project_medias.find_in_batches(:batch_size => 1000) do |pms|
+          pm_ids = pms.map(&:id)
+          # Get published items
+          published_ids = Annotation.where(
+            annotation_type: "report_design",
+            annotated_type: "ProjectMedia",
+            annotated_id: pm_ids
+          ).select{ |a| a.data['state'] == 'published'}.map(&:annotated_id)
+          # Get items with fact checks
+          fact_checks_ids = ProjectMedia.where(id: published_ids)
+          .joins('INNER JOIN claim_descriptions cd ON project_medias.id = cd.project_media_id')
+          .joins('INNER JOIN fact_checks fc ON cd.id = fc.claim_description_id').map(&:id)
+          # Get published items without fact checks
+          diff = published_ids - fact_checks_ids
+          unless diff.empty?
+            Dynamic.where(annotation_type: "report_design", annotated_type: "ProjectMedia", annotated_id: diff).find_each do |report|
+              pm = report.annotated
+              begin
+                user_id = report.annotator_id
+                cd = pm.claim_description || ClaimDescription.create!(project_media: pm, description: '​', user_id: user_id)
+                language = report.report_design_field_value('language')
+                fc_language = languages.include?(language) ? language : 'und'
+                fields = { user_id: user_id, skip_report_update: true, language: fc_language }
+                if report.report_design_field_value('use_text_message')
+                  fields.merge!({
+                    title: report.report_design_field_value('title'),
+                    summary: report.report_design_field_value('text'),
+                    url: report.report_design_field_value('published_article_url')
+                  })
+                elsif report.report_design_field_value('use_visual_card')
+                  fields.merge!({
+                    title: report.report_design_field_value('headline'),
+                    summary: report.report_design_field_value('description'),
+                    url: report.report_design_field_value('published_article_url')
+                  })
+                end
+                fc = FactCheck.create!({ claim_description: cd }.merge(fields))
+                n += 1
+                puts "[#{Time.now}] #{n}. Created fact-check #{fc.id}"
+              rescue Exception => e
+                puts "[#{Time.now}] Could not create fact-check for report #{report.id}: #{e.message}"
+              end
+            end
+          end
+        end
+        Rails.cache.write('check:migrate:set_fact_check_for_published_items:team_id', team.id)
+      end
       minutes = ((Time.now.to_i - started) / 60).to_i
       puts "[#{Time.now}] Done in #{minutes} minutes."
     end

--- a/lib/tasks/migrate/20231003085827_unpublish_items_without_fact_check.rake
+++ b/lib/tasks/migrate/20231003085827_unpublish_items_without_fact_check.rake
@@ -1,0 +1,53 @@
+namespace :check do
+  namespace :migrate do
+    task unpublish_items_without_fact_check: :environment do
+      started = Time.now.to_i
+      RequestStore.store[:skip_notifications] = true
+      last_team_id = Rails.cache.read('check:migrate:unpublish_items_without_fact_check:team_id') || 0
+      log_items = []
+      failed_items = []
+      Team.where('id > ?', last_team_id).find_each do |team|
+        print '.'
+        total = 0
+        team.project_medias.find_in_batches(:batch_size => 1000) do |pms|
+          pm_ids = pms.map(&:id)
+          # Get published items
+          published_ids = Annotation.where(
+            annotation_type: "report_design",
+            annotated_type: "ProjectMedia",
+            annotated_id: pm_ids
+          ).select{ |a| a.data['state'] == 'published'}.map(&:annotated_id)
+          # Get items with fact checks
+          fact_checks_ids = ProjectMedia.where(id: published_ids)
+          .joins('INNER JOIN claim_descriptions cd ON project_medias.id = cd.project_media_id')
+          .joins('INNER JOIN fact_checks fc ON cd.id = fc.claim_description_id').map(&:id)
+          # Get published items without fact checks
+          diff = published_ids - fact_checks_ids
+          unless diff.empty?
+            Dynamic.where(
+              annotation_type: "report_design",
+              annotated_type: "ProjectMedia",
+              annotated_id: diff
+            ).find_each do |a|
+              print '.'
+              new_data = a.data
+              new_data['state'] = 'unpublished'
+              a.data = new_data
+              begin a.save! rescue failed_items << a.id end
+            end
+            total += diff.length 
+          end
+        end
+        unless total == 0
+          log_items << { team_slug: team.slug, total: total }  
+        end
+        Rails.cache.write('check:migrate:unpublish_items_without_fact_check:team_id', team.id)
+      end
+      RequestStore.store[:skip_notifications] = false
+      puts "Logs data is: #{log_items.inspect}" if log_items.length > 0
+      puts "Failed items: #{failed_items.inspect}" if failed_items.length > 0
+      minutes = ((Time.now.to_i - started) / 60).to_i
+      puts "[#{Time.now}] Done in #{minutes} minutes."
+    end
+  end
+end


### PR DESCRIPTION
## Description

Add  two rake tasks:

1. `check:migrate:export_published_items_without_fact_check`: export published items without fact-check to CSV file
2. `check:migrate:set_fact_check_for_published_items`: create fact-check using report data for published items

References: CV2-3771

## How has this been tested?

Tested both rake tasks locally using a live DB dump.
1. `check:migrate:export_published_items_without_fact_check`:  Done in 19 minutes.
2. `check:migrate:set_fact_check_for_published_items`: Done in 36 minutes.  for a workspace contains **2586 items**


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

