### PR TITLE
3884 – Improve seeds script: create more Tipline requests

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,7 +32,8 @@ data = {
     'https://meedan.com/post/what-is-gendered-health-misinformation-and-why-is-it-an-equity-problem-worth',
     'https://meedan.com/post/the-case-for-a-public-health-approach-to-moderate-health-misinformation',
   ],
-  quotes: ['Garlic can help you fight covid', 'Tea with garlic is a covid treatment', 'If you have covid you should eat garlic', 'Are you allergic to garlic?', 'Vampires can\'t eat garlic']
+  quotes: ['Garlic can help you fight covid', 'Tea with garlic is a covid treatment', 'If you have covid you should eat garlic', 'Are you allergic to garlic?', 'Vampires can\'t eat garlic'],
+  tipline_claims: Array.new(9) { Faker::Lorem.paragraph(sentence_count: 10) }
 }
 
 def open_file(file)
@@ -215,77 +216,76 @@ ActiveRecord::Base.transaction do
     end
   end
 
-  # puts 'Making Medias...'
-  # puts 'Making Medias and Project Medias: Claims...'
-  # 9.times { Claim.create!(user_id: user.id, quote: Faker::Quotes::Shakespeare.hamlet_quote) }
-  # create_project_medias(user, project, team)
-  # add_claim_descriptions_and_fact_checks(user)
+  puts 'Making Medias...'
+  puts 'Making Medias and Project Medias: Claims...'
+  9.times { Claim.create!(user_id: user.id, quote: Faker::Quotes::Shakespeare.hamlet_quote) }
+  create_project_medias(user, project, team)
+  add_claim_descriptions_and_fact_checks(user)
 
-  # puts 'Making Medias and Project Medias: Links...'
-  # begin
-  #   data[:link_media_links].each { |link_media_link| Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}") }
-  #   create_project_medias(user, project, team)
-  #   add_claim_descriptions_and_fact_checks(user)
-  # rescue
-  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  # end
+  puts 'Making Medias and Project Medias: Links...'
+  begin
+    data[:link_media_links].each { |link_media_link| Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}") }
+    create_project_medias(user, project, team)
+    add_claim_descriptions_and_fact_checks(user)
+  rescue
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  end
 
-  # puts 'Making Medias and Project Medias: Audios...'
-  # data[:audios].each { |audio| UploadedAudio.create!(user_id: user.id, file: open_file(audio)) }
-  # create_project_medias(user, project, team)
-  # add_claim_descriptions_and_fact_checks(user)
+  puts 'Making Medias and Project Medias: Audios...'
+  data[:audios].each { |audio| UploadedAudio.create!(user_id: user.id, file: open_file(audio)) }
+  create_project_medias(user, project, team)
+  add_claim_descriptions_and_fact_checks(user)
 
-  # puts 'Making Medias and Project Medias: Images...'
-  # data[:images].each { |image| UploadedImage.create!(user_id: user.id, file: open_file(image))}
-  # create_project_medias(user, project, team)
-  # add_claim_descriptions_and_fact_checks(user)
+  puts 'Making Medias and Project Medias: Images...'
+  data[:images].each { |image| UploadedImage.create!(user_id: user.id, file: open_file(image))}
+  create_project_medias(user, project, team)
+  add_claim_descriptions_and_fact_checks(user)
 
-  # puts 'Making Medias and Project Medias: Videos...'
-  # data[:videos].each { |video| UploadedVideo.create!(user_id: user.id, file: open_file(video)) }
-  # create_project_medias(user, project, team)
-  # add_claim_descriptions_and_fact_checks(user)
+  puts 'Making Medias and Project Medias: Videos...'
+  data[:videos].each { |video| UploadedVideo.create!(user_id: user.id, file: open_file(video)) }
+  create_project_medias(user, project, team)
+  add_claim_descriptions_and_fact_checks(user)
 
-  # puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
-  # data[:fact_check_links].each { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
+  puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
+  data[:fact_check_links].each { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
 
-  # puts 'Making Relationship between Claims...'
-  # project_medias_for_relationship_claims = []
-  # relationship_claims = data[:quotes].map { |quote| Claim.create!(user_id: user.id, quote: quote) }
-  # relationship_claims.each { |claim| project_medias_for_relationship_claims.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: claim))}
+  puts 'Making Relationship between Claims...'
+  project_medias_for_relationship_claims = []
+  relationship_claims = data[:quotes].map { |quote| Claim.create!(user_id: user.id, quote: quote) }
+  relationship_claims.each { |claim| project_medias_for_relationship_claims.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: claim))}
 
-  # Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[1].id, relationship_type: Relationship.confirmed_type)
-  # Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[2].id, relationship_type: Relationship.confirmed_type)
-  # Relationship.create!(source_id: project_medias_for_relationship_claims[3].id, target_id: project_medias_for_relationship_claims[4].id, relationship_type: Relationship.suggested_type)
+  Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[1].id, relationship_type: Relationship.confirmed_type)
+  Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[2].id, relationship_type: Relationship.confirmed_type)
+  Relationship.create!(source_id: project_medias_for_relationship_claims[3].id, target_id: project_medias_for_relationship_claims[4].id, relationship_type: Relationship.suggested_type)
 
-  # puts 'Making Relationship between Images...'
-  # project_medias_for_images = []
-  # 2.times { project_medias_for_images.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedImage.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.png'))))) }
-  # Relationship.create!(source_id: project_medias_for_images[0].id, target_id: project_medias_for_images[1].id, relationship_type: Relationship.confirmed_type)
+  puts 'Making Relationship between Images...'
+  project_medias_for_images = []
+  2.times { project_medias_for_images.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedImage.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.png'))))) }
+  Relationship.create!(source_id: project_medias_for_images[0].id, target_id: project_medias_for_images[1].id, relationship_type: Relationship.confirmed_type)
 
-  # puts 'Making Relationship between Audios...'
-  # project_medias_for_audio = []
-  # 2.times { project_medias_for_audio.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedAudio.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.mp3'))))) }
-  # Relationship.create!(source_id: project_medias_for_audio[0].id, target_id: project_medias_for_audio[1].id, relationship_type: Relationship.confirmed_type)
+  puts 'Making Relationship between Audios...'
+  project_medias_for_audio = []
+  2.times { project_medias_for_audio.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedAudio.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.mp3'))))) }
+  Relationship.create!(source_id: project_medias_for_audio[0].id, target_id: project_medias_for_audio[1].id, relationship_type: Relationship.confirmed_type)
 
-  puts 'Making Tipline requests for claim items...'
-  tipline_claims_arr = []
-  6.times { tipline_claims_arr.push(Faker::Lorem.paragraph(sentence_count: 10))}
-  create_tipline_requests(team, project, user, tipline_claims_arr, 'Claim')
+  puts 'Making Tipline requests...'
+  puts 'Making Tipline requests: Claims...'
+  create_tipline_requests(team, project, user, data[:tipline_claims], 'Claim')
 
-  puts 'Making Tipline requests for link items...'
+  puts 'Making Tipline requests: Links...'
   begin
     create_tipline_requests(team, project, user, data[:link_media_links], 'Link')
   rescue
     puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
   end  
 
-  puts 'Making Tipline requests for audio items...'
+  puts 'Making Tipline requests: Audios...'
   create_tipline_requests(team, project, user, data[:audios], 'UploadedAudio')
 
-  puts 'Making Tipline requests for image items...'
+  puts 'Making Tipline requests: Images...'
   create_tipline_requests(team, project, user, data[:images], 'UploadedImage')
 
-  puts 'Making Tipline requests for video items...'
+  puts 'Making Tipline requests: Videos...'
   create_tipline_requests(team, project, user, data[:videos], 'UploadedVideo')
 
   add_claim_descriptions_and_fact_checks(user)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -274,15 +274,35 @@ ActiveRecord::Base.transaction do
   #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
   # end
 
-  puts 'Making Tipline requests for audio items...'
-  tipline_pm_audios_arr = []
-  data[:audios][0..5].each do |audio| 
-    audio_media = UploadedAudio.create!(user_id: user.id, file: open_file(audio)) 
-    project_media = create_tipline_project_media(project, team, audio_media)
-    tipline_pm_audios_arr.push(project_media)
+  # puts 'Making Tipline requests for audio items...'
+  # tipline_pm_audios_arr = []
+  # data[:audios][0..5].each do |audio| 
+  #   audio_media = UploadedAudio.create!(user_id: user.id, file: open_file(audio)) 
+  #   project_media = create_tipline_project_media(project, team, audio_media)
+  #   tipline_pm_audios_arr.push(project_media)
+  # end
+  # tipline_pm_audios_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
+  # tipline_pm_audios_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
+
+  # puts 'Making Tipline requests for image items...'
+  # tipline_pm_images_arr = []
+  # data[:images][0..5].each do |image| 
+  #   image_media = UploadedImage.create!(user_id: user.id, file: open_file(image)) 
+  #   project_media = create_tipline_project_media(project, team, image_media)
+  #   tipline_pm_images_arr.push(project_media)
+  # end
+  # tipline_pm_images_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
+  # tipline_pm_images_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
+
+  puts 'Making Tipline requests for video items...'
+  tipline_pm_videos_arr = []
+  data[:videos][0..5].each do |video| 
+    video_media = UploadedVideo.create!(user_id: user.id, file: open_file(video)) 
+    project_media = create_tipline_project_media(project, team, video_media)
+    tipline_pm_videos_arr.push(project_media)
   end
-  tipline_pm_audios_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
-  tipline_pm_audios_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
+  tipline_pm_videos_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
+  tipline_pm_videos_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
 
   add_claim_descriptions_and_fact_checks(user)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -248,33 +248,41 @@ ActiveRecord::Base.transaction do
   # 2.times { project_medias_for_audio.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedAudio.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.mp3'))))) }
   # Relationship.create!(source_id: project_medias_for_audio[0].id, target_id: project_medias_for_audio[1].id, relationship_type: Relationship.confirmed_type)
 
-  puts 'Making Tipline requests for claims...'
-  tipline_pm_claims_arr = []
-  6.times do
-    claim_media = Claim.create!(user_id: user.id, quote: Faker::Lorem.paragraph(sentence_count: 10))
-    project_media = create_tipline_project_media(project, team, claim_media)
-    tipline_pm_claims_arr.push(project_media)
-  end
+  # puts 'Making Tipline requests for claim items...'
+  # tipline_pm_claims_arr = []
+  # 6.times do
+  #   claim_media = Claim.create!(user_id: user.id, quote: Faker::Lorem.paragraph(sentence_count: 10))
+  #   project_media = create_tipline_project_media(project, team, claim_media)
+  #   tipline_pm_claims_arr.push(project_media)
+  # end
+  # tipline_pm_claims_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)} 
+  # tipline_pm_claims_arr[3..5].each do |pm|
+  #   15.times { create_tipline_user_and_data(pm, team) }
+  # end
 
-  tipline_pm_claims_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)} 
-  tipline_pm_claims_arr[3..5].each do |pm|
-    15.times { create_tipline_user_and_data(pm, team) }
-  end
+  # puts 'Making Tipline requests for link items...'
+  # begin
+  #   tipline_pm_links_arr = []
+  #   data[:link_media_links][0..5].each do |link_media_link| 
+  #     link_media = Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}") 
+  #     project_media = create_tipline_project_media(project, team, link_media)
+  #     tipline_pm_links_arr.push(project_media)
+  #   end
+  #   tipline_pm_links_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
+  #   tipline_pm_links_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
+  # rescue
+  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  # end
 
-  puts 'Making Tipline requests for links...'
-  begin
-    tipline_pm_links_arr = []
-    data[:link_media_links][0..5].each do |link_media_link| 
-      link_media = Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}") 
-      project_media = create_tipline_project_media(project, team, link_media)
-      tipline_pm_links_arr.push(project_media)
-    end
-
-    tipline_pm_links_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
-    tipline_pm_links_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
-  rescue
-    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  puts 'Making Tipline requests for audio items...'
+  tipline_pm_audios_arr = []
+  data[:audios][0..5].each do |audio| 
+    audio_media = UploadedAudio.create!(user_id: user.id, file: open_file(audio)) 
+    project_media = create_tipline_project_media(project, team, audio_media)
+    tipline_pm_audios_arr.push(project_media)
   end
+  tipline_pm_audios_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
+  tipline_pm_audios_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
 
   add_claim_descriptions_and_fact_checks(user)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -169,83 +169,85 @@ ActiveRecord::Base.transaction do
     claim_media = Claim.create!(user_id: user.id, quote: Faker::Lorem.paragraph(sentence_count: 10))
     project_media = ProjectMedia.create!(project: project, team: team, media: claim_media, channel: { main: CheckChannels::ChannelCodes::WHATSAPP })
 
-    tipline_user_name = Faker::Name.first_name.downcase
-    tipline_user_surname = Faker::Name.last_name
-    tipline_text = Faker::Lorem.paragraph(sentence_count: 10)
-    phone = [ Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone, Faker::PhoneNumber.cell_phone_in_e164, Faker::PhoneNumber.phone_number_with_country_code, Faker::PhoneNumber.cell_phone_with_country_code].sample
-    uid = random_string
+    10.times do
+      tipline_user_name = Faker::Name.first_name.downcase
+      tipline_user_surname = Faker::Name.last_name
+      tipline_text = Faker::Lorem.paragraph(sentence_count: 10)
+      phone = [ Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone, Faker::PhoneNumber.cell_phone_in_e164, Faker::PhoneNumber.phone_number_with_country_code, Faker::PhoneNumber.cell_phone_with_country_code].sample
+      uid = random_string
 
-    # Tipline user
-    smooch_user_data = {
-      'id': uid,
-      'raw': {
-        '_id': uid,
-        'givenName': tipline_user_name,
-        'surname': tipline_user_surname,
-        'signedUpAt': Time.now.to_s,
-        'properties': {},
-        'conversationStarted': true,
-        'clients': [
-          {
-            'id': random_string,
-            'status': 'active',
-            'externalId': phone,
-            'active': true,
-            'lastSeen': Time.now.to_s,
-            'platform': 'whatsapp',
-            'integrationId': random_string,
-            'displayName': phone,
-            'raw': {
-              'profile': {
-                'name': tipline_user_name
-              },
-              'from': phone
+      # Tipline user
+      smooch_user_data = {
+        'id': uid,
+        'raw': {
+          '_id': uid,
+          'givenName': tipline_user_name,
+          'surname': tipline_user_surname,
+          'signedUpAt': Time.now.to_s,
+          'properties': {},
+          'conversationStarted': true,
+          'clients': [
+            {
+              'id': random_string,
+              'status': 'active',
+              'externalId': phone,
+              'active': true,
+              'lastSeen': Time.now.to_s,
+              'platform': 'whatsapp',
+              'integrationId': random_string,
+              'displayName': phone,
+              'raw': {
+                'profile': {
+                  'name': tipline_user_name
+                },
+                'from': phone
+              }
             }
-          }
-        ],
-        'pendingClients': []
-      },
-      'identifier': random_string,
-      'app_name': random_string
-    }
+          ],
+          'pendingClients': []
+        },
+        'identifier': random_string,
+        'app_name': random_string
+      }
 
-    fields = {
-      smooch_user_id: uid,
-      smooch_user_app_id: random_string,
-      smooch_user_data: smooch_user_data.to_json
-    }
+      fields = {
+        smooch_user_id: uid,
+        smooch_user_app_id: random_string,
+        smooch_user_data: smooch_user_data.to_json
+      }
 
-    Dynamic.create!(annotation_type: 'smooch_user', annotated: team, annotator: BotUser.smooch_user, set_fields: fields.to_json)
+      Dynamic.create!(annotation_type: 'smooch_user', annotated: team, annotator: BotUser.smooch_user, set_fields: fields.to_json)
 
-    # Tipline request
-    smooch_data = {
-      'role': 'appUser',
-      'source': {
-        'type': 'whatsapp',
-        'id': random_string,
-        'integrationId': random_string,
-        'originalMessageId': random_string,
-        'originalMessageTimestamp': Time.now.to_i
-      },
-      'authorId': uid,
-      'name': tipline_user_name,
-      '_id': random_string,
-      'type': 'text',
-      'received': Time.now.to_f,
-      'text': tipline_text,
-      'language': 'en',
-      'mediaUrl': nil,
-      'mediaSize': 0,
-      'archived': 3,
-      'app_id': random_string
-    }
+      # Tipline request
+      smooch_data = {
+        'role': 'appUser',
+        'source': {
+          'type': 'whatsapp',
+          'id': random_string,
+          'integrationId': random_string,
+          'originalMessageId': random_string,
+          'originalMessageTimestamp': Time.now.to_i
+        },
+        'authorId': uid,
+        'name': tipline_user_name,
+        '_id': random_string,
+        'type': 'text',
+        'received': Time.now.to_f,
+        'text': tipline_text,
+        'language': 'en',
+        'mediaUrl': nil,
+        'mediaSize': 0,
+        'archived': 3,
+        'app_id': random_string
+      }
 
-    fields = {
-      smooch_request_type: 'default_requests',
-      smooch_data: smooch_data.to_json
-    }
+      fields = {
+        smooch_request_type: 'default_requests',
+        smooch_data: smooch_data.to_json
+      }
 
-    a = Dynamic.create!(annotation_type: 'smooch', annotated: project_media, annotator: BotUser.smooch_user, set_fields: fields.to_json)
+      Dynamic.create!(annotation_type: 'smooch', annotated: project_media, annotator: BotUser.smooch_user, set_fields: fields.to_json)
+    end
   end
 
   add_claim_descriptions_and_fact_checks(user)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -112,57 +112,57 @@ ActiveRecord::Base.transaction do
     end
   end
 
-  puts 'Making Medias...'
-  puts 'Making Medias and Project Medias: Claims...'
-  9.times { Claim.create!(user_id: user.id, quote: Faker::Quotes::Shakespeare.hamlet_quote) }
-  create_project_medias(user, project, team)
-  add_claim_descriptions_and_fact_checks(user)
+  # puts 'Making Medias...'
+  # puts 'Making Medias and Project Medias: Claims...'
+  # 9.times { Claim.create!(user_id: user.id, quote: Faker::Quotes::Shakespeare.hamlet_quote) }
+  # create_project_medias(user, project, team)
+  # add_claim_descriptions_and_fact_checks(user)
 
-  puts 'Making Medias and Project Medias: Links...'
-  begin
-    data[:link_media_links].each { |link_media_link| Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}") }
-    create_project_medias(user, project, team)
-    add_claim_descriptions_and_fact_checks(user)
-  rescue
-    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  end
+  # puts 'Making Medias and Project Medias: Links...'
+  # begin
+  #   data[:link_media_links].each { |link_media_link| Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}") }
+  #   create_project_medias(user, project, team)
+  #   add_claim_descriptions_and_fact_checks(user)
+  # rescue
+  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  # end
 
-  puts 'Making Medias and Project Medias: Audios...'
-  data[:audios].each { |audio| UploadedAudio.create!(user_id: user.id, file: open_file(audio)) }
-  create_project_medias(user, project, team)
-  add_claim_descriptions_and_fact_checks(user)
+  # puts 'Making Medias and Project Medias: Audios...'
+  # data[:audios].each { |audio| UploadedAudio.create!(user_id: user.id, file: open_file(audio)) }
+  # create_project_medias(user, project, team)
+  # add_claim_descriptions_and_fact_checks(user)
 
-  puts 'Making Medias and Project Medias: Images...'
-  data[:images].each { |image| UploadedImage.create!(user_id: user.id, file: open_file(image))}
-  create_project_medias(user, project, team)
-  add_claim_descriptions_and_fact_checks(user)
+  # puts 'Making Medias and Project Medias: Images...'
+  # data[:images].each { |image| UploadedImage.create!(user_id: user.id, file: open_file(image))}
+  # create_project_medias(user, project, team)
+  # add_claim_descriptions_and_fact_checks(user)
 
-  puts 'Making Medias and Project Medias: Videos...'
-  data[:videos].each { |video| UploadedVideo.create!(user_id: user.id, file: open_file(video)) }
-  create_project_medias(user, project, team)
-  add_claim_descriptions_and_fact_checks(user)
+  # puts 'Making Medias and Project Medias: Videos...'
+  # data[:videos].each { |video| UploadedVideo.create!(user_id: user.id, file: open_file(video)) }
+  # create_project_medias(user, project, team)
+  # add_claim_descriptions_and_fact_checks(user)
 
-  puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
-  data[:fact_check_links].each { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
+  # puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
+  # data[:fact_check_links].each { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
 
-  puts 'Making Relationship between Claims...'
-  project_medias_for_relationship_claims = []
-  relationship_claims = data[:quotes].map { |quote| Claim.create!(user_id: user.id, quote: quote) }
-  relationship_claims.each { |claim| project_medias_for_relationship_claims.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: claim))}
+  # puts 'Making Relationship between Claims...'
+  # project_medias_for_relationship_claims = []
+  # relationship_claims = data[:quotes].map { |quote| Claim.create!(user_id: user.id, quote: quote) }
+  # relationship_claims.each { |claim| project_medias_for_relationship_claims.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: claim))}
 
-  Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[1].id, relationship_type: Relationship.confirmed_type)
-  Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[2].id, relationship_type: Relationship.confirmed_type)
-  Relationship.create!(source_id: project_medias_for_relationship_claims[3].id, target_id: project_medias_for_relationship_claims[4].id, relationship_type: Relationship.suggested_type)
+  # Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[1].id, relationship_type: Relationship.confirmed_type)
+  # Relationship.create!(source_id: project_medias_for_relationship_claims[0].id, target_id: project_medias_for_relationship_claims[2].id, relationship_type: Relationship.confirmed_type)
+  # Relationship.create!(source_id: project_medias_for_relationship_claims[3].id, target_id: project_medias_for_relationship_claims[4].id, relationship_type: Relationship.suggested_type)
 
-  puts 'Making Relationship between Images...'
-  project_medias_for_images = []
-  2.times { project_medias_for_images.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedImage.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.png'))))) }
-  Relationship.create!(source_id: project_medias_for_images[0].id, target_id: project_medias_for_images[1].id, relationship_type: Relationship.confirmed_type)
+  # puts 'Making Relationship between Images...'
+  # project_medias_for_images = []
+  # 2.times { project_medias_for_images.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedImage.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.png'))))) }
+  # Relationship.create!(source_id: project_medias_for_images[0].id, target_id: project_medias_for_images[1].id, relationship_type: Relationship.confirmed_type)
 
-  puts 'Making Relationship between Audios...'
-  project_medias_for_audio = []
-  2.times { project_medias_for_audio.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedAudio.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.mp3'))))) }
-  Relationship.create!(source_id: project_medias_for_audio[0].id, target_id: project_medias_for_audio[1].id, relationship_type: Relationship.confirmed_type)
+  # puts 'Making Relationship between Audios...'
+  # project_medias_for_audio = []
+  # 2.times { project_medias_for_audio.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedAudio.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.mp3'))))) }
+  # Relationship.create!(source_id: project_medias_for_audio[0].id, target_id: project_medias_for_audio[1].id, relationship_type: Relationship.confirmed_type)
 
   puts 'Making Tipline requests...'
   9.times do

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -248,10 +248,14 @@ ActiveRecord::Base.transaction do
   # 2.times { project_medias_for_audio.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedAudio.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.mp3'))))) }
   # Relationship.create!(source_id: project_medias_for_audio[0].id, target_id: project_medias_for_audio[1].id, relationship_type: Relationship.confirmed_type)
 
-  def create_tipline_requests_for_files(team, project, user, files, model)
+  def create_tipline_requests(team, project, user, data_instances, model)
     tipline_pm_arr = []
-    files[0..5].each do |file| 
-      media = model.create!(user_id: user.id, file: open_file(file)) 
+    data_instances[0..5].each do |data_instance| 
+      if model == Claim
+        media = model.create!(user_id: user.id, quote: data_instance)
+      else
+        media = model.create!(user_id: user.id, file: open_file(data_instance)) 
+      end
       project_media = create_tipline_project_media(project, team, media)
       tipline_pm_arr.push(project_media)
     end
@@ -261,16 +265,8 @@ ActiveRecord::Base.transaction do
 
   puts 'Making Tipline requests for claim items...'
   tipline_claims_arr = []
-  tipline_pm_claims_arr = []
   6.times { tipline_claims_arr.push(Faker::Lorem.paragraph(sentence_count: 10))}
-  
-  tipline_claims_arr.each do |claim|
-    claim_media = Claim.create!(user_id: user.id, quote: claim)
-    project_media = create_tipline_project_media(project, team, claim_media)
-    tipline_pm_claims_arr.push(project_media)
-  end  
-  tipline_pm_claims_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
-  tipline_pm_claims_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
+  create_tipline_requests(team, project, user, tipline_claims_arr, Claim)
 
   # puts 'Making Tipline requests for link items...'
   # begin
@@ -286,14 +282,14 @@ ActiveRecord::Base.transaction do
   #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
   # end  
 
-  # puts 'Making Tipline requests for audio items...'
-  # create_tipline_requests_for_files(team, project, user, data[:audios], UploadedAudio)
+  puts 'Making Tipline requests for audio items...'
+  create_tipline_requests(team, project, user, data[:audios], UploadedAudio)
 
-  # puts 'Making Tipline requests for image items...'
-  # create_tipline_requests_for_files(team, project, user, data[:images], UploadedImage)
+  puts 'Making Tipline requests for image items...'
+  create_tipline_requests(team, project, user, data[:images], UploadedImage)
 
-  # puts 'Making Tipline requests for video items...'
-  # create_tipline_requests_for_files(team, project, user, data[:videos], UploadedVideo)
+  puts 'Making Tipline requests for video items...'
+  create_tipline_requests(team, project, user, data[:videos], UploadedVideo)
 
   add_claim_descriptions_and_fact_checks(user)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -248,18 +248,18 @@ ActiveRecord::Base.transaction do
   # 2.times { project_medias_for_audio.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedAudio.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.mp3'))))) }
   # Relationship.create!(source_id: project_medias_for_audio[0].id, target_id: project_medias_for_audio[1].id, relationship_type: Relationship.confirmed_type)
 
-  # puts 'Making Tipline requests for claims...'
-  # tipline_pm_claims_arr = []
-  # 9.times do
-  #   claim_media = Claim.create!(user_id: user.id, quote: Faker::Lorem.paragraph(sentence_count: 10))
-  #   project_media = create_tipline_project_media(project, team, claim_media)
-  #   tipline_pm_claims_arr.push(project_media)
-  # end
+  puts 'Making Tipline requests for claims...'
+  tipline_pm_claims_arr = []
+  6.times do
+    claim_media = Claim.create!(user_id: user.id, quote: Faker::Lorem.paragraph(sentence_count: 10))
+    project_media = create_tipline_project_media(project, team, claim_media)
+    tipline_pm_claims_arr.push(project_media)
+  end
 
-  # tipline_pm_claims_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)} 
-  # tipline_pm_claims_arr[3..5].each do |pm|
-  #   15.times { create_tipline_user_and_data(pm, team) }
-  # end
+  tipline_pm_claims_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)} 
+  tipline_pm_claims_arr[3..5].each do |pm|
+    15.times { create_tipline_user_and_data(pm, team) }
+  end
 
   puts 'Making Tipline requests for links...'
   tipline_pm_links_arr = []

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -75,6 +75,10 @@ def create_claim_description(user, project, team)
   ClaimDescription.create!(description: Faker::Company.catch_phrase, context: Faker::Lorem.sentence, user: user, project_media: create_blank(project, team))
 end
 
+def create_tipline_project_media(project, team, media)
+  ProjectMedia.create!(project: project, team: team, media: media, channel: { main: CheckChannels::ChannelCodes::WHATSAPP })
+end
+
 def create_tipline_user_and_data(project_media, team)
   tipline_user_name = Faker::Name.first_name.downcase
   tipline_user_surname = Faker::Name.last_name
@@ -244,14 +248,17 @@ ActiveRecord::Base.transaction do
   # 2.times { project_medias_for_audio.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedAudio.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.mp3'))))) }
   # Relationship.create!(source_id: project_medias_for_audio[0].id, target_id: project_medias_for_audio[1].id, relationship_type: Relationship.confirmed_type)
 
-  puts 'Making Tipline requests...'
+  puts 'Making Tipline requests for claims...'
+  tipline_pm_claims_arr = []
   9.times do
     claim_media = Claim.create!(user_id: user.id, quote: Faker::Lorem.paragraph(sentence_count: 10))
-    project_media = ProjectMedia.create!(project: project, team: team, media: claim_media, channel: { main: CheckChannels::ChannelCodes::WHATSAPP })
+    project_media = create_tipline_project_media(project, team, claim_media)
+    tipline_pm_claims_arr.push(project_media)
+  end
 
-    10.times do
-      create_tipline_user_and_data(project_media, team)
-    end
+  tipline_pm_claims_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)} 
+  tipline_pm_claims_arr[3..5].each do |pm|
+    15.times { create_tipline_user_and_data(pm, team) }
   end
 
   add_claim_descriptions_and_fact_checks(user)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -75,6 +75,86 @@ def create_claim_description(user, project, team)
   ClaimDescription.create!(description: Faker::Company.catch_phrase, context: Faker::Lorem.sentence, user: user, project_media: create_blank(project, team))
 end
 
+def create_tipline_user_and_data(project_media, team)
+  tipline_user_name = Faker::Name.first_name.downcase
+  tipline_user_surname = Faker::Name.last_name
+  tipline_text = Faker::Lorem.paragraph(sentence_count: 10)
+  phone = [ Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone, Faker::PhoneNumber.cell_phone_in_e164, Faker::PhoneNumber.phone_number_with_country_code, Faker::PhoneNumber.cell_phone_with_country_code].sample
+  uid = random_string
+
+  # Tipline user
+  smooch_user_data = {
+    'id': uid,
+    'raw': {
+      '_id': uid,
+      'givenName': tipline_user_name,
+      'surname': tipline_user_surname,
+      'signedUpAt': Time.now.to_s,
+      'properties': {},
+      'conversationStarted': true,
+      'clients': [
+        {
+          'id': random_string,
+          'status': 'active',
+          'externalId': phone,
+          'active': true,
+          'lastSeen': Time.now.to_s,
+          'platform': 'whatsapp',
+          'integrationId': random_string,
+          'displayName': phone,
+          'raw': {
+            'profile': {
+              'name': tipline_user_name
+            },
+            'from': phone
+          }
+        }
+      ],
+      'pendingClients': []
+    },
+    'identifier': random_string,
+    'app_name': random_string
+  }
+
+  fields = {
+    smooch_user_id: uid,
+    smooch_user_app_id: random_string,
+    smooch_user_data: smooch_user_data.to_json
+  }
+
+  Dynamic.create!(annotation_type: 'smooch_user', annotated: team, annotator: BotUser.smooch_user, set_fields: fields.to_json)
+
+  # Tipline request
+  smooch_data = {
+    'role': 'appUser',
+    'source': {
+      'type': 'whatsapp',
+      'id': random_string,
+      'integrationId': random_string,
+      'originalMessageId': random_string,
+      'originalMessageTimestamp': Time.now.to_i
+    },
+    'authorId': uid,
+    'name': tipline_user_name,
+    '_id': random_string,
+    'type': 'text',
+    'received': Time.now.to_f,
+    'text': tipline_text,
+    'language': 'en',
+    'mediaUrl': nil,
+    'mediaSize': 0,
+    'archived': 3,
+    'app_id': random_string
+  }
+
+  fields = {
+    smooch_request_type: 'default_requests',
+    smooch_data: smooch_data.to_json
+  }
+
+  Dynamic.create!(annotation_type: 'smooch', annotated: project_media, annotator: BotUser.smooch_user, set_fields: fields.to_json)
+end
+
 puts "If you want to create a new user: press 1 then enter"
 puts "If you want to add more data to an existing user: press 2 then enter"
 print ">> "
@@ -170,83 +250,7 @@ ActiveRecord::Base.transaction do
     project_media = ProjectMedia.create!(project: project, team: team, media: claim_media, channel: { main: CheckChannels::ChannelCodes::WHATSAPP })
 
     10.times do
-      tipline_user_name = Faker::Name.first_name.downcase
-      tipline_user_surname = Faker::Name.last_name
-      tipline_text = Faker::Lorem.paragraph(sentence_count: 10)
-      phone = [ Faker::PhoneNumber.phone_number, Faker::PhoneNumber.cell_phone, Faker::PhoneNumber.cell_phone_in_e164, Faker::PhoneNumber.phone_number_with_country_code, Faker::PhoneNumber.cell_phone_with_country_code].sample
-      uid = random_string
-
-      # Tipline user
-      smooch_user_data = {
-        'id': uid,
-        'raw': {
-          '_id': uid,
-          'givenName': tipline_user_name,
-          'surname': tipline_user_surname,
-          'signedUpAt': Time.now.to_s,
-          'properties': {},
-          'conversationStarted': true,
-          'clients': [
-            {
-              'id': random_string,
-              'status': 'active',
-              'externalId': phone,
-              'active': true,
-              'lastSeen': Time.now.to_s,
-              'platform': 'whatsapp',
-              'integrationId': random_string,
-              'displayName': phone,
-              'raw': {
-                'profile': {
-                  'name': tipline_user_name
-                },
-                'from': phone
-              }
-            }
-          ],
-          'pendingClients': []
-        },
-        'identifier': random_string,
-        'app_name': random_string
-      }
-
-      fields = {
-        smooch_user_id: uid,
-        smooch_user_app_id: random_string,
-        smooch_user_data: smooch_user_data.to_json
-      }
-
-      Dynamic.create!(annotation_type: 'smooch_user', annotated: team, annotator: BotUser.smooch_user, set_fields: fields.to_json)
-
-      # Tipline request
-      smooch_data = {
-        'role': 'appUser',
-        'source': {
-          'type': 'whatsapp',
-          'id': random_string,
-          'integrationId': random_string,
-          'originalMessageId': random_string,
-          'originalMessageTimestamp': Time.now.to_i
-        },
-        'authorId': uid,
-        'name': tipline_user_name,
-        '_id': random_string,
-        'type': 'text',
-        'received': Time.now.to_f,
-        'text': tipline_text,
-        'language': 'en',
-        'mediaUrl': nil,
-        'mediaSize': 0,
-        'archived': 3,
-        'app_id': random_string
-      }
-
-      fields = {
-        smooch_request_type: 'default_requests',
-        smooch_data: smooch_data.to_json
-      }
-
-      Dynamic.create!(annotation_type: 'smooch', annotated: project_media, annotator: BotUser.smooch_user, set_fields: fields.to_json)
+      create_tipline_user_and_data(project_media, team)
     end
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -250,9 +250,11 @@ ActiveRecord::Base.transaction do
 
   def create_tipline_requests(team, project, user, data_instances, model)
     tipline_pm_arr = []
-    data_instances[0..5].each do |data_instance| 
+    data_instances[0..5].each do |data_instance|
       if model == Claim
         media = model.create!(user_id: user.id, quote: data_instance)
+      elsif model == Link
+        media = model.create!(user_id: user.id, url: data_instance+"?timestamp=#{Time.now.to_f}")
       else
         media = model.create!(user_id: user.id, file: open_file(data_instance)) 
       end
@@ -268,19 +270,12 @@ ActiveRecord::Base.transaction do
   6.times { tipline_claims_arr.push(Faker::Lorem.paragraph(sentence_count: 10))}
   create_tipline_requests(team, project, user, tipline_claims_arr, Claim)
 
-  # puts 'Making Tipline requests for link items...'
-  # begin
-  #   tipline_pm_links_arr = []
-  #   data[:link_media_links][0..5].each do |link_media_link|
-  #     link_media = Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}")
-  #     project_media = create_tipline_project_media(project, team, link_media)
-  #     tipline_pm_links_arr.push(project_media)
-  #   end  
-  #   tipline_pm_links_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
-  #   tipline_pm_links_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
-  # rescue
-  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  # end  
+  puts 'Making Tipline requests for link items...'
+  begin
+    create_tipline_requests(team, project, user, data[:link_media_links], Link)
+  rescue
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  end  
 
   puts 'Making Tipline requests for audio items...'
   create_tipline_requests(team, project, user, data[:audios], UploadedAudio)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -248,30 +248,6 @@ ActiveRecord::Base.transaction do
   # 2.times { project_medias_for_audio.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedAudio.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.mp3'))))) }
   # Relationship.create!(source_id: project_medias_for_audio[0].id, target_id: project_medias_for_audio[1].id, relationship_type: Relationship.confirmed_type)
 
-  puts 'Making Tipline requests for claim items...'
-  tipline_pm_claims_arr = []
-  6.times do
-    claim_media = Claim.create!(user_id: user.id, quote: Faker::Lorem.paragraph(sentence_count: 10))
-    project_media = create_tipline_project_media(project, team, claim_media)
-    tipline_pm_claims_arr.push(project_media)
-  end
-  tipline_pm_claims_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
-  tipline_pm_claims_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
-
-  puts 'Making Tipline requests for link items...'
-  begin
-    tipline_pm_links_arr = []
-    data[:link_media_links][0..5].each do |link_media_link|
-      link_media = Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}")
-      project_media = create_tipline_project_media(project, team, link_media)
-      tipline_pm_links_arr.push(project_media)
-    end
-    tipline_pm_links_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
-    tipline_pm_links_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
-  rescue
-    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  end
-
   def create_tipline_requests_for_files(team, project, user, files, model)
     tipline_pm_arr = []
     files[0..5].each do |file| 
@@ -283,14 +259,41 @@ ActiveRecord::Base.transaction do
     tipline_pm_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
   end
 
-  puts 'Making Tipline requests for audio items...'
-  create_tipline_requests_for_files(team, project, user, data[:audios], UploadedAudio)
+  puts 'Making Tipline requests for claim items...'
+  tipline_claims_arr = []
+  tipline_pm_claims_arr = []
+  6.times { tipline_claims_arr.push(Faker::Lorem.paragraph(sentence_count: 10))}
+  
+  tipline_claims_arr.each do |claim|
+    claim_media = Claim.create!(user_id: user.id, quote: claim)
+    project_media = create_tipline_project_media(project, team, claim_media)
+    tipline_pm_claims_arr.push(project_media)
+  end  
+  tipline_pm_claims_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
+  tipline_pm_claims_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
 
-  puts 'Making Tipline requests for image items...'
-  create_tipline_requests_for_files(team, project, user, data[:images], UploadedImage)
+  # puts 'Making Tipline requests for link items...'
+  # begin
+  #   tipline_pm_links_arr = []
+  #   data[:link_media_links][0..5].each do |link_media_link|
+  #     link_media = Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}")
+  #     project_media = create_tipline_project_media(project, team, link_media)
+  #     tipline_pm_links_arr.push(project_media)
+  #   end  
+  #   tipline_pm_links_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
+  #   tipline_pm_links_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
+  # rescue
+  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  # end  
 
-  puts 'Making Tipline requests for video items...'
-  create_tipline_requests_for_files(team, project, user, data[:videos], UploadedVideo)
+  # puts 'Making Tipline requests for audio items...'
+  # create_tipline_requests_for_files(team, project, user, data[:audios], UploadedAudio)
+
+  # puts 'Making Tipline requests for image items...'
+  # create_tipline_requests_for_files(team, project, user, data[:images], UploadedImage)
+
+  # puts 'Making Tipline requests for video items...'
+  # create_tipline_requests_for_files(team, project, user, data[:videos], UploadedVideo)
 
   add_claim_descriptions_and_fact_checks(user)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -248,61 +248,49 @@ ActiveRecord::Base.transaction do
   # 2.times { project_medias_for_audio.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedAudio.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.mp3'))))) }
   # Relationship.create!(source_id: project_medias_for_audio[0].id, target_id: project_medias_for_audio[1].id, relationship_type: Relationship.confirmed_type)
 
-  # puts 'Making Tipline requests for claim items...'
-  # tipline_pm_claims_arr = []
-  # 6.times do
-  #   claim_media = Claim.create!(user_id: user.id, quote: Faker::Lorem.paragraph(sentence_count: 10))
-  #   project_media = create_tipline_project_media(project, team, claim_media)
-  #   tipline_pm_claims_arr.push(project_media)
-  # end
-  # tipline_pm_claims_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)} 
-  # tipline_pm_claims_arr[3..5].each do |pm|
-  #   15.times { create_tipline_user_and_data(pm, team) }
-  # end
+  puts 'Making Tipline requests for claim items...'
+  tipline_pm_claims_arr = []
+  6.times do
+    claim_media = Claim.create!(user_id: user.id, quote: Faker::Lorem.paragraph(sentence_count: 10))
+    project_media = create_tipline_project_media(project, team, claim_media)
+    tipline_pm_claims_arr.push(project_media)
+  end
+  tipline_pm_claims_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
+  tipline_pm_claims_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
 
-  # puts 'Making Tipline requests for link items...'
-  # begin
-  #   tipline_pm_links_arr = []
-  #   data[:link_media_links][0..5].each do |link_media_link| 
-  #     link_media = Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}") 
-  #     project_media = create_tipline_project_media(project, team, link_media)
-  #     tipline_pm_links_arr.push(project_media)
-  #   end
-  #   tipline_pm_links_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
-  #   tipline_pm_links_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
-  # rescue
-  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  # end
+  puts 'Making Tipline requests for link items...'
+  begin
+    tipline_pm_links_arr = []
+    data[:link_media_links][0..5].each do |link_media_link|
+      link_media = Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}")
+      project_media = create_tipline_project_media(project, team, link_media)
+      tipline_pm_links_arr.push(project_media)
+    end
+    tipline_pm_links_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
+    tipline_pm_links_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
+  rescue
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  end
 
-  # puts 'Making Tipline requests for audio items...'
-  # tipline_pm_audios_arr = []
-  # data[:audios][0..5].each do |audio| 
-  #   audio_media = UploadedAudio.create!(user_id: user.id, file: open_file(audio)) 
-  #   project_media = create_tipline_project_media(project, team, audio_media)
-  #   tipline_pm_audios_arr.push(project_media)
-  # end
-  # tipline_pm_audios_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
-  # tipline_pm_audios_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
+  def create_tipline_requests_for_files(team, project, user, files, model)
+    tipline_pm_arr = []
+    files[0..5].each do |file| 
+      media = model.create!(user_id: user.id, file: open_file(file)) 
+      project_media = create_tipline_project_media(project, team, media)
+      tipline_pm_arr.push(project_media)
+    end
+    tipline_pm_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
+    tipline_pm_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
+  end
 
-  # puts 'Making Tipline requests for image items...'
-  # tipline_pm_images_arr = []
-  # data[:images][0..5].each do |image| 
-  #   image_media = UploadedImage.create!(user_id: user.id, file: open_file(image)) 
-  #   project_media = create_tipline_project_media(project, team, image_media)
-  #   tipline_pm_images_arr.push(project_media)
-  # end
-  # tipline_pm_images_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
-  # tipline_pm_images_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
+  puts 'Making Tipline requests for audio items...'
+  create_tipline_requests_for_files(team, project, user, data[:audios], UploadedAudio)
+
+  puts 'Making Tipline requests for image items...'
+  create_tipline_requests_for_files(team, project, user, data[:images], UploadedImage)
 
   puts 'Making Tipline requests for video items...'
-  tipline_pm_videos_arr = []
-  data[:videos][0..5].each do |video| 
-    video_media = UploadedVideo.create!(user_id: user.id, file: open_file(video)) 
-    project_media = create_tipline_project_media(project, team, video_media)
-    tipline_pm_videos_arr.push(project_media)
-  end
-  tipline_pm_videos_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
-  tipline_pm_videos_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
+  create_tipline_requests_for_files(team, project, user, data[:videos], UploadedVideo)
 
   add_claim_descriptions_and_fact_checks(user)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -248,18 +248,29 @@ ActiveRecord::Base.transaction do
   # 2.times { project_medias_for_audio.push(ProjectMedia.create!(user_id: user.id, project: project, team: team, media: UploadedAudio.create!(user_id: user.id, file: File.open(File.join(Rails.root, 'test', 'data', 'rails.mp3'))))) }
   # Relationship.create!(source_id: project_medias_for_audio[0].id, target_id: project_medias_for_audio[1].id, relationship_type: Relationship.confirmed_type)
 
-  puts 'Making Tipline requests for claims...'
-  tipline_pm_claims_arr = []
-  9.times do
-    claim_media = Claim.create!(user_id: user.id, quote: Faker::Lorem.paragraph(sentence_count: 10))
-    project_media = create_tipline_project_media(project, team, claim_media)
-    tipline_pm_claims_arr.push(project_media)
+  # puts 'Making Tipline requests for claims...'
+  # tipline_pm_claims_arr = []
+  # 9.times do
+  #   claim_media = Claim.create!(user_id: user.id, quote: Faker::Lorem.paragraph(sentence_count: 10))
+  #   project_media = create_tipline_project_media(project, team, claim_media)
+  #   tipline_pm_claims_arr.push(project_media)
+  # end
+
+  # tipline_pm_claims_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)} 
+  # tipline_pm_claims_arr[3..5].each do |pm|
+  #   15.times { create_tipline_user_and_data(pm, team) }
+  # end
+
+  puts 'Making Tipline requests for links...'
+  tipline_pm_links_arr = []
+  data[:link_media_links][0..5].each do |link_media_link| 
+    link_media = Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}") 
+    project_media = create_tipline_project_media(project, team, link_media)
+    tipline_pm_links_arr.push(project_media)
   end
 
-  tipline_pm_claims_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)} 
-  tipline_pm_claims_arr[3..5].each do |pm|
-    15.times { create_tipline_user_and_data(pm, team) }
-  end
+  tipline_pm_links_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
+  tipline_pm_links_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
 
   add_claim_descriptions_and_fact_checks(user)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -262,15 +262,19 @@ ActiveRecord::Base.transaction do
   end
 
   puts 'Making Tipline requests for links...'
-  tipline_pm_links_arr = []
-  data[:link_media_links][0..5].each do |link_media_link| 
-    link_media = Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}") 
-    project_media = create_tipline_project_media(project, team, link_media)
-    tipline_pm_links_arr.push(project_media)
-  end
+  begin
+    tipline_pm_links_arr = []
+    data[:link_media_links][0..5].each do |link_media_link| 
+      link_media = Link.create!(user_id: user.id, url: link_media_link+"?timestamp=#{Time.now.to_f}") 
+      project_media = create_tipline_project_media(project, team, link_media)
+      tipline_pm_links_arr.push(project_media)
+    end
 
-  tipline_pm_links_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
-  tipline_pm_links_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
+    tipline_pm_links_arr[0..2].each {|pm| create_tipline_user_and_data(pm, team)}
+    tipline_pm_links_arr[3..5].each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
+  rescue
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  end
 
   add_claim_descriptions_and_fact_checks(user)
 


### PR DESCRIPTION
## Description

This is the first part of ticket 3884.
We were creating claim items with 1 request and other types of items with 0. We want to change that, we want to:
- create enough requests so that we trigger pagination (creating 15 does that)
- keep generating some items with 1 request (we want some variation)
- add requests to different types of items (claims, links, audio, image and video)

References: 3884

## How has this been tested?

By running the seeds script inside the container either adding to a user or creating a new one.