### PR TITLE
CV2-2897: fix return updated_objects for bulk read action

### DIFF
--- a/app/graph/mutations/graphql_crud_operations.rb
+++ b/app/graph/mutations/graphql_crud_operations.rb
@@ -192,7 +192,7 @@ class GraphqlCrudOperations
       method_mapping = { update: :bulk_update, destroy: :bulk_destroy, mark_read: :bulk_mark_read }
       method = method_mapping[update_or_destroy.to_sym]
       result = klass.send(method, sql_ids, filtered_inputs, Team.current)
-      if update_or_destroy.to_s == "update"
+      if update_or_destroy.to_s != "destroy"
         result.merge!({ updated_objects: klass.where(id: sql_ids) })
       end
       { ids: processed_ids }.merge(result)

--- a/test/controllers/graphql_controller_4_test.rb
+++ b/test/controllers/graphql_controller_4_test.rb
@@ -326,7 +326,7 @@ class GraphqlController4Test < ActionController::TestCase
     post :create, params: { query: query, team: @t.slug }
     assert_response :success
     updated_objects = JSON.parse(@response.body)['data']['bulkProjectMediaMarkRead']['updated_objects']
-    assert_equal @ids.count, updated_objects.count
+    assert_equal @pms.map(&:id).sort, updated_objects.collect{|obj| obj['dbid']}.sort
     @pms.each { |pm| assert pm.reload.read }
     assert_search_finds_all({ read: 1 })
     assert_search_finds_none({ read: 0 })

--- a/test/controllers/graphql_controller_4_test.rb
+++ b/test/controllers/graphql_controller_4_test.rb
@@ -322,9 +322,11 @@ class GraphqlController4Test < ActionController::TestCase
     @pms.each { |pm| assert_not pm.read }
     assert_search_finds_all({ read: 0 })
     assert_search_finds_none({ read: 1 })
-    query = 'mutation { bulkProjectMediaMarkRead(input: { clientMutationId: "1", ids: ' + @ids + ', read: true }) { ids, team { dbid } } }'
+    query = 'mutation { bulkProjectMediaMarkRead(input: { clientMutationId: "1", ids: ' + @ids + ', read: true }) { updated_objects { id, is_read, dbid }, ids, team { dbid } } }'
     post :create, params: { query: query, team: @t.slug }
     assert_response :success
+    updated_objects = JSON.parse(@response.body)['data']['bulkProjectMediaMarkRead']['updated_objects']
+    assert_equal @ids.count, updated_objects.count
     @pms.each { |pm| assert pm.reload.read }
     assert_search_finds_all({ read: 1 })
     assert_search_finds_none({ read: 0 })


### PR DESCRIPTION
## Description

Include `updated_objects` in `bulkProjectMediaMarkRead` return fields

References: CV2-2897

## How has this been tested?

Added a unit test.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

