### PR TITLE
Trying to avoid menu being sent before resources and greeting.

### DIFF
--- a/app/controllers/concerns/facebook_authentication.rb
+++ b/app/controllers/concerns/facebook_authentication.rb
@@ -5,7 +5,7 @@ module FacebookAuthentication
     # pages_manage_metadata is for Facebook API > 7
     # manage_pages is for Facebook API < 7
     # An error will be displayed for Facebook users that are admins of the Facebook app, but should be transparent for other users
-    request.env['omniauth.strategy'].options[:scope] = 'pages_manage_metadata,manage_pages,pages_messaging,instagram_manage_messages' if params[:context] == 'smooch'
+    request.env['omniauth.strategy'].options[:scope] = 'pages_manage_metadata,manage_pages,pages_messaging,instagram_manage_messages,instagram_basic' if params[:context] == 'smooch'
     prefix = facebook_context == 'smooch' ? 'smooch_' : ''
     request.env['omniauth.strategy'].options[:client_id] = CheckConfig.get("#{prefix}facebook_app_id")
     request.env['omniauth.strategy'].options[:client_secret] = CheckConfig.get("#{prefix}facebook_app_secret")

--- a/app/models/concerns/smooch_menus.rb
+++ b/app/models/concerns/smooch_menus.rb
@@ -303,7 +303,7 @@ module SmoochMenus
         text = self.get_custom_string('smooch_message_smooch_bot_greetings', workflow['smooch_workflow_language'])
         image = workflow['smooch_greeting_image'] if workflow['smooch_greeting_image'] =~ /^https?:\/\//
         image.blank? || image == 'none' ? self.send_message_to_user(uid, text) : self.send_message_to_user(uid, text, { 'type' => 'image', 'mediaUrl' => image })
-        sleep 2 # Give it some time, so the main menu message is sent after the greetings
+        sleep 3 # Give it some time, so the main menu message is sent after the greetings
       end
     end
   end

--- a/app/models/concerns/smooch_resources.rb
+++ b/app/models/concerns/smooch_resources.rb
@@ -14,7 +14,7 @@ module SmoochResources
           type = 'video' if type == 'audio' # Audio gets converted to video with a cover
           type = 'file' if type == 'video' && RequestStore.store[:smooch_bot_provider] == 'ZENDESK' # Smooch doesn't support video
           self.send_message_to_user(uid, message, { 'type' => type, 'mediaUrl' => CheckS3.rewrite_url(resource.header_media_url) }, false, true, 'resource')
-          sleep 2 # Wait a couple of seconds before sending the main menu
+          sleep 3 # Wait a few seconds before sending the main menu
           self.send_message_for_state(uid, workflow, 'main', language)
         else
           preview_url = (resource.header_type == 'link_preview')


### PR DESCRIPTION
## Description

Mostly for Instagram. Just increasing one second before sending the main menu after greetings and resources. Also adding one more permission required by Instagram.

Fixes CV2-3727.

## How has this been tested?

To be tested on QA, because it requires a real connection to a Instagram profile.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

