### PR TITLE
CV2-3776: implement a custom pagination for TiplineMessageType

### DIFF
--- a/app/graph/mutations/tipline_messages_pagination.rb
+++ b/app/graph/mutations/tipline_messages_pagination.rb
@@ -5,39 +5,39 @@ class TiplineMessagesPagination < GraphQL::Pagination::ArrayConnection
 
   def load_nodes
     @nodes ||= begin
-      sliced_nodes = if before && after
-        end_idx = index_from_cursor(before)
-        start_idx = index_from_cursor(after)
-        items.where(id: start_idx..end_idx)
-      elsif before
-        end_idx = index_from_cursor(before)
-        items.where('id < ?', end_idx)
-      elsif after
-        start_idx = index_from_cursor(after)
-        items.where('id > ?', start_idx)
-      else
-        items
-      end
+      sliced_nodes =  if before && after
+                        end_idx = index_from_cursor(before)
+                        start_idx = index_from_cursor(after)
+                        items.where(id: start_idx..end_idx)
+                      elsif before
+                        end_idx = index_from_cursor(before)
+                        items.where('id < ?', end_idx)
+                      elsif after
+                        start_idx = index_from_cursor(after)
+                        items.where('id > ?', start_idx)
+                      else
+                        items
+                      end
 
-      @has_previous_page = if last
-        # There are items preceding the ones in this result
-        sliced_nodes.count > last
-      elsif after
-        # We've paginated into the Array a bit, there are some behind us
-        index_from_cursor(after) > items.map(&:id).min
-      else
-        false
-      end
+      @has_previous_page =  if last
+                              # There are items preceding the ones in this result
+                              sliced_nodes.count > last
+                            elsif after
+                              # We've paginated into the Array a bit, there are some behind us
+                              index_from_cursor(after) > items.map(&:id).min
+                            else
+                              false
+                            end
 
-      @has_next_page = if first
-        # There are more items after these items
-        sliced_nodes.count > first
-      elsif before
-        # The original array is longer than the `before` index
-        index_from_cursor(before) < items.map(&:id).max
-      else
-        false
-      end
+      @has_next_page =  if first
+                          # There are more items after these items
+                          sliced_nodes.count > first
+                        elsif before
+                          # The original array is longer than the `before` index
+                          index_from_cursor(before) < items.map(&:id).max
+                        else
+                          false
+                        end
 
       limited_nodes = sliced_nodes
 

--- a/app/graph/mutations/tipline_messages_pagination.rb
+++ b/app/graph/mutations/tipline_messages_pagination.rb
@@ -3,7 +3,7 @@ class TiplineMessagesPagination < GraphQL::Pagination::ArrayConnection
     encode(item.id.to_i.to_s)
   end
 
-   def load_nodes
+  def load_nodes
     @nodes ||= begin
       sliced_nodes = if before && after
         end_idx = index_from_cursor(before)

--- a/app/graph/mutations/tipline_messages_pagination.rb
+++ b/app/graph/mutations/tipline_messages_pagination.rb
@@ -2,4 +2,49 @@ class TiplineMessagesPagination < GraphQL::Pagination::ArrayConnection
   def cursor_for(item)
     encode(item.id.to_i.to_s)
   end
+
+   def load_nodes
+    @nodes ||= begin
+      sliced_nodes = if before && after
+        end_idx = index_from_cursor(before)
+        start_idx = index_from_cursor(after)
+        items.where(id: start_idx..end_idx)
+      elsif before
+        end_idx = index_from_cursor(before)
+        items.where('id < ?', end_idx)
+      elsif after
+        start_idx = index_from_cursor(after)
+        items.where('id > ?', start_idx)
+      else
+        items
+      end
+
+      @has_previous_page = if last
+        # There are items preceding the ones in this result
+        sliced_nodes.count > last
+      elsif after
+        # We've paginated into the Array a bit, there are some behind us
+        index_from_cursor(after) > items.map(&:id).min
+      else
+        false
+      end
+
+      @has_next_page = if first
+        # There are more items after these items
+        sliced_nodes.count > first
+      elsif before
+        # The original array is longer than the `before` index
+        index_from_cursor(before) < items.map(&:id).max
+      else
+        false
+      end
+
+      limited_nodes = sliced_nodes
+
+      limited_nodes = limited_nodes.first(first) if first
+      limited_nodes = limited_nodes.last(last) if last
+
+      limited_nodes
+    end
+  end
 end

--- a/app/graph/mutations/tipline_messages_pagination.rb
+++ b/app/graph/mutations/tipline_messages_pagination.rb
@@ -1,0 +1,5 @@
+class TiplineMessagesPagination < GraphQL::Pagination::ArrayConnection
+  def cursor_for(item)
+    encode(item.id.to_i.to_s)
+  end
+end

--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -215,6 +215,7 @@ class QueryType < BaseObject
     feed
     request
     feed_invitation
+    tipline_message
   ].each do |type|
     field type,
           "#{type.to_s.camelize}Type",

--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -301,6 +301,6 @@ class TeamType < DefaultObject
   end
 
   def tipline_messages(uid:)
-    TiplineMessagesPagination.new(object.tipline_messages.where(uid: uid).order('sent_at DESC'))
+    TiplineMessagesPagination.new(object.tipline_messages.where(uid: uid).order('sent_at ASC'))
   end
 end

--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -301,6 +301,6 @@ class TeamType < DefaultObject
   end
 
   def tipline_messages(uid:)
-    TiplineMessagesPagination.new(object.tipline_messages.where(uid: uid).order('sent_at ASC'))
+    TiplineMessagesPagination.new(object.tipline_messages.where(uid: uid).order('id ASC'))
   end
 end

--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -301,6 +301,6 @@ class TeamType < DefaultObject
   end
 
   def tipline_messages(uid:)
-    object.tipline_messages.where(uid: uid).order('sent_at DESC')
+    TiplineMessagesPagination.new(object.tipline_messages.where(uid: uid).order('sent_at DESC'))
   end
 end

--- a/app/graph/types/tipline_message_type.rb
+++ b/app/graph/types/tipline_message_type.rb
@@ -16,8 +16,13 @@ class TiplineMessageType < DefaultObject
   field :team, TeamType, null: true
   field :sent_at, GraphQL::Types::String, null: true, camelize: false
   field :media_url, GraphQL::Types::String, null: true
+  field :cursor, GraphQL::Types::String, null: true
 
   def sent_at
     object.sent_at.to_i.to_s
+  end
+
+  def cursor
+    GraphQL::Schema::Base64Encoder.encode(object.id.to_i.to_s)
   end
 end

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -13423,6 +13423,7 @@ TiplineMessage type
 """
 type TiplineMessage implements Node {
   created_at: String
+  cursor: String
   dbid: Int
   direction: String
   event: String

--- a/public/relay.json
+++ b/public/relay.json
@@ -70086,6 +70086,20 @@
               "deprecationReason": null
             },
             {
+              "name": "cursor",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "dbid",
               "description": null,
               "args": [

--- a/test/controllers/graphql_controller_9_test.rb
+++ b/test/controllers/graphql_controller_9_test.rb
@@ -430,7 +430,7 @@ class GraphqlController9Test < ActionController::TestCase
     data = JSON.parse(@response.body)['data']['team']['tipline_messages']
     results = data['edges'].to_a.collect{ |e| e['node']['dbid'] }
     assert_equal 1, results.size
-    assert_equal tp3_uid.id, results[0]
+    assert_equal tp1_uid.id, results[0]
     page_info = data['pageInfo']
     assert page_info['hasNextPage']
 
@@ -452,25 +452,25 @@ class GraphqlController9Test < ActionController::TestCase
     data = JSON.parse(@response.body)['data']['team']['tipline_messages']
     results = data['edges'].to_a.collect{ |e| e['node']['dbid'] }
     assert_equal 1, results.size
-    assert_equal tp1_uid.id, results[0]
+    assert_equal tp3_uid.id, results[0]
     page_info = data['pageInfo']
     assert !page_info['hasNextPage']
     # paginate using specific message id
     tp4_uid = create_tipline_message team_id: t.id, uid: uid
-    query = 'query read { team(slug: "test") { tipline_messages(uid:"'+ uid +'") { pageInfo { endCursor, startCursor, hasPreviousPage, hasNextPage } edges { node { dbid }, cursor } } } }'
+    tp5_uid = create_tipline_message team_id: t.id, uid: uid
+    tp6_uid = create_tipline_message team_id: t.id, uid: uid
+    query = 'query read { tipline_message(id: "' + tp4_uid.id.to_s + '") { cursor } }'
     post :create, params: { query: query }
     assert_response :success
-    data = JSON.parse(@response.body)['data']['team']['tipline_messages']
-    id_cursor = {}
-    data['edges'].to_a.each{ |e| id_cursor[e['node']['dbid']] = e['cursor'] }
-    # Start with tp4_uid message
-    query = 'query read { team(slug: "test") { tipline_messages(first: 1, after: "' + id_cursor[tp4_uid.id] + '", uid:"'+ uid +'") { pageInfo { endCursor, startCursor, hasPreviousPage, hasNextPage } edges { node { dbid } } } } }'
+    id_cursor = JSON.parse(@response.body)['data']['tipline_message']['cursor']
+    # Start with tp4_uid message and use after
+    query = 'query read { team(slug: "test") { tipline_messages(first: 1, after: "' + id_cursor + '", uid:"'+ uid +'") { pageInfo { endCursor, startCursor, hasPreviousPage, hasNextPage } edges { node { dbid } } } } }'
     post :create, params: { query: query }
     assert_response :success
     data = JSON.parse(@response.body)['data']['team']['tipline_messages']
     results = data['edges'].to_a.collect{ |e| e['node']['dbid'] }
     assert_equal 1, results.size
-    assert_equal tp3_uid.id, results[0]
+    assert_equal tp5_uid.id, results[0]
     page_info = data['pageInfo']
     assert page_info['hasNextPage']
     # Next page
@@ -480,7 +480,18 @@ class GraphqlController9Test < ActionController::TestCase
     data = JSON.parse(@response.body)['data']['team']['tipline_messages']
     results = data['edges'].to_a.collect{ |e| e['node']['dbid'] }
     assert_equal 1, results.size
-    assert_equal tp2_uid.id, results[0]
+    assert_equal tp6_uid.id, results[0]
+    page_info = data['pageInfo']
+    assert page_info['hasPreviousPage']
+    assert !page_info['hasNextPage']
+    # Start with tp4_uid message and use before
+    query = 'query read { team(slug: "test") { tipline_messages(last: 1, before: "' + id_cursor + '", uid:"'+ uid +'") { pageInfo { endCursor, startCursor, hasPreviousPage, hasNextPage } edges { node { dbid } } } } }'
+    post :create, params: { query: query }
+    assert_response :success
+    data = JSON.parse(@response.body)['data']['team']['tipline_messages']
+    results = data['edges'].to_a.collect{ |e| e['node']['dbid'] }
+    assert_equal 1, results.size
+    assert_equal tp3_uid.id, results[0]
     page_info = data['pageInfo']
     assert page_info['hasNextPage']
   end

--- a/test/controllers/graphql_controller_9_test.rb
+++ b/test/controllers/graphql_controller_9_test.rb
@@ -444,7 +444,7 @@ class GraphqlController9Test < ActionController::TestCase
     assert_equal tp2_uid.id, results[0]
     page_info = data['pageInfo']
     assert page_info['hasNextPage']
-
+    id_cursor_2 = page_info['endCursor']
     # Page 3
     query = 'query read { team(slug: "test") { tipline_messages(first: 1, after: "' + page_info['endCursor'] + '", uid:"'+ uid +'") { pageInfo { endCursor, startCursor, hasPreviousPage, hasNextPage } edges { node { dbid } } } } }'
     post :create, params: { query: query }
@@ -462,9 +462,9 @@ class GraphqlController9Test < ActionController::TestCase
     query = 'query read { tipline_message(id: "' + tp4_uid.id.to_s + '") { cursor } }'
     post :create, params: { query: query }
     assert_response :success
-    id_cursor = JSON.parse(@response.body)['data']['tipline_message']['cursor']
+    id_cursor_4 = JSON.parse(@response.body)['data']['tipline_message']['cursor']
     # Start with tp4_uid message and use after
-    query = 'query read { team(slug: "test") { tipline_messages(first: 1, after: "' + id_cursor + '", uid:"'+ uid +'") { pageInfo { endCursor, startCursor, hasPreviousPage, hasNextPage } edges { node { dbid } } } } }'
+    query = 'query read { team(slug: "test") { tipline_messages(first: 1, after: "' + id_cursor_4 + '", uid:"'+ uid +'") { pageInfo { endCursor, startCursor, hasPreviousPage, hasNextPage } edges { node { dbid } } } } }'
     post :create, params: { query: query }
     assert_response :success
     data = JSON.parse(@response.body)['data']['team']['tipline_messages']
@@ -485,7 +485,7 @@ class GraphqlController9Test < ActionController::TestCase
     assert page_info['hasPreviousPage']
     assert !page_info['hasNextPage']
     # Start with tp4_uid message and use before
-    query = 'query read { team(slug: "test") { tipline_messages(last: 1, before: "' + id_cursor + '", uid:"'+ uid +'") { pageInfo { endCursor, startCursor, hasPreviousPage, hasNextPage } edges { node { dbid } } } } }'
+    query = 'query read { team(slug: "test") { tipline_messages(last: 1, before: "' + id_cursor_4 + '", uid:"'+ uid +'") { pageInfo { endCursor, startCursor, hasPreviousPage, hasNextPage } edges { node { dbid } } } } }'
     post :create, params: { query: query }
     assert_response :success
     data = JSON.parse(@response.body)['data']['team']['tipline_messages']
@@ -494,6 +494,14 @@ class GraphqlController9Test < ActionController::TestCase
     assert_equal tp3_uid.id, results[0]
     page_info = data['pageInfo']
     assert page_info['hasNextPage']
+    # User after and before
+    query = 'query read { team(slug: "test") { tipline_messages(after: "' + id_cursor_2 + '", before: "' + id_cursor_4 + '", uid:"'+ uid +'") { pageInfo { endCursor, startCursor, hasPreviousPage, hasNextPage } edges { node { dbid } } } } }'
+    post :create, params: { query: query }
+    assert_response :success
+    data = JSON.parse(@response.body)['data']['team']['tipline_messages']
+    results = data['edges'].to_a.collect{ |e| e['node']['dbid'] }
+    assert_equal 3, results.size
+    assert_equal [tp2_uid.id, tp3_uid.id, tp4_uid.id], results.sort
   end
 
   protected


### PR DESCRIPTION
## Description

Currently to get the cursor we should retrieve all messages and the cursor is the index of the item not item ID so I implement a custom pagination to override current behavior for cursor to use item id instead of index of the item so I can retrieve a cursor for a specific message

so I did the following:

- Add a cursor to TiplineMessageType so you can query a cursor for specific message
- Override `cursor_for` method in a custom class
- Override  `load_nodes` method in a custom class


References: CV2-3776

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

