### PR TITLE
Do not submit as unconfirmed media a text with just a few words.

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -818,11 +818,12 @@ class Bot::Smooch < BotUser
       extra = {}
       if link.nil?
         claim = self.extract_claim(text).gsub(/\s+/, ' ').strip
-        if message['archived'] == CheckArchivedFlags::FlagCodes::UNCONFIRMED && ::Bot::Alegre.get_number_of_words(claim) < CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer)
-          return team
-        end
         extra = { quote: claim }
         pm = ProjectMedia.joins(:media).where('trim(lower(quote)) = ?', claim.downcase).where('project_medias.team_id' => team.id).last
+        # Don't create a new text media if it's an unconfirmed request with just a few words
+        if pm.nil? && message['archived'] == CheckArchivedFlags::FlagCodes::UNCONFIRMED && ::Bot::Alegre.get_number_of_words(claim) < CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer)
+          return team
+        end
       else
         extra = { url: link.url }
         pm = ProjectMedia.joins(:media).where('medias.url' => link.url, 'project_medias.team_id' => team.id).last

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -818,6 +818,9 @@ class Bot::Smooch < BotUser
       extra = {}
       if link.nil?
         claim = self.extract_claim(text).gsub(/\s+/, ' ').strip
+        if message['archived'] == CheckArchivedFlags::FlagCodes::UNCONFIRMED && ::Bot::Alegre.get_number_of_words(claim) < CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer)
+          return team
+        end
         extra = { quote: claim }
         pm = ProjectMedia.joins(:media).where('trim(lower(quote)) = ?', claim.downcase).where('project_medias.team_id' => team.id).last
       else

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -335,10 +335,10 @@ module SmoochMessages
       self.get_installation(self.installation_setting_id_keys, app_id)
       Team.current = Team.where(id: self.config['team_id']).last
       annotated = nil
-      if ['default_requests', 'timeout_requests', 'resource_requests', 'irrelevant_search_result_requests'].include?(request_type)
+      if ['default_requests', 'timeout_requests', 'irrelevant_search_result_requests'].include?(request_type)
         message['archived'] = ['default_requests', 'irrelevant_search_result_requests'].include?(request_type) ? self.default_archived_flag : CheckArchivedFlags::FlagCodes::UNCONFIRMED
         annotated = self.create_project_media_from_message(message)
-      elsif ['menu_options_requests', 'relevant_search_result_requests', 'timeout_search_requests'].include?(request_type)
+      elsif ['menu_options_requests', 'relevant_search_result_requests', 'timeout_search_requests', 'resource_requests'].include?(request_type)
         annotated = annotated_obj
       end
 

--- a/test/controllers/graphql_controller_10_test.rb
+++ b/test/controllers/graphql_controller_10_test.rb
@@ -809,4 +809,50 @@ class GraphqlController10Test < ActionController::TestCase
     assert_response :success
     assert !JSON.parse(@response.body)['data']['sendTiplineMessage']['success']
   end
+
+  test "should set smooch user Slack channel URL in background" do
+    u = create_user
+    t = create_team
+    create_team_user team: t, user: u, role: 'admin'
+    p = create_project team: t
+    author_id = random_string
+    set_fields = { smooch_user_data: { id: author_id }.to_json, smooch_user_app_id: 'fake', smooch_user_id: 'fake' }.to_json
+    d = create_dynamic_annotation annotated: p, annotation_type: 'smooch_user', set_fields: set_fields
+    authenticate_with_token
+    url = random_url
+    query = 'mutation { updateDynamicAnnotationSmoochUser(input: { clientMutationId: "1", id: "' + d.graphql_id + '", set_fields: "{\"smooch_user_slack_channel_url\":\"' + url + '\"}" }) { project { dbid } } }'
+
+    Sidekiq::Testing.fake! do
+      post :create, params: { query: query }
+      assert_response :success
+    end
+    Sidekiq::Worker.drain_all
+    assert_equal url, Dynamic.find(d.id).get_field_value('smooch_user_slack_channel_url')
+
+    # Check that cache key exists
+    key = "SmoochUserSlackChannelUrl:Team:#{d.team_id}:#{author_id}"
+    assert_equal url, Rails.cache.read(key)
+
+    # Test using a new mutation `smoochBotAddSlackChannelUrl`
+    url2 = random_url
+    query = 'mutation { smoochBotAddSlackChannelUrl(input: { clientMutationId: "1", id: "' + d.id.to_s + '", set_fields: "{\"smooch_user_slack_channel_url\":\"' + url2 + '\"}" }) { annotation { dbid } } }'
+    Sidekiq::Testing.fake! do
+      post :create, params: { query: query }
+      assert_response :success
+    end
+    assert Sidekiq::Worker.jobs.size > 0
+    assert_equal url, d.reload.get_field_value('smooch_user_slack_channel_url')
+
+    # Execute job and check that URL was set
+    Sidekiq::Worker.drain_all
+    assert_equal url2, d.get_field_value('smooch_user_slack_channel_url')
+
+    # Check that cache key exists
+    assert_equal url2, Rails.cache.read(key)
+
+    # Call mutation with non existing ID
+    query = 'mutation { smoochBotAddSlackChannelUrl(input: { clientMutationId: "1", id: "99999", set_fields: "{\"smooch_user_slack_channel_url\":\"' + url2 + '\"}" }) { annotation { dbid } } }'
+    post :create, params: { query: query }
+    assert_response :success
+  end
 end

--- a/test/controllers/graphql_controller_3_test.rb
+++ b/test/controllers/graphql_controller_3_test.rb
@@ -341,49 +341,6 @@ class GraphqlController3Test < ActionController::TestCase
     assert_equal 1, response['item_navigation_offset']
   end
 
-  test "should set smooch user slack channel url in background" do
-    Sidekiq::Testing.fake! do
-      u = create_user
-      t = create_team
-      create_team_user team: t, user: u, role: 'admin'
-      p = create_project team: t
-      author_id = random_string
-      set_fields = { smooch_user_data: { id: author_id }.to_json, smooch_user_app_id: 'fake', smooch_user_id: 'fake' }.to_json
-      d = create_dynamic_annotation annotated: p, annotation_type: 'smooch_user', set_fields: set_fields
-      Sidekiq::Worker.drain_all
-      assert_equal 0, Sidekiq::Worker.jobs.size
-      authenticate_with_token
-      url = random_url
-      query = 'mutation { updateDynamicAnnotationSmoochUser(input: { clientMutationId: "1", id: "' + d.graphql_id + '", set_fields: "{\"smooch_user_slack_channel_url\":\"' + url + '\"}" }) { project { dbid } } }'
-      post :create, params: { query: query }
-      assert_response :success
-      Sidekiq::Worker.drain_all
-      sleep 1
-      assert_equal url, Dynamic.find(d.id).get_field_value('smooch_user_slack_channel_url')
-      # check that cache key exists
-      key = "SmoochUserSlackChannelUrl:Team:#{d.team_id}:#{author_id}"
-      assert_equal url, Rails.cache.read(key)
-      # test using a new mutation `smoochBotAddSlackChannelUrl`
-      Sidekiq::Worker.drain_all
-      assert_equal 0, Sidekiq::Worker.jobs.size
-      url2 = random_url
-      query = 'mutation { smoochBotAddSlackChannelUrl(input: { clientMutationId: "1", id: "' + d.id.to_s + '", set_fields: "{\"smooch_user_slack_channel_url\":\"' + url2 + '\"}" }) { annotation { dbid } } }'
-      post :create, params: { query: query }
-      assert_response :success
-      assert Sidekiq::Worker.jobs.size > 0
-      assert_equal url, d.reload.get_field_value('smooch_user_slack_channel_url')
-      # execute job and check that url was set
-      Sidekiq::Worker.drain_all
-      assert_equal url2, d.get_field_value('smooch_user_slack_channel_url')
-      # check that cache key exists
-      assert_equal url2, Rails.cache.read(key)
-      # call mutation with non existing id
-      query = 'mutation { smoochBotAddSlackChannelUrl(input: { clientMutationId: "1", id: "99999", set_fields: "{\"smooch_user_slack_channel_url\":\"' + url2 + '\"}" }) { annotation { dbid } } }'
-      post :create, params: { query: query }
-      assert_response :success
-    end
-  end
-
   test "should get requests from media" do
     u = create_user is_admin: true
     t = create_team


### PR DESCRIPTION
## Description

In that case, the request should still be saved, but associated with the workspace, not with a text media.

Fixes CV2-3784.

## How has this been tested?

I implemented two new unit tests for this.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

