### PR TITLE
CV2-3940: fix default language for duplicated team

### DIFF
--- a/app/models/concerns/team_duplication.rb
+++ b/app/models/concerns/team_duplication.rb
@@ -45,6 +45,7 @@ module TeamDuplication
       new_list_columns = old_team.get_list_columns.to_a.collect{|lc| lc.include?("task_value_") ? "task_value_#{team_task_map[lc.split("_").last.to_i]}" : lc}
       new_team.set_list_columns = new_list_columns unless new_list_columns.blank?
       new_team.set_languages = old_team.get_languages
+      new_team.set_language = old_team.get_language
       new_team
     end
 

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -984,6 +984,16 @@ class TeamTest < ActiveSupport::TestCase
     assert_equal ['alegre'], tbi.map(&:user).map(&:login)
   end
 
+  test "should duplicate team with non english default language" do
+    t1 = create_team
+    t1.set_languages = ['fr']
+    t1.set_language = 'fr'
+    t1.save!
+    t2 = Team.duplicate(t1)
+    assert_equal ['fr'], t2.get_languages
+    assert_equal 'fr', t2.get_language
+  end
+
   test "should delete team and partition" do
     t = create_team
     assert_difference 'Team.count', -1 do


### PR DESCRIPTION
## Description

Set the default language when duplicate existing workspace.

References: CV2-3940

## How has this been tested?

Implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

