### PR TITLE
Exposing new fields on GraphQL API for shared feeds invitations

### DIFF
--- a/app/graph/types/feed_type.rb
+++ b/app/graph/types/feed_type.rb
@@ -44,4 +44,5 @@ class FeedType < DefaultObject
 
   field :feed_invitations, FeedInvitationType.connection_type, null: false
   field :teams, TeamType.connection_type, null: false
+  field :feed_teams, FeedTeamType.connection_type, null: false
 end

--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -215,6 +215,7 @@ class QueryType < BaseObject
     feed
     request
     feed_invitation
+    feed_team
     tipline_message
   ].each do |type|
     field type,

--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -293,6 +293,7 @@ class TeamType < DefaultObject
   field :saved_searches, SavedSearchType.connection_type, null: true
   field :project_groups, ProjectGroupType.connection_type, null: true
   field :feeds, FeedType.connection_type, null: true
+  field :feed_teams, FeedTeamType.connection_type, null: false
   field :tipline_newsletters, TiplineNewsletterType.connection_type, null: true
   field :tipline_resources, TiplineResourceType.connection_type, null: true
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -85,6 +85,9 @@ class Ability
     end
     can [:create, :update, :read, :destroy], [Account, Source, TiplineNewsletter, TiplineResource, Feed, FeedTeam], :team_id => @context_team.id
     can [:create, :update, :destroy], FeedInvitation, { feed: { team_id: @context_team.id } }
+    can :destroy, FeedTeam do |obj|
+      obj.team.id == @context_team.id || obj.feed.team.id == @context_team.id
+    end
     can [:cud], AccountSource, source: { team: { team_users: { team_id: @context_team.id }}}
     %w(annotation comment dynamic task tag).each do |annotation_type|
       can [:cud], annotation_type.classify.constantize do |obj|

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -8430,6 +8430,27 @@ type Feed implements Node {
     """
     last: Int
   ): FeedInvitationConnection!
+  feed_teams(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): FeedTeamConnection!
   filters: JsonStringType
   id: ID!
   licenses: [Int]
@@ -8609,6 +8630,27 @@ type FeedTeam implements Node {
   team: Team
   team_id: Int
   updated_at: String
+}
+
+"""
+The connection type for FeedTeam.
+"""
+type FeedTeamConnection {
+  """
+  A list of edges.
+  """
+  edges: [FeedTeamEdge]
+
+  """
+  A list of nodes.
+  """
+  nodes: [FeedTeam]
+
+  """
+  Information to aid in pagination.
+  """
+  pageInfo: PageInfo!
+  totalCount: Int
 }
 
 """
@@ -11691,6 +11733,11 @@ type Query {
   feed_invitation(id: ID!): FeedInvitation
 
   """
+  Information about the feed_team with given id
+  """
+  feed_team(id: ID!): FeedTeam
+
+  """
   Find whether a team exists
   """
   find_public_team(slug: String!): PublicTeam
@@ -12875,6 +12922,27 @@ type Team implements Node {
   description: String
   dynamic_search_fields_json_schema: JsonStringType
   feed(dbid: Int!): Feed
+  feed_teams(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): FeedTeamConnection!
   feeds(
     """
     Returns the elements in the list that come after the specified cursor.

--- a/public/relay.json
+++ b/public/relay.json
@@ -45753,6 +45753,71 @@
               "deprecationReason": null
             },
             {
+              "name": "feed_teams",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FeedTeamConnection",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "filters",
               "description": null,
               "args": [
@@ -46940,6 +47005,87 @@
               "name": "Node",
               "ofType": null
             }
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "FeedTeamConnection",
+          "description": "The connection type for FeedTeam.",
+          "fields": [
+            {
+              "name": "edges",
+              "description": "A list of edges.",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FeedTeamEdge",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "nodes",
+              "description": "A list of nodes.",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FeedTeam",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "pageInfo",
+              "description": "Information to aid in pagination.",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "PageInfo",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "totalCount",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
           ],
           "enumValues": null,
           "possibleTypes": null
@@ -61530,6 +61676,35 @@
               "deprecationReason": null
             },
             {
+              "name": "feed_team",
+              "description": "Information about the feed_team with given id",
+              "args": [
+                {
+                  "name": "id",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "ID",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "FeedTeam",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "find_public_team",
               "description": "Find whether a team exists",
               "args": [
@@ -67333,6 +67508,71 @@
                 "kind": "OBJECT",
                 "name": "Feed",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "feed_teams",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "FeedTeamConnection",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -1305,4 +1305,34 @@ class AbilityTest < ActiveSupport::TestCase
       assert ability.cannot?(:destroy, fi2)
     end
   end
+
+  test "permissions for feed team" do
+    t1 = create_team
+    t2 = create_team
+    t3 = create_team
+    u1 = create_user
+    u2 = create_user
+    u3 = create_user
+    create_team_user user: u1, team: t1, role: 'admin'
+    create_team_user user: u2, team: t2, role: 'admin'
+    create_team_user user: u3, team: t3, role: 'admin'
+    f = create_feed team: t1
+    ft2 = create_feed_team feed: f, team: t2
+    ft3 = create_feed_team feed: f, team: t3
+    with_current_user_and_team(u1, t1) do
+      ability = Ability.new
+      assert ability.can?(:destroy, ft2)
+      assert ability.can?(:destroy, ft3)
+    end
+    with_current_user_and_team(u2, t2) do
+      ability = Ability.new
+      assert ability.can?(:destroy, ft2)
+      assert ability.cannot?(:destroy, ft3)
+    end
+    with_current_user_and_team(u3, t3) do
+      ability = Ability.new
+      assert ability.cannot?(:destroy, ft2)
+      assert ability.can?(:destroy, ft3)
+    end
+  end
 end


### PR DESCRIPTION
## Description

- Adding `feed_teams` connection to `Feed`
- Adding `feed_team` (get by database ID) to the root query type
- Allow feed owner to delete a `FeedTeam`

Reference: CV2-3900.

## How has this been tested?

Automated tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

