### PR TITLE
Change how tipline search result feedback is stored

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -63,6 +63,8 @@ class Bot::Smooch < BotUser
 
     def self.inherit_status_and_send_report(rid)
       relationship = Relationship.find_by_id(rid)
+      # A relationship created by the Smooch Bot is related to search results, so the user has already received the report as a search result
+      return if relationship&.user && relationship.user == BotUser.smooch_user
       unless relationship.nil?
         target = relationship.target
         parent = relationship.source

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -338,8 +338,14 @@ module SmoochMessages
       if ['default_requests', 'timeout_requests', 'irrelevant_search_result_requests'].include?(request_type)
         message['archived'] = ['default_requests', 'irrelevant_search_result_requests'].include?(request_type) ? self.default_archived_flag : CheckArchivedFlags::FlagCodes::UNCONFIRMED
         annotated = self.create_project_media_from_message(message)
-      elsif ['menu_options_requests', 'relevant_search_result_requests', 'timeout_search_requests', 'resource_requests'].include?(request_type)
+      elsif ['menu_options_requests', 'resource_requests'].include?(request_type)
         annotated = annotated_obj
+      elsif ['relevant_search_result_requests', 'timeout_search_requests'].include?(request_type)
+        message['archived'] = (request_type == 'relevant_search_result_requests' ? self.default_archived_flag : CheckArchivedFlags::FlagCodes::UNCONFIRMED)
+        annotated = self.create_project_media_from_message(message)
+        if annotated != annotated_obj && annotated.is_a?(ProjectMedia)
+          Relationship.create!(relationship_type: Relationship.suggested_type, source: annotated_obj, target: annotated, user: BotUser.smooch_user)
+        end
       end
 
       return if annotated.nil?

--- a/db/migrate/20231023002756_update_relationship_target_id_index.rb
+++ b/db/migrate/20231023002756_update_relationship_target_id_index.rb
@@ -1,0 +1,9 @@
+class UpdateRelationshipTargetIdIndex < ActiveRecord::Migration[6.1]
+  def change
+    remove_index :relationships, name: 'index_relationships_on_target_id'
+    add_index :relationships, :target_id
+    add_index :relationships, :source_id
+    add_index :relationships, [:target_id, :relationship_type]
+    add_index :relationships, [:source_id, :relationship_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -133,6 +133,7 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
 
   create_table "accounts", id: :serial, force: :cascade do |t|
     t.integer "user_id"
+    t.integer "team_id"
     t.string "url"
     t.text "omniauth_info"
     t.string "uid"
@@ -141,7 +142,6 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "team_id"
     t.index ["uid", "provider", "token", "email"], name: "index_accounts_on_uid_and_provider_and_token_and_email"
     t.index ["url"], name: "index_accounts_on_url", unique: true
     t.index ["user_id"], name: "index_accounts_on_user_id"
@@ -156,37 +156,37 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
     t.integer "annotator_id"
     t.text "entities"
     t.text "data"
-    t.datetime "created_at"
-    t.datetime "updated_at"
     t.string "file"
-    t.text "attribution"
     t.integer "lock_version", default: 0, null: false
     t.boolean "locked", default: false
+    t.text "attribution"
     t.text "fragment"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index "task_fieldset((annotation_type)::text, data)", name: "task_fieldset", where: "((annotation_type)::text = 'task'::text)"
     t.index "task_team_task_id((annotation_type)::text, data)", name: "task_team_task_id", where: "((annotation_type)::text = 'task'::text)"
     t.index ["annotated_type", "annotated_id"], name: "index_annotations_on_annotated_type_and_annotated_id"
-    t.index ["annotation_type"], name: "index_annotation_type_order"
+    t.index ["annotation_type"], name: "index_annotation_type_order", opclass: :varchar_pattern_ops
     t.index ["annotation_type"], name: "index_annotations_on_annotation_type"
   end
 
   create_table "api_keys", id: :serial, force: :cascade do |t|
     t.string "access_token", default: "", null: false
     t.datetime "expire_at"
+    t.jsonb "rate_limits", default: {}
+    t.string "application"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "application"
-    t.jsonb "rate_limits", default: {}
   end
 
   create_table "assignments", id: :serial, force: :cascade do |t|
     t.integer "assigned_id", null: false
     t.integer "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "assigned_type"
     t.integer "assigner_id"
     t.text "message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["assigned_id", "assigned_type", "user_id"], name: "index_assignments_on_assigned_id_and_assigned_type_and_user_id", unique: true
     t.index ["assigned_id", "assigned_type"], name: "index_assignments_on_assigned_id_and_assigned_type"
     t.index ["assigned_id"], name: "index_assignments_on_assigned_id"
@@ -213,9 +213,9 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
     t.text "description"
     t.bigint "user_id", null: false
     t.bigint "project_media_id", null: false
+    t.text "context"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "context"
     t.index ["project_media_id"], name: "index_claim_descriptions_on_project_media_id", unique: true
     t.index ["user_id"], name: "index_claim_descriptions_on_user_id"
   end
@@ -223,20 +223,20 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
   create_table "clusters", force: :cascade do |t|
     t.integer "project_medias_count", default: 0
     t.integer "project_media_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.datetime "first_item_at"
     t.datetime "last_item_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["project_media_id"], name: "index_clusters_on_project_media_id", unique: true
   end
 
   create_table "dynamic_annotation_annotation_types", primary_key: "annotation_type", id: :string, force: :cascade do |t|
     t.string "label", null: false
     t.text "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.boolean "singleton", default: true
     t.jsonb "json_schema"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["json_schema"], name: "index_dynamic_annotation_annotation_types_on_json_schema", using: :gin
   end
 
@@ -259,7 +259,7 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "dynamic_annotation_fields", id: :integer, default: -> { "nextval('new_dynamic_annotation_fields_id_seq'::regclass)" }, force: :cascade do |t|
+  create_table "dynamic_annotation_fields", id: :serial, force: :cascade do |t|
     t.integer "annotation_id", null: false
     t.string "field_name", null: false
     t.string "annotation_type", null: false
@@ -270,11 +270,14 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
     t.datetime "updated_at", null: false
     t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
+    t.index ["annotation_id"], name: "index_dynamic_annotation_fields_on_annotation_id"
+    t.index ["annotation_type"], name: "index_dynamic_annotation_fields_on_annotation_type"
     t.index ["field_name"], name: "index_dynamic_annotation_fields_on_field_name"
     t.index ["field_type"], name: "index_dynamic_annotation_fields_on_field_type"
     t.index ["value"], name: "fetch_unique_id", unique: true, where: "(((field_name)::text = 'external_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
     t.index ["value"], name: "index_status", where: "((field_name)::text = 'verification_status_status'::text)"
     t.index ["value"], name: "smooch_user_unique_id", unique: true, where: "(((field_name)::text = 'smooch_user_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
+    t.index ["value"], name: "translation_request_id", unique: true, where: "((field_name)::text = 'translation_request_id'::text)"
     t.index ["value_json"], name: "index_dynamic_annotation_fields_on_value_json", using: :gin
   end
 
@@ -284,9 +287,9 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
     t.string "title"
     t.bigint "user_id", null: false
     t.bigint "claim_description_id", null: false
+    t.string "language", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "language", default: "", null: false
     t.string "signature"
     t.index ["claim_description_id"], name: "index_fact_checks_on_claim_description_id", unique: true
     t.index ["language"], name: "index_fact_checks_on_language"
@@ -310,9 +313,9 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
     t.bigint "team_id", null: false
     t.bigint "feed_id", null: false
     t.jsonb "settings", default: {}
+    t.boolean "shared", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "shared", default: false
     t.bigint "saved_search_id"
     t.index ["feed_id"], name: "index_feed_teams_on_feed_id"
     t.index ["saved_search_id"], name: "index_feed_teams_on_saved_search_id"
@@ -323,9 +326,9 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
   create_table "feeds", force: :cascade do |t|
     t.string "name", null: false
     t.jsonb "settings", default: {}
+    t.boolean "published", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "published", default: false
     t.bigint "saved_search_id"
     t.bigint "user_id"
     t.bigint "team_id"
@@ -359,11 +362,11 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
     t.integer "user_id"
     t.integer "account_id"
     t.string "url"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "file"
     t.string "quote"
     t.string "type"
-    t.string "file"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["url"], name: "index_medias_on_url", unique: true
   end
 
@@ -441,20 +444,20 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
   end
 
   create_table "project_medias", id: :serial, force: :cascade do |t|
+    t.integer "project_id"
     t.integer "media_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.integer "source_id"
+    t.integer "cluster_id"
+    t.integer "team_id"
+    t.jsonb "channel", default: {"main"=>0}
+    t.boolean "read", default: false, null: false
+    t.integer "sources_count", default: 0, null: false
     t.integer "archived", default: 0
     t.integer "targets_count", default: 0, null: false
-    t.integer "sources_count", default: 0, null: false
-    t.integer "team_id"
-    t.boolean "read", default: false, null: false
-    t.integer "source_id"
-    t.integer "project_id"
     t.integer "last_seen"
-    t.integer "cluster_id"
-    t.jsonb "channel", default: {"main"=>0}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "unmatched", default: 0
     t.index ["channel"], name: "index_project_medias_on_channel"
     t.index ["cluster_id"], name: "index_project_medias_on_cluster_id"
@@ -470,18 +473,18 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
   create_table "projects", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "team_id"
+    t.integer "project_group_id"
     t.string "title"
     t.boolean "is_default", default: false
     t.text "description"
     t.string "lead_image"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "archived", default: 0
-    t.text "settings"
     t.string "token"
     t.integer "assignments_count", default: 0
-    t.integer "project_group_id"
     t.integer "privacy", default: 0, null: false
+    t.integer "archived", default: 0
+    t.text "settings"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["id"], name: "index_projects_on_id"
     t.index ["is_default"], name: "index_projects_on_is_default"
     t.index ["privacy"], name: "index_projects_on_privacy"
@@ -493,23 +496,24 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
   create_table "relationships", id: :serial, force: :cascade do |t|
     t.integer "source_id", null: false
     t.integer "target_id", null: false
-    t.string "relationship_type", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.integer "user_id"
-    t.float "weight", default: 0.0
-    t.integer "confirmed_by"
-    t.datetime "confirmed_at"
-    t.string "source_field"
-    t.string "target_field"
-    t.string "model"
-    t.jsonb "details", default: "{}"
+    t.string "relationship_type", null: false
     t.float "original_weight", default: 0.0
+    t.float "float", default: 0.0
     t.jsonb "original_details", default: "{}"
     t.string "original_relationship_type"
     t.string "original_model"
     t.integer "original_source_id"
     t.string "original_source_field"
+    t.integer "confirmed_by"
+    t.datetime "confirmed_at"
+    t.float "weight", default: 0.0
+    t.string "source_field"
+    t.string "target_field"
+    t.string "model"
+    t.jsonb "details", default: "{}"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index "LEAST(source_id, target_id), GREATEST(source_id, target_id)", name: "relationships_least_greatest_idx", unique: true
     t.index ["relationship_type"], name: "index_relationships_on_relationship_type"
     t.index ["source_id", "relationship_type"], name: "index_relationships_on_source_id_and_relationship_type"
@@ -523,18 +527,18 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
     t.bigint "feed_id", null: false
     t.string "request_type", null: false
     t.text "content", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.integer "request_id"
     t.integer "media_id"
+    t.integer "fact_checked_by_count", default: 0, null: false
+    t.integer "project_medias_count", default: 0, null: false
     t.integer "medias_count", default: 0, null: false
     t.integer "requests_count", default: 0, null: false
     t.datetime "last_submitted_at"
     t.string "webhook_url"
     t.datetime "last_called_webhook_at"
     t.integer "subscriptions_count", default: 0, null: false
-    t.integer "fact_checked_by_count", default: 0, null: false
-    t.integer "project_medias_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["feed_id"], name: "index_requests_on_feed_id"
     t.index ["media_id"], name: "index_requests_on_media_id"
     t.index ["request_id"], name: "index_requests_on_request_id"
@@ -567,15 +571,15 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
 
   create_table "sources", id: :serial, force: :cascade do |t|
     t.integer "user_id"
+    t.integer "team_id"
     t.string "name"
     t.string "slogan"
     t.string "avatar"
+    t.integer "archived", default: 0
+    t.string "file"
+    t.integer "lock_version", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "team_id"
-    t.string "file"
-    t.integer "archived", default: 0
-    t.integer "lock_version", default: 0, null: false
   end
 
   create_table "tag_texts", id: :serial, force: :cascade do |t|
@@ -598,12 +602,12 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
     t.integer "team_id", null: false
     t.integer "order", default: 0
     t.string "associated_type", default: "ProjectMedia", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "json_schema"
     t.string "fieldset", default: "", null: false
     t.boolean "show_in_browser_extension", default: true, null: false
+    t.string "json_schema"
     t.text "conditional_info"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["team_id", "fieldset", "associated_type"], name: "index_team_tasks_on_team_id_and_fieldset_and_associated_type"
   end
 
@@ -615,35 +619,33 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
     t.string "invitation_token"
     t.string "raw_invitation_token"
     t.datetime "invitation_accepted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "file"
+    t.text "settings"
     t.string "role"
     t.string "status", default: "member"
-    t.text "settings"
     t.string "invitation_email"
-    t.string "file"
     t.integer "lock_version", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["team_id", "user_id"], name: "index_team_users_on_team_id_and_user_id", unique: true
     t.index ["type"], name: "index_team_users_on_type"
     t.index ["user_id", "team_id", "status"], name: "index_team_users_on_user_id_and_team_id_and_status"
-    t.index ["user_id", "team_id"], name: "index_team_users_on_user_id_and_team_id"
   end
 
   create_table "teams", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "logo"
-    t.boolean "private", default: true
+    t.boolean "private", default: true, null: false
     t.integer "archived", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "country"
     t.text "description"
     t.string "slug"
-    t.text "settings"
     t.boolean "inactive", default: false
-    t.string "country"
+    t.text "settings"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["country"], name: "index_teams_on_country"
     t.index ["inactive"], name: "index_teams_on_inactive"
-    t.index ["slug"], name: "index_teams_on_slug"
     t.index ["slug"], name: "unique_team_slugs", unique: true
   end
 
@@ -718,7 +720,7 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
     t.datetime "updated_at"
     t.string "language"
     t.string "content_type"
-    t.string "header_type", default: "none", null: false
+    t.string "header_type", default: "link_preview", null: false
     t.string "header_file"
     t.string "header_overlay_text"
     t.string "header_media_url"
@@ -765,31 +767,32 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
     t.integer "invitation_limit"
     t.integer "invited_by_id"
     t.string "invited_by_type"
+    t.datetime "last_accepted_terms_at"
+    t.string "image"
+    t.string "type"
+    t.integer "source_id"
+    t.boolean "is_active", default: true
+    t.boolean "is_admin", default: false
+    t.integer "current_project_id"
+    t.integer "integer"
+    t.text "settings"
+    t.datetime "last_active_at"
+    t.text "cached_teams"
+    t.integer "current_team_id"
+    t.boolean "completed_signup", default: true
+    t.integer "api_key_id"
+    t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "image"
-    t.integer "current_team_id"
-    t.text "settings"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.boolean "is_admin", default: false
-    t.text "cached_teams"
-    t.string "type"
-    t.integer "api_key_id"
-    t.integer "source_id"
-    t.string "unconfirmed_email"
-    t.integer "current_project_id"
-    t.boolean "is_active", default: true
-    t.datetime "last_accepted_terms_at"
     t.string "encrypted_otp_secret"
     t.string "encrypted_otp_secret_iv"
     t.string "encrypted_otp_secret_salt"
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.string "otp_backup_codes", array: true
-    t.boolean "completed_signup", default: true
-    t.datetime "last_active_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true, where: "((email IS NOT NULL) AND ((email)::text <> ''::text))"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
@@ -809,11 +812,11 @@ ActiveRecord::Schema.define(version: 2023_10_23_002756) do
     t.text "object_changes"
     t.datetime "created_at"
     t.text "meta"
-    t.string "event_type"
-    t.text "object_after"
     t.integer "associated_id"
     t.string "associated_type"
+    t.string "event_type"
     t.integer "team_id"
+    t.text "object_after"
     t.index ["associated_id"], name: "index_versions_on_associated_id"
     t.index ["event_type"], name: "index_versions_on_event_type"
     t.index ["item_type", "item_id", "whodunnit"], name: "index_versions_on_item_type_and_item_id_and_whodunnit"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_15_203900) do
+ActiveRecord::Schema.define(version: 2023_10_23_002756) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,7 +133,6 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
 
   create_table "accounts", id: :serial, force: :cascade do |t|
     t.integer "user_id"
-    t.integer "team_id"
     t.string "url"
     t.text "omniauth_info"
     t.string "uid"
@@ -142,6 +141,7 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "team_id"
     t.index ["uid", "provider", "token", "email"], name: "index_accounts_on_uid_and_provider_and_token_and_email"
     t.index ["url"], name: "index_accounts_on_url", unique: true
     t.index ["user_id"], name: "index_accounts_on_user_id"
@@ -156,37 +156,37 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
     t.integer "annotator_id"
     t.text "entities"
     t.text "data"
-    t.string "file"
-    t.integer "lock_version", default: 0, null: false
-    t.boolean "locked", default: false
-    t.text "attribution"
-    t.text "fragment"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "file"
+    t.text "attribution"
+    t.integer "lock_version", default: 0, null: false
+    t.boolean "locked", default: false
+    t.text "fragment"
     t.index "task_fieldset((annotation_type)::text, data)", name: "task_fieldset", where: "((annotation_type)::text = 'task'::text)"
     t.index "task_team_task_id((annotation_type)::text, data)", name: "task_team_task_id", where: "((annotation_type)::text = 'task'::text)"
     t.index ["annotated_type", "annotated_id"], name: "index_annotations_on_annotated_type_and_annotated_id"
-    t.index ["annotation_type"], name: "index_annotation_type_order", opclass: :varchar_pattern_ops
+    t.index ["annotation_type"], name: "index_annotation_type_order"
     t.index ["annotation_type"], name: "index_annotations_on_annotation_type"
   end
 
   create_table "api_keys", id: :serial, force: :cascade do |t|
     t.string "access_token", default: "", null: false
     t.datetime "expire_at"
-    t.jsonb "rate_limits", default: {}
-    t.string "application"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string "application"
+    t.jsonb "rate_limits", default: {}
   end
 
   create_table "assignments", id: :serial, force: :cascade do |t|
     t.integer "assigned_id", null: false
     t.integer "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string "assigned_type"
     t.integer "assigner_id"
     t.text "message"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index ["assigned_id", "assigned_type", "user_id"], name: "index_assignments_on_assigned_id_and_assigned_type_and_user_id", unique: true
     t.index ["assigned_id", "assigned_type"], name: "index_assignments_on_assigned_id_and_assigned_type"
     t.index ["assigned_id"], name: "index_assignments_on_assigned_id"
@@ -213,9 +213,9 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
     t.text "description"
     t.bigint "user_id", null: false
     t.bigint "project_media_id", null: false
-    t.text "context"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "context"
     t.index ["project_media_id"], name: "index_claim_descriptions_on_project_media_id", unique: true
     t.index ["user_id"], name: "index_claim_descriptions_on_user_id"
   end
@@ -223,20 +223,20 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
   create_table "clusters", force: :cascade do |t|
     t.integer "project_medias_count", default: 0
     t.integer "project_media_id"
-    t.datetime "first_item_at"
-    t.datetime "last_item_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "first_item_at"
+    t.datetime "last_item_at"
     t.index ["project_media_id"], name: "index_clusters_on_project_media_id", unique: true
   end
 
   create_table "dynamic_annotation_annotation_types", primary_key: "annotation_type", id: :string, force: :cascade do |t|
     t.string "label", null: false
     t.text "description"
-    t.boolean "singleton", default: true
-    t.jsonb "json_schema"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "singleton", default: true
+    t.jsonb "json_schema"
     t.index ["json_schema"], name: "index_dynamic_annotation_annotation_types_on_json_schema", using: :gin
   end
 
@@ -259,7 +259,7 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "dynamic_annotation_fields", id: :serial, force: :cascade do |t|
+  create_table "dynamic_annotation_fields", id: :integer, default: -> { "nextval('new_dynamic_annotation_fields_id_seq'::regclass)" }, force: :cascade do |t|
     t.integer "annotation_id", null: false
     t.string "field_name", null: false
     t.string "annotation_type", null: false
@@ -270,14 +270,11 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
     t.datetime "updated_at", null: false
     t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
-    t.index ["annotation_id"], name: "index_dynamic_annotation_fields_on_annotation_id"
-    t.index ["annotation_type"], name: "index_dynamic_annotation_fields_on_annotation_type"
     t.index ["field_name"], name: "index_dynamic_annotation_fields_on_field_name"
     t.index ["field_type"], name: "index_dynamic_annotation_fields_on_field_type"
     t.index ["value"], name: "fetch_unique_id", unique: true, where: "(((field_name)::text = 'external_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
     t.index ["value"], name: "index_status", where: "((field_name)::text = 'verification_status_status'::text)"
     t.index ["value"], name: "smooch_user_unique_id", unique: true, where: "(((field_name)::text = 'smooch_user_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
-    t.index ["value"], name: "translation_request_id", unique: true, where: "((field_name)::text = 'translation_request_id'::text)"
     t.index ["value_json"], name: "index_dynamic_annotation_fields_on_value_json", using: :gin
   end
 
@@ -287,9 +284,9 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
     t.string "title"
     t.bigint "user_id", null: false
     t.bigint "claim_description_id", null: false
-    t.string "language", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "language", default: "", null: false
     t.string "signature"
     t.index ["claim_description_id"], name: "index_fact_checks_on_claim_description_id", unique: true
     t.index ["language"], name: "index_fact_checks_on_language"
@@ -313,9 +310,9 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
     t.bigint "team_id", null: false
     t.bigint "feed_id", null: false
     t.jsonb "settings", default: {}
-    t.boolean "shared", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "shared", default: false
     t.bigint "saved_search_id"
     t.index ["feed_id"], name: "index_feed_teams_on_feed_id"
     t.index ["saved_search_id"], name: "index_feed_teams_on_saved_search_id"
@@ -326,9 +323,9 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
   create_table "feeds", force: :cascade do |t|
     t.string "name", null: false
     t.jsonb "settings", default: {}
-    t.boolean "published", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "published", default: false
     t.bigint "saved_search_id"
     t.bigint "user_id"
     t.bigint "team_id"
@@ -362,11 +359,11 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
     t.integer "user_id"
     t.integer "account_id"
     t.string "url"
-    t.string "file"
-    t.string "quote"
-    t.string "type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "quote"
+    t.string "type"
+    t.string "file"
     t.index ["url"], name: "index_medias_on_url", unique: true
   end
 
@@ -444,20 +441,20 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
   end
 
   create_table "project_medias", id: :serial, force: :cascade do |t|
-    t.integer "project_id"
     t.integer "media_id"
-    t.integer "user_id"
-    t.integer "source_id"
-    t.integer "cluster_id"
-    t.integer "team_id"
-    t.jsonb "channel", default: {"main"=>0}
-    t.boolean "read", default: false, null: false
-    t.integer "sources_count", default: 0, null: false
-    t.integer "archived", default: 0
-    t.integer "targets_count", default: 0, null: false
-    t.integer "last_seen"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.integer "archived", default: 0
+    t.integer "targets_count", default: 0, null: false
+    t.integer "sources_count", default: 0, null: false
+    t.integer "team_id"
+    t.boolean "read", default: false, null: false
+    t.integer "source_id"
+    t.integer "project_id"
+    t.integer "last_seen"
+    t.integer "cluster_id"
+    t.jsonb "channel", default: {"main"=>0}
     t.integer "unmatched", default: 0
     t.index ["channel"], name: "index_project_medias_on_channel"
     t.index ["cluster_id"], name: "index_project_medias_on_cluster_id"
@@ -473,18 +470,18 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
   create_table "projects", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "team_id"
-    t.integer "project_group_id"
     t.string "title"
     t.boolean "is_default", default: false
     t.text "description"
     t.string "lead_image"
-    t.string "token"
-    t.integer "assignments_count", default: 0
-    t.integer "privacy", default: 0, null: false
-    t.integer "archived", default: 0
-    t.text "settings"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "archived", default: 0
+    t.text "settings"
+    t.string "token"
+    t.integer "assignments_count", default: 0
+    t.integer "project_group_id"
+    t.integer "privacy", default: 0, null: false
     t.index ["id"], name: "index_projects_on_id"
     t.index ["is_default"], name: "index_projects_on_is_default"
     t.index ["privacy"], name: "index_projects_on_privacy"
@@ -496,46 +493,48 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
   create_table "relationships", id: :serial, force: :cascade do |t|
     t.integer "source_id", null: false
     t.integer "target_id", null: false
-    t.integer "user_id"
     t.string "relationship_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.float "weight", default: 0.0
+    t.integer "confirmed_by"
+    t.datetime "confirmed_at"
+    t.string "source_field"
+    t.string "target_field"
+    t.string "model"
+    t.jsonb "details", default: "{}"
     t.float "original_weight", default: 0.0
-    t.float "float", default: 0.0
     t.jsonb "original_details", default: "{}"
     t.string "original_relationship_type"
     t.string "original_model"
     t.integer "original_source_id"
     t.string "original_source_field"
-    t.integer "confirmed_by"
-    t.datetime "confirmed_at"
-    t.float "weight", default: 0.0
-    t.string "source_field"
-    t.string "target_field"
-    t.string "model"
-    t.jsonb "details", default: "{}"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.index "LEAST(source_id, target_id), GREATEST(source_id, target_id)", name: "relationships_least_greatest_idx", unique: true
     t.index ["relationship_type"], name: "index_relationships_on_relationship_type"
+    t.index ["source_id", "relationship_type"], name: "index_relationships_on_source_id_and_relationship_type"
     t.index ["source_id", "target_id", "relationship_type"], name: "relationship_index", unique: true
-    t.index ["target_id"], name: "index_relationships_on_target_id", unique: true
+    t.index ["source_id"], name: "index_relationships_on_source_id"
+    t.index ["target_id", "relationship_type"], name: "index_relationships_on_target_id_and_relationship_type"
+    t.index ["target_id"], name: "index_relationships_on_target_id"
   end
 
   create_table "requests", force: :cascade do |t|
     t.bigint "feed_id", null: false
     t.string "request_type", null: false
     t.text "content", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "request_id"
     t.integer "media_id"
-    t.integer "fact_checked_by_count", default: 0, null: false
-    t.integer "project_medias_count", default: 0, null: false
     t.integer "medias_count", default: 0, null: false
     t.integer "requests_count", default: 0, null: false
     t.datetime "last_submitted_at"
     t.string "webhook_url"
     t.datetime "last_called_webhook_at"
     t.integer "subscriptions_count", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer "fact_checked_by_count", default: 0, null: false
+    t.integer "project_medias_count", default: 0, null: false
     t.index ["feed_id"], name: "index_requests_on_feed_id"
     t.index ["media_id"], name: "index_requests_on_media_id"
     t.index ["request_id"], name: "index_requests_on_request_id"
@@ -568,15 +567,15 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
 
   create_table "sources", id: :serial, force: :cascade do |t|
     t.integer "user_id"
-    t.integer "team_id"
     t.string "name"
     t.string "slogan"
     t.string "avatar"
-    t.integer "archived", default: 0
-    t.string "file"
-    t.integer "lock_version", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "team_id"
+    t.string "file"
+    t.integer "archived", default: 0
+    t.integer "lock_version", default: 0, null: false
   end
 
   create_table "tag_texts", id: :serial, force: :cascade do |t|
@@ -599,12 +598,12 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
     t.integer "team_id", null: false
     t.integer "order", default: 0
     t.string "associated_type", default: "ProjectMedia", null: false
-    t.string "fieldset", default: "", null: false
-    t.boolean "show_in_browser_extension", default: true, null: false
-    t.string "json_schema"
-    t.text "conditional_info"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "json_schema"
+    t.string "fieldset", default: "", null: false
+    t.boolean "show_in_browser_extension", default: true, null: false
+    t.text "conditional_info"
     t.index ["team_id", "fieldset", "associated_type"], name: "index_team_tasks_on_team_id_and_fieldset_and_associated_type"
   end
 
@@ -616,33 +615,35 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
     t.string "invitation_token"
     t.string "raw_invitation_token"
     t.datetime "invitation_accepted_at"
-    t.string "file"
-    t.text "settings"
-    t.string "role"
-    t.string "status", default: "member"
-    t.string "invitation_email"
-    t.integer "lock_version", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "role"
+    t.string "status", default: "member"
+    t.text "settings"
+    t.string "invitation_email"
+    t.string "file"
+    t.integer "lock_version", default: 0, null: false
     t.index ["team_id", "user_id"], name: "index_team_users_on_team_id_and_user_id", unique: true
     t.index ["type"], name: "index_team_users_on_type"
     t.index ["user_id", "team_id", "status"], name: "index_team_users_on_user_id_and_team_id_and_status"
+    t.index ["user_id", "team_id"], name: "index_team_users_on_user_id_and_team_id"
   end
 
   create_table "teams", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "logo"
-    t.boolean "private", default: true, null: false
+    t.boolean "private", default: true
     t.integer "archived", default: 0
-    t.string "country"
-    t.text "description"
-    t.string "slug"
-    t.boolean "inactive", default: false
-    t.text "settings"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "description"
+    t.string "slug"
+    t.text "settings"
+    t.boolean "inactive", default: false
+    t.string "country"
     t.index ["country"], name: "index_teams_on_country"
     t.index ["inactive"], name: "index_teams_on_inactive"
+    t.index ["slug"], name: "index_teams_on_slug"
     t.index ["slug"], name: "unique_team_slugs", unique: true
   end
 
@@ -717,7 +718,7 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
     t.datetime "updated_at"
     t.string "language"
     t.string "content_type"
-    t.string "header_type", default: "link_preview", null: false
+    t.string "header_type", default: "none", null: false
     t.string "header_file"
     t.string "header_overlay_text"
     t.string "header_media_url"
@@ -764,32 +765,31 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
     t.integer "invitation_limit"
     t.integer "invited_by_id"
     t.string "invited_by_type"
-    t.datetime "last_accepted_terms_at"
-    t.string "image"
-    t.string "type"
-    t.integer "source_id"
-    t.boolean "is_active", default: true
-    t.boolean "is_admin", default: false
-    t.integer "current_project_id"
-    t.integer "integer"
-    t.text "settings"
-    t.datetime "last_active_at"
-    t.text "cached_teams"
-    t.integer "current_team_id"
-    t.boolean "completed_signup", default: true
-    t.integer "api_key_id"
-    t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "image"
+    t.integer "current_team_id"
+    t.text "settings"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
+    t.boolean "is_admin", default: false
+    t.text "cached_teams"
+    t.string "type"
+    t.integer "api_key_id"
+    t.integer "source_id"
+    t.string "unconfirmed_email"
+    t.integer "current_project_id"
+    t.boolean "is_active", default: true
+    t.datetime "last_accepted_terms_at"
     t.string "encrypted_otp_secret"
     t.string "encrypted_otp_secret_iv"
     t.string "encrypted_otp_secret_salt"
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.string "otp_backup_codes", array: true
+    t.boolean "completed_signup", default: true
+    t.datetime "last_active_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true, where: "((email IS NOT NULL) AND ((email)::text <> ''::text))"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
@@ -809,11 +809,11 @@ ActiveRecord::Schema.define(version: 2023_10_15_203900) do
     t.text "object_changes"
     t.datetime "created_at"
     t.text "meta"
+    t.string "event_type"
+    t.text "object_after"
     t.integer "associated_id"
     t.string "associated_type"
-    t.string "event_type"
     t.integer "team_id"
-    t.text "object_after"
     t.index ["associated_id"], name: "index_versions_on_associated_id"
     t.index ["event_type"], name: "index_versions_on_event_type"
     t.index ["item_type", "item_id", "whodunnit"], name: "index_versions_on_item_type_and_item_id_and_whodunnit"

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -223,7 +223,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     Sidekiq::Testing.inline! do
       send_message 'hello', '1', '1', 'Foo bar', '1'
       assert_state 'search_result'
-      assert_difference 'Dynamic.count + ProjectMedia.count' do
+      assert_difference 'Dynamic.where(annotation_type: "smooch").count + ProjectMedia.count + Relationship.where(relationship_type: Relationship.suggested_type).count', 3 do
         send_message '1'
       end
       assert_state 'main'
@@ -240,7 +240,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     Sidekiq::Testing.inline! do
       send_message 'hello', '1', '1', 'Foo bar foo bar foo bar', '1'
       assert_state 'search_result'
-      assert_difference 'Dynamic.count + ProjectMedia.count' do
+      assert_difference 'Dynamic.where(annotation_type: "smooch").count + ProjectMedia.count + Relationship.where(relationship_type: Relationship.suggested_type).count', 3 do
         send_message '1'
       end
       assert_state 'main'
@@ -261,7 +261,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     Sidekiq::Testing.inline! do
       send_message 'hello', '1', '1', 'Image here', '1'
       assert_state 'search_result'
-      assert_difference 'Dynamic.count + ProjectMedia.count' do
+      assert_difference 'Dynamic.where(annotation_type: "smooch").count + ProjectMedia.count + Relationship.where(relationship_type: Relationship.suggested_type).count', 3 do
         send_message '1'
       end
       assert_state 'main'

--- a/test/models/relationship_2_test.rb
+++ b/test/models/relationship_2_test.rb
@@ -361,17 +361,4 @@ class Relationship2Test < ActiveSupport::TestCase
     r.destroy!
     assert_queries(0, '=') { assert_nil pm2.confirmed_as_similar_by_name }
   end
-
-  test "should not save duplicate values for target_id column" do
-    t = create_team
-    pm1 = create_project_media team: t
-    pm2 = create_project_media team: t
-    pm3 = create_project_media team: t
-    assert_nothing_raised do
-      create_relationship source_id: pm1.id, target_id: pm3.id
-    end
-    assert_raises 'ActiveRecord::RecordNotUnique' do
-      create_relationship source_id: pm2.id, target_id: pm3.id
-    end
-  end
 end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -80,14 +80,15 @@ class RelationshipTest < ActiveSupport::TestCase
 
   test "should remove suggested relation when same items added as similar" do
     team = create_team
+    b = create_bot name: 'Alegre', login: 'alegre'
     s = create_project_media team: team
     t = create_project_media team: team
-    r = create_relationship source_id: s.id, target_id: t.id, relationship_type: Relationship.suggested_type
-    r2 = create_relationship source_id: s.id, target_id: t.id, relationship_type: Relationship.confirmed_type
+    r = create_relationship source_id: s.id, target_id: t.id, relationship_type: Relationship.suggested_type, user: b
+    r2 = create_relationship source_id: s.id, target_id: t.id, relationship_type: Relationship.confirmed_type, user: b
     assert_nil Relationship.where(id: r.id).last
     assert_not_nil Relationship.where(id: r2.id).last
     assert_raises ActiveRecord::RecordInvalid do
-      create_relationship source_id: s.id, target_id: t.id, relationship_type: Relationship.suggested_type
+      create_relationship source_id: s.id, target_id: t.id, relationship_type: Relationship.suggested_type, user: b
     end
   end
 


### PR DESCRIPTION
## Description

Previously: When users received tipline search results and voted on them as relevant or chose not to vote, a request was generated and linked to the items returned in the search results. No new media or items were created.

Now: When users receive tipline search results and cast votes on them as relevant or abstain from voting, a request is generated and associated with newly created media and items. These new items are linked to the search results through suggestion relationships, unless identical media already exist, in which case the previous behavior remains unchanged.

Additionally:

- To prevent redundancy, refrain from sending reports to users when their suggestions are accepted, as they have already received the report through the search results.
- When confirming a match, delete any suggestion relationship between the same items, but exclusively when the suggestion was initiated by a bot.
- When confirming a suggestion initiated by the Smooch Bot, remove other suggestions made by the Smooch Bot for the same item.
- Introduce new database indexes to enhance performance.

## How has this been tested?

Automated tests updated for all these changes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

