### PR TITLE
A few fixes/changes for `TiplineMessages` API

### DIFF
--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -301,6 +301,6 @@ class TeamType < DefaultObject
   end
 
   def tipline_messages(uid:)
-    object.tipline_messages.where(uid: uid).order("id DESC")
+    object.tipline_messages.where(uid: uid).order('sent_at DESC')
   end
 end

--- a/app/graph/types/tipline_message_type.rb
+++ b/app/graph/types/tipline_message_type.rb
@@ -15,6 +15,7 @@ class TiplineMessageType < DefaultObject
   field :state, GraphQL::Types::String, null: true
   field :team, TeamType, null: true
   field :sent_at, GraphQL::Types::String, null: true, camelize: false
+  field :media_url, GraphQL::Types::String, null: true
 
   def sent_at
     object.sent_at.to_i.to_s

--- a/app/models/concerns/smooch_menus.rb
+++ b/app/models/concerns/smooch_menus.rb
@@ -8,7 +8,7 @@ module SmoochMenus
       self.config['smooch_version'] == 'v2'
     end
 
-    def send_message_to_user_with_main_menu_appended(uid, text, workflow, language, tbi_id = nil)
+    def send_message_to_user_with_main_menu_appended(uid, text, workflow, language, tbi_id = nil, event = nil)
       self.get_installation('team_bot_installation_id', tbi_id) { |i| i.id == tbi_id } if self.config.blank? && !tbi_id.nil?
       main = []
       counter = 1
@@ -114,7 +114,7 @@ module SmoochMenus
         fallback = [text]
       end
 
-      self.send_message_to_user(uid, fallback.join("\n"), extra)
+      self.send_message_to_user(uid, fallback.join("\n"), extra, false, true, event)
     end
 
     def adjust_language_options(rows, language, number_of_options)
@@ -166,7 +166,7 @@ module SmoochMenus
       label.to_s.truncate(truncate_at)
     end
 
-    def send_message_to_user_with_buttons(uid, text, options, image_url = nil)
+    def send_message_to_user_with_buttons(uid, text, options, image_url = nil, event = nil)
       buttons = []
       options.each_with_index do |option, i|
         buttons << {
@@ -203,7 +203,7 @@ module SmoochMenus
         }
       } unless image_url.blank?
       extra, fallback = self.format_fallback_text_menu_from_options(text, options, extra)
-      self.send_message_to_user(uid, fallback.join("\n"), extra)
+      self.send_message_to_user(uid, fallback.join("\n"), extra, false, true, event)
     end
 
     def send_message_to_user_with_single_section_menu(uid, text, options, menu_label)

--- a/app/models/concerns/smooch_resources.rb
+++ b/app/models/concerns/smooch_resources.rb
@@ -13,12 +13,12 @@ module SmoochResources
           type = resource.header_type
           type = 'video' if type == 'audio' # Audio gets converted to video with a cover
           type = 'file' if type == 'video' && RequestStore.store[:smooch_bot_provider] == 'ZENDESK' # Smooch doesn't support video
-          self.send_message_to_user(uid, message, { 'type' => type, 'mediaUrl' => CheckS3.rewrite_url(resource.header_media_url) })
+          self.send_message_to_user(uid, message, { 'type' => type, 'mediaUrl' => CheckS3.rewrite_url(resource.header_media_url) }, false, true, 'resource')
           sleep 2 # Wait a couple of seconds before sending the main menu
           self.send_message_for_state(uid, workflow, 'main', language)
         else
           preview_url = (resource.header_type == 'link_preview')
-          self.send_final_messages_to_user(uid, message, workflow, language, 1, preview_url) unless message.blank?
+          self.send_final_messages_to_user(uid, message, workflow, language, 1, preview_url, 'resource') unless message.blank?
         end
       end
       resource

--- a/app/models/tipline_message.rb
+++ b/app/models/tipline_message.rb
@@ -14,6 +14,18 @@ class TiplineMessage < ApplicationRecord
     end
   end
 
+  def media_url
+    payload = begin JSON.parse(self.payload).to_h rescue self.payload.to_h end
+    media_url = nil
+    if self.direction == 'incoming'
+      media_url = payload.dig('messages', 0, 'mediaUrl')
+    elsif self.direction == 'outgoing'
+      header = payload.dig('override', 'whatsapp', 'payload', 'interactive', 'header')
+      media_url = header[header['type']]['link'] unless header.nil?
+    end
+    media_url || payload['mediaUrl']
+  end
+
   class << self
     def from_smooch_payload(msg, payload, event = nil, language = nil)
       msg = msg.with_indifferent_access

--- a/app/models/tipline_newsletter.rb
+++ b/app/models/tipline_newsletter.rb
@@ -164,7 +164,7 @@ class TiplineNewsletter < ApplicationRecord
     message = self.build_content
     message = (self.team.get_shorten_outgoing_urls ? UrlRewriter.shorten_and_utmize_urls(message, self.team.get_outgoing_urls_utm_code) : message)
     params = (['image', 'audio', 'video'].include?(self.header_type) ? { 'type' => NON_WHATSAPP_HEADER_TYPE_MAPPING[self.header_type], 'mediaUrl' => CheckS3.rewrite_url(self.header_media_url) } : {})
-    [message, params]
+    [message, params, false, true, 'newsletter']
   end
 
   def self.content_name

--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -40,7 +40,7 @@ class TiplineNewsletterWorker
         RequestStore.store[:smooch_bot_platform] = ts.platform
         Bot::Smooch.get_installation('team_bot_installation_id', tbi.id) { |i| i.id == tbi.id }
 
-        response = (ts.platform == 'WhatsApp' ? Bot::Smooch.send_message_to_user(ts.uid, newsletter.format_as_template_message) : Bot::Smooch.send_message_to_user(ts.uid, *newsletter.format_as_tipline_message))
+        response = (ts.platform == 'WhatsApp' ? Bot::Smooch.send_message_to_user(ts.uid, newsletter.format_as_template_message, {}, false, true, 'newsletter') : Bot::Smooch.send_message_to_user(ts.uid, *newsletter.format_as_tipline_message))
 
         if response.code.to_i < 400
           log team_id, language, "Newsletter sent to subscriber ##{ts.id}, response: (#{response.code}) #{response.body.inspect}"

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -13177,6 +13177,7 @@ type TiplineMessage implements Node {
   external_id: String
   id: ID!
   language: String
+  media_url: String
   payload: JsonStringType
   permissions: String
   platform: String

--- a/public/relay.json
+++ b/public/relay.json
@@ -69033,6 +69033,20 @@
               "deprecationReason": null
             },
             {
+              "name": "media_url",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "payload",
               "description": null,
               "args": [

--- a/test/models/tipline_message_test.rb
+++ b/test/models/tipline_message_test.rb
@@ -198,4 +198,29 @@ class TiplineMessageTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should return media URL for tipline messages" do
+    url = random_url
+    payload = { 'mediaUrl' => url }
+    incoming_payload = { 'messages' => [{ 'mediaUrl' => url }] }
+    outgoing_payload = {
+      'override' => {
+        'whatsapp' => {
+          'payload' => {
+            'interactive' => {
+              'header' => {
+                'type' => 'image',
+                'image' => {
+                  'link' => url
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    assert_equal url, create_tipline_message(payload: payload).media_url
+    assert_equal url, create_tipline_message(direction: 'incoming', payload: incoming_payload).media_url
+    assert_equal url, create_tipline_message(direction: 'outgoing', payload: outgoing_payload).media_url
+  end
 end


### PR DESCRIPTION
## Description

* Set `event` for tipline messages that are sent
* Return media URL for tipline messages on GraphQL API
* Sort tipline messages by `sent_at` instead of ID  (sometimes messages in the history were out of order… this is because the sorting on the backend was by ID, but the messages are created in background, so the ID wouldn't guarantee the order)

Reference: CV2-3853.

## How has this been tested?

I added one new unit test, for `media_url`. Other changes should be covered by existing tests.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

