### PR TITLE
Block tipline users when they send more than X messages in 24 hours.

### DIFF
--- a/app/models/tipline_message.rb
+++ b/app/models/tipline_message.rb
@@ -36,7 +36,7 @@ class TiplineMessage < ApplicationRecord
   def verify_user_rate_limit
     rate_limit = CheckConfig.get('tipline_user_max_messages_per_day', 1500, :integer)
     # Block tipline user when they have sent more than X messages in 24 hours
-    if self.state == 'received' && TiplineMessage.where(uid: self.uid, created_at: Time.now.ago(1.day)..Time.now, state: 'received').count > rate_limit 
+    if self.state == 'received' && TiplineMessage.where(uid: self.uid, created_at: Time.now.ago(1.day)..Time.now, state: 'received').count > rate_limit
       Bot::Smooch.block_user(self.uid)
     end
   end

--- a/app/models/tipline_message.rb
+++ b/app/models/tipline_message.rb
@@ -6,6 +6,8 @@ class TiplineMessage < ApplicationRecord
   validates_presence_of :team, :uid, :platform, :language, :direction, :sent_at, :payload, :state
   validates_inclusion_of :state, in: ['sent', 'received', 'delivered']
 
+  after_commit :verify_user_rate_limit, on: :create
+
   def save_ignoring_duplicate!
     begin
       self.save!
@@ -27,6 +29,16 @@ class TiplineMessage < ApplicationRecord
       media_url ||= payload.dig('text').to_s.match(/header_image=\[\[([^\]]+)\]\]/).to_a.last
     end
     media_url || payload['mediaUrl']
+  end
+
+  private
+
+  def verify_user_rate_limit
+    rate_limit = CheckConfig.get('tipline_user_max_messages_per_day', 1500, :integer)
+    # Block tipline user when they have sent more than X messages in 24 hours
+    if self.state == 'received' && TiplineMessage.where(uid: self.uid, created_at: Time.now.ago(1.day)..Time.now, state: 'received').count > rate_limit 
+      Bot::Smooch.block_user(self.uid)
+    end
   end
 
   class << self

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -258,6 +258,13 @@ development: &default
   otel_traces_sampler:
   otel_custom_sampling_rate:
 
+  # Rate limit for tipline submissions, tipline users are blocked after reaching this limit
+  #
+  # OPTIONAL
+  # When not set, a default number will be used.
+  #
+  tipline_user_max_messages_per_day: 1500
+
 test:
   <<: *default
   checkdesk_base_url_private: http://api:3000

--- a/test/models/tipline_message_test.rb
+++ b/test/models/tipline_message_test.rb
@@ -223,4 +223,26 @@ class TiplineMessageTest < ActiveSupport::TestCase
     assert_equal url, create_tipline_message(direction: 'incoming', payload: incoming_payload).media_url
     assert_equal url, create_tipline_message(direction: 'outgoing', payload: outgoing_payload).media_url
   end
+
+  test "should block user when rate limit is reached" do
+    uid = random_string
+    assert !Bot::Smooch.user_blocked?(uid)
+    stub_configs({ 'tipline_user_max_messages_per_day' => 2 }) do
+      # User sent a message
+      create_tipline_message uid: uid, state: 'received'
+      assert !Bot::Smooch.user_blocked?(uid)
+      # User sent a message
+      create_tipline_message uid: uid, state: 'received'
+      assert !Bot::Smooch.user_blocked?(uid)
+      # Another user sent a message
+      create_tipline_message state: 'received'
+      assert !Bot::Smooch.user_blocked?(uid)
+      # User received a message
+      create_tipline_message uid: uid, state: 'delivered'
+      assert !Bot::Smooch.user_blocked?(uid)
+      # User sent a message and is now over rate limit, so should be blocked
+      create_tipline_message uid: uid, state: 'received'
+      assert Bot::Smooch.user_blocked?(uid)
+    end
+  end
 end


### PR DESCRIPTION
## Description

"X" is defined by a configuration key but has a default value.

Reference: CV2-3860.

## How has this been tested?

I added a unit test for different cases.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

