### PR TITLE
Tipline: NLU disambiguation.

### DIFF
--- a/app/lib/smooch_nlu_menus.rb
+++ b/app/lib/smooch_nlu_menus.rb
@@ -88,8 +88,7 @@ module SmoochNluMenus
     def process_menu_options(uid, options, message, language, workflow, app_id)
 
       if options.size == 1
-        option = options.first
-        Bot::Smooch.process_menu_option_value(option['smooch_menu_option_value'], option, message, language, workflow, app_id)
+        Bot::Smooch.process_menu_option_value(options.first['smooch_menu_option_value'], options.first, message, language, workflow, app_id)
       # Disambiguation
       else
         buttons = options.collect do |option|

--- a/app/lib/smooch_nlu_menus.rb
+++ b/app/lib/smooch_nlu_menus.rb
@@ -67,20 +67,39 @@ module SmoochNluMenus
   end
 
   module ClassMethods
-    def menu_option_from_message(message, language, options)
-      return nil if options.blank?
-      option = nil
+    def menu_options_from_message(message, language, options)
+      return [{ 'smooch_menu_option_value' => 'main_state' }] if message == 'cancel_nlu'
+      return [] if options.blank?
       context = {
         context: ALEGRE_CONTEXT_KEY_MENU
       }
       matches = SmoochNlu.alegre_matches_from_message(message, language, context, 'menu_option_id')
-      # Select the top menu option that exists in `options`
+      # Select the top two menu options that exists in `options`
+      top_options = []
       matches.each do |r|
-        option = options.find{ |o| !o['smooch_menu_option_id'].blank? && o['smooch_menu_option_id'] == r }
-        break unless option.nil?
+        option = options.find { |o| !o['smooch_menu_option_id'].blank? && o['smooch_menu_option_id'] == r['key'] }
+        top_options << { 'option' => option, 'score' => r['score'] } if !option.nil? && (top_options.empty? || (top_options.first['score'] - r['score']) <= SmoochNlu.disambiguation_threshold)
+        break if top_options.size == 2
       end
-      Rails.logger.info("[Smooch NLU] [Menu Option From Message] Menu option: #{option} | Message: #{message}")
-      option
+      Rails.logger.info("[Smooch NLU] [Menu Option From Message] Menu options: #{top_options.inspect} | Message: #{message}")
+      top_options.collect{ |o| o['option'] }
+    end
+
+    def process_menu_options(uid, options, message, language, workflow, app_id)
+
+      if options.size == 1
+        option = options.first
+        Bot::Smooch.process_menu_option_value(option['smooch_menu_option_value'], option, message, language, workflow, app_id)
+      # Disambiguation
+      else
+        buttons = options.collect do |option|
+          {
+            value: { keyword: option['smooch_menu_option_keyword'] }.to_json,
+            label: option['smooch_menu_option_label']
+          }
+        end.concat([{ value: { keyword: 'cancel_nlu' }.to_json, label: Bot::Smooch.get_string('main_state_button_label', language, 20) }])
+        Bot::Smooch.send_message_to_user_with_buttons(uid, Bot::Smooch.get_string('nlu_disambiguation', language), buttons)
+      end
     end
   end
 end

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -575,9 +575,9 @@ class Bot::Smooch < BotUser
     end
     # ...if nothing is matched, try using the NLU feature
     if state != 'query'
-      option = SmoochNlu.menu_option_from_message(typed, language, options)
-      unless option.nil?
-        self.process_menu_option_value(option['smooch_menu_option_value'], option, message, language, workflow, app_id)
+      options = SmoochNlu.menu_options_from_message(typed, language, options)
+      unless options.blank?
+        SmoochNlu.process_menu_options(uid, options, message, language, workflow, app_id)
         return true
       end
       resource = TiplineResource.resource_from_message(typed, language)

--- a/app/models/concerns/tipline_resource_nlu.rb
+++ b/app/models/concerns/tipline_resource_nlu.rb
@@ -36,7 +36,7 @@ module TiplineResourceNlu
       context = {
         context: ALEGRE_CONTEXT_KEY_RESOURCE
       }
-      matches = SmoochNlu.alegre_matches_from_message(message, language, context, 'resource_id')
+      matches = SmoochNlu.alegre_matches_from_message(message, language, context, 'resource_id').collect{ |m| m['key'] }
       # Select the top resource that exists
       resource_id = matches.find { |id| TiplineResource.where(id: id).exists? }
       Rails.logger.info("[Smooch NLU] [Resource From Message] Resource ID: #{resource_id} | Message: #{message}")

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -44,6 +44,7 @@ development: &default
   text_cluster_similarity_threshold: 0.9
   similarity_media_file_url_host: ''
   min_number_of_words_for_tipline_submit_shortcut: 10
+  nlu_disambiguation_threshold: 0.11
 
   # Localization
   #

--- a/config/tipline_strings.yml
+++ b/config/tipline_strings.yml
@@ -261,6 +261,7 @@ en:
   subscribed: You are currently subscribed to our newsletter.
   unsubscribe_button_label: Unsubscribe
   unsubscribed: You are currently not subscribed to our newsletter.
+  nlu_disambiguation: "Choose one of the options below:"
 fil:
   add_more_details_state_button_label: Dagdagan pa
   ask_if_ready_state_button_label: Kanselahin

--- a/test/lib/smooch_nlu_test.rb
+++ b/test/lib/smooch_nlu_test.rb
@@ -110,7 +110,7 @@ class SmoochNluTest < ActiveSupport::TestCase
     team = create_team_with_smooch_bot_installed
     SmoochNlu.new(team.slug).disable!
     Bot::Smooch.get_installation('smooch_id', 'test')
-    assert_nil SmoochNlu.menu_options_from_message('I want to subscribe to the newsletter', 'en', @menu_options)
+    assert_equal [], SmoochNlu.menu_options_from_message('I want to subscribe to the newsletter', 'en', @menu_options)
   end
 
   test 'should return a menu option if NLU is enabled' do

--- a/test/lib/smooch_nlu_test.rb
+++ b/test/lib/smooch_nlu_test.rb
@@ -110,7 +110,7 @@ class SmoochNluTest < ActiveSupport::TestCase
     team = create_team_with_smooch_bot_installed
     SmoochNlu.new(team.slug).disable!
     Bot::Smooch.get_installation('smooch_id', 'test')
-    assert_nil SmoochNlu.menu_option_from_message('I want to subscribe to the newsletter', 'en', @menu_options)
+    assert_nil SmoochNlu.menu_options_from_message('I want to subscribe to the newsletter', 'en', @menu_options)
   end
 
   test 'should return a menu option if NLU is enabled' do
@@ -120,6 +120,6 @@ class SmoochNluTest < ActiveSupport::TestCase
     team = create_team_with_smooch_bot_installed
     SmoochNlu.new(team.slug).enable!
     Bot::Smooch.get_installation('smooch_id', 'test')
-    assert_not_nil SmoochNlu.menu_option_from_message('I want to subscribe to the newsletter', 'en', @menu_options)
+    assert_not_nil SmoochNlu.menu_options_from_message('I want to subscribe to the newsletter', 'en', @menu_options)
   end
 end


### PR DESCRIPTION
## Description

If NLU identifies that two options are very similar, present both to the user and let them choose.

Reference: CV2-3710.

## How has this been tested?

Automated tests.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

