### PR TITLE
CV2-3828 First pass on check api integration updates for audio on alegre

### DIFF
--- a/app/lib/smooch_nlu.rb
+++ b/app/lib/smooch_nlu.rb
@@ -79,7 +79,7 @@ class SmoochNlu
           language: language,
         }.merge(context)
       }
-      response = Bot::Alegre.request('get', '/text/similarity/', params)
+      response = Bot::Alegre.request('post', '/text/similarity/search/', params)
 
       # One approach would be to take the option that has the most matches
       # Unfortunately this approach is influenced by the number of keywords per option

--- a/app/lib/smooch_nlu.rb
+++ b/app/lib/smooch_nlu.rb
@@ -50,7 +50,7 @@ class SmoochNlu
       alegre_params = common_alegre_params.merge({ quiet: true })
     end
     # FIXME: Add error handling and better logging
-    Bot::Alegre.request_api(alegre_operation, '/text/similarity/', alegre_params) if alegre_operation && alegre_params
+    Bot::Alegre.request(alegre_operation, '/text/similarity/', alegre_params) if alegre_operation && alegre_params
     keywords
   end
 
@@ -79,7 +79,7 @@ class SmoochNlu
           language: language,
         }.merge(context)
       }
-      response = Bot::Alegre.request_api('get', '/text/similarity/', params)
+      response = Bot::Alegre.request('get', '/text/similarity/', params)
 
       # One approach would be to take the option that has the most matches
       # Unfortunately this approach is influenced by the number of keywords per option

--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -33,7 +33,7 @@ class Bot::Alegre < BotUser
           'UploadedImage' => 'image',
         }[self.media.type].to_s
         threshold = [{value: thresholds.dig(media_type.to_sym, :value)}] || Bot::Alegre.get_threshold_for_query(media_type, self, true)
-        ids_and_scores = Bot::Alegre.get_items_with_similar_media(Bot::Alegre.media_file_url(self), threshold, team_ids, "/#{media_type}/similarity/").to_h
+        ids_and_scores = Bot::Alegre.get_items_with_similar_media(Bot::Alegre.media_file_url(self), threshold, team_ids, "/#{media_type}/similarity/search/").to_h
       elsif self.is_text?
         ids_and_scores = {}
         threads = []

--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -400,7 +400,7 @@ class Bot::Alegre < BotUser
     elsif result['job_status'] == 'DONE'
       completed = true
     end
-    self.delay_for(10.seconds, retry: 5).update_audio_transcription(annotation.id, attempts + 1) if !completed && attempts < 2000 # Maximum: ~5h of transcription
+    self.delay_for(10.seconds, retry: 5).update_audio_transcription(annotation.id, attempts + 1) if !completed && attempts < 200 # Maximum: ~5h of transcription
   end
 
   def self.transcribe_audio(pm)

--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -229,7 +229,7 @@ class Bot::Alegre < BotUser
     threshold ||= self.get_threshold_for_query('text', nil, true)
     models ||= [self.matching_model_to_use(team_ids)].flatten
     Hash[self.get_similar_items_from_api(
-      '/text/similarity/',
+      '/text/similarity/search/',
       self.similar_texts_from_api_conditions(text, models, fuzzy, team_ids, fields, threshold),
       threshold
     ).collect{|k,v| [k, v.merge(model: v[:model]||Bot::Alegre.default_matching_model)]}]
@@ -375,21 +375,21 @@ class Bot::Alegre < BotUser
 
   def self.get_flags(pm)
     if pm.report_type == 'uploadedimage'
-      result = self.request('get', '/image/classification/', { uri: self.media_file_url(pm) })
+      result = self.request('post', '/image/classification/', { uri: self.media_file_url(pm) })
       self.save_annotation(pm, 'flag', result['result'])
     end
   end
 
   def self.get_extracted_text(pm)
     if pm.report_type == 'uploadedimage'
-      result = self.request('get', '/image/ocr/', { url: self.media_file_url(pm) })
+      result = self.request('post', '/image/ocr/', { url: self.media_file_url(pm) })
       self.save_annotation(pm, 'extracted_text', result) if result
     end
   end
 
   def self.update_audio_transcription(transcription_annotation_id, attempts)
     annotation = Dynamic.find(transcription_annotation_id)
-    result = self.request('get', '/audio/transcription/', { job_name: annotation.get_field_value('job_name') })
+    result = self.request('post', '/audio/transcription/result/', { job_name: annotation.get_field_value('job_name') })
     completed = false
     if result['job_status'] == 'COMPLETED'
       annotation.disable_es_callbacks = Rails.env.to_s == 'test'

--- a/app/models/concerns/alegre_similarity.rb
+++ b/app/models/concerns/alegre_similarity.rb
@@ -35,11 +35,11 @@ module AlegreSimilarity
       end
     end
 
-    def get_items_with_similarity(type, pm, threshold, query_or_body = 'body')
+    def get_items_with_similarity(type, pm, threshold)
       if type == 'text'
         self.get_merged_items_with_similar_text(pm, threshold)
       else
-        results = self.get_items_with_similar_media(self.media_file_url(pm), threshold, pm.team_id, "/#{type}/similarity/", query_or_body).reject{ |id, _score_with_context| pm.id == id }
+        results = self.get_items_with_similar_media(self.media_file_url(pm), threshold, pm.team_id, "/#{type}/similarity/").reject{ |id, _score_with_context| pm.id == id }
         self.merge_response_with_source_and_target_fields(results, type)
       end
     end
@@ -214,10 +214,10 @@ module AlegreSimilarity
       es_matches
     end
 
-    def get_similar_items_from_api(path, conditions, _threshold = {}, query_or_body = 'body')
+    def get_similar_items_from_api(path, conditions, _threshold = {})
       Rails.logger.error("[Alegre Bot] Sending request to alegre : #{path} , #{conditions.to_json}")
       response = {}
-      result = self.request('get', path, conditions, query_or_body)&.dig('result')
+      result = self.request('get', path, conditions)&.dig('result')
       project_medias = result.collect{ |r| self.extract_project_medias_from_context(r) } if !result.nil? && result.is_a?(Array)
       project_medias.each do |request_response|
         request_response.each do |pmid, score_with_context|
@@ -293,7 +293,7 @@ module AlegreSimilarity
       params
     end
 
-    def get_items_with_similar_media(media_url, threshold, team_id, path, query_or_body = 'body')
+    def get_items_with_similar_media(media_url, threshold, team_id, path)
       self.get_similar_items_from_api(
         path,
         self.similar_media_content_from_api_conditions(
@@ -301,8 +301,7 @@ module AlegreSimilarity
           media_url,
           threshold
         ),
-        threshold,
-        query_or_body
+        threshold
       )
     end
 

--- a/app/models/concerns/alegre_similarity.rb
+++ b/app/models/concerns/alegre_similarity.rb
@@ -217,7 +217,7 @@ module AlegreSimilarity
     def get_similar_items_from_api(path, conditions, _threshold = {})
       Rails.logger.error("[Alegre Bot] Sending request to alegre : #{path} , #{conditions.to_json}")
       response = {}
-      result = self.request('get', path, conditions)&.dig('result')
+      result = self.request('post', path, conditions)&.dig('result')
       project_medias = result.collect{ |r| self.extract_project_medias_from_context(r) } if !result.nil? && result.is_a?(Array)
       project_medias.each do |request_response|
         request_response.each do |pmid, score_with_context|

--- a/app/models/concerns/alegre_similarity.rb
+++ b/app/models/concerns/alegre_similarity.rb
@@ -39,7 +39,7 @@ module AlegreSimilarity
       if type == 'text'
         self.get_merged_items_with_similar_text(pm, threshold)
       else
-        results = self.get_items_with_similar_media(self.media_file_url(pm), threshold, pm.team_id, "/#{type}/similarity/").reject{ |id, _score_with_context| pm.id == id }
+        results = self.get_items_with_similar_media(self.media_file_url(pm), threshold, pm.team_id, "/#{type}/similarity/search").reject{ |id, _score_with_context| pm.id == id }
         self.merge_response_with_source_and_target_fields(results, type)
       end
     end

--- a/app/models/concerns/alegre_similarity.rb
+++ b/app/models/concerns/alegre_similarity.rb
@@ -39,7 +39,7 @@ module AlegreSimilarity
       if type == 'text'
         self.get_merged_items_with_similar_text(pm, threshold)
       else
-        results = self.get_items_with_similar_media(self.media_file_url(pm), threshold, pm.team_id, "/#{type}/similarity/search").reject{ |id, _score_with_context| pm.id == id }
+        results = self.get_items_with_similar_media(self.media_file_url(pm), threshold, pm.team_id, "/#{type}/similarity/search/").reject{ |id, _score_with_context| pm.id == id }
         self.merge_response_with_source_and_target_fields(results, type)
       end
     end

--- a/app/models/concerns/alegre_similarity.rb
+++ b/app/models/concerns/alegre_similarity.rb
@@ -117,16 +117,6 @@ module AlegreSimilarity
       })
     end
 
-    def get_context(pm, field=nil)
-      context = {
-        team_id: pm.team_id,
-        project_media_id: pm.id,
-        has_custom_id: true
-      }
-      context[:field] = field if field
-      context
-    end
-
     def send_to_text_similarity_index_package(pm, field, text, doc_id)
       models ||= self.indexing_models_to_use(pm)
       language = self.language_for_similarity(pm&.team_id)

--- a/app/models/concerns/alegre_similarity.rb
+++ b/app/models/concerns/alegre_similarity.rb
@@ -110,7 +110,7 @@ module AlegreSimilarity
     end
 
     def delete_from_text_similarity_index(doc_id, context, quiet=false)
-      self.request_api('delete', '/text/similarity/', {
+      self.request('delete', '/text/similarity/', {
         doc_id: doc_id,
         context: context,
         quiet: quiet
@@ -141,7 +141,7 @@ module AlegreSimilarity
     end
 
     def send_to_text_similarity_index(pm, field, text, doc_id)
-      self.request_api(
+      self.request(
         'post',
         '/text/similarity/',
         self.send_to_text_similarity_index_package(pm, field, text, doc_id)
@@ -168,7 +168,7 @@ module AlegreSimilarity
           quiet: quiet,
           context: self.get_context(pm),
         }
-        self.request_api(
+        self.request(
           'delete',
           "/#{type}/similarity/",
           params
@@ -186,7 +186,7 @@ module AlegreSimilarity
           match_across_content_types: true,
           requires_callback: true
         }
-        self.request_api(
+        self.request(
           'post',
           "/#{type}/similarity/",
           params
@@ -217,7 +217,7 @@ module AlegreSimilarity
     def get_similar_items_from_api(path, conditions, _threshold = {}, query_or_body = 'body')
       Rails.logger.error("[Alegre Bot] Sending request to alegre : #{path} , #{conditions.to_json}")
       response = {}
-      result = self.request_api('get', path, conditions, query_or_body)&.dig('result')
+      result = self.request('get', path, conditions, query_or_body)&.dig('result')
       project_medias = result.collect{ |r| self.extract_project_medias_from_context(r) } if !result.nil? && result.is_a?(Array)
       project_medias.each do |request_response|
         request_response.each do |pmid, score_with_context|

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -33,7 +33,9 @@ module AlegreV2
     end
 
     def get_request_object(method, _path, uri)
-      return ('Net::HTTP::' + method.capitalize).constantize.new(uri.path, 'Content-Type' => 'application/json')
+      full_path = uri.path
+      full_path += "?#{uri.query}" if uri.query
+      return ('Net::HTTP::' + method.capitalize).constantize.new(full_path, 'Content-Type' => 'application/json')
     end
 
     def generate_request(method, path, params)

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -35,7 +35,8 @@ module AlegreV2
     def get_request_object(method, _path, uri)
       full_path = uri.path
       full_path += "?#{uri.query}" if uri.query
-      return ('Net::HTTP::' + method.capitalize).constantize.new(full_path, 'Content-Type' => 'application/json')
+      headers = method.downcase == "post" ? {'Content-Type' => 'application/json'} : {}
+      return ('Net::HTTP::' + method.capitalize).constantize.new(full_path, headers)
     end
 
     def generate_request(method, path, params)

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -42,7 +42,7 @@ module AlegreV2
       uri = URI(host + path)
       if method.downcase == 'get' && params.any?
         temp_params = params.dup
-        temp_params[:context] = temp_params[:context].to_json
+        temp_params[:context] = temp_params[:context].to_json if temp_params[:context]
         uri.query = URI.encode_www_form(temp_params)
       end
       request = get_request_object(method, path, uri)

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -41,13 +41,6 @@ module AlegreV2
 
     def generate_request(method, path, params)
       uri = URI(host + path)
-      if method.downcase == 'get' && params.any?
-        temp_params = params.dup
-        [:context, :models, :vector, :per_model_threshold].each do |key|
-          temp_params[key] = temp_params[key].to_json if temp_params[key]
-        end
-        uri.query = URI.encode_www_form(temp_params)
-      end
       request = get_request_object(method, path, uri)
       if method.downcase == 'post' || method.downcase == 'delete'
         request.body = params.to_json

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -56,7 +56,7 @@ module AlegreV2
       JSON.parse(response.body)
     end
 
-    def request(method, path, params, retries=3)
+    def alegre_request(method, path, params, retries=3)
       http, request = generate_request(method, path, params)
       begin
         Rails.logger.info("[Alegre Bot] Alegre Bot request: (#{method}, #{path}, #{params.inspect}, #{retries})")
@@ -66,7 +66,7 @@ module AlegreV2
       rescue StandardError => e
         if retries > 0
           sleep 1
-          self.request(method, path, params, retries - 1)
+          self.alegre_request(method, path, params, retries - 1)
         end
         Rails.logger.error("[Alegre Bot] Alegre error: #{e.message}")
         { 'type' => 'error', 'data' => { 'message' => e.message } }
@@ -74,15 +74,15 @@ module AlegreV2
     end
 
     def request_delete(data, project_media)
-      request("delete", delete_path(project_media), data)
+      alegre_request("delete", delete_path(project_media), data)
     end
 
     def request_sync(data)
-      request("get", sync_path, data)
+      alegre_request("get", sync_path, data)
     end
 
     def request_async(data)
-      request("get", async_path, data)
+      alegre_request("get", async_path, data)
     end
 
     def get_type(project_media)

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -1,0 +1,237 @@
+require 'active_support/concern'
+
+module AlegreV2
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def host
+      CheckConfig.get('alegre_host')
+    end
+
+    def sync_path
+      "/similarity/sync/audio"
+    end
+
+    def async_path
+      "/similarity/async/audio"
+    end
+
+    def delete_path(project_media)
+      type = get_type(project_media)
+      "/#{type}/similarity/"
+    end
+
+    def release_db
+      if RequestStore.store[:pause_database_connection]
+        ActiveRecord::Base.clear_active_connections!
+        ActiveRecord::Base.connection.close
+      end
+    end
+
+    def reconnect_db
+      ActiveRecord::Base.connection.reconnect! if RequestStore.store[:pause_database_connection]
+    end
+
+    def get_request_object(method, path, uri)
+      return ('Net::HTTP::' + method.capitalize).constantize.new(uri.path, 'Content-Type' => 'application/json')
+    end
+
+    def generate_request(method, path, params)
+      uri = URI(host + path)
+      request = get_request_object(method, path, uri)
+      request.body = params.to_json
+      http = Net::HTTP.new(uri.hostname, uri.port)
+      http.use_ssl = uri.scheme == 'https'
+      return http, request
+    end
+
+    def run_request(http, request)
+      http.request(request)
+    end
+
+    def parse_response(http, request)
+      release_db
+      response = run_request(http, request)
+      reconnect_db
+      JSON.parse(response.body)
+    end
+
+    def request(method, path, params, retries=3)
+      http, request = generate_request(method, path, params)
+      begin
+        Rails.logger.info("[Alegre Bot] Alegre Bot request: (#{method}, #{path}, #{params.inspect}, #{retries})")
+        parsed_response = parse_response(http, request)
+        Rails.logger.info("[Alegre Bot] Alegre response: #{parsed_response.inspect}")
+        parsed_response
+      rescue StandardError => e
+        if retries > 0
+          sleep 1
+          self.request(method, path, params, retries - 1)
+        end
+        Rails.logger.error("[Alegre Bot] Alegre error: #{e.message}")
+        { 'type' => 'error', 'data' => { 'message' => e.message } }
+      end
+    end
+
+    def request_delete(data, project_media)
+      request("delete", delete_path(project_media), data)
+    end
+
+    def request_sync(data)
+      request("get", sync_path, data)
+    end
+
+    def request_async(data)
+      request("get", async_path, data)
+    end
+
+    def get_type(project_media)
+      type = nil
+      if project_media.is_text?
+        type = 'text'
+      elsif project_media.is_image?
+        type = 'image'
+      elsif project_media.is_video?
+        type = 'video'
+      elsif project_media.is_audio?
+        type = 'audio'
+      end
+      return type
+    end
+
+    def generic_package(project_media, field)
+      {
+        doc_id: item_doc_id(project_media, field),
+        context: get_context(project_media, field)
+      }
+    end
+
+    def delete_package(project_media, field, params={}, quiet=false)
+      generic_package(project_media, field).merge(
+        self.send("delete_package_#{get_type(project_media)}", project_media, field, params)
+      ).merge(
+        quiet: quiet
+      ).merge(params)
+    end
+
+    def generic_package_audio(project_media, params)
+      generic_package(project_media, nil).merge(
+        url: media_file_url(project_media),
+      ).merge(params)
+    end
+
+    def delete_package_audio(project_media, field, params)
+      generic_package_audio(project_media, params)
+    end
+
+    def store_package(project_media, field, params={})
+      generic_package(project_media, field).merge(
+        self.send("store_package_#{get_type(project_media)}", project_media, field, params)
+      )
+    end
+
+    def is_not_generic_field(field)
+      !["audio", "video", "image"].include?(field)
+    end
+
+    def get_context(project_media, field=nil)
+      context = {
+        team_id: project_media.team_id,
+        project_media_id: project_media.id,
+        has_custom_id: true
+      }
+      context[:field] = field if field && is_not_generic_field(field)
+      context
+    end
+
+    def store_package_audio(project_media, field, params)
+      generic_package_audio(project_media, params)
+    end
+
+    def get_sync(project_media, field=nil, params={})
+      request_sync(
+        store_package(project_media, field, params)
+      )
+    end
+
+    def get_async(project_media, field=nil, params={})
+      request_async(
+        store_package(project_media, field, params)
+      )
+    end
+
+    def delete(project_media, field=nil, params={})
+      request_delete(
+        delete_package(project_media, field, params),
+        project_media
+      )
+    end
+
+    def get_per_model_threshold(project_media, threshold)
+      type = get_type(project_media)
+      if type == "text"
+        {per_model_threshold: threshold.collect{|x| {model: x[:model], value: x[:value]}}}
+      else
+        {threshold: threshold[0][:value]}
+      end
+    end
+
+    def isolate_relevant_context(project_media, result)
+      result["context"].select{|x| x["team_id"] == project_media.team_id}.first
+    end
+
+    def get_target_field(project_media, field)
+      type = get_type(project_media)
+      return field if type == "text"
+      return type if !type.nil?
+      field || type
+    end
+
+    def parse_similarity_results(project_media, field, results, relationship_type)
+      Hash[results.collect{|result|
+        result["context"] = isolate_relevant_context(project_media, result)
+        [
+          result["context"] && result["context"]["project_media_id"],
+          {
+            score: result["score"],
+            context: result["context"],
+            model: result["model"],
+            source_field: get_target_field(project_media, field),
+            target_field: get_target_field(project_media, result["field"]),
+            relationship_type: relationship_type
+          }
+        ]
+      }.reject{|k,v| k == project_media.id}]
+    end
+
+    def get_items(project_media, field, confirmed=false)
+      relationship_type = confirmed ? Relationship.confirmed_type : Relationship.suggested_type
+      type = get_type(project_media)
+      threshold = get_per_model_threshold(project_media, Bot::Alegre.get_threshold_for_query(type, project_media, confirmed))
+      parse_similarity_results(
+        project_media,
+        field,
+        get_sync(project_media, field, threshold)["result"],
+        relationship_type
+      )
+    end
+
+    def get_suggested_items(project_media, field)
+      get_items(project_media, field)
+    end
+
+    def get_confirmed_items(project_media, field)
+      get_items(project_media, field, true)
+    end
+
+    def get_similar_items_v2(project_media, field)
+      suggested_or_confirmed = get_suggested_items(project_media, field)
+      confirmed = get_confirmed_items(project_media, field)
+      Bot::Alegre.merge_suggested_and_confirmed(suggested_or_confirmed, confirmed, project_media)
+    end
+
+    def relate_project_media(project_media, field=nil)
+      self.add_relationships(project_media, self.get_similar_items_v2(project_media, field)) unless project_media.is_blank?
+    end
+  end
+end

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -41,7 +41,9 @@ module AlegreV2
     def generate_request(method, path, params)
       uri = URI(host + path)
       if method.downcase == 'get' && params.any?
-        uri.query = URI.encode_www_form(params)
+        temp_params = params.dup
+        temp_params[:context] = temp_params[:context].to_json
+        uri.query = URI.encode_www_form(temp_params)
       end
       request = get_request_object(method, path, uri)
       if method.downcase == 'post'

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -56,7 +56,7 @@ module AlegreV2
       JSON.parse(response.body)
     end
 
-    def alegre_request(method, path, params, retries=3)
+    def request(method, path, params, retries=3)
       http, request = generate_request(method, path, params)
       begin
         Rails.logger.info("[Alegre Bot] Alegre Bot request: (#{method}, #{path}, #{params.inspect}, #{retries})")
@@ -66,7 +66,7 @@ module AlegreV2
       rescue StandardError => e
         if retries > 0
           sleep 1
-          self.alegre_request(method, path, params, retries - 1)
+          self.request(method, path, params, retries - 1)
         end
         Rails.logger.error("[Alegre Bot] Alegre error: #{e.message}")
         { 'type' => 'error', 'data' => { 'message' => e.message } }
@@ -74,15 +74,15 @@ module AlegreV2
     end
 
     def request_delete(data, project_media)
-      alegre_request("delete", delete_path(project_media), data)
+      request("delete", delete_path(project_media), data)
     end
 
     def request_sync(data)
-      alegre_request("get", sync_path, data)
+      request("get", sync_path, data)
     end
 
     def request_async(data)
-      alegre_request("get", async_path, data)
+      request("get", async_path, data)
     end
 
     def get_type(project_media)

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -90,11 +90,11 @@ module AlegreV2
     end
 
     def request_sync(data)
-      request("get", sync_path, data)
+      request("post", sync_path, data)
     end
 
     def request_async(data)
-      request("get", async_path, data)
+      request("post", async_path, data)
     end
 
     def get_type(project_media)

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -42,7 +42,9 @@ module AlegreV2
       uri = URI(host + path)
       if method.downcase == 'get' && params.any?
         temp_params = params.dup
-        temp_params[:context] = temp_params[:context].to_json if temp_params[:context]
+        [:context, :models, :vector, :per_model_threshold].each do |key|
+          temp_params[key] = temp_params[key].to_json if temp_params[key]
+        end
         uri.query = URI.encode_www_form(temp_params)
       end
       request = get_request_object(method, path, uri)

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -35,7 +35,7 @@ module AlegreV2
     def get_request_object(method, _path, uri)
       full_path = uri.path
       full_path += "?#{uri.query}" if uri.query
-      headers = method.downcase == "post" ? {'Content-Type' => 'application/json'} : {}
+      headers = ["post", "delete"].include?(method.downcase)  ? {'Content-Type' => 'application/json'} : {}
       return ('Net::HTTP::' + method.capitalize).constantize.new(full_path, headers)
     end
 
@@ -49,7 +49,7 @@ module AlegreV2
         uri.query = URI.encode_www_form(temp_params)
       end
       request = get_request_object(method, path, uri)
-      if method.downcase == 'post'
+      if method.downcase == 'post' || method.downcase == 'delete'
         request.body = params.to_json
       end
       http = Net::HTTP.new(uri.hostname, uri.port)

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -53,13 +53,13 @@ class Request < ApplicationRecord
         models_thresholds = self.text_similarity_settings.reject{ |_k, v| v['min_words'] > words }
         if models_thresholds.count > 0
           params = { text: media.quote, models: models_thresholds.keys, per_model_threshold: models_thresholds.transform_values{ |v| v['threshold'] }, limit: alegre_limit, context: context }
-          similar_request_id = ::Bot::Alegre.request_api('get', '/text/similarity/', params)&.dig('result').to_a.collect{ |result| result&.dig('_source', 'context', 'request_id').to_i }.find{ |id| id != 0 && id < self.id }
+          similar_request_id = ::Bot::Alegre.request('get', '/text/similarity/', params)&.dig('result').to_a.collect{ |result| result&.dig('_source', 'context', 'request_id').to_i }.find{ |id| id != 0 && id < self.id }
         end
       elsif ['UploadedImage', 'UploadedAudio', 'UploadedVideo'].include?(media.type)
         threshold = 0.85 #FIXME: Should be feed setting
         type = media.type.gsub(/^Uploaded/, '').downcase
         params = { url: media.file.file.public_url, threshold: threshold, limit: alegre_limit, context: context }
-        similar_request_id = ::Bot::Alegre.request_api('get', "/#{type}/similarity/", params)&.dig('result').to_a.collect{ |result| result&.dig('context').to_a.collect{ |c| c['request_id'].to_i } }.flatten.find{ |id| id != 0 && id < self.id }
+        similar_request_id = ::Bot::Alegre.request('get', "/#{type}/similarity/", params)&.dig('result').to_a.collect{ |result| result&.dig('context').to_a.collect{ |c| c['request_id'].to_i } }.flatten.find{ |id| id != 0 && id < self.id }
       end
     end
     unless similar_request_id.blank?
@@ -194,7 +194,7 @@ class Request < ApplicationRecord
         models: request.text_similarity_settings.keys(),
         context: context
       }
-      ::Bot::Alegre.request_api('post', '/text/similarity/', params)
+      ::Bot::Alegre.request('post', '/text/similarity/', params)
     elsif ['UploadedImage', 'UploadedAudio', 'UploadedVideo'].include?(media.type)
       type = media.type.gsub(/^Uploaded/, '').downcase
       url = media.file&.file&.public_url
@@ -204,7 +204,7 @@ class Request < ApplicationRecord
         context: context,
         match_across_content_types: true,
       }
-      ::Bot::Alegre.request_api('post', "/#{type}/similarity/", params)
+      ::Bot::Alegre.request('post', "/#{type}/similarity/", params)
     end
   end
 

--- a/app/workers/reindex_alegre_workspace.rb
+++ b/app/workers/reindex_alegre_workspace.rb
@@ -68,7 +68,7 @@ class ReindexAlegreWorkspace
     # manage dispatch of documents to bulk similarity api call in parallel
     if running_bucket.length > 500 || write_remains
       log(event_id, 'Writing to Alegre...')
-      Parallel.map(running_bucket.each_slice(30).to_a, in_processes: in_processes) { |bucket_slice| Bot::Alegre.request_api('post', '/text/bulk_similarity/', { documents: bucket_slice }) }
+      Parallel.map(running_bucket.each_slice(30).to_a, in_processes: in_processes) { |bucket_slice| Bot::Alegre.request('post', '/text/bulk_similarity/', { documents: bucket_slice }) }
       log(event_id, 'Wrote to Alegre.')
       # track state in case job needs to restart
       write_last_id(event_id, team_id, running_bucket.last[:context][:project_media_id]) if running_bucket.length > 0 && running_bucket.last[:context]

--- a/spec/pacts/check_api-alegre.json
+++ b/spec/pacts/check_api-alegre.json
@@ -7,6 +7,26 @@
   },
   "interactions": [
     {
+      "description": "a request to extract text",
+      "providerState": "an image URL",
+      "request": {
+        "method": "get",
+        "path": "/image/ocr/",
+        "body": {
+            "url": "https://i.imgur.com/ewGClFQ.png"
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "text": "X X X\n3\nTranslate this sentence\nو عندي وقت في الساعة العاشرة.\n"
+        }
+      }
+    },
+    {
       "description": "a request to identify its language",
       "providerState": "a text exists",
       "request": {
@@ -37,6 +57,70 @@
             }
           ],
           "provider": "google"
+        }
+      }
+    },
+    {
+      "description": "a request to get image flags",
+      "providerState": "an image URL",
+      "request": {
+        "method": "get",
+        "path": "/image/classification/",
+        "body": {
+            "uri": "https://i.imgur.com/ewGClFQ.png",
+            "threshold": 0.89,
+            "context": {}
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "result": {
+            "flags": {
+              "adult": 1,
+              "spoof": 1,
+              "medical": 2,
+              "violence": 1,
+              "racy": 1,
+              "spam": 0
+            }
+          }
+        }
+      }
+    },
+    {
+      "description": "a request to link similar images",
+      "providerState": "an image URL",
+      "request": {
+        "method": "get",
+        "path": "/image/similarity/",
+        "body": {
+            "url": "https://i.imgur.com/ewGClFQ.png",
+            "threshold": 0.89,
+            "context": {}
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "result": [
+            {
+              "id": 1,
+              "sha256": "9bb1b8da9eec7caaea50099ba0488a1bdd221305a327097057fb8f626b6ba39b",
+              "phash": 26558343354958209,
+              "url": "https://i.imgur.com/ewGClFQ.png",
+              "context": {
+                
+              },
+              "score": 0
+            }
+          ]
         }
       }
     }

--- a/spec/pacts/check_api-alegre.json
+++ b/spec/pacts/check_api-alegre.json
@@ -7,24 +7,6 @@
   },
   "interactions": [
     {
-      "description": "a request to extract text",
-      "providerState": "an image URL",
-      "request": {
-        "method": "get",
-        "path": "/image/ocr/",
-        "query": "url=https%3A%2F%2Fi.imgur.com%2FewGClFQ.png"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "body": {
-          "text": "X X X\n3\nTranslate this sentence\nو عندي وقت في الساعة العاشرة.\n"
-        }
-      }
-    },
-    {
       "description": "a request to identify its language",
       "providerState": "a text exists",
       "request": {
@@ -55,61 +37,6 @@
             }
           ],
           "provider": "google"
-        }
-      }
-    },
-    {
-      "description": "a request to get image flags",
-      "providerState": "an image URL",
-      "request": {
-        "method": "get",
-        "path": "/image/classification/",
-        "query": "uri=https%3A%2F%2Fi.imgur.com%2FewGClFQ.png"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "body": {
-          "result": {
-            "flags": {
-              "adult": 1,
-              "spoof": 1,
-              "medical": 2,
-              "violence": 1,
-              "racy": 1,
-              "spam": 0
-            }
-          }
-        }
-      }
-    },
-    {
-      "description": "a request to link similar images",
-      "providerState": "an image URL",
-      "request": {
-        "method": "get",
-        "path": "/image/similarity/",
-        "query": "url=https%3A%2F%2Fi.imgur.com%2FewGClFQ.png&threshold=0.89"
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "body": {
-          "result": [
-            {
-              "id": 1,
-              "sha256": "9bb1b8da9eec7caaea50099ba0488a1bdd221305a327097057fb8f626b6ba39b",
-              "phash": 26558343354958209,
-              "url": "https://i.imgur.com/ewGClFQ.png",
-              "context": {
-              },
-              "score": 0
-            }
-          ]
         }
       }
     }

--- a/spec/pacts/check_api-alegre.json
+++ b/spec/pacts/check_api-alegre.json
@@ -10,10 +10,10 @@
       "description": "a request to extract text",
       "providerState": "an image URL",
       "request": {
-        "method": "get",
+        "method": "post",
         "path": "/image/ocr/",
         "body": {
-            "url": "https://i.imgur.com/ewGClFQ.png"
+          "url": "https://i.imgur.com/ewGClFQ.png"
         }
       },
       "response": {
@@ -23,6 +23,37 @@
         },
         "body": {
           "text": "X X X\n3\nTranslate this sentence\nو عندي وقت في الساعة العاشرة.\n"
+        }
+      }
+    },
+    {
+      "description": "a request to link similar images",
+      "providerState": "an image URL",
+      "request": {
+        "method": "post",
+        "path": "/image/similarity/search/",
+        "body": {
+          "url": "https://i.imgur.com/ewGClFQ.png",
+          "threshold": 0.89
+        }
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "result": [
+            {
+              "id": 1,
+              "sha256": "9bb1b8da9eec7caaea50099ba0488a1bdd221305a327097057fb8f626b6ba39b",
+              "phash": 26558343354958209,
+              "url": "https://i.imgur.com/ewGClFQ.png",
+              "context": {
+              },
+              "score": 0
+            }
+          ]
         }
       }
     },
@@ -64,12 +95,10 @@
       "description": "a request to get image flags",
       "providerState": "an image URL",
       "request": {
-        "method": "get",
+        "method": "post",
         "path": "/image/classification/",
         "body": {
-            "uri": "https://i.imgur.com/ewGClFQ.png",
-            "threshold": 0.89,
-            "context": {}
+          "uri": "https://i.imgur.com/ewGClFQ.png"
         }
       },
       "response": {
@@ -88,39 +117,6 @@
               "spam": 0
             }
           }
-        }
-      }
-    },
-    {
-      "description": "a request to link similar images",
-      "providerState": "an image URL",
-      "request": {
-        "method": "get",
-        "path": "/image/similarity/",
-        "body": {
-            "url": "https://i.imgur.com/ewGClFQ.png",
-            "threshold": 0.89,
-            "context": {}
-        }
-      },
-      "response": {
-        "status": 200,
-        "headers": {
-          "Content-Type": "application/json"
-        },
-        "body": {
-          "result": [
-            {
-              "id": 1,
-              "sha256": "9bb1b8da9eec7caaea50099ba0488a1bdd221305a327097057fb8f626b6ba39b",
-              "phash": 26558343354958209,
-              "url": "https://i.imgur.com/ewGClFQ.png",
-              "context": {
-                
-              },
-              "score": 0
-            }
-          ]
         }
       }
     }

--- a/test/contract/alegre_contract_test.rb
+++ b/test/contract/alegre_contract_test.rb
@@ -24,7 +24,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
     WebMock.stub_request(:post, 'http://localhost:3100/text/similarity/').to_return(body: 'success')
     WebMock.stub_request(:delete, 'http://localhost:3100/text/similarity/').to_return(body: { success: true }.to_json)
     WebMock.stub_request(:post, 'http://localhost:3100/image/similarity/').to_return(body: { 'success': true }.to_json)
-    WebMock.stub_request(:get, 'http://localhost:3100/image/classification/').with({ query: { uri: url} }).to_return(body:{ result: @flags }.to_json)
+    WebMock.stub_request(:get, 'http://localhost:3100/image/classification/').with({ body: { uri: url} }).to_return(body:{ result: @flags }.to_json)
     WebMock.stub_request(:get, 'http://localhost:3100/image/similarity/').to_return(body: { "result": [] }.to_json)
   end
 
@@ -58,14 +58,14 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
   test "should get image flags" do
     stub_configs({ 'alegre_host' => 'http://localhost:3100' }) do
       stub_similarity_requests(@url2)
-      WebMock.stub_request(:get, 'http://localhost:3100/image/ocr/').with({ query: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
+      WebMock.stub_request(:get, 'http://localhost:3100/image/ocr/').with({ body: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
       Bot::Alegre.unstub(:media_file_url)
       alegre.given('an image URL').
       upon_receiving('a request to get image flags').
       with(
         method: :get,
         path: '/image/classification/',
-        query: { uri: @url },
+        body: { uri: @url },
         ).
         will_respond_with(
           status: 200,
@@ -92,7 +92,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
       with(
         method: :get,
         path: '/image/ocr/',
-        query: { url: @url },
+        body: { url: @url },
       ).
       will_respond_with(
         status: 200,
@@ -114,7 +114,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
   test "should link similar images" do
     stub_configs({ 'alegre_host' => 'http://localhost:3100' }) do
       stub_similarity_requests(@url)
-      WebMock.stub_request(:get, 'http://localhost:3100/image/ocr/').with({ query: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
+      WebMock.stub_request(:get, 'http://localhost:3100/image/ocr/').with({ body: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
       pm1 = create_project_media team: @pm.team, media: create_uploaded_image
       Bot::Alegre.stubs(:media_file_url).with(pm1).returns(@url)
       assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
@@ -124,7 +124,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
       with(
         method: :get,
         path: '/image/similarity/',
-        query: {
+        body: {
           url: @url,
           threshold: "0.89",
           context: {}

--- a/test/contract/alegre_contract_test.rb
+++ b/test/contract/alegre_contract_test.rb
@@ -24,7 +24,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
     WebMock.stub_request(:post, 'http://localhost:3100/text/similarity/').to_return(body: 'success')
     WebMock.stub_request(:delete, 'http://localhost:3100/text/similarity/').to_return(body: { success: true }.to_json)
     WebMock.stub_request(:post, 'http://localhost:3100/image/similarity/').to_return(body: { 'success': true }.to_json)
-    WebMock.stub_request(:get, 'http://localhost:3100/image/classification/').with({ body: { uri: url} }).to_return(body:{ result: @flags }.to_json)
+    WebMock.stub_request(:get, 'http://localhost:3100/image/classification/').with({ query: { uri: url} }).to_return(body:{ result: @flags }.to_json)
     WebMock.stub_request(:get, 'http://localhost:3100/image/similarity/').to_return(body: { "result": [] }.to_json)
   end
 
@@ -58,7 +58,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
   test "should get image flags" do
     stub_configs({ 'alegre_host' => 'http://localhost:3100' }) do
       stub_similarity_requests(@url2)
-      WebMock.stub_request(:get, 'http://localhost:3100/image/ocr/').with({ body: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
+      WebMock.stub_request(:get, 'http://localhost:3100/image/ocr/').with({ query: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
       Bot::Alegre.unstub(:media_file_url)
       alegre.given('an image URL').
       upon_receiving('a request to get image flags').
@@ -111,10 +111,10 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
     end
   end
 
-  test "should link similar images" do
+  test "should link similar images zzz" do
     stub_configs({ 'alegre_host' => 'http://localhost:3100' }) do
       stub_similarity_requests(@url)
-      WebMock.stub_request(:get, 'http://localhost:3100/image/ocr/').with({ body: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
+      WebMock.stub_request(:get, 'http://localhost:3100/image/ocr/').with({ query: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
       pm1 = create_project_media team: @pm.team, media: create_uploaded_image
       Bot::Alegre.stubs(:media_file_url).with(pm1).returns(@url)
       assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })

--- a/test/contract/alegre_contract_test.rb
+++ b/test/contract/alegre_contract_test.rb
@@ -24,12 +24,9 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
     WebMock.stub_request(:post, 'http://localhost:3100/text/similarity/').to_return(body: 'success')
     WebMock.stub_request(:delete, 'http://localhost:3100/text/similarity/').to_return(body: { success: true }.to_json)
     WebMock.stub_request(:post, 'http://localhost:3100/image/similarity/').to_return(body: { 'success': true }.to_json)
-    params = URI.encode_www_form({ uri: url})
-    WebMock.stub_request(:get, 'http://localhost:3100/image/classification/?'+params).to_return(body:{ result: @flags }.to_json)
-    params = URI.encode_www_form({:url=>"https://i.imgur.com/ewGClFQ.png", :context=>{:has_custom_id=>true, :team_id=>pm.team_id}.to_json, :match_across_content_types=>true, :threshold=>0.89})
-    WebMock.stub_request(:get, 'http://localhost:3100/image/similarity/?'+params).to_return(body: { "result": [] }.to_json)
-    params = URI.encode_www_form({:url=>"https://i.imgur.com/ewGClFQ.png", :context=>{:has_custom_id=>true, :team_id=>pm.team_id}.to_json, :match_across_content_types=>true, :threshold=>0.95})
-    WebMock.stub_request(:get, 'http://localhost:3100/image/similarity/?'+params).to_return(body: { "result": [] }.to_json)
+    WebMock.stub_request(:post, 'http://localhost:3100/image/classification/').with(body: { uri: url}).to_return(body:{ result: @flags }.to_json)
+    WebMock.stub_request(:post, 'http://localhost:3100/image/similarity/search/').with(body: {:url=>"https://i.imgur.com/ewGClFQ.png", :context=>{:has_custom_id=>true, :team_id=>pm.team_id}.to_json, :match_across_content_types=>true, :threshold=>0.89}).to_return(body: { "result": [] }.to_json)
+    WebMock.stub_request(:post, 'http://localhost:3100/image/similarity/search/').with(body: {:url=>"https://i.imgur.com/ewGClFQ.png", :context=>{:has_custom_id=>true, :team_id=>pm.team_id}.to_json, :match_across_content_types=>true, :threshold=>0.95}).to_return(body: { "result": [] }.to_json)
   end
 
   # def teardown
@@ -61,14 +58,14 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
 
   test "should get image flags" do
     stub_configs({ 'alegre_host' => 'http://localhost:3100' }) do
-      WebMock.stub_request(:get, 'http://localhost:3100/image/ocr/').with({ query: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
+      WebMock.stub_request(:post, 'http://localhost:3100/image/ocr/').with({ query: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
       Bot::Alegre.unstub(:media_file_url)
       alegre.given('an image URL').
       upon_receiving('a request to get image flags').
       with(
-        method: :get,
+        method: :post,
         path: '/image/classification/',
-        query: { uri: @url },
+        body: { uri: @url },
         ).
         will_respond_with(
           status: 200,
@@ -88,15 +85,14 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
 
   test "should extract text" do
     stub_configs({ 'alegre_host' => 'http://localhost:3100' }) do
-      WebMock.stub_request(:get, 'http://localhost:3100/text/similarity/').to_return(body: {success: true}.to_json)
+      WebMock.stub_request(:post, 'http://localhost:3100/text/similarity/search/').to_return(body: {success: true}.to_json)
       Bot::Alegre.unstub(:media_file_url)
-      params = URI.encode_www_form({ url: @url })
       alegre.given('an image URL').
       upon_receiving('a request to extract text').
       with(
-        method: :get,
+        method: :post,
         path: '/image/ocr/',
-        query: { url: @url }
+        body: { url: @url }
       ).
       will_respond_with(
         status: 200,
@@ -118,21 +114,19 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
 
   test "should link similar images" do
     stub_configs({ 'alegre_host' => 'http://localhost:3100' }) do
-      params = URI.encode_www_form({ uri: @url2})
-      WebMock.stub_request(:get, 'http://localhost:3100/image/classification/?'+params).to_return(body:{ result: @flags }.to_json)
-      WebMock.stub_request(:get, 'http://localhost:3100/image/ocr/').with({ query: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
+      WebMock.stub_request(:post, 'http://localhost:3100/image/classification/').with(body: { uri: @url2}).to_return(body:{ result: @flags }.to_json)
+      WebMock.stub_request(:post, 'http://localhost:3100/image/ocr/').with({ query: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
       pm1 = create_project_media team: @pm.team, media: create_uploaded_image
       stub_similarity_requests(@url, pm1)
       Bot::Alegre.stubs(:media_file_url).with(pm1).returns(@url)
       assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
-      params = URI.encode_www_form({url: @url,threshold: "0.89"})
       Bot::Alegre.unstub(:media_file_url)
       alegre.given('an image URL').
       upon_receiving('a request to link similar images').
       with(
-        method: :get,
-        path: '/image/similarity/',
-        query: {url: @url,threshold: "0.89"}
+        method: :post,
+        path: '/image/similarity/search/',
+        body: {url: @url,threshold: "0.89"}
       ).
       will_respond_with(
         status: 200,
@@ -153,7 +147,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
         }
       )
       conditions = {url: @url, threshold: 0.89}
-      Bot::Alegre.get_similar_items_from_api('/image/similarity/', conditions, 0.89)
+      Bot::Alegre.get_similar_items_from_api('/image/similarity/search/', conditions, 0.89)
     end
   end
 end

--- a/test/contract/alegre_contract_test.rb
+++ b/test/contract/alegre_contract_test.rb
@@ -26,9 +26,9 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
     WebMock.stub_request(:post, 'http://localhost:3100/image/similarity/').to_return(body: { 'success': true }.to_json)
     params = URI.encode_www_form({ uri: url})
     WebMock.stub_request(:get, 'http://localhost:3100/image/classification/?'+params).to_return(body:{ result: @flags }.to_json)
-    params = URI.encode_www_form({:url=>"https://i.imgur.com/ewGClFQ.png", :context=>{:has_custom_id=>true, :team_id=>pm.team_id}, :match_across_content_types=>true, :threshold=>0.89})
+    params = URI.encode_www_form({:url=>"https://i.imgur.com/ewGClFQ.png", :context=>{:has_custom_id=>true, :team_id=>pm.team_id}.to_json, :match_across_content_types=>true, :threshold=>0.89})
     WebMock.stub_request(:get, 'http://localhost:3100/image/similarity/?'+params).to_return(body: { "result": [] }.to_json)
-    params = URI.encode_www_form({:url=>"https://i.imgur.com/ewGClFQ.png", :context=>{:has_custom_id=>true, :team_id=>pm.team_id}, :match_across_content_types=>true, :threshold=>0.95})
+    params = URI.encode_www_form({:url=>"https://i.imgur.com/ewGClFQ.png", :context=>{:has_custom_id=>true, :team_id=>pm.team_id}.to_json, :match_across_content_types=>true, :threshold=>0.95})
     WebMock.stub_request(:get, 'http://localhost:3100/image/similarity/?'+params).to_return(body: { "result": [] }.to_json)
   end
 

--- a/test/contract/alegre_contract_test.rb
+++ b/test/contract/alegre_contract_test.rb
@@ -25,8 +25,8 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
     WebMock.stub_request(:delete, 'http://localhost:3100/text/similarity/').to_return(body: { success: true }.to_json)
     WebMock.stub_request(:post, 'http://localhost:3100/image/similarity/').to_return(body: { 'success': true }.to_json)
     WebMock.stub_request(:post, 'http://localhost:3100/image/classification/').with(body: { uri: url}).to_return(body:{ result: @flags }.to_json)
-    WebMock.stub_request(:post, 'http://localhost:3100/image/similarity/search/').with(body: {:url=>"https://i.imgur.com/ewGClFQ.png", :context=>{:has_custom_id=>true, :team_id=>pm.team_id}.to_json, :match_across_content_types=>true, :threshold=>0.89}).to_return(body: { "result": [] }.to_json)
-    WebMock.stub_request(:post, 'http://localhost:3100/image/similarity/search/').with(body: {:url=>"https://i.imgur.com/ewGClFQ.png", :context=>{:has_custom_id=>true, :team_id=>pm.team_id}.to_json, :match_across_content_types=>true, :threshold=>0.95}).to_return(body: { "result": [] }.to_json)
+    WebMock.stub_request(:post, 'http://localhost:3100/image/similarity/search/').with(body: {:url=>"https://i.imgur.com/ewGClFQ.png", :context=>{:has_custom_id=>true, :team_id=>pm.team_id}, :match_across_content_types=>true, :threshold=>0.89}).to_return(body: { "result": [] }.to_json)
+    WebMock.stub_request(:post, 'http://localhost:3100/image/similarity/search/').with(body: {:url=>"https://i.imgur.com/ewGClFQ.png", :context=>{:has_custom_id=>true, :team_id=>pm.team_id}, :match_across_content_types=>true, :threshold=>0.95}).to_return(body: { "result": [] }.to_json)
   end
 
   # def teardown
@@ -58,7 +58,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
 
   test "should get image flags" do
     stub_configs({ 'alegre_host' => 'http://localhost:3100' }) do
-      WebMock.stub_request(:post, 'http://localhost:3100/image/ocr/').with({ query: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
+      WebMock.stub_request(:post, 'http://localhost:3100/image/ocr/').with({ body: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
       Bot::Alegre.unstub(:media_file_url)
       alegre.given('an image URL').
       upon_receiving('a request to get image flags').
@@ -115,7 +115,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
   test "should link similar images" do
     stub_configs({ 'alegre_host' => 'http://localhost:3100' }) do
       WebMock.stub_request(:post, 'http://localhost:3100/image/classification/').with(body: { uri: @url2}).to_return(body:{ result: @flags }.to_json)
-      WebMock.stub_request(:post, 'http://localhost:3100/image/ocr/').with({ query: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
+      WebMock.stub_request(:post, 'http://localhost:3100/image/ocr/').with({ body: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
       pm1 = create_project_media team: @pm.team, media: create_uploaded_image
       stub_similarity_requests(@url, pm1)
       Bot::Alegre.stubs(:media_file_url).with(pm1).returns(@url)
@@ -126,7 +126,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
       with(
         method: :post,
         path: '/image/similarity/search/',
-        body: {url: @url,threshold: "0.89"}
+        body: {url: @url,threshold: 0.89}
       ).
       will_respond_with(
         status: 200,

--- a/test/contract/alegre_contract_test.rb
+++ b/test/contract/alegre_contract_test.rb
@@ -61,17 +61,14 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
 
   test "should get image flags" do
     stub_configs({ 'alegre_host' => 'http://localhost:3100' }) do
-      params = URI.encode_www_form({ url: @url })
-      WebMock.stub_request(:get, 'http://localhost:3100/image/ocr/?'+params).to_return(body: { "text": @extracted_text  }.to_json)
-      WebMock.stub_request(:get, 'http://localhost:3100/image/ocr/?url=https%3A%2F%2Fi.imgur.com%2FewGClFQ.png').to_return(body: { "text": @extracted_text  }.to_json)
-      WebMock.stub_request(:get, 'http://localhost:3100/image/classification/?uri=https%3A%2F%2Fi.imgur.com%2FewGClFQ.png').to_return(body: { "result": @flags  }.to_json)
+      WebMock.stub_request(:get, 'http://localhost:3100/image/ocr/').with({ query: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
       Bot::Alegre.unstub(:media_file_url)
-      params = URI.encode_www_form({ uri: @url })
       alegre.given('an image URL').
       upon_receiving('a request to get image flags').
       with(
         method: :get,
-        path: '/image/classification/?uri=https%3A%2F%2Fi.imgur.com%2FewGClFQ.png',
+        path: '/image/classification/',
+        query: { uri: @url },
         ).
         will_respond_with(
           status: 200,
@@ -81,7 +78,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
           body: { result: @flags }
         )
       pm1 = create_project_media team: @pm.team, media: create_uploaded_image
-      stub_similarity_requests(@url, pm1)
+      stub_similarity_requests(@url2, pm1)
       Bot::Alegre.stubs(:media_file_url).with(pm1).returns(@url)
       assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
       assert_not_nil pm1.get_annotations('flag').last
@@ -98,7 +95,8 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
       upon_receiving('a request to extract text').
       with(
         method: :get,
-        path: '/image/ocr/?'+params
+        path: '/image/ocr/',
+        query: { url: @url }
       ).
       will_respond_with(
         status: 200,
@@ -133,7 +131,8 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
       upon_receiving('a request to link similar images').
       with(
         method: :get,
-        path: '/image/similarity/?'+params
+        path: '/image/similarity/',
+        query: {url: @url,threshold: "0.89"}
       ).
       will_respond_with(
         status: 200,

--- a/test/contract/alegre_contract_test.rb
+++ b/test/contract/alegre_contract_test.rb
@@ -65,7 +65,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
       with(
         method: :get,
         path: '/image/classification/',
-        body: { uri: @url },
+        query: { uri: @url },
         ).
         will_respond_with(
           status: 200,
@@ -92,7 +92,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
       with(
         method: :get,
         path: '/image/ocr/',
-        body: { url: @url },
+        query: { url: @url },
       ).
       will_respond_with(
         status: 200,
@@ -111,7 +111,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
     end
   end
 
-  test "should link similar images zzz" do
+  test "should link similar images" do
     stub_configs({ 'alegre_host' => 'http://localhost:3100' }) do
       stub_similarity_requests(@url)
       WebMock.stub_request(:get, 'http://localhost:3100/image/ocr/').with({ query: { url: @url } }).to_return(body: { "text": @extracted_text  }.to_json)
@@ -124,7 +124,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
       with(
         method: :get,
         path: '/image/similarity/',
-        body: {
+        query: {
           url: @url,
           threshold: "0.89",
           context: {}

--- a/test/contract/alegre_contract_test.rb
+++ b/test/contract/alegre_contract_test.rb
@@ -150,7 +150,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
 
       )
       conditions = {url: @url, threshold: 0.89}
-      Bot::Alegre.get_similar_items_from_api('/image/similarity/', conditions, 0.89, 'query')
+      Bot::Alegre.get_similar_items_from_api('/image/similarity/', conditions, 0.89)
     end
   end
 end

--- a/test/controllers/elastic_search_9_test.rb
+++ b/test/controllers/elastic_search_9_test.rb
@@ -124,9 +124,6 @@ class ElasticSearch9Test < ActionController::TestCase
       WebMock.stub_request(:post, 'http://alegre/text/similarity/').to_return(body: 'success')
       WebMock.stub_request(:delete, 'http://alegre/text/similarity/').to_return(body: {success: true}.to_json)
       WebMock.stub_request(:get, 'http://alegre/text/similarity/').to_return(body: {success: true}.to_json)
-      WebMock.stub_request(:get, 'http://alegre/image/similarity/').to_return(body: {
-        "result": []
-      }.to_json)
       WebMock.stub_request(:get, 'http://alegre/image/classification/').with({ query: { uri: 'some/path' } }).to_return(body: {
         "result": valid_flags_data
       }.to_json)
@@ -137,6 +134,14 @@ class ElasticSearch9Test < ActionController::TestCase
       # Text extraction
       Bot::Alegre.unstub(:media_file_url)
       pm = create_project_media team: team, media: create_uploaded_image, disable_es_callbacks: false
+      params = URI.encode_www_form({context: {:has_custom_id=>true, :team_id=>pm.team_id}, match_across_content_types: true, threshold: 0.89, url: "some/path"})
+      WebMock.stub_request(:get, 'http://alegre/image/similarity/?'+params).to_return(body: {
+        "result": []
+      }.to_json)
+      params = URI.encode_www_form({context: {:has_custom_id=>true, :team_id=>pm.team_id}, match_across_content_types: true, threshold: 0.95, url: "some/path"})
+      WebMock.stub_request(:get, 'http://alegre/image/similarity/?'+params).to_return(body: {
+        "result": []
+      }.to_json)
       Bot::Alegre.stubs(:media_file_url).with(pm).returns("some/path")
       assert Bot::Alegre.run({ data: { dbid: pm.id }, event: 'create_project_media' })
       sleep 2

--- a/test/controllers/elastic_search_9_test.rb
+++ b/test/controllers/elastic_search_9_test.rb
@@ -117,7 +117,6 @@ class ElasticSearch9Test < ActionController::TestCase
     bot.install_to!(team)
     create_flag_annotation_type
     create_extracted_text_annotation_type
-    Bot::Alegre.unstub(:request_api)
     Rails.stubs(:env).returns('development'.inquiry)
     stub_configs({ 'alegre_host' => 'http://alegre', 'alegre_token' => 'test' }) do
       WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/

--- a/test/controllers/elastic_search_9_test.rb
+++ b/test/controllers/elastic_search_9_test.rb
@@ -134,11 +134,11 @@ class ElasticSearch9Test < ActionController::TestCase
       # Text extraction
       Bot::Alegre.unstub(:media_file_url)
       pm = create_project_media team: team, media: create_uploaded_image, disable_es_callbacks: false
-      params = URI.encode_www_form({context: {:has_custom_id=>true, :team_id=>pm.team_id}, match_across_content_types: true, threshold: 0.89, url: "some/path"})
+      params = URI.encode_www_form({context: {:has_custom_id=>true, :team_id=>pm.team_id}.to_json, match_across_content_types: true, threshold: 0.89, url: "some/path"})
       WebMock.stub_request(:get, 'http://alegre/image/similarity/?'+params).to_return(body: {
         "result": []
       }.to_json)
-      params = URI.encode_www_form({context: {:has_custom_id=>true, :team_id=>pm.team_id}, match_across_content_types: true, threshold: 0.95, url: "some/path"})
+      params = URI.encode_www_form({context: {:has_custom_id=>true, :team_id=>pm.team_id}.to_json, match_across_content_types: true, threshold: 0.95, url: "some/path"})
       WebMock.stub_request(:get, 'http://alegre/image/similarity/?'+params).to_return(body: {
         "result": []
       }.to_json)

--- a/test/controllers/elastic_search_9_test.rb
+++ b/test/controllers/elastic_search_9_test.rb
@@ -127,10 +127,10 @@ class ElasticSearch9Test < ActionController::TestCase
       WebMock.stub_request(:get, 'http://alegre/image/similarity/').to_return(body: {
         "result": []
       }.to_json)
-      WebMock.stub_request(:get, 'http://alegre/image/classification/').with({ query: { uri: 'some/path' } }).to_return(body: {
+      WebMock.stub_request(:get, 'http://alegre/image/classification/').with({ body: { uri: 'some/path' } }).to_return(body: {
         "result": valid_flags_data
       }.to_json)
-      WebMock.stub_request(:get, 'http://alegre/image/ocr/').with({ query: { url: 'some/path' } }).to_return(body: {
+      WebMock.stub_request(:get, 'http://alegre/image/ocr/').with({ body: { url: 'some/path' } }).to_return(body: {
         "text": "ocr_text"
       }.to_json)
       WebMock.stub_request(:post, 'http://alegre/image/similarity/').to_return(body: 'success')

--- a/test/controllers/elastic_search_9_test.rb
+++ b/test/controllers/elastic_search_9_test.rb
@@ -123,23 +123,21 @@ class ElasticSearch9Test < ActionController::TestCase
       WebMock.stub_request(:post, 'http://alegre/text/langid/').to_return(body: { 'result' => { 'language' => 'es' }}.to_json)
       WebMock.stub_request(:post, 'http://alegre/text/similarity/').to_return(body: 'success')
       WebMock.stub_request(:delete, 'http://alegre/text/similarity/').to_return(body: {success: true}.to_json)
-      WebMock.stub_request(:get, 'http://alegre/text/similarity/').to_return(body: {success: true}.to_json)
-      WebMock.stub_request(:get, 'http://alegre/image/classification/').with({ query: { uri: 'some/path' } }).to_return(body: {
+      WebMock.stub_request(:post, 'http://alegre/text/similarity/search/').to_return(body: {success: true}.to_json)
+      WebMock.stub_request(:post, 'http://alegre/image/classification/').with({ body: { uri: 'some/path' } }).to_return(body: {
         "result": valid_flags_data
       }.to_json)
-      WebMock.stub_request(:get, 'http://alegre/image/ocr/').with({ query: { url: 'some/path' } }).to_return(body: {
+      WebMock.stub_request(:post, 'http://alegre/image/ocr/').with({ body: { url: 'some/path' } }).to_return(body: {
         "text": "ocr_text"
       }.to_json)
       WebMock.stub_request(:post, 'http://alegre/image/similarity/').to_return(body: 'success')
       # Text extraction
       Bot::Alegre.unstub(:media_file_url)
       pm = create_project_media team: team, media: create_uploaded_image, disable_es_callbacks: false
-      params = URI.encode_www_form({context: {:has_custom_id=>true, :team_id=>pm.team_id}.to_json, match_across_content_types: true, threshold: 0.89, url: "some/path"})
-      WebMock.stub_request(:get, 'http://alegre/image/similarity/?'+params).to_return(body: {
+      WebMock.stub_request(:post, 'http://alegre/image/similarity/search/').with(body: {context: {:has_custom_id=>true, :team_id=>pm.team_id}.to_json, match_across_content_types: true, threshold: 0.89, url: "some/path"}).to_return(body: {
         "result": []
       }.to_json)
-      params = URI.encode_www_form({context: {:has_custom_id=>true, :team_id=>pm.team_id}.to_json, match_across_content_types: true, threshold: 0.95, url: "some/path"})
-      WebMock.stub_request(:get, 'http://alegre/image/similarity/?'+params).to_return(body: {
+      WebMock.stub_request(:post, 'http://alegre/image/similarity/search/').with(body: {context: {:has_custom_id=>true, :team_id=>pm.team_id}.to_json, match_across_content_types: true, threshold: 0.95, url: "some/path"}).to_return(body: {
         "result": []
       }.to_json)
       Bot::Alegre.stubs(:media_file_url).with(pm).returns("some/path")

--- a/test/controllers/elastic_search_9_test.rb
+++ b/test/controllers/elastic_search_9_test.rb
@@ -127,10 +127,10 @@ class ElasticSearch9Test < ActionController::TestCase
       WebMock.stub_request(:get, 'http://alegre/image/similarity/').to_return(body: {
         "result": []
       }.to_json)
-      WebMock.stub_request(:get, 'http://alegre/image/classification/').with({ body: { uri: 'some/path' } }).to_return(body: {
+      WebMock.stub_request(:get, 'http://alegre/image/classification/').with({ query: { uri: 'some/path' } }).to_return(body: {
         "result": valid_flags_data
       }.to_json)
-      WebMock.stub_request(:get, 'http://alegre/image/ocr/').with({ body: { url: 'some/path' } }).to_return(body: {
+      WebMock.stub_request(:get, 'http://alegre/image/ocr/').with({ query: { url: 'some/path' } }).to_return(body: {
         "text": "ocr_text"
       }.to_json)
       WebMock.stub_request(:post, 'http://alegre/image/similarity/').to_return(body: 'success')

--- a/test/controllers/elastic_search_9_test.rb
+++ b/test/controllers/elastic_search_9_test.rb
@@ -134,10 +134,10 @@ class ElasticSearch9Test < ActionController::TestCase
       # Text extraction
       Bot::Alegre.unstub(:media_file_url)
       pm = create_project_media team: team, media: create_uploaded_image, disable_es_callbacks: false
-      WebMock.stub_request(:post, 'http://alegre/image/similarity/search/').with(body: {context: {:has_custom_id=>true, :team_id=>pm.team_id}.to_json, match_across_content_types: true, threshold: 0.89, url: "some/path"}).to_return(body: {
+      WebMock.stub_request(:post, 'http://alegre/image/similarity/search/').with(body: {context: {:has_custom_id=>true, :team_id=>pm.team_id}, match_across_content_types: true, threshold: 0.89, url: "some/path"}).to_return(body: {
         "result": []
       }.to_json)
-      WebMock.stub_request(:post, 'http://alegre/image/similarity/search/').with(body: {context: {:has_custom_id=>true, :team_id=>pm.team_id}.to_json, match_across_content_types: true, threshold: 0.95, url: "some/path"}).to_return(body: {
+      WebMock.stub_request(:post, 'http://alegre/image/similarity/search/').with(body: {context: {:has_custom_id=>true, :team_id=>pm.team_id}, match_across_content_types: true, threshold: 0.95, url: "some/path"}).to_return(body: {
         "result": []
       }.to_json)
       Bot::Alegre.stubs(:media_file_url).with(pm).returns("some/path")

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -105,7 +105,7 @@ class FeedsControllerTest < ActionController::TestCase
   end
 
   test "should save request query" do
-    Bot::Alegre.stubs(:request_api).returns({})
+    Bot::Alegre.stubs(:request).returns({})
     Sidekiq::Testing.inline!
     authenticate_with_token @a
     assert_difference 'Request.count' do
@@ -116,28 +116,28 @@ class FeedsControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal 2, json_response['data'].size
     assert_equal 2, json_response['meta']['record-count']
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 
   test "should save relationship between request and results" do
-    Bot::Alegre.stubs(:request_api).returns({})
+    Bot::Alegre.stubs(:request).returns({})
     Sidekiq::Testing.inline!
     authenticate_with_token @a
     assert_difference 'Request.count' do
       get :index, params: { filter: { type: 'text', query: 'Foo', feed_id: @f.id } }
     end
     assert_response :success
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 
   test "should parse the full query" do
     Bot::Smooch.unstub(:search_for_similar_published_fact_checks)
-    Bot::Alegre.stubs(:request_api).returns({})
+    Bot::Alegre.stubs(:request).returns({})
     Sidekiq::Testing.inline!
     authenticate_with_token @a
     get :index, params: { filter: { type: 'text', query: 'Foo, bar and test', feed_id: @f.id } }
     assert_response :success
     assert_equal 'Foo, bar and test', Media.last.quote
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 end

--- a/test/controllers/graphql_controller_8_test.rb
+++ b/test/controllers/graphql_controller_8_test.rb
@@ -393,7 +393,7 @@ class GraphqlController8Test < ActionController::TestCase
     stub_configs({ 'alegre_host' => 'http://alegre', 'alegre_token' => 'test' }) do
       Sidekiq::Testing.fake! do
         WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
-        WebMock.stub_request(:get, 'http://alegre/image/ocr/').with({ query: { url: "some/path" } }).to_return(body: { text: 'Foo bar' }.to_json)
+        WebMock.stub_request(:get, 'http://alegre/image/ocr/').with({ body: { url: "some/path" } }).to_return(body: { text: 'Foo bar' }.to_json)
         WebMock.stub_request(:get, 'http://alegre/text/similarity/')
 
         u = create_user

--- a/test/controllers/graphql_controller_8_test.rb
+++ b/test/controllers/graphql_controller_8_test.rb
@@ -393,8 +393,8 @@ class GraphqlController8Test < ActionController::TestCase
     stub_configs({ 'alegre_host' => 'http://alegre', 'alegre_token' => 'test' }) do
       Sidekiq::Testing.fake! do
         WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
-        WebMock.stub_request(:get, 'http://alegre/image/ocr/').with({ query: { url: "some/path" } }).to_return(body: { text: 'Foo bar' }.to_json)
-        WebMock.stub_request(:get, 'http://alegre/text/similarity/')
+        WebMock.stub_request(:post, 'http://alegre/image/ocr/').with({ query: { url: "some/path" } }).to_return(body: { text: 'Foo bar' }.to_json)
+        WebMock.stub_request(:post, 'http://alegre/text/similarity/')
 
         u = create_user
         t = create_team
@@ -804,7 +804,7 @@ class GraphqlController8Test < ActionController::TestCase
 
       Bot::Alegre.stubs(:request).returns({ success: true })
       Bot::Alegre.stubs(:request).with('post', '/audio/transcription/', { url: s3_url, job_name: '0c481e87f2774b1bd41a0a70d9b70d11' }).returns({ 'job_status' => 'IN_PROGRESS' })
-      Bot::Alegre.stubs(:request).with('get', '/audio/transcription/', { job_name: '0c481e87f2774b1bd41a0a70d9b70d11' }).returns({ 'job_status' => 'COMPLETED', 'transcription' => 'Foo bar' })
+      Bot::Alegre.stubs(:request).with('post', '/audio/transcription/result/', { job_name: '0c481e87f2774b1bd41a0a70d9b70d11' }).returns({ 'job_status' => 'COMPLETED', 'transcription' => 'Foo bar' })
       WebMock.stub_request(:post, 'http://alegre/text/langid/').to_return(body: { 'result' => { 'language' => 'es' }}.to_json)
 
       b = create_bot_user login: 'alegre', name: 'Alegre', approved: true

--- a/test/controllers/graphql_controller_8_test.rb
+++ b/test/controllers/graphql_controller_8_test.rb
@@ -393,7 +393,7 @@ class GraphqlController8Test < ActionController::TestCase
     stub_configs({ 'alegre_host' => 'http://alegre', 'alegre_token' => 'test' }) do
       Sidekiq::Testing.fake! do
         WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
-        WebMock.stub_request(:post, 'http://alegre/image/ocr/').with({ query: { url: "some/path" } }).to_return(body: { text: 'Foo bar' }.to_json)
+        WebMock.stub_request(:post, 'http://alegre/image/ocr/').with({ body: { url: "some/path" } }).to_return(body: { text: 'Foo bar' }.to_json)
         WebMock.stub_request(:post, 'http://alegre/text/similarity/')
 
         u = create_user

--- a/test/controllers/graphql_controller_8_test.rb
+++ b/test/controllers/graphql_controller_8_test.rb
@@ -390,7 +390,6 @@ class GraphqlController8Test < ActionController::TestCase
   test "should get OCR" do
     b = create_alegre_bot(name: 'alegre', login: 'alegre')
     b.approve!
-    Bot::Alegre.unstub(:request_api)
     stub_configs({ 'alegre_host' => 'http://alegre', 'alegre_token' => 'test' }) do
       Sidekiq::Testing.fake! do
         WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
@@ -803,10 +802,9 @@ class GraphqlController8Test < ActionController::TestCase
       url = Bot::Alegre.media_file_url(pm)
       s3_url = url.gsub(/^https?:\/\/[^\/]+/, "s3://#{CheckConfig.get('storage_bucket')}")
 
-      Bot::Alegre.unstub(:request_api)
-      Bot::Alegre.stubs(:request_api).returns({ success: true })
-      Bot::Alegre.stubs(:request_api).with('post', '/audio/transcription/', { url: s3_url, job_name: '0c481e87f2774b1bd41a0a70d9b70d11' }).returns({ 'job_status' => 'IN_PROGRESS' })
-      Bot::Alegre.stubs(:request_api).with('get', '/audio/transcription/', { job_name: '0c481e87f2774b1bd41a0a70d9b70d11' }).returns({ 'job_status' => 'COMPLETED', 'transcription' => 'Foo bar' })
+      Bot::Alegre.stubs(:request).returns({ success: true })
+      Bot::Alegre.stubs(:request).with('post', '/audio/transcription/', { url: s3_url, job_name: '0c481e87f2774b1bd41a0a70d9b70d11' }).returns({ 'job_status' => 'IN_PROGRESS' })
+      Bot::Alegre.stubs(:request).with('get', '/audio/transcription/', { job_name: '0c481e87f2774b1bd41a0a70d9b70d11' }).returns({ 'job_status' => 'COMPLETED', 'transcription' => 'Foo bar' })
       WebMock.stub_request(:post, 'http://alegre/text/langid/').to_return(body: { 'result' => { 'language' => 'es' }}.to_json)
 
       b = create_bot_user login: 'alegre', name: 'Alegre', approved: true
@@ -820,7 +818,7 @@ class GraphqlController8Test < ActionController::TestCase
       assert_response :success
       assert_equal 'Foo bar', JSON.parse(@response.body)['data']['transcribeAudio']['annotation']['data']['text']
 
-      Bot::Alegre.unstub(:request_api)
+      Bot::Alegre.unstub(:request)
     end
   end
 

--- a/test/controllers/graphql_controller_8_test.rb
+++ b/test/controllers/graphql_controller_8_test.rb
@@ -393,7 +393,7 @@ class GraphqlController8Test < ActionController::TestCase
     stub_configs({ 'alegre_host' => 'http://alegre', 'alegre_token' => 'test' }) do
       Sidekiq::Testing.fake! do
         WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
-        WebMock.stub_request(:get, 'http://alegre/image/ocr/').with({ body: { url: "some/path" } }).to_return(body: { text: 'Foo bar' }.to_json)
+        WebMock.stub_request(:get, 'http://alegre/image/ocr/').with({ query: { url: "some/path" } }).to_return(body: { text: 'Foo bar' }.to_json)
         WebMock.stub_request(:get, 'http://alegre/text/similarity/')
 
         u = create_user

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -40,7 +40,7 @@ class ReportsControllerTest < ActionController::TestCase
     pm5 = create_project_media team: @t, media: create_uploaded_video
     create_project_media team: @t
 
-    Bot::Alegre.stubs(:request_api).returns({ 'result' => [from_alegre(@pm), from_alegre(pm), from_alegre(pm2), from_alegre(pm3), from_alegre(pm4), from_alegre(pm5)] })
+    Bot::Alegre.stubs(:request).returns({ 'result' => [from_alegre(@pm), from_alegre(pm), from_alegre(pm2), from_alegre(pm3), from_alegre(pm4), from_alegre(pm5)] })
 
     post :index, params: {}
     assert_response :success
@@ -57,7 +57,7 @@ class ReportsControllerTest < ActionController::TestCase
     assert_equal 1, json_response['data'].size
     assert_equal 1, json_response['meta']['record-count']
     
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 
   test "should return empty set if Alegre doesn't return anything" do
@@ -65,14 +65,14 @@ class ReportsControllerTest < ActionController::TestCase
     authenticate_with_token @a
     3.times { create_project_media(team: @t) }
 
-    Bot::Alegre.stubs(:request_api).returns({ 'result' => [] })
+    Bot::Alegre.stubs(:request).returns({ 'result' => [] })
 
     get :index, params: { filter: { similar_to_text: 'Test' } }
     assert_response :success
     assert_equal 0, json_response['data'].size
     assert_equal 0, json_response['meta']['record-count']
 
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 
   test "should return empty set if Alegre Bot is not installed" do
@@ -81,13 +81,13 @@ class ReportsControllerTest < ActionController::TestCase
     3.times { create_project_media }
     TeamBotInstallation.delete_all
     BotUser.delete_all
-    Bot::Alegre.stubs(:request_api).returns({ 'result' => [] })
+    Bot::Alegre.stubs(:request).returns({ 'result' => [] })
 
     get :index, params: { filter: { similar_to_text: 'Test' } }
     assert_response :success
     assert_equal 0, json_response['data'].size
     assert_equal 0, json_response['meta']['record-count']
 
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 end

--- a/test/lib/smooch_nlu_test.rb
+++ b/test/lib/smooch_nlu_test.rb
@@ -64,7 +64,7 @@ class SmoochNluTest < ActiveSupport::TestCase
     team = create_team_with_smooch_bot_installed
     nlu = SmoochNlu.new(team.slug)
     nlu.enable!
-    Bot::Alegre.expects(:request_api).with{ |x, y, _z| x == 'post' && y == '/text/similarity/' }.once
+    Bot::Alegre.expects(:request).with{ |x, y, _z| x == 'post' && y == '/text/similarity/' }.once
     nlu.add_keyword_to_menu_option('en', 'main', 0, 'subscribe')
     expected_output = {
       'en' => {
@@ -85,7 +85,7 @@ class SmoochNluTest < ActiveSupport::TestCase
   end
 
   test 'should add keyword if it does not exist' do
-    Bot::Alegre.expects(:request_api).with{ |x, y, _z| x == 'post' && y == '/text/similarity/' }.once
+    Bot::Alegre.expects(:request).with{ |x, y, _z| x == 'post' && y == '/text/similarity/' }.once
     team = create_team_with_smooch_bot_installed
     SmoochNlu.new(team.slug).add_keyword_to_menu_option('en', 'main', 0, 'subscribe to the newsletter')
   end
@@ -93,20 +93,20 @@ class SmoochNluTest < ActiveSupport::TestCase
   test 'should not add keyword if it exists' do
     team = create_team_with_smooch_bot_installed
     nlu = SmoochNlu.new(team.slug)
-    Bot::Alegre.expects(:request_api).with{ |x, y, _z| x == 'post' && y == '/text/similarity/' }.once
+    Bot::Alegre.expects(:request).with{ |x, y, _z| x == 'post' && y == '/text/similarity/' }.once
     nlu.add_keyword_to_menu_option('en', 'main', 0, 'subscribe to the newsletter')
-    Bot::Alegre.expects(:request_api).with{ |x, y, _z| x == 'post' && y == '/text/similarity/' }.never
+    Bot::Alegre.expects(:request).with{ |x, y, _z| x == 'post' && y == '/text/similarity/' }.never
     nlu.add_keyword_to_menu_option('en', 'main', 0, 'subscribe to the newsletter')
   end
 
   test 'should delete keyword' do
-    Bot::Alegre.expects(:request_api).with{ |x, y, _z| x == 'delete' && y == '/text/similarity/' }.once
+    Bot::Alegre.expects(:request).with{ |x, y, _z| x == 'delete' && y == '/text/similarity/' }.once
     team = create_team_with_smooch_bot_installed
     SmoochNlu.new(team.slug).remove_keyword_from_menu_option('en', 'main', 0, 'subscribe to the newsletter')
   end
 
   test 'should not return a menu option if NLU is not enabled' do
-    Bot::Alegre.stubs(:request_api).never
+    Bot::Alegre.stubs(:request).never
     team = create_team_with_smooch_bot_installed
     SmoochNlu.new(team.slug).disable!
     Bot::Smooch.get_installation('smooch_id', 'test')
@@ -114,7 +114,7 @@ class SmoochNluTest < ActiveSupport::TestCase
   end
 
   test 'should return a menu option if NLU is enabled' do
-    Bot::Alegre.stubs(:request_api).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && z[:text] =~ /newsletter/ }.returns({ 'result' => [
+    Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && z[:text] =~ /newsletter/ }.returns({ 'result' => [
       { '_score' => 0.9, '_source' => { 'context' => { 'menu_option_id' => 'test' } } },
     ]})
     team = create_team_with_smooch_bot_installed

--- a/test/lib/smooch_nlu_test.rb
+++ b/test/lib/smooch_nlu_test.rb
@@ -114,7 +114,7 @@ class SmoochNluTest < ActiveSupport::TestCase
   end
 
   test 'should return a menu option if NLU is enabled' do
-    Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && z[:text] =~ /newsletter/ }.returns({ 'result' => [
+    Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'post' && y == '/text/similarity/search/' && z[:text] =~ /newsletter/ }.returns({ 'result' => [
       { '_score' => 0.9, '_source' => { 'context' => { 'menu_option_id' => 'test' } } },
     ]})
     team = create_team_with_smooch_bot_installed

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -310,7 +310,7 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
   test "should pause database connection when calling Alegre" do
     RequestStore.store[:pause_database_connection] = true
     assert_nothing_raised do
-      Bot::Alegre.request_api('post', '/text/langid/')
+      Bot::Alegre.request('post', '/text/langid/')
     end
     RequestStore.store[:pause_database_connection] = false
   end
@@ -320,7 +320,7 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
     stubbed_response.stubs(:body).returns({"queue" => "audio__Model", "body" => {"id" => "123", "callback_url" => "http://example.com/callback"}}.to_json)
     Net::HTTP.any_instance.stubs(:request).returns(stubbed_response)
     Redis.any_instance.stubs(:blpop).with("alegre:webhook:123", 120).returns(["alegre:webhook:123", {"tested" => true}.to_json])
-    assert_equal Bot::Alegre.request_api('get', '/audio/similarity/', @params, 'body'), {"tested" => true}
+    assert_equal Bot::Alegre.request('get', '/audio/similarity/', @params, 'body'), {"tested" => true}
     Net::HTTP.any_instance.unstub(:request)
     Redis.any_instance.unstub(:blpop)
   end

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -314,16 +314,6 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
     RequestStore.store[:pause_database_connection] = false
   end
 
-  test "should block calls on redis blpop for audio request" do
-    stubbed_response = Net::HTTPSuccess.new(1.0, '200', 'OK')
-    stubbed_response.stubs(:body).returns({"queue" => "audio__Model", "body" => {"id" => "123", "callback_url" => "http://example.com/callback"}}.to_json)
-    Net::HTTP.any_instance.stubs(:request).returns(stubbed_response)
-    Redis.any_instance.stubs(:blpop).with("alegre:webhook:123", 120).returns(["alegre:webhook:123", {"tested" => true}.to_json])
-    assert_equal Bot::Alegre.request('get', '/audio/similarity/', @params), {"tested" => true}
-    Net::HTTP.any_instance.unstub(:request)
-    Redis.any_instance.unstub(:blpop)
-  end
-
   test "should get items with similar title" do
     create_verification_status_stuff
     RequestStore.store[:skip_cached_field_update] = false

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -261,7 +261,7 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
         "team_id" => pm1.team.id.to_s,
         "project_media_id" => pm1.id.to_s
       }]
-      path = URI.encode_www_form({:url=>image_path, :context=>{:has_custom_id=>true, :team_id=>pm1.team_id}, :match_across_content_types=>true, :threshold=>0.89})
+      path = URI.encode_www_form({:url=>image_path, :context=>{:has_custom_id=>true, :team_id=>pm1.team_id}.to_json, :match_across_content_types=>true, :threshold=>0.89})
       WebMock.stub_request(:get, "http://alegre.test/image/similarity/?#{path}").to_return(body: {
         "result": [
           {
@@ -274,7 +274,7 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
           }
         ]
       }.to_json)
-      path = URI.encode_www_form({:url=>image_path, :context=>{:has_custom_id=>true, :team_id=>pm1.team_id}, :match_across_content_types=>true, :threshold=>0.95})
+      path = URI.encode_www_form({:url=>image_path, :context=>{:has_custom_id=>true, :team_id=>pm1.team_id}.to_json, :match_across_content_types=>true, :threshold=>0.95})
       WebMock.stub_request(:get, "http://alegre.test/image/similarity/?#{path}").to_return(body: {
         "result": [
           {

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -249,10 +249,10 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
       WebMock.stub_request(:get, 'http://alegre.test/image/similarity/').to_return(body: {
         "result": []
       }.to_json)
-      WebMock.stub_request(:get, 'http://alegre.test/image/classification/').with({ body: { uri: image_path } }).to_return(body: {
+      WebMock.stub_request(:get, 'http://alegre.test/image/classification/').with({ query: { uri: image_path } }).to_return(body: {
         "result": valid_flags_data
       }.to_json)
-      WebMock.stub_request(:get, 'http://alegre.test/image/ocr/').with({ body: { url: image_path } }).to_return(body: {
+      WebMock.stub_request(:get, 'http://alegre.test/image/ocr/').with({ query: { url: image_path } }).to_return(body: {
         "text": "Foo bar"
       }.to_json)
       WebMock.stub_request(:post, 'http://alegre.test/image/similarity/').to_return(body: 'success')

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -261,7 +261,7 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
         "team_id" => pm1.team.id.to_s,
         "project_media_id" => pm1.id.to_s
       }]
-      WebMock.stub_request(:post, "http://alegre.test/image/similarity/search/").with(body: {:url=>image_path, :context=>{:has_custom_id=>true, :team_id=>pm1.team_id}.to_json, :match_across_content_types=>true, :threshold=>0.89}).to_return(body: {
+      WebMock.stub_request(:post, "http://alegre.test/image/similarity/search/").with(body: {:url=>image_path, :context=>{:has_custom_id=>true, :team_id=>pm1.team_id}, :match_across_content_types=>true, :threshold=>0.89}).to_return(body: {
         "result": [
           {
             "id": pm1.id,
@@ -273,7 +273,7 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
           }
         ]
       }.to_json)
-      WebMock.stub_request(:post, "http://alegre.test/image/similarity/search/").with(body: {:url=>image_path, :context=>{:has_custom_id=>true, :team_id=>pm1.team_id}.to_json, :match_across_content_types=>true, :threshold=>0.95}).to_return(body: {
+      WebMock.stub_request(:post, "http://alegre.test/image/similarity/search/").with(body: {:url=>image_path, :context=>{:has_custom_id=>true, :team_id=>pm1.team_id}, :match_across_content_types=>true, :threshold=>0.95}).to_return(body: {
         "result": [
           {
             "id": pm1.id,

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -309,7 +309,7 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
   test "should pause database connection when calling Alegre" do
     RequestStore.store[:pause_database_connection] = true
     assert_nothing_raised do
-      Bot::Alegre.request('post', '/text/langid/')
+      Bot::Alegre.request('post', '/text/langid/', {})
     end
     RequestStore.store[:pause_database_connection] = false
   end
@@ -319,7 +319,7 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
     stubbed_response.stubs(:body).returns({"queue" => "audio__Model", "body" => {"id" => "123", "callback_url" => "http://example.com/callback"}}.to_json)
     Net::HTTP.any_instance.stubs(:request).returns(stubbed_response)
     Redis.any_instance.stubs(:blpop).with("alegre:webhook:123", 120).returns(["alegre:webhook:123", {"tested" => true}.to_json])
-    assert_equal Bot::Alegre.request('get', '/audio/similarity/', @params, 'body'), {"tested" => true}
+    assert_equal Bot::Alegre.request('get', '/audio/similarity/', @params), {"tested" => true}
     Net::HTTP.any_instance.unstub(:request)
     Redis.any_instance.unstub(:blpop)
   end

--- a/test/models/bot/alegre_3_test.rb
+++ b/test/models/bot/alegre_3_test.rb
@@ -155,7 +155,7 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
         "success": true
       }.to_json)
       WebMock.stub_request(:get, 'http://alegre/similarity/sync/audio').to_return(body: {
-        "success": true
+        "result" => []
       }.to_json)
 
       media_file_url = 'https://example.com/test/data/rails.mp3'

--- a/test/models/bot/alegre_3_test.rb
+++ b/test/models/bot/alegre_3_test.rb
@@ -82,8 +82,8 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
       WebMock.stub_request(:post, 'http://alegre/text/similarity/').to_return(body: 'success')
       WebMock.stub_request(:delete, 'http://alegre/text/similarity/').to_return(body: {success: true}.to_json)
       WebMock.stub_request(:get, 'http://alegre/text/similarity/').to_return(body: {success: true}.to_json)
-      WebMock.stub_request(:post, 'http://alegre/audio/similarity/').to_return(body: {
-        "success": true
+      WebMock.stub_request(:get, 'http://alegre/similarity/sync/audio').to_return(body: {
+        "result": []
       }.to_json)
       WebMock.stub_request(:get, 'http://alegre/audio/similarity/').to_return(body: {
         "result": []
@@ -154,8 +154,8 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
       WebMock.stub_request(:post, 'http://alegre/audio/similarity/').to_return(body: {
         "success": true
       }.to_json)
-      WebMock.stub_request(:get, 'http://alegre/audio/similarity/').to_return(body: {
-        "result": []
+      WebMock.stub_request(:get, 'http://alegre/similarity/sync/audio').to_return(body: {
+        "success": true
       }.to_json)
 
       media_file_url = 'https://example.com/test/data/rails.mp3'

--- a/test/models/bot/alegre_3_test.rb
+++ b/test/models/bot/alegre_3_test.rb
@@ -92,7 +92,7 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
       Bot::Alegre.stubs(:media_file_url).returns(media_file_url)
 
       pm1 = create_project_media team: @pm.team, media: create_uploaded_audio(file: 'rails.mp3')
-      params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>media_file_url, :threshold=>0.9})
+      params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>media_file_url, :threshold=>0.9})
       WebMock.stub_request(:get, "http://alegre/similarity/sync/audio?#{params}").to_return(body: {
         "result": []
       }.to_json)
@@ -160,7 +160,7 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
       Bot::Alegre.stubs(:media_file_url).returns(media_file_url)
 
       pm1 = create_project_media team: @pm.team, media: create_uploaded_audio(file: 'rails.mp3')
-      params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>media_file_url, :threshold=>0.9})
+      params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>media_file_url, :threshold=>0.9})
       WebMock.stub_request(:get, "http://alegre/similarity/sync/audio?#{params}").to_return(body: {
         "result": []
       }.to_json)

--- a/test/models/bot/alegre_3_test.rb
+++ b/test/models/bot/alegre_3_test.rb
@@ -82,9 +82,6 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
       WebMock.stub_request(:post, 'http://alegre/text/similarity/').to_return(body: 'success')
       WebMock.stub_request(:delete, 'http://alegre/text/similarity/').to_return(body: {success: true}.to_json)
       WebMock.stub_request(:get, 'http://alegre/text/similarity/').to_return(body: {success: true}.to_json)
-      WebMock.stub_request(:get, 'http://alegre/similarity/sync/audio').to_return(body: {
-        "result": []
-      }.to_json)
       WebMock.stub_request(:get, 'http://alegre/audio/similarity/').to_return(body: {
         "result": []
       }.to_json)
@@ -95,12 +92,14 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
       Bot::Alegre.stubs(:media_file_url).returns(media_file_url)
 
       pm1 = create_project_media team: @pm.team, media: create_uploaded_audio(file: 'rails.mp3')
+      params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>media_file_url, :threshold=>0.9})
+      WebMock.stub_request(:get, "http://alegre/similarity/sync/audio?#{params}").to_return(body: {
+        "result": []
+      }.to_json)
+      WebMock.stub_request(:get, 'http://alegre/audio/transcription/?job_name=0c481e87f2774b1bd41a0a70d9b70d11').to_return(body: { 'job_status' => 'DONE' }.to_json)
       WebMock.stub_request(:post, 'http://alegre/audio/transcription/').with({
         body: { url: s3_file_url, job_name: '0c481e87f2774b1bd41a0a70d9b70d11' }.to_json
       }).to_return(body: { 'job_status' => 'IN_PROGRESS' }.to_json)
-      WebMock.stub_request(:get, 'http://alegre/audio/transcription/').with(
-        body: { job_name: '0c481e87f2774b1bd41a0a70d9b70d11' }
-      ).to_return(body: { 'job_status' => 'DONE' }.to_json)
       # Verify with transcription_similarity_enabled = false
       assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
       a = pm1.annotations('transcription').last
@@ -154,9 +153,6 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
       WebMock.stub_request(:post, 'http://alegre/audio/similarity/').to_return(body: {
         "success": true
       }.to_json)
-      WebMock.stub_request(:get, 'http://alegre/similarity/sync/audio').to_return(body: {
-        "result" => []
-      }.to_json)
 
       media_file_url = 'https://example.com/test/data/rails.mp3'
       s3_file_url = "s3://check-api-test/test/data/rails.mp3"
@@ -164,12 +160,14 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
       Bot::Alegre.stubs(:media_file_url).returns(media_file_url)
 
       pm1 = create_project_media team: @pm.team, media: create_uploaded_audio(file: 'rails.mp3')
+      params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>media_file_url, :threshold=>0.9})
+      WebMock.stub_request(:get, "http://alegre/similarity/sync/audio?#{params}").to_return(body: {
+        "result": []
+      }.to_json)
       WebMock.stub_request(:post, 'http://alegre/audio/transcription/').with({
         body: { url: s3_file_url, job_name: '0c481e87f2774b1bd41a0a70d9b70d11' }.to_json
       }).to_return(body: { 'job_status' => 'IN_PROGRESS' }.to_json)
-      WebMock.stub_request(:get, 'http://alegre/audio/transcription/').with(
-        body: { job_name: '0c481e87f2774b1bd41a0a70d9b70d11' }
-      ).to_return(body: { 'job_status' => 'COMPLETED', 'transcription' => 'Foo bar' }.to_json)
+      WebMock.stub_request(:get, 'http://alegre/audio/transcription/?job_name=0c481e87f2774b1bd41a0a70d9b70d11').to_return(body: { 'job_status' => 'COMPLETED', 'transcription' => 'Foo bar' }.to_json)
       # Verify with transcription_similarity_enabled = false
       assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
       a = pm1.annotations('transcription').last

--- a/test/models/bot/alegre_3_test.rb
+++ b/test/models/bot/alegre_3_test.rb
@@ -92,7 +92,7 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
       Bot::Alegre.stubs(:media_file_url).returns(media_file_url)
 
       pm1 = create_project_media team: @pm.team, media: create_uploaded_audio(file: 'rails.mp3')
-      WebMock.stub_request(:post, "http://alegre/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>media_file_url, :threshold=>0.9}).to_return(body: {
+      WebMock.stub_request(:post, "http://alegre/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>media_file_url, :threshold=>0.9}).to_return(body: {
         "result": []
       }.to_json)
       WebMock.stub_request(:post, 'http://alegre/audio/transcription/result/').with(body: {job_name: "0c481e87f2774b1bd41a0a70d9b70d11"}).to_return(body: { 'job_status' => 'DONE' }.to_json)
@@ -159,7 +159,7 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
       Bot::Alegre.stubs(:media_file_url).returns(media_file_url)
 
       pm1 = create_project_media team: @pm.team, media: create_uploaded_audio(file: 'rails.mp3')
-      WebMock.stub_request(:post, "http://alegre/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>media_file_url, :threshold=>0.9}).to_return(body: {
+      WebMock.stub_request(:post, "http://alegre/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>media_file_url, :threshold=>0.9}).to_return(body: {
         "result": []
       }.to_json)
       WebMock.stub_request(:post, 'http://alegre/audio/transcription/').with({

--- a/test/models/bot/alegre_test.rb
+++ b/test/models/bot/alegre_test.rb
@@ -40,10 +40,10 @@ class Bot::AlegreTest < ActiveSupport::TestCase
 
   test "should capture error when failing to call service" do
     stub_configs({ 'alegre_host' => 'http://alegre', 'alegre_token' => 'test' }) do
-       WebMock.stub_request(:get, 'http://alegre/text/langid/').to_return(body: 'bad JSON response')
+       WebMock.stub_request(:post, 'http://alegre/text/langid/').to_return(body: 'bad JSON response')
        WebMock.stub_request(:post, 'http://alegre/text/langid/').to_return(body: 'bad JSON response')
        WebMock.stub_request(:post, 'http://alegre/text/similarity/').to_return(body: 'success')
-       WebMock.stub_request(:get, 'http://alegre/text/similarity/').to_return(body: 'success')
+       WebMock.stub_request(:post, 'http://alegre/text/similarity/search/').to_return(body: 'success')
        WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
        Bot::Alegre.any_instance.stubs(:get_language).raises(RuntimeError)
        assert_nothing_raised do

--- a/test/models/bot/alegre_test.rb
+++ b/test/models/bot/alegre_test.rb
@@ -129,7 +129,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     pm1 = create_project_media project: p, quote: "for testing short text", team: @team
     pm2 = create_project_media project: p, quote: "testing short text", team: @team
     pm2.analysis = { content: 'short text' }
-    Bot::Alegre.stubs(:request_api).returns({
+    Bot::Alegre.stubs(:request).returns({
       "result" => [
         {
           "_score" => 26.493948,
@@ -147,7 +147,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     # Relation should be confirmed if at least one field size > threshold
     pm3 = create_project_media project: p, quote: 'This is also a long enough title', team: @team
     pm4 = create_project_media project: p, quote: 'This is also a long enough title so as to allow an actual check of other titles', team: @team
-    Bot::Alegre.stubs(:request_api).returns({
+    Bot::Alegre.stubs(:request).returns({
       "result" => [
         {
           "_score" => 26.493948,
@@ -162,7 +162,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     end
     r = Relationship.last
     assert_equal Relationship.confirmed_type, r.relationship_type
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 
   test "should set similarity relationship based on date threshold" do
@@ -170,7 +170,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     p = create_project team: @team
     pm1 = create_project_media project: p, quote: "This is also a long enough Title so as to allow an actual check of other titles", team: @team
     pm2 = create_project_media project: p, quote: "This is also a long enough Title so as to allow an actual check of other titles 2", team: @team
-    Bot::Alegre.stubs(:request_api).returns({
+    Bot::Alegre.stubs(:request).returns({
       "result" => [
         {
           "_score" => 26.493948,
@@ -197,7 +197,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     end
     r = Relationship.last
     assert_equal Relationship.suggested_type, r.relationship_type
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 
   test "should index report data" do
@@ -222,7 +222,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   test "should use OCR data for similarity matching 2" do
     pm = create_project_media team: @team, media: create_uploaded_image
     pm2 = create_project_media team: @team, media: create_uploaded_image
-    Bot::Alegre.stubs(:request_api).returns({"result"=> [{
+    Bot::Alegre.stubs(:request).returns({"result"=> [{
       "_index"=>"alegre_similarity",
       "_type"=>"_doc",
       "_id"=>"i8XY53UB36CYclMPF5wC",
@@ -250,7 +250,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     assert_equal r.model, "elasticsearch"
     assert_equal Bot::Alegre.get_pm_type(r.source), "image"
     assert_equal Bot::Alegre.get_pm_type(r.target), "image"
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 
 

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -115,7 +115,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       }
     }
-    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/async/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1)}).to_return(body: response.to_json)
+    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/async/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)}).to_return(body: response.to_json)
     assert_equal JSON.parse(Bot::Alegre.get_async(pm1).to_json), JSON.parse(response.to_json)
   end
 
@@ -222,7 +222,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1)}).to_return(body: response.to_json)
+    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)}).to_return(body: response.to_json)
     assert_equal JSON.parse(Bot::Alegre.get_sync(pm1).to_json), JSON.parse(response.to_json)
   end
 
@@ -322,7 +322,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9}).to_return(body: response.to_json)
+    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9}).to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_items(pm1, nil), {(pm1.id+1)=>{:score=>1.0, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>(pm1.id+1)}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.suggested_type}}
   end
 
@@ -402,11 +402,11 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9}).to_return(body: response.to_json)
+    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9}).to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_items(pm1, nil), {(pm1.id+1)=>{:score=>0.91, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>(pm1.id+1)}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.suggested_type}}
   end
 
-  test "should get_confirmed_items" do
+  test "should get_confirmed_items zzz" do
     pm1 = create_project_media team: @team, media: create_uploaded_audio
     response = {
       "result": [
@@ -482,7 +482,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9}).to_return(body: response.to_json)
+    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9}).to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_confirmed_items(pm1, nil), {(pm1.id+1)=>{:score=>0.91, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>(pm1.id+1)}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.confirmed_type}}
   end
 
@@ -562,7 +562,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9}).to_return(body: response.to_json)
+    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9}).to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_similar_items_v2(pm1, nil), {}
   end
 

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -1,0 +1,581 @@
+require_relative '../../test_helper'
+
+class Bot::AlegreTest < ActiveSupport::TestCase
+  def setup
+    super
+    ft = DynamicAnnotation::FieldType.where(field_type: 'language').last || create_field_type(field_type: 'language', label: 'Language')
+    at = create_annotation_type annotation_type: 'language', label: 'Language'
+    create_field_instance annotation_type_object: at, name: 'language', label: 'Language', field_type_object: ft, optional: false
+    @bot = create_alegre_bot(name: "alegre", login: "alegre")
+    @bot.approve!
+    p = create_project
+    p.team.set_languages = ['en','pt','es']
+    p.team.save!
+    @bot.install_to!(p.team)
+    @team = p.team
+    m = create_claim_media quote: 'I like apples'
+    @pm = create_project_media project: p, media: m
+    create_flag_annotation_type
+    create_extracted_text_annotation_type
+    Sidekiq::Testing.inline!
+  end
+
+  def teardown
+    super
+  end
+
+  test "should generate media file url" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    assert_equal Bot::Alegre.media_file_url(pm1).class, String
+  end
+
+  test "should generate item_doc_id" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    assert_equal Bot::Alegre.item_doc_id(pm1).class, String
+  end
+
+  test "should return proper types per object" do
+    p = create_project team: @team
+    pm1 = create_project_media project: p, team: @team, media: create_uploaded_audio
+    assert_equal Bot::Alegre.get_type(pm1), "audio"
+    pm2 = create_project_media project: p, team: @team, media: create_uploaded_video
+    assert_equal Bot::Alegre.get_type(pm2), "video"
+    pm3 = create_project_media project: p, team: @team, media: create_uploaded_image
+    assert_equal Bot::Alegre.get_type(pm3), "image"
+    pm4 = create_project_media project: p, quote: "testing short text", team: @team
+    assert_equal Bot::Alegre.get_type(pm4), "text"
+  end
+
+
+  test "should have host and paths" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    assert_equal Bot::Alegre.host, CheckConfig.get('alegre_host')
+    assert_equal Bot::Alegre.sync_path, "/similarity/sync/audio"
+    assert_equal Bot::Alegre.async_path, "/similarity/async/audio"
+    assert_equal Bot::Alegre.delete_path(pm1), "/audio/similarity/"
+  end
+
+  test "should release and reconnect db" do
+    RequestStore.store[:pause_database_connection] = true
+    assert_equal Bot::Alegre.release_db.class, Thread::ConditionVariable
+    assert_equal Bot::Alegre.reconnect_db[0].class, PG::Result
+    RequestStore.store[:pause_database_connection] = false
+  end
+
+  test "should create a generic_package" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    assert_equal Bot::Alegre.generic_package(pm1, "audio"), {:doc_id=>Bot::Alegre.item_doc_id(pm1, "audio"), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}}
+  end
+
+  test "should create a generic_package_audio" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    assert_equal Bot::Alegre.generic_package_audio(pm1, {}), {:doc_id=>Bot::Alegre.item_doc_id(pm1, nil), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)}
+    assert_equal Bot::Alegre.store_package_audio(pm1, "audio", {}), {:doc_id=>Bot::Alegre.item_doc_id(pm1, nil), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)}
+    assert_equal Bot::Alegre.store_package(pm1, "audio", {}), {:doc_id=>Bot::Alegre.item_doc_id(pm1, nil), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)}
+  end
+
+  test "should create a context for audio" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    assert_equal Bot::Alegre.get_context(pm1, "audio"), {:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}
+  end
+
+  test "should create a delete_package" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    package = Bot::Alegre.delete_package(pm1, "audio")
+    assert_equal package[:doc_id], Bot::Alegre.item_doc_id(pm1, nil)
+    assert_equal package[:context], {:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}
+    assert_equal package[:url].class, String
+    assert_equal package[:quiet], false
+  end
+
+  test "should run audio async request" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    response = {
+      "message": "Message pushed successfully",
+      "queue": "audio__Model",
+      "body": {
+        "callback_url": "http:\/\/alegre:3100\/presto\/receive\/add_item\/audio",
+        "id": "f0d43d29-853d-4099-9e92-073203afa75b",
+        "url": Bot::Alegre.media_file_url(pm1),
+        "text": nil,
+        "raw": {
+          "limit": 200,
+          "url": Bot::Alegre.media_file_url(pm1),
+          "callback_url": "http:\/\/example.com\/search_results",
+          "doc_id": Bot::Alegre.item_doc_id(pm1, "audio"),
+          "context": Bot::Alegre.get_context(pm1, "audio"),
+          "created_at": "2023-10-27T22:40:14.205586",
+          "command": "search",
+          "threshold": 0.0,
+          "per_model_threshold": {},
+          "match_across_content_types": false,
+          "requires_callback": true,
+          "final_task": "search"
+        }
+      }
+    }
+    WebMock.stub_request(:get, Bot::Alegre.host+Bot::Alegre.async_path).to_return(body: response.to_json)
+    assert_equal JSON.parse(Bot::Alegre.get_async(pm1).to_json), JSON.parse(response.to_json)
+  end
+
+  test "should isolate relevant_context" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    assert_equal Bot::Alegre.isolate_relevant_context(pm1, {"context"=>[{"team_id"=>pm1.team_id}]}), {"team_id"=>pm1.team_id}
+  end
+
+  test "should return field or type on get_target_field" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    Bot::Alegre.stubs(:get_type).returns(nil)
+    assert_equal Bot::Alegre.get_target_field(pm1, "blah"), "blah"
+    Bot::Alegre.unstub(:get_type)
+  end
+
+  test "should generate per model threshold for text" do
+    p = create_project team: @team
+    pm1 = create_project_media project: p, quote: "testing short text", team: @team
+    sample = [{:value=>0.9, :key=>"vector_hash_suggestion_threshold", :automatic=>false, :model=>"vector"}]
+    assert_equal Bot::Alegre.get_per_model_threshold(pm1, sample), {:per_model_threshold=>[{:model=>"vector", :value=>0.9}]}
+  end
+
+  test "should generate per model threshold" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    sample = [{:value=>0.9, :key=>"audio_hash_suggestion_threshold", :automatic=>false, :model=>"hash"}]
+    assert_equal Bot::Alegre.get_per_model_threshold(pm1, sample), {:threshold=>0.9}
+  end
+
+  test "should get target field" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    assert_equal Bot::Alegre.get_target_field(pm1, nil), "audio"
+  end
+
+  test "should parse similarity results" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    results = [
+      {
+        "id"=>15346,
+        "doc_id"=>"Y2hlY2stcHJvamVjdF9tZWRpYS0yMzE4MC1hdWRpbw",
+        "chromaprint_fingerprint"=>[
+          -714426431,
+          -731146431,
+          -731138797,
+          -597050061
+        ],
+        "url"=>"https://qa-assets.checkmedia.org/uploads/uploaded_audio/47237/51845f9bbf47bcfc47e90ab2083f94c1.mp3",
+        "context"=>[{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>pm1.id}],
+        "score"=>1.0,
+        "model"=>"audio"},
+      {
+        "id"=>15347,
+        "doc_id"=>"Y2hlY2stcHJvamVjdF9tZWRpYS0yMzE4MS1hdWRpbw",
+        "chromaprint_fingerprint"=>[
+          -546788830,
+          -566629838,
+          -29630958,
+          -29638141
+        ],
+        "url"=>"https://qa-assets.checkmedia.org/uploads/uploaded_audio/47238/e6cd55fd06742929124cdeaeebfa58d6.mp3",
+        "context"=>[{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>23181}],
+        "score"=>0.915364583333333,
+        "model"=>"audio"
+      }
+    ]
+    assert_equal Bot::Alegre.parse_similarity_results(pm1, nil, results, Relationship.suggested_type), {23181=>{:score=>0.915364583333333, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>23181}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.suggested_type}}
+  end
+
+  test "should run audio sync request" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    response = {
+      "result": [
+        {
+          "id": 1,
+          "doc_id": "f0d43d29-853d-4099-9e92-073203afa75b",
+          "chromaprint_fingerprint": [
+            377259661,
+            376226445,
+            305001149,
+            306181093,
+            1379918309,
+            1383899364,
+            1995219172,
+            1974379732,
+            1957603396,
+            1961789696,
+            1416464641,
+            1429048627,
+            1999429922,
+            1999380774,
+            2100043878,
+            2083467494,
+            -59895634,
+            -118617698,
+            -122811506
+          ],
+          "url": "http:\/\/devingaffney.com\/files\/audio.ogg",
+          "context": [
+            {
+              "team_id": 1
+            }
+          ],
+          "score": 1.0,
+          "model": "audio"
+        }
+      ]
+    }
+    WebMock.stub_request(:get, Bot::Alegre.host+Bot::Alegre.sync_path).to_return(body: response.to_json)
+    assert_equal JSON.parse(Bot::Alegre.get_sync(pm1).to_json), JSON.parse(response.to_json)
+  end
+
+  test "should run delete request" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    response = {"requested"=>
+      {"limit"=>200,
+       "url"=>"https://qa-assets.checkmedia.org/uploads/uploaded_audio/47237/51845f9bbf47bcfc47e90ab2083f94c1.mp3",
+       "callback_url"=>nil,
+       "doc_id"=>"Y2hlY2stcHJvamVjdF9tZWRpYS0yMzE4MC1hdWRpbw",
+       "context"=>{"team_id"=>183, "project_media_id"=>23180, "has_custom_id"=>true},
+       "created_at"=>nil,
+       "command"=>"delete",
+       "threshold"=>0.0,
+       "per_model_threshold"=>{},
+       "match_across_content_types"=>false,
+       "requires_callback"=>false},
+     "result"=>{"url"=>"https://qa-assets.checkmedia.org/uploads/uploaded_audio/47237/51845f9bbf47bcfc47e90ab2083f94c1.mp3", "deleted"=>1}
+   }
+   WebMock.stub_request(:delete, Bot::Alegre.host+Bot::Alegre.delete_path(pm1)).to_return(body: response.to_json)
+   assert_equal JSON.parse(Bot::Alegre.delete(pm1).to_json), JSON.parse(response.to_json)
+  end
+
+  test "should get_items" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    response = {
+      "result": [
+        {
+          "id": 1,
+          "doc_id": "f0d43d29-853d-4099-9e92-073203afa75b",
+          "chromaprint_fingerprint": [
+            377259661,
+            376226445,
+            305001149,
+            306181093,
+            1379918309,
+            1383899364,
+            1995219172,
+            1974379732,
+            1957603396,
+            1961789696,
+            1416464641,
+            1429048627,
+            1999429922,
+            1999380774,
+            2100043878,
+            2083467494,
+            -59895634,
+            -118617698,
+            -122811506
+          ],
+          "url": "http:\/\/devingaffney.com\/files\/audio.ogg",
+          "context": [
+            {
+              "team_id": pm1.team_id,
+              "project_media_id": pm1.id,
+              "has_custom_id": true,
+            }
+          ],
+          "score": 1.0,
+          "model": "audio"
+        },
+        {
+          "id": 2,
+          "doc_id": "f0d43d29-853d-4099-9e92-073203afa75c",
+          "chromaprint_fingerprint": [
+            377259661,
+            376226445,
+            305001149,
+            306181093,
+            1379918309,
+            1383899364,
+            1995219172,
+            1974379732,
+            1957603396,
+            1961789696,
+            1416464641,
+            1429048627,
+            1999429922,
+            1999380774,
+            2100043878,
+            2083467494,
+            -59895634,
+            -118617698,
+            -122811506
+          ],
+          "url": "http:\/\/devingaffney.com\/files\/audio.mp3",
+          "context": [
+            {
+              "team_id": pm1.team_id,
+              "project_media_id": pm1.id+1,
+              "has_custom_id": true,
+            }
+          ],
+          "score": 1.0,
+          "model": "audio"
+        }
+      ]
+    }
+    WebMock.stub_request(:get, Bot::Alegre.host+Bot::Alegre.sync_path).to_return(body: response.to_json)
+    assert_equal Bot::Alegre.get_items(pm1, nil), {(pm1.id+1)=>{:score=>1.0, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>(pm1.id+1)}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.suggested_type}}
+  end
+
+  test "should get_suggested_items" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    response = {
+      "result": [
+        {
+          "id": 1,
+          "doc_id": "f0d43d29-853d-4099-9e92-073203afa75b",
+          "chromaprint_fingerprint": [
+            377259661,
+            376226445,
+            305001149,
+            306181093,
+            1379918309,
+            1383899364,
+            1995219172,
+            1974379732,
+            1957603396,
+            1961789696,
+            1416464641,
+            1429048627,
+            1999429922,
+            1999380774,
+            2100043878,
+            2083467494,
+            -59895634,
+            -118617698,
+            -122811506
+          ],
+          "url": "http:\/\/devingaffney.com\/files\/audio.ogg",
+          "context": [
+            {
+              "team_id": pm1.team_id,
+              "project_media_id": pm1.id,
+              "has_custom_id": true,
+            }
+          ],
+          "score": 1.0,
+          "model": "audio"
+        },
+        {
+          "id": 2,
+          "doc_id": "f0d43d29-853d-4099-9e92-073203afa75c",
+          "chromaprint_fingerprint": [
+            377259661,
+            376226445,
+            305001149,
+            306181093,
+            1379918309,
+            1383899364,
+            1995219172,
+            1974379732,
+            1957603396,
+            1961789696,
+            1416464641,
+            1429048627,
+            1999429922,
+            1999380774,
+            2100043878,
+            2083467494,
+            -59895634,
+            -118617698,
+            -122811506
+          ],
+          "url": "http:\/\/devingaffney.com\/files\/audio.mp3",
+          "context": [
+            {
+              "team_id": pm1.team_id,
+              "project_media_id": pm1.id+1,
+              "has_custom_id": true,
+            }
+          ],
+          "score": 0.91,
+          "model": "audio"
+        }
+      ]
+    }
+    WebMock.stub_request(:get, Bot::Alegre.host+Bot::Alegre.sync_path).to_return(body: response.to_json)
+    assert_equal Bot::Alegre.get_items(pm1, nil), {(pm1.id+1)=>{:score=>0.91, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>(pm1.id+1)}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.suggested_type}}
+  end
+
+  test "should get_confirmed_items" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    response = {
+      "result": [
+        {
+          "id": 1,
+          "doc_id": "f0d43d29-853d-4099-9e92-073203afa75b",
+          "chromaprint_fingerprint": [
+            377259661,
+            376226445,
+            305001149,
+            306181093,
+            1379918309,
+            1383899364,
+            1995219172,
+            1974379732,
+            1957603396,
+            1961789696,
+            1416464641,
+            1429048627,
+            1999429922,
+            1999380774,
+            2100043878,
+            2083467494,
+            -59895634,
+            -118617698,
+            -122811506
+          ],
+          "url": "http:\/\/devingaffney.com\/files\/audio.ogg",
+          "context": [
+            {
+              "team_id": pm1.team_id,
+              "project_media_id": pm1.id,
+              "has_custom_id": true,
+            }
+          ],
+          "score": 1.0,
+          "model": "audio"
+        },
+        {
+          "id": 2,
+          "doc_id": "f0d43d29-853d-4099-9e92-073203afa75c",
+          "chromaprint_fingerprint": [
+            377259661,
+            376226445,
+            305001149,
+            306181093,
+            1379918309,
+            1383899364,
+            1995219172,
+            1974379732,
+            1957603396,
+            1961789696,
+            1416464641,
+            1429048627,
+            1999429922,
+            1999380774,
+            2100043878,
+            2083467494,
+            -59895634,
+            -118617698,
+            -122811506
+          ],
+          "url": "http:\/\/devingaffney.com\/files\/audio.mp3",
+          "context": [
+            {
+              "team_id": pm1.team_id,
+              "project_media_id": pm1.id+1,
+              "has_custom_id": true,
+            }
+          ],
+          "score": 0.91,
+          "model": "audio"
+        }
+      ]
+    }
+    WebMock.stub_request(:get, Bot::Alegre.host+Bot::Alegre.sync_path).to_return(body: response.to_json)
+    assert_equal Bot::Alegre.get_confirmed_items(pm1, nil), {(pm1.id+1)=>{:score=>0.91, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>(pm1.id+1)}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.confirmed_type}}
+  end
+
+  test "should get_similar_items_v2" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    response = {
+      "result": [
+        {
+          "id": 1,
+          "doc_id": "f0d43d29-853d-4099-9e92-073203afa75b",
+          "chromaprint_fingerprint": [
+            377259661,
+            376226445,
+            305001149,
+            306181093,
+            1379918309,
+            1383899364,
+            1995219172,
+            1974379732,
+            1957603396,
+            1961789696,
+            1416464641,
+            1429048627,
+            1999429922,
+            1999380774,
+            2100043878,
+            2083467494,
+            -59895634,
+            -118617698,
+            -122811506
+          ],
+          "url": "http:\/\/devingaffney.com\/files\/audio.ogg",
+          "context": [
+            {
+              "team_id": pm1.team_id,
+              "project_media_id": pm1.id,
+              "has_custom_id": true,
+            }
+          ],
+          "score": 1.0,
+          "model": "audio"
+        },
+        {
+          "id": 2,
+          "doc_id": "f0d43d29-853d-4099-9e92-073203afa75c",
+          "chromaprint_fingerprint": [
+            377259661,
+            376226445,
+            305001149,
+            306181093,
+            1379918309,
+            1383899364,
+            1995219172,
+            1974379732,
+            1957603396,
+            1961789696,
+            1416464641,
+            1429048627,
+            1999429922,
+            1999380774,
+            2100043878,
+            2083467494,
+            -59895634,
+            -118617698,
+            -122811506
+          ],
+          "url": "http:\/\/devingaffney.com\/files\/audio.mp3",
+          "context": [
+            {
+              "team_id": pm1.team_id,
+              "project_media_id": pm1.id+1,
+              "has_custom_id": true,
+            }
+          ],
+          "score": 0.91,
+          "model": "audio"
+        }
+      ]
+    }
+    WebMock.stub_request(:get, Bot::Alegre.host+Bot::Alegre.sync_path).to_return(body: response.to_json)
+    assert_equal Bot::Alegre.get_similar_items_v2(pm1, nil), {}
+  end
+
+  test "should relate project media for audio" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    pm2 = create_project_media team: @team, media: create_uploaded_audio
+    Bot::Alegre.stubs(:get_similar_items_v2).returns({pm2.id=>{:score=>0.91, :context=>{"team_id"=>pm2.team_id, "has_custom_id"=>true, "project_media_id"=>pm2.id}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.suggested_type}})
+    relationship = nil
+    assert_difference 'Relationship.count' do
+      relationship = Bot::Alegre.relate_project_media(pm1)
+    end
+    assert_equal relationship.source, pm2
+    assert_equal relationship.target, pm1
+    assert_equal relationship.relationship_type, Relationship.suggested_type
+    Bot::Alegre.unstub(:get_similar_items_v2)
+  end
+end

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -115,7 +115,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       }
     }
-    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)})
+    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1)})
     WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/async/audio?#{params}").to_return(body: response.to_json)
     assert_equal JSON.parse(Bot::Alegre.get_async(pm1).to_json), JSON.parse(response.to_json)
   end
@@ -223,7 +223,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)})
+    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1)})
     WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio?#{params}").to_return(body: response.to_json)
     assert_equal JSON.parse(Bot::Alegre.get_sync(pm1).to_json), JSON.parse(response.to_json)
   end
@@ -324,7 +324,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
+    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
     WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio?#{params}").to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_items(pm1, nil), {(pm1.id+1)=>{:score=>1.0, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>(pm1.id+1)}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.suggested_type}}
   end
@@ -405,7 +405,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
+    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
     WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio?#{params}").to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_items(pm1, nil), {(pm1.id+1)=>{:score=>0.91, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>(pm1.id+1)}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.suggested_type}}
   end
@@ -486,7 +486,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
+    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
     WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio?#{params}").to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_confirmed_items(pm1, nil), {(pm1.id+1)=>{:score=>0.91, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>(pm1.id+1)}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.confirmed_type}}
   end
@@ -567,7 +567,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
+    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
     WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio?#{params}").to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_similar_items_v2(pm1, nil), {}
   end

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -18,6 +18,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     create_flag_annotation_type
     create_extracted_text_annotation_type
     Sidekiq::Testing.inline!
+    WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
   end
 
   def teardown
@@ -114,7 +115,8 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       }
     }
-    WebMock.stub_request(:get, Bot::Alegre.host+Bot::Alegre.async_path).to_return(body: response.to_json)
+    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)})
+    WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/async/audio?#{params}").to_return(body: response.to_json)
     assert_equal JSON.parse(Bot::Alegre.get_async(pm1).to_json), JSON.parse(response.to_json)
   end
 
@@ -221,7 +223,8 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    WebMock.stub_request(:get, Bot::Alegre.host+Bot::Alegre.sync_path).to_return(body: response.to_json)
+    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)})
+    WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio?#{params}").to_return(body: response.to_json)
     assert_equal JSON.parse(Bot::Alegre.get_sync(pm1).to_json), JSON.parse(response.to_json)
   end
 
@@ -321,7 +324,8 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    WebMock.stub_request(:get, Bot::Alegre.host+Bot::Alegre.sync_path).to_return(body: response.to_json)
+    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
+    WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio?#{params}").to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_items(pm1, nil), {(pm1.id+1)=>{:score=>1.0, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>(pm1.id+1)}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.suggested_type}}
   end
 
@@ -401,7 +405,8 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    WebMock.stub_request(:get, Bot::Alegre.host+Bot::Alegre.sync_path).to_return(body: response.to_json)
+    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
+    WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio?#{params}").to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_items(pm1, nil), {(pm1.id+1)=>{:score=>0.91, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>(pm1.id+1)}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.suggested_type}}
   end
 
@@ -481,7 +486,8 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    WebMock.stub_request(:get, Bot::Alegre.host+Bot::Alegre.sync_path).to_return(body: response.to_json)
+    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
+    WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio?#{params}").to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_confirmed_items(pm1, nil), {(pm1.id+1)=>{:score=>0.91, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>(pm1.id+1)}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.confirmed_type}}
   end
 
@@ -561,7 +567,8 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    WebMock.stub_request(:get, Bot::Alegre.host+Bot::Alegre.sync_path).to_return(body: response.to_json)
+    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
+    WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio?#{params}").to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_similar_items_v2(pm1, nil), {}
   end
 

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -115,8 +115,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       }
     }
-    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1)})
-    WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/async/audio?#{params}").to_return(body: response.to_json)
+    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/async/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1)}).to_return(body: response.to_json)
     assert_equal JSON.parse(Bot::Alegre.get_async(pm1).to_json), JSON.parse(response.to_json)
   end
 
@@ -223,8 +222,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1)})
-    WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio?#{params}").to_return(body: response.to_json)
+    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1)}).to_return(body: response.to_json)
     assert_equal JSON.parse(Bot::Alegre.get_sync(pm1).to_json), JSON.parse(response.to_json)
   end
 
@@ -324,8 +322,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
-    WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio?#{params}").to_return(body: response.to_json)
+    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9}).to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_items(pm1, nil), {(pm1.id+1)=>{:score=>1.0, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>(pm1.id+1)}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.suggested_type}}
   end
 
@@ -405,8 +402,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
-    WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio?#{params}").to_return(body: response.to_json)
+    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9}).to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_items(pm1, nil), {(pm1.id+1)=>{:score=>0.91, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>(pm1.id+1)}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.suggested_type}}
   end
 
@@ -486,8 +482,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
-    WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio?#{params}").to_return(body: response.to_json)
+    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9}).to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_confirmed_items(pm1, nil), {(pm1.id+1)=>{:score=>0.91, :context=>{"team_id"=>pm1.team_id, "has_custom_id"=>true, "project_media_id"=>(pm1.id+1)}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.confirmed_type}}
   end
 
@@ -567,8 +562,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     }
-    params = URI.encode_www_form({:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9})
-    WebMock.stub_request(:get, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio?#{params}").to_return(body: response.to_json)
+    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}.to_json, :url=>Bot::Alegre.media_file_url(pm1), :threshold=>0.9}).to_return(body: response.to_json)
     assert_equal Bot::Alegre.get_similar_items_v2(pm1, nil), {}
   end
 

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -753,9 +753,9 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
 
   test 'should process menu option using NLU' do
     # Mock any call to Alegre like `POST /text/similarity/` with a "text" parameter that contains "want"
-    Bot::Alegre.stubs(:request_api).with{ |x, y, z| x == 'post' && y == '/text/similarity/' && z[:text] =~ /want/ }.returns(true)
+    Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'post' && y == '/text/similarity/' && z[:text] =~ /want/ }.returns(true)
     # Mock any call to Alegre like `GET /text/similarity/` with a "text" parameter that does not contain "want"
-    Bot::Alegre.stubs(:request_api).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && (z[:text] =~ /want/).nil? }.returns({ 'result' => [] })
+    Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && (z[:text] =~ /want/).nil? }.returns({ 'result' => [] })
 
     # Enable NLU and add a couple of keywords for the newsletter menu option
     nlu = SmoochNlu.new(@team.slug)
@@ -768,7 +768,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     subscription_option_id = @installation.get_smooch_workflows[0]['smooch_state_main']['smooch_menu_options'][2]['smooch_menu_option_id']
 
     # Mock a call to Alegre like `GET /text/similarity/` with a "text" parameter that contains "want"
-    Bot::Alegre.stubs(:request_api).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && z[:text] =~ /want/ }.returns({ 'result' => [
+    Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && z[:text] =~ /want/ }.returns({ 'result' => [
       { '_score' => 0.9, '_source' => { 'context' => { 'menu_option_id' => subscription_option_id } } },
       { '_score' => 0.2, '_source' => { 'context' => { 'menu_option_id' => query_option_id } } }
     ]})
@@ -798,7 +798,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     assert_state 'main'
 
     # Delete two keywords, so expect two calls to Alegre
-    Bot::Alegre.expects(:request_api).with{ |x, y, _z| x == 'delete' && y == '/text/similarity/' }.twice
+    Bot::Alegre.expects(:request).with{ |x, y, _z| x == 'delete' && y == '/text/similarity/' }.twice
     nlu.remove_keyword_from_menu_option('en', 'main', 2, 'I want to subscribe to the newsletter')
     nlu.remove_keyword_from_menu_option('en', 'main', 2, 'I want to unsubscribe from the newsletter')
   end
@@ -821,9 +821,9 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     Sidekiq::Testing.fake! do
       WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
       # Mock any call to Alegre like `POST /text/similarity/` with a "text" parameter that contains "who are you"
-      Bot::Alegre.stubs(:request_api).with{ |x, y, z| x == 'post' && y == '/text/similarity/' && z[:text] =~ /who are you/ }.returns(true)
+      Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'post' && y == '/text/similarity/' && z[:text] =~ /who are you/ }.returns(true)
       # Mock any call to Alegre like `GET /text/similarity/` with a "text" parameter that does not contain "who are you"
-      Bot::Alegre.stubs(:request_api).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && (z[:text] =~ /who are you/).nil? }.returns({ 'result' => [] })
+      Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && (z[:text] =~ /who are you/).nil? }.returns({ 'result' => [] })
 
       # Enable NLU and add a couple of keywords to a new "About Us" resource
       nlu = SmoochNlu.new(@team.slug)
@@ -833,7 +833,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
       r.add_keyword('who are you')
 
       # Mock a call to Alegre like `GET /text/similarity/` with a "text" parameter that contains "who are you"
-      Bot::Alegre.stubs(:request_api).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && z[:text] =~ /who are you/ }.returns({ 'result' => [
+      Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && z[:text] =~ /who are you/ }.returns({ 'result' => [
         { '_score' => 0.9, '_source' => { 'context' => { 'resource_id' => 0 } } },
         { '_score' => 0.8, '_source' => { 'context' => { 'resource_id' => r.id } } }
       ]})
@@ -851,8 +851,9 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
       assert_no_saved_query
 
       # Delete one keyword, so expect one call to Alegre
-      Bot::Alegre.expects(:request_api).with{ |x, y, _z| x == 'delete' && y == '/text/similarity/' }.once
+      Bot::Alegre.expects(:request).with{ |x, y, _z| x == 'delete' && y == '/text/similarity/' }.once
       r.remove_keyword('who are you')
+      Bot::Alegre.unstub(:request)
     end
   end
 

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -138,7 +138,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
   end
 
   test "should submit query without details on tipline bot v2" do
-    WebMock.stub_request(:get, /\/text\/similarity\//).to_return(body: {}.to_json)
+    WebMock.stub_request(:post, /\/text\/similarity\/search\//).to_return(body: {}.to_json)
     claim = 'This is a test claim'
     send_message 'hello', '1', '1', random_string, random_string, claim, random_string, random_string, '1'
     assert_saved_query_type 'default_requests'
@@ -208,7 +208,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
   end
 
   test "should submit query with details on tipline bot v2" do
-    WebMock.stub_request(:get, /\/text\/similarity\//).to_return(body: {}.to_json)
+    WebMock.stub_request(:post, /\/text\/similarity\/search\//).to_return(body: {}.to_json)
     claim = 'This is a test claim'
     send_message 'hello', '1', '1', random_string, '2', random_string, claim, '1'
     assert_saved_query_type 'default_requests'
@@ -755,7 +755,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     # Mock any call to Alegre like `POST /text/similarity/` with a "text" parameter that contains "want"
     Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'post' && y == '/text/similarity/' && z[:text] =~ /want/ }.returns(true)
     # Mock any call to Alegre like `GET /text/similarity/` with a "text" parameter that does not contain "want"
-    Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && (z[:text] =~ /want/).nil? }.returns({ 'result' => [] })
+    Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'post' && y == '/text/similarity/search/' && (z[:text] =~ /want/).nil? }.returns({ 'result' => [] })
 
     # Enable NLU and add a couple of keywords for the newsletter menu option
     nlu = SmoochNlu.new(@team.slug)
@@ -768,7 +768,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     subscription_option_id = @installation.get_smooch_workflows[0]['smooch_state_main']['smooch_menu_options'][2]['smooch_menu_option_id']
 
     # Mock a call to Alegre like `GET /text/similarity/` with a "text" parameter that contains "want"
-    Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && z[:text] =~ /want/ }.returns({ 'result' => [
+    Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'post' && y == '/text/similarity/search/' && z[:text] =~ /want/ }.returns({ 'result' => [
       { '_score' => 0.9, '_source' => { 'context' => { 'menu_option_id' => subscription_option_id } } },
       { '_score' => 0.2, '_source' => { 'context' => { 'menu_option_id' => query_option_id } } }
     ]})
@@ -782,7 +782,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     assert_state 'main'
 
     # Mock a call to Alegre like `GET /text/similarity/` with a "text" parameter that contains "want"
-    Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && z[:text] =~ /want/ }.returns({ 'result' => [
+    Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'post' && y == '/text/similarity/search/' && z[:text] =~ /want/ }.returns({ 'result' => [
       { '_score' => 0.96, '_source' => { 'context' => { 'menu_option_id' => subscription_option_id } } },
       { '_score' => 0.91, '_source' => { 'context' => { 'menu_option_id' => query_option_id } } }
     ]})
@@ -823,7 +823,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
       # Mock any call to Alegre like `POST /text/similarity/` with a "text" parameter that contains "who are you"
       Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'post' && y == '/text/similarity/' && z[:text] =~ /who are you/ }.returns(true)
       # Mock any call to Alegre like `GET /text/similarity/` with a "text" parameter that does not contain "who are you"
-      Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && (z[:text] =~ /who are you/).nil? }.returns({ 'result' => [] })
+      Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'post' && y == '/text/similarity/search/' && (z[:text] =~ /who are you/).nil? }.returns({ 'result' => [] })
 
       # Enable NLU and add a couple of keywords to a new "About Us" resource
       nlu = SmoochNlu.new(@team.slug)
@@ -833,7 +833,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
       r.add_keyword('who are you')
 
       # Mock a call to Alegre like `GET /text/similarity/` with a "text" parameter that contains "who are you"
-      Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && z[:text] =~ /who are you/ }.returns({ 'result' => [
+      Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'post' && y == '/text/similarity/search' && z[:text] =~ /who are you/ }.returns({ 'result' => [
         { '_score' => 0.9, '_source' => { 'context' => { 'resource_id' => 0 } } },
         { '_score' => 0.8, '_source' => { 'context' => { 'resource_id' => r.id } } }
       ]})

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -833,7 +833,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
       r.add_keyword('who are you')
 
       # Mock a call to Alegre like `GET /text/similarity/` with a "text" parameter that contains "who are you"
-      Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'post' && y == '/text/similarity/search' && z[:text] =~ /who are you/ }.returns({ 'result' => [
+      Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'post' && y == '/text/similarity/search/' && z[:text] =~ /who are you/ }.returns({ 'result' => [
         { '_score' => 0.9, '_source' => { 'context' => { 'resource_id' => 0 } } },
         { '_score' => 0.8, '_source' => { 'context' => { 'resource_id' => r.id } } }
       ]})

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -782,7 +782,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     assert_state 'main'
 
     # Mock a call to Alegre like `GET /text/similarity/` with a "text" parameter that contains "want"
-    Bot::Alegre.stubs(:request_api).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && z[:text] =~ /want/ }.returns({ 'result' => [
+    Bot::Alegre.stubs(:request).with{ |x, y, z| x == 'get' && y == '/text/similarity/' && z[:text] =~ /want/ }.returns({ 'result' => [
       { '_score' => 0.96, '_source' => { 'context' => { 'menu_option_id' => subscription_option_id } } },
       { '_score' => 0.91, '_source' => { 'context' => { 'menu_option_id' => query_option_id } } }
     ]})

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -139,7 +139,7 @@ class RequestTest < ActiveSupport::TestCase
     m2 = Media.create! type: 'Claim', quote: 'Foo bar foo bar 2'
     r2 = create_request media: m2, feed: f
     response = { 'result' => [{ '_source' => { 'context' => { 'request_id' => r1.id } } }] }
-    Bot::Alegre.stubs(:request).with('get', '/text/similarity/', { text: 'Foo bar foo bar 2', models: [::Bot::Alegre::ELASTICSEARCH_MODEL, ::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::ELASTICSEARCH_MODEL => 0.85, ::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
+    Bot::Alegre.stubs(:request).with('post', '/text/similarity/search/', { text: 'Foo bar foo bar 2', models: [::Bot::Alegre::ELASTICSEARCH_MODEL, ::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::ELASTICSEARCH_MODEL => 0.85, ::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
     r2.attach_to_similar_request!
     #Alegre should be called with ES and vector model for request with 4 or more words
     assert_equal r1, r2.reload.similar_to_request
@@ -155,7 +155,7 @@ class RequestTest < ActiveSupport::TestCase
     m2 = Media.create! type: 'Claim', quote: 'Foo bar 2'
     r2 = create_request media: m2, feed: f
     response = { 'result' => [{ '_source' => { 'context' => { 'request_id' => r1.id } } }] }
-    Bot::Alegre.stubs(:request).with('get', '/text/similarity/', { text: 'Foo bar 2', models: [::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
+    Bot::Alegre.stubs(:request).with('post', '/text/similarity/search/', { text: 'Foo bar 2', models: [::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
     r2.attach_to_similar_request!
     #Alegre should only be called with vector models for 2 or 3 word request
     assert_equal r1, r2.reload.similar_to_request
@@ -185,7 +185,7 @@ class RequestTest < ActiveSupport::TestCase
     m2 = create_uploaded_image
     r2 = create_request request_type: 'image', media: m2, feed: f
     response = { 'result' => [{ 'context' => [{ 'request_id' => r1.id }] }] }
-    Bot::Alegre.stubs(:request).with('get', '/image/similarity/', { url: m2.file.file.public_url, threshold: 0.85, limit: 20, context: { feed_id: f.id } }).returns(response)
+    Bot::Alegre.stubs(:request).with('post', '/image/similarity/search/', { url: m2.file.file.public_url, threshold: 0.85, limit: 20, context: { feed_id: f.id } }).returns(response)
     r2.attach_to_similar_request!
     assert_equal r1, r2.reload.similar_to_request
     assert_equal [r2], r1.reload.similar_requests

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -116,55 +116,55 @@ class RequestTest < ActiveSupport::TestCase
   end
 
   test "should send text request to Alegre" do
-    Bot::Alegre.stubs(:request_api).returns(true)
+    Bot::Alegre.stubs(:request).returns(true)
     assert_nothing_raised do
       create_request(media: create_claim_media)
     end
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 
   test "should send media request to Alegre" do
-    Bot::Alegre.stubs(:request_api).returns(true)
+    Bot::Alegre.stubs(:request).returns(true)
     assert_nothing_raised do
       create_request(media: create_uploaded_image)
     end
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 
   test "should attach to similar text long" do
-    Bot::Alegre.stubs(:request_api).returns(true)
+    Bot::Alegre.stubs(:request).returns(true)
     f = create_feed
     m1 = Media.create! type: 'Claim', quote: 'Foo bar foo bar'
     r1 = create_request media: m1, feed: f
     m2 = Media.create! type: 'Claim', quote: 'Foo bar foo bar 2'
     r2 = create_request media: m2, feed: f
     response = { 'result' => [{ '_source' => { 'context' => { 'request_id' => r1.id } } }] }
-    Bot::Alegre.stubs(:request_api).with('get', '/text/similarity/', { text: 'Foo bar foo bar 2', models: [::Bot::Alegre::ELASTICSEARCH_MODEL, ::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::ELASTICSEARCH_MODEL => 0.85, ::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
+    Bot::Alegre.stubs(:request).with('get', '/text/similarity/', { text: 'Foo bar foo bar 2', models: [::Bot::Alegre::ELASTICSEARCH_MODEL, ::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::ELASTICSEARCH_MODEL => 0.85, ::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
     r2.attach_to_similar_request!
     #Alegre should be called with ES and vector model for request with 4 or more words
     assert_equal r1, r2.reload.similar_to_request
     assert_equal [r2], r1.reload.similar_requests
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
   
   test "should attach to similar text short" do
-    Bot::Alegre.stubs(:request_api).returns(true)
+    Bot::Alegre.stubs(:request).returns(true)
     f = create_feed
     m1 = Media.create! type: 'Claim', quote: 'Foo bar foo bar'
     r1 = create_request media: m1, feed: f
     m2 = Media.create! type: 'Claim', quote: 'Foo bar 2'
     r2 = create_request media: m2, feed: f
     response = { 'result' => [{ '_source' => { 'context' => { 'request_id' => r1.id } } }] }
-    Bot::Alegre.stubs(:request_api).with('get', '/text/similarity/', { text: 'Foo bar 2', models: [::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
+    Bot::Alegre.stubs(:request).with('get', '/text/similarity/', { text: 'Foo bar 2', models: [::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
     r2.attach_to_similar_request!
     #Alegre should only be called with vector models for 2 or 3 word request
     assert_equal r1, r2.reload.similar_to_request
     assert_equal [r2], r1.reload.similar_requests
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
   
   test "should not attach to similar text short" do
-    Bot::Alegre.stubs(:request_api).returns(true)
+    Bot::Alegre.stubs(:request).returns(true)
     f = create_feed
     m1 = Media.create! type: 'Claim', quote: 'Foo bar foo bar'
     r1 = create_request media: m1, feed: f
@@ -174,26 +174,26 @@ class RequestTest < ActiveSupport::TestCase
     # Alegre should not be called for a one word request
     assert_not_equal r1, r2.reload.similar_to_request
     assert_not_equal [r2], r1.reload.similar_requests
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 
   test "should attach to similar media" do
-    Bot::Alegre.stubs(:request_api).returns(true)
+    Bot::Alegre.stubs(:request).returns(true)
     f = create_feed
     m1 = create_uploaded_image
     r1 = create_request request_type: 'image', media: m1, feed: f
     m2 = create_uploaded_image
     r2 = create_request request_type: 'image', media: m2, feed: f
     response = { 'result' => [{ 'context' => [{ 'request_id' => r1.id }] }] }
-    Bot::Alegre.stubs(:request_api).with('get', '/image/similarity/', { url: m2.file.file.public_url, threshold: 0.85, limit: 20, context: { feed_id: f.id } }).returns(response)
+    Bot::Alegre.stubs(:request).with('get', '/image/similarity/', { url: m2.file.file.public_url, threshold: 0.85, limit: 20, context: { feed_id: f.id } }).returns(response)
     r2.attach_to_similar_request!
     assert_equal r1, r2.reload.similar_to_request
     assert_equal [r2], r1.reload.similar_requests
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 
   test "should attach to similar link" do
-    Bot::Alegre.stubs(:request_api).returns(true)
+    Bot::Alegre.stubs(:request).returns(true)
     f = create_feed
     m = create_valid_media
     create_request request_type: 'text', media: m
@@ -203,6 +203,7 @@ class RequestTest < ActiveSupport::TestCase
     r2.attach_to_similar_request!
     assert_equal r1, r2.reload.similar_to_request
     assert_equal [r2], r1.reload.similar_requests
+    Bot::Alegre.unstub(:request)
   end
 
   test "should set fields" do
@@ -213,7 +214,7 @@ class RequestTest < ActiveSupport::TestCase
   end
 
   test "should update fields" do
-    Bot::Alegre.stubs(:request_api).returns({})
+    Bot::Alegre.stubs(:request).returns({})
     m1 = create_uploaded_image
     m2 = create_uploaded_image
     r1 = create_request media: m1
@@ -226,11 +227,11 @@ class RequestTest < ActiveSupport::TestCase
     assert_equal r4.created_at.to_s, r1.reload.last_submitted_at.to_s
     assert_equal 2, r1.reload.medias_count
     assert_equal 4, r1.reload.requests_count
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 
   test "should return medias" do
-    Bot::Alegre.stubs(:request_api).returns({})
+    Bot::Alegre.stubs(:request).returns({})
     create_request
     create_uploaded_image
     m1 = create_uploaded_image
@@ -241,11 +242,11 @@ class RequestTest < ActiveSupport::TestCase
     r3 = create_request media: m2
     r3.similar_to_request = r1 ; r3.save!
     assert_equal [m1, m2].map(&:id).sort, r1.reload.medias.map(&:id).sort
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 
   test "should cache team names that fact-checked a request" do
-    Bot::Alegre.stubs(:request_api).returns({})
+    Bot::Alegre.stubs(:request).returns({})
     RequestStore.store[:skip_cached_field_update] = false
     u = create_user is_admin: true
     f = create_feed
@@ -279,7 +280,7 @@ class RequestTest < ActiveSupport::TestCase
     ProjectMediaRequest.create!(project_media: create_project_media(team: t4), request: r)
     assert_equal 'Bar, Foo, Test', r.reload.fact_checked_by
     assert_equal 3, r.reload.fact_checked_by_count
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
     User.unstub(:current)
   end
 
@@ -326,12 +327,12 @@ class RequestTest < ActiveSupport::TestCase
   end
 
   test "should cache media type" do
-    Bot::Alegre.stubs(:request_api).returns({})
+    Bot::Alegre.stubs(:request).returns({})
     RequestStore.store[:skip_cached_field_update] = false
     m = create_uploaded_image
     r = create_request media: m
     assert_equal 'UploadedImage', r.media_type(true)
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 
   test "should not have a circular dependency" do

--- a/test/workers/reindex_alegre_workspace_test.rb
+++ b/test/workers/reindex_alegre_workspace_test.rb
@@ -90,7 +90,7 @@ class ReindexAlegreWorkspaceTest < ActiveSupport::TestCase
     assert_equal Array, response.class
   end
   
-  test "tests the parallel request_api" do
+  test "tests the parallel request" do
     package = {
       :doc_id=>Bot::Alegre.item_doc_id(@pm, "title"),
       :text=>"Some text",

--- a/test/workers/reindex_alegre_workspace_test.rb
+++ b/test/workers/reindex_alegre_workspace_test.rb
@@ -25,14 +25,14 @@ class ReindexAlegreWorkspaceTest < ActiveSupport::TestCase
     @tbi.save
     Bot::Alegre.stubs(:get_alegre_tbi).returns(TeamBotInstallation.new)
     Sidekiq::Testing.inline!
-    Bot::Alegre.stubs(:request_api).with('post', '/text/bulk_similarity/', anything).returns("done")
+    Bot::Alegre.stubs(:request).with('post', '/text/bulk_similarity/', anything).returns("done")
   end
 
   def teardown
     super
     [@tbi, @pm, @m, @p, @team, @bot].collect(&:destroy)
     Bot::Alegre.unstub(:get_alegre_tbi)
-    Bot::Alegre.unstub(:request_api)
+    Bot::Alegre.unstub(:request)
   end
 
   test "should trigger reindex" do


### PR DESCRIPTION
## Description

This work introduces the beginning of a rewrite of the check-api/alegre integration. We do this by using the sync endpoint on alegre, which does an entire store/search loop using presto within a single query. We will continue that pattern through all other modalities, so this ticket is important in conceptually considering the structure of the new code, which, once all modalities are covered, will replace the existing monolith of code that is the check-api/alegre integration.

References: 3828

## How has this been tested?

I've added what I believe are complete, well documented, and representative unit tests for the entire new set of code. I think that its passing 100% right now, but will make sure if its not!

## Things to pay attention to during code review

This code will eventually replace the entire check-api/alegre integration. This should be scrutinized and we should have conversations about whether or not it will be extensible, whether or not it will be easier to work with, and what sorts of business logic it may disrupt. please pick it apart!

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

