### PR TITLE
Delete `FeedTeam`'s when deleting a `Feed`.

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -11,6 +11,7 @@ class Feed < ApplicationRecord
   belongs_to :saved_search, optional: true
   belongs_to :team, optional: true
 
+  before_destroy :delete_feed_teams
   before_validation :set_user_and_team, on: :create
   validates_presence_of :name
   validates_presence_of :licenses, if: proc { |feed| feed.discoverable }
@@ -164,5 +165,9 @@ class Feed < ApplicationRecord
 
   def create_feed_team
     FeedTeam.create!(feed: self, team: self.team, shared: true) unless self.team.nil?
+  end
+
+  def delete_feed_teams
+    self.feed_teams.destroy_all
   end
 end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -4,14 +4,13 @@ class Feed < ApplicationRecord
   check_settings
 
   has_many :requests
-  has_many :feed_teams
+  has_many :feed_teams, dependent: :destroy
   has_many :teams, through: :feed_teams
   has_many :feed_invitations
   belongs_to :user, optional: true
   belongs_to :saved_search, optional: true
   belongs_to :team, optional: true
 
-  before_destroy :delete_feed_teams
   before_validation :set_user_and_team, on: :create
   validates_presence_of :name
   validates_presence_of :licenses, if: proc { |feed| feed.discoverable }
@@ -165,9 +164,5 @@ class Feed < ApplicationRecord
 
   def create_feed_team
     FeedTeam.create!(feed: self, team: self.team, shared: true) unless self.team.nil?
-  end
-
-  def delete_feed_teams
-    self.feed_teams.destroy_all
   end
 end

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -161,4 +161,20 @@ class FeedTest < ActiveSupport::TestCase
 
     CheckSearch.any_instance.unstub(:medias)
   end
+
+  test "should delete feed teams when feed is deleted" do
+    f = create_feed
+    f.teams << create_team
+    ft = create_feed_team team: create_team, feed: f
+    assert_no_difference 'Feed.count' do
+      assert_difference 'FeedTeam.count', -1 do
+        ft.destroy!
+      end
+    end
+    assert_difference 'Feed.count', -1 do
+      assert_difference 'FeedTeam.count', -1 do
+        f.destroy!
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description

Otherwise, we get a violation when deleting the feed.

Reference: CV2-3801.

## How has this been tested?

@danielevalverde tested this :)
I added a unit test too.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

