### PR TITLE
CV2-3827 restructure expectation on callback

### DIFF
--- a/app/models/concerns/alegre_webhooks.rb
+++ b/app/models/concerns/alegre_webhooks.rb
@@ -12,7 +12,7 @@ module AlegreWebhooks
 
     def webhook(request)
       begin
-        doc_id = request.params.dig('data', 'requested', 'body', 'id')
+        doc_id = request.params.dig('requested', 'id')
         raise 'Unexpected params format' if doc_id.blank?
         redis = Redis.new(REDIS_CONFIG)
         key = "alegre:webhook:#{doc_id}"

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -237,12 +237,12 @@ class WebhooksControllerTest < ActionController::TestCase
     CheckSentry.expects(:notify).never
     redis = Redis.new(REDIS_CONFIG)
     redis.del('foo')
-    payload = { 'action' => 'audio', 'data' => { 'requested' => { 'body' => { 'id' => 'foo', 'context' => { 'project_media_id' => random_number } } } } }
+    payload = { 'action' => 'audio', 'requested' => { 'id' => 'foo', 'context' => { 'project_media_id' => random_number } } }
     assert_nil redis.lpop('alegre:webhook:foo')
 
     post :index, params: { name: :alegre, token: CheckConfig.get('alegre_token') }.merge(payload)
     response = JSON.parse(redis.lpop('alegre:webhook:foo'))
-    assert_equal 'foo', response.dig('data', 'requested', 'body', 'id')
+    assert_equal 'foo', response.dig('requested', 'id')
 
     travel_to Time.now.since(2.days)
     assert_nil redis.lpop('alegre:webhook:foo')


### PR DESCRIPTION
## Description

We updated Alegre to accommodate a sync similarity endpoint - this caused some changes in expectations for Check API in terms of the callback response. I believe that this change is sufficient to reflect the latest changes on Alegre.

References: CV2-3827

## How has this been tested?

I've tested with mocked responses on qa REPL sessions, and confirmed that this will fix the immediate issue of blocked responses on add attempts - there may be another downstream issue with lookups, and we'll resolve here as well.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

