### PR TITLE
Update tagger bot name and description and make the rake task idempotent

### DIFF
--- a/lib/tasks/migrate/202306040000_add_tagger_bot_user.rake
+++ b/lib/tasks/migrate/202306040000_add_tagger_bot_user.rake
@@ -1,47 +1,42 @@
 namespace :check do
-    namespace :migrate do
-        desc "Create the Bot user Tagger for the Tagger bot"
-        task create_tagger_user: :environment do
-            RequestStore.store[:skip_notifications] = true
+  namespace :migrate do
+    desc 'Create the bot user Tagger for the Tagger bot'
+    task create_tagger_user: :environment do
+      RequestStore.store[:skip_notifications] = true
 
-            if !BotUser.get_user("tagger").nil?
-                puts "Tagger user already exists, exiting"
-                return
-            end
+      meedan_team = Team.where(slug: 'meedan').last || Team.new(name: 'Meedan', slug: 'meedan')
+      meedan_team.skip_notifications = true
+      meedan_team.skip_clear_cache = true
+      meedan_team.skip_check_ability = true
+      meedan_team.save! if meedan_team.id.nil?
+    
+      Team.current = meedan_team
+      tb = BotUser.get_user('tagger') || BotUser.new
+      tb.login = 'tagger'
+      tb.name = 'Tagger (in beta)'
+      tb.set_description 'Automatically tags items based on similar items - this feature is in beta, please consult with the Meedan support team before enabling it.'
+      File.open(File.join(Rails.root, 'public', 'tagger.png')) do |f|
+        tb.image = f
+      end
+      tb.set_role 'editor'
+      tb.set_version '0.0.1'
+      tb.set_source_code_url 'https://github.com/meedan/check-api/blob/develop/app/models/bot/tagger.rb'
+      tb.set_team_author_id meedan_team.id
+      tb.set_events [{ 'event' => 'create_project_media', 'graphql' => 'dbid, title, description, type' }]
+      tb.set_settings [
+        { name: 'auto_tag_prefix', label: 'Emoji prefix', description: 'Emoji to be placed in front of autotags', type: 'string', default: '⚡' },
+        { name: 'threshold', label: 'threshold', description: 'Search similarity threshold (0-100)', type: 'integer', default: 70 },
+        { name: 'ignore_autotags', label: 'Ignore auto-tags?', description:'If enabled, autotags will not be considered in finding the most common tag', type: 'boolean', default: false },
+        { name: 'minimum_count', label: 'Minimum count', description:'Minimum number of times a tag must appear to be applied', type: 'integer', default: 0 }
+      ]
+      tb.set_approved true
+      tb['settings']['listed'] = true # Appear on the integrations tab of Check Web
+      tb.save!
+    
+      Team.current = nil
+      RequestStore.store[:skip_notifications] = false
 
-            meedan_team = Team.where(slug: 'meedan').last || Team.new(name: 'Meedan', slug: 'meedan')
-            meedan_team.skip_notifications = true
-            meedan_team.skip_clear_cache = true
-            meedan_team.skip_check_ability = true
-            meedan_team.save!
-        
-            Team.current = meedan_team
-            tb = BotUser.new
-            tb.login = 'tagger'
-            tb.name = 'Tagger'
-            tb.set_description 'Add tags to items automatically based on similar items.'
-            File.open(File.join(Rails.root, 'public', 'tagger.png')) do |f|
-            tb.image = f
-            end
-            tb.set_role 'editor'
-            tb.set_version '0.0.1'
-            tb.set_source_code_url 'https://github.com/meedan/check-api/blob/develop/app/models/bot/tagger.rb'
-            tb.set_team_author_id meedan_team.id
-            tb.set_events [{"event"=>"create_project_media", "graphql"=>"dbid, title, description, type"}]
-            tb.set_settings [
-            { name: 'auto_tag_prefix', label: 'Emoji prefix', description: 'Emoji to be placed in front of autotags', type: 'string', default: '⚡' },
-            { name: 'threshold', label: 'threshold', description: 'Search similarity threshold (0-100)', type: 'integer', default: 70 },
-            { name: 'ignore_autotags', label: 'Ignore auto-tags?', description:'If enabled, autotags will not be considered in finding the most common tag', type: 'boolean', default: false },
-            { name: 'minimum_count', label: 'Minimum count', description:'Minimum number of times a tag must appear to be applied', type: 'integer', default: 0 }
-            ]
-            tb.set_approved true
-            tb['settings']['listed']=true #Appear on the integrations tab of Check Web
-            tb.save!
-        
-            Team.current = nil
-            RequestStore.store[:skip_notifications] = false
-
-            puts "Tagger user successfully created"
-        end
+      puts 'Tagger bot successfully saved.'
     end
-end      
+  end
+end    

--- a/lib/tasks/migrate/202306040000_add_tagger_bot_user.rake
+++ b/lib/tasks/migrate/202306040000_add_tagger_bot_user.rake
@@ -14,7 +14,7 @@ namespace :check do
       tb = BotUser.get_user('tagger') || BotUser.new
       tb.login = 'tagger'
       tb.name = 'Tagger (in beta)'
-      tb.set_description 'Automatically tags items based on similar items - this feature is in beta, please consult with the Meedan support team before enabling it.'
+      tb.set_description 'Automatically tags new items based on existing similar items. This feature is in beta, please consult with the Meedan support team before enabling it.'
       File.open(File.join(Rails.root, 'public', 'tagger.png')) do |f|
         tb.image = f
       end


### PR DESCRIPTION
## Description

There is a rake task to add the Tagger bot. I updated the bot name and description in that rake task and also changed it so it updates the bot if it already exists.

Reference: CV2-3877.

## How has this been tested?

Manually (it's a rake task). Run the rake task and it should either create the bot or update the bot.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

