### PR TITLE
CV2-3779: add tipline requests cached fields

### DIFF
--- a/app/graph/types/project_media_type.rb
+++ b/app/graph/types/project_media_type.rb
@@ -41,6 +41,8 @@ class ProjectMediaType < DefaultObject
   field :cluster, ClusterType, null: true
   field :is_suggested, GraphQL::Types::Boolean, null: true
   field :is_confirmed, GraphQL::Types::Boolean, null: true
+  field :positive_tipline_search_results_count, GraphQL::Types::Int, null: true
+  field :tipline_search_results_count, GraphQL::Types::Int, null: true
 
   field :claim_description, ClaimDescriptionType, null: true
 

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -114,7 +114,6 @@ module SmoochSearch
         query = message['text']
         query = message['mediaUrl'] unless type == 'text'
         results = self.search_for_similar_published_fact_checks(type, query, [team_id], after, nil, language).select{ |pm| is_a_valid_search_result(pm) }
-        results = ProjectMedia.where(id: [1, 2])
       rescue StandardError => e
         self.handle_search_error(uid, e, language)
       end

--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -114,6 +114,7 @@ module SmoochSearch
         query = message['text']
         query = message['mediaUrl'] unless type == 'text'
         results = self.search_for_similar_published_fact_checks(type, query, [team_id], after, nil, language).select{ |pm| is_a_valid_search_result(pm) }
+        results = ProjectMedia.where(id: [1, 2])
       rescue StandardError => e
         self.handle_search_error(uid, e, language)
       end

--- a/app/repositories/media_search.rb
+++ b/app/repositories/media_search.rb
@@ -136,5 +136,9 @@ class MediaSearch
     indexes :report_language, { type: 'keyword', normalizer: 'check' }
 
     indexes :fact_check_published_on, { type: 'long' }
+
+    indexes :positive_tipline_search_results_count, { type: 'long' }
+
+    indexes :tipline_search_results_count, { type: 'long' }
   end
 end

--- a/db/migrate/20231008074526_add_mapping_for_tipline_search_results_fields.rb
+++ b/db/migrate/20231008074526_add_mapping_for_tipline_search_results_fields.rb
@@ -1,0 +1,14 @@
+class AddMappingForTiplineSearchResultsFields < ActiveRecord::Migration[6.1]
+  def change
+    options = {
+      index: CheckElasticSearchModel.get_index_alias,
+      body: {
+        properties: {
+          positive_tipline_search_results_count: { type: 'long' },
+          tipline_search_results_count: { type: 'long' },
+        }
+      }
+    }
+    $repository.client.indices.put_mapping options
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_02_202443) do
+ActiveRecord::Schema.define(version: 2023_10_08_074526) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -268,7 +268,7 @@ ActiveRecord::Schema.define(version: 2023_10_02_202443) do
     t.jsonb "value_json", default: "{}"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
+    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY (ARRAY[('external_id'::character varying)::text, ('smooch_user_id'::character varying)::text, ('verification_status_status'::character varying)::text]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
     t.index ["annotation_id"], name: "index_dynamic_annotation_fields_on_annotation_id"
     t.index ["annotation_type"], name: "index_dynamic_annotation_fields_on_annotation_type"

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -11211,6 +11211,7 @@ type ProjectMedia implements Node {
   oembed_metadata: String
   permissions: String
   picture: String
+  positive_tipline_search_results_count: Int
   project: Project
   project_group: ProjectGroup
   project_id: Int
@@ -11336,6 +11337,7 @@ type ProjectMedia implements Node {
   tasks_count: JsonStringType
   team: Team
   team_name: String
+  tipline_search_results_count: Int
   title: String
   type: String
   updated_at: String

--- a/public/relay.json
+++ b/public/relay.json
@@ -58979,6 +58979,20 @@
               "deprecationReason": null
             },
             {
+              "name": "positive_tipline_search_results_count",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "project",
               "description": null,
               "args": [
@@ -59556,6 +59570,20 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tipline_search_results_count",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               },
               "isDeprecated": false,


### PR DESCRIPTION
## Description

- Store number of tipline requests (positive_tipline_search_results_count & tipline_search_results_count)
- Expose cached field to graphql ProjectMediaType

References: CV2-3779

## How has this been tested?

Implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

