### PR TITLE
3884 – Improve seeds: create feed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,8 +3,6 @@ require "faker"
 
 Rails.env.development? || raise('To run the seeds file you should be in the development environment')
 
-Rails.cache.clear
-
 data = {
   team_name: Faker::Company.name,
   user_name: Faker::Name.first_name.downcase,
@@ -316,3 +314,5 @@ ActiveRecord::Base.transaction do
     puts "Data added to user: #{user.email}"
   end
 end
+
+Rails.cache.clear

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -67,11 +67,11 @@ end
 
 def add_claim_descriptions_and_fact_checks(user, project_medias)
   claim_descriptions = project_medias.map { |project_media| ClaimDescription.create!(description: create_description(project_media), context: Faker::Lorem.sentence, user: user, project_media: project_media) }
-  claim_descriptions.values_at(0,3,6).each { |claim_description| FactCheck.create!(summary: Faker::Company.catch_phrase, title: Faker::Company.name, user: user, claim_description: claim_description, language: 'en') }
+  claim_descriptions.values_at(0,1,3,4,6,7).each { |claim_description| FactCheck.create!(summary: Faker::Company.catch_phrase, title: Faker::Company.name, user: user, claim_description: claim_description, language: 'en') }
 end
 
 def verify_fact_check_and_publish_report(project_medias)
-  project_medias.values_at(0,3,6).each do |pm|
+  project_medias.values_at(0,1,3,4,6,7).each do |pm|
     annotations = Dynamic.where(annotated_id: pm)
     status = ['verified', 'false'].sample
 
@@ -242,10 +242,10 @@ ActiveRecord::Base.transaction do
   end
 
   puts 'Making Medias...'
-  puts 'Making Medias and Project Medias: Claims...'
-  claims = data[:claims].map { |data| create_media(user, data, 'Claim')}
-  claim_project_medias = create_tipline_project_medias(user, project, team, claims)
-  add_claim_descriptions_and_fact_checks(user, claim_project_medias)
+  # puts 'Making Medias and Project Medias: Claims...'
+  # claims = data[:claims].map { |data| create_media(user, data, 'Claim')}
+  # claim_project_medias = create_tipline_project_medias(user, project, team, claims)
+  # add_claim_descriptions_and_fact_checks(user, claim_project_medias)
 
   puts 'Making Medias and Project Medias: Links...'
   begin
@@ -256,66 +256,66 @@ ActiveRecord::Base.transaction do
     puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
   end
 
-  puts 'Making Medias and Project Medias: Audios...'
-  audios = data[:audios].map { |data| create_media(user, data, 'UploadedAudio')}
-  audio_project_medias = create_tipline_project_medias(user, project, team, audios)
-  add_claim_descriptions_and_fact_checks(user, audio_project_medias)
+  # puts 'Making Medias and Project Medias: Audios...'
+  # audios = data[:audios].map { |data| create_media(user, data, 'UploadedAudio')}
+  # audio_project_medias = create_tipline_project_medias(user, project, team, audios)
+  # add_claim_descriptions_and_fact_checks(user, audio_project_medias)
 
-  puts 'Making Medias and Project Medias: Images...'
-  images = data[:images].map { |data| create_media(user, data, 'UploadedImage')}
-  image_project_medias = create_tipline_project_medias(user, project, team, images)
-  add_claim_descriptions_and_fact_checks(user, image_project_medias)
+  # puts 'Making Medias and Project Medias: Images...'
+  # images = data[:images].map { |data| create_media(user, data, 'UploadedImage')}
+  # image_project_medias = create_tipline_project_medias(user, project, team, images)
+  # add_claim_descriptions_and_fact_checks(user, image_project_medias)
 
-  puts 'Making Medias and Project Medias: Videos...'
-  videos = data[:videos].map { |data| create_media(user, data, 'UploadedVideo')}
-  video_project_medias = create_tipline_project_medias(user, project, team, videos)
-  add_claim_descriptions_and_fact_checks(user, video_project_medias)
+  # puts 'Making Medias and Project Medias: Videos...'
+  # videos = data[:videos].map { |data| create_media(user, data, 'UploadedVideo')}
+  # video_project_medias = create_tipline_project_medias(user, project, team, videos)
+  # add_claim_descriptions_and_fact_checks(user, video_project_medias)
 
-  puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
-  data[:fact_check_links].map { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
+  # puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
+  # data[:fact_check_links].map { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
 
   puts 'Making Relationship...'
-  puts 'Making Relationship: Claims / Confirmed Type and Suggested Type...'
-  create_relationship(claim_project_medias)
+  # puts 'Making Relationship: Claims / Confirmed Type and Suggested Type...'
+  # create_relationship(claim_project_medias)
   puts 'Making Relationship: Links / Suggested Type...'
   begin
     create_relationship(link_project_medias)
   rescue
     puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
   end
-  puts 'Making Relationship: Audios / Confirmed Type and Suggested Type...'
-  create_relationship(audio_project_medias)
-  puts 'Making Relationship: Images / Confirmed Type and Suggested Type...'
-  create_relationship(image_project_medias)
-  puts 'Making Relationship: Videos / Confirmed Type and Suggested Type...'
-  create_relationship(video_project_medias)
+  # puts 'Making Relationship: Audios / Confirmed Type and Suggested Type...'
+  # create_relationship(audio_project_medias)
+  # puts 'Making Relationship: Images / Confirmed Type and Suggested Type...'
+  # create_relationship(image_project_medias)
+  # puts 'Making Relationship: Videos / Confirmed Type and Suggested Type...'
+  # create_relationship(video_project_medias)
 
   puts 'Publishing Reports...'
-  verify_fact_check_and_publish_report(claim_project_medias)
+  # verify_fact_check_and_publish_report(claim_project_medias)
   begin
     verify_fact_check_and_publish_report(link_project_medias)
   rescue
     puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
   end
-  verify_fact_check_and_publish_report(audio_project_medias)
-  verify_fact_check_and_publish_report(image_project_medias)
-  verify_fact_check_and_publish_report(video_project_medias)
+  # verify_fact_check_and_publish_report(audio_project_medias)
+  # verify_fact_check_and_publish_report(image_project_medias)
+  # verify_fact_check_and_publish_report(video_project_medias)
 
   puts 'Making Tipline requests...'
-  puts 'Making Tipline requests: Claims...'
-  create_tipline_requests(team, claim_project_medias)
+  # puts 'Making Tipline requests: Claims...'
+  # create_tipline_requests(team, claim_project_medias)
   puts 'Making Tipline requests: Links...'
   begin
     create_tipline_requests(team, link_project_medias)
   rescue
     puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
   end
-  puts 'Making Tipline requests: Audios...'
-  create_tipline_requests(team, audio_project_medias)
-  puts 'Making Tipline requests: Images...'
-  create_tipline_requests(team, image_project_medias)
-  puts 'Making Tipline requests: Videos...'
-  create_tipline_requests(team, video_project_medias)
+  # puts 'Making Tipline requests: Audios...'
+  # create_tipline_requests(team, audio_project_medias)
+  # puts 'Making Tipline requests: Images...'
+  # create_tipline_requests(team, image_project_medias)
+  # puts 'Making Tipline requests: Videos...'
+  # create_tipline_requests(team, video_project_medias)
 
   puts 'Making Shared Feed'
   saved_search = SavedSearch.create!(title: "#{data[:user_name]}'s list", team: team, filters: {created_by: data[:user_name]})

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -240,13 +240,16 @@ ActiveRecord::Base.transaction do
   add_claim_descriptions_and_fact_checks(user, claim_project_medias)
 
   claim_project_medias.values_at(0,3,6).each do |pm|
-    a = Dynamic.where(annotation_type: 'verification_status').find_by(annotated_id: pm)
-    a.set_fields = { verification_status_status: 'verified' }.to_json
-    a.reload
-    a.save!
+    annotations = Dynamic.where(annotated_id: pm)
+    status = ['verified', 'false'].sample
 
-    r = Dynamic.where(annotation_type: 'report_design').find_by(annotated_id: pm)
-    r.set_fields = { status_label: 'verified' }.to_json
+    v = annotations.find_by(annotation_type: 'verification_status')
+    v.set_fields = { verification_status_status: status }.to_json
+    v.reload
+    v.save!
+
+    r = annotations.find_by(annotation_type: 'report_design')
+    r.set_fields = { status_label: status }.to_json
     r.set_fields = { state: 'published' }.to_json
     r.action = 'publish'
     r.save!

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -53,7 +53,7 @@ def create_media(user, data, model_string)
 end
 
 def create_project_medias(user, project, team, data)
-  data.map { |media| ProjectMedia.create!(user_id: user.id, project: project, team: team, media: media) }
+  data.map { |media| ProjectMedia.create!(user_id: user.id, project: project, team: team, media: media, channel: { main: CheckChannels::ChannelCodes::WHATSAPP }) }
 end
 
 def humanize_link(link)
@@ -113,8 +113,8 @@ def create_relationship(project_medias)
   project_medias[4..9].each { |pm| Relationship.create!(source_id: project_medias[2].id, target_id: pm.id, relationship_type: Relationship.suggested_type)}    
 end
 
-def create_tipline_project_media(user, project, team, media)
-  ProjectMedia.create!(user_id: user.id, project: project, team: team, media: media, channel: { main: CheckChannels::ChannelCodes::WHATSAPP })
+def create_tipline_project_media(user, project, team, data)
+  data.map { |media| ProjectMedia.create!(user_id: user.id, project: project, team: team, media: media, channel: { main: CheckChannels::ChannelCodes::WHATSAPP })}
 end
 
 def create_tipline_user_and_data(project_media, team)
@@ -247,83 +247,88 @@ ActiveRecord::Base.transaction do
   claim_project_medias = create_project_medias(user, project, team, claims)
   add_claim_descriptions_and_fact_checks(user, claim_project_medias)
 
-  puts 'Making Medias and Project Medias: Links...'
-  begin
-    links = data[:link_media_links].map { |data| create_media(user, data, 'Link')}
-    link_project_medias = create_project_medias(user, project, team, links)
-    add_claim_descriptions_and_fact_checks(user, link_project_medias)
-  rescue
-    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  end
+  # puts 'Making Medias and Project Medias: Links...'
+  # begin
+  #   links = data[:link_media_links].map { |data| create_media(user, data, 'Link')}
+  #   link_project_medias = create_project_medias(user, project, team, links)
+  #   add_claim_descriptions_and_fact_checks(user, link_project_medias)
+  # rescue
+  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  # end
 
-  puts 'Making Medias and Project Medias: Audios...'
-  audios = data[:audios].map { |data| create_media(user, data, 'UploadedAudio')}
-  audio_project_medias = create_project_medias(user, project, team, audios)
-  add_claim_descriptions_and_fact_checks(user, audio_project_medias)
+  # puts 'Making Medias and Project Medias: Audios...'
+  # audios = data[:audios].map { |data| create_media(user, data, 'UploadedAudio')}
+  # audio_project_medias = create_project_medias(user, project, team, audios)
+  # add_claim_descriptions_and_fact_checks(user, audio_project_medias)
 
-  puts 'Making Medias and Project Medias: Images...'
-  images = data[:images].map { |data| create_media(user, data, 'UploadedImage')}
-  image_project_medias = create_project_medias(user, project, team, images)
-  add_claim_descriptions_and_fact_checks(user, image_project_medias)
+  # puts 'Making Medias and Project Medias: Images...'
+  # images = data[:images].map { |data| create_media(user, data, 'UploadedImage')}
+  # image_project_medias = create_project_medias(user, project, team, images)
+  # add_claim_descriptions_and_fact_checks(user, image_project_medias)
 
-  puts 'Making Medias and Project Medias: Videos...'
-  videos = data[:videos].map { |data| create_media(user, data, 'UploadedVideo')}
-  video_project_medias = create_project_medias(user, project, team, videos)
-  add_claim_descriptions_and_fact_checks(user, video_project_medias)
+  # puts 'Making Medias and Project Medias: Videos...'
+  # videos = data[:videos].map { |data| create_media(user, data, 'UploadedVideo')}
+  # video_project_medias = create_project_medias(user, project, team, videos)
+  # add_claim_descriptions_and_fact_checks(user, video_project_medias)
 
-  puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
-  data[:fact_check_links].map { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
+  # puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
+  # data[:fact_check_links].map { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
 
-  puts 'Making Relationship...'
-  puts 'Making Relationship: Claims / Confirmed Type and Suggested Type...'
-  create_relationship(claim_project_medias)
+  # puts 'Making Relationship...'
+  # puts 'Making Relationship: Claims / Confirmed Type and Suggested Type...'
+  # create_relationship(claim_project_medias)
 
-  puts 'Making Relationship: Links / Suggested Type...'
-  begin
-    create_relationship(link_project_medias)
-  rescue
-    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  end
+  # puts 'Making Relationship: Links / Suggested Type...'
+  # begin
+  #   create_relationship(link_project_medias)
+  # rescue
+  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  # end
 
-  puts 'Making Relationship: Audios / Confirmed Type and Suggested Type...'
-  create_relationship(audio_project_medias)
+  # puts 'Making Relationship: Audios / Confirmed Type and Suggested Type...'
+  # create_relationship(audio_project_medias)
 
-  puts 'Making Relationship: Images / Confirmed Type and Suggested Type...'
-  create_relationship(image_project_medias)
+  # puts 'Making Relationship: Images / Confirmed Type and Suggested Type...'
+  # create_relationship(image_project_medias)
 
-  puts 'Making Relationship: Videos / Confirmed Type and Suggested Type...'
-  create_relationship(video_project_medias)
+  # puts 'Making Relationship: Videos / Confirmed Type and Suggested Type...'
+  # create_relationship(video_project_medias)
 
   puts 'Publishing Reports...'
   verify_fact_check_and_publish_report(claim_project_medias)
-  begin
-    verify_fact_check_and_publish_report(link_project_medias)
-  rescue
-    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  end
-  verify_fact_check_and_publish_report(audio_project_medias)
-  verify_fact_check_and_publish_report(image_project_medias)
-  verify_fact_check_and_publish_report(video_project_medias)
+  # begin
+  #   verify_fact_check_and_publish_report(link_project_medias)
+  # rescue
+  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  # end
+  # verify_fact_check_and_publish_report(audio_project_medias)
+  # verify_fact_check_and_publish_report(image_project_medias)
+  # verify_fact_check_and_publish_report(video_project_medias)
 
   puts 'Making Tipline requests...'
   puts 'Making Tipline requests: Claims...'
+  # tipline_claims = data[:claims].map { |data| create_media(user, data, 'Claim')}
+  # tipline_claim_project_medias = create_tipline_project_media(user, project, team, tipline_claims)
+  # add_claim_descriptions_and_fact_checks(user, tipline_claim_project_medias)
+  # create_relationship(tipline_claim_project_medias)
+  # verify_fact_check_and_publish_report(tipline_claim_project_medias)
   create_tipline_requests(team, claim_project_medias)
 
-  puts 'Making Tipline requests: Links...'
-  begin
-    create_tipline_requests(team, link_project_medias)
-  rescue
-    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  end
+  # puts 'Making Tipline requests: Links...'
+  # begin
+  #   create_tipline_requests(team, link_project_medias)
+  # rescue
+  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  # end
 
-  puts 'Making Tipline requests: Audios...'
-  create_tipline_requests(team, audio_project_medias)
+  # puts 'Making Tipline requests: Audios...'
+  # create_tipline_requests(team, audio_project_medias)
 
-  puts 'Making Tipline requests: Images...'
-  create_tipline_requests(team, image_project_medias)
+  # puts 'Making Tipline requests: Images...'
+  # create_tipline_requests(team, image_project_medias)
 
-  puts 'Making Tipline requests: Videos...'
-  create_tipline_requests(team, video_project_medias)
+  # puts 'Making Tipline requests: Videos...'
+  # create_tipline_requests(team, video_project_medias)
 
   puts 'Making Shared Feed'
   saved_search = SavedSearch.create!(title: "#{data[:user_name]}'s list", team: team, filters: {created_by: data[:user_name]})

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -197,20 +197,10 @@ def create_tipline_user_and_data(project_media, team)
   Dynamic.create!(annotation_type: 'smooch', annotated: project_media, annotator: BotUser.smooch_user, set_fields: fields.to_json)
 end
 
-def create_tipline_requests(team, project, user, data_instances, model_string)
-  tipline_pm_arr = []
-  
-  data_instances.each do |data_instance|
-    media = create_media(user, data_instance, model_string)
-    project_media = create_tipline_project_media(user, project, team, media)
-    tipline_pm_arr.push(project_media)
-  end
-  add_claim_descriptions_and_fact_checks(user, tipline_pm_arr)
-  create_relationship(tipline_pm_arr)
-
-  tipline_pm_arr.values_at(0,3,6).each {|pm| create_tipline_user_and_data(pm, team)}
-  tipline_pm_arr.values_at(1,4,7).each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
-  tipline_pm_arr.values_at(2,5,8).each {|pm| 20.times {create_tipline_user_and_data(pm, team)}}
+def create_tipline_requests(team, project_medias)
+  project_medias.values_at(0,3,6).each {|pm| create_tipline_user_and_data(pm, team)}
+  project_medias.values_at(1,4,7).each {|pm| 15.times {create_tipline_user_and_data(pm, team)}}
+  project_medias.values_at(2,5,8).each {|pm| 20.times {create_tipline_user_and_data(pm, team)}}
 end
 
 puts "If you want to create a new user: press 1 then enter"
@@ -313,23 +303,23 @@ ActiveRecord::Base.transaction do
 
   puts 'Making Tipline requests...'
   puts 'Making Tipline requests: Claims...'
-  create_tipline_requests(team, project, user, data[:claims], 'Claim')
+  create_tipline_requests(team, claim_project_medias)
 
   puts 'Making Tipline requests: Links...'
   begin
-    create_tipline_requests(team, project, user, data[:link_media_links], 'Link')
+    create_tipline_requests(team, link_project_medias)
   rescue
     puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
   end
 
   puts 'Making Tipline requests: Audios...'
-  create_tipline_requests(team, project, user, data[:audios], 'UploadedAudio')
+  create_tipline_requests(team, audio_project_medias)
 
   puts 'Making Tipline requests: Images...'
-  create_tipline_requests(team, project, user, data[:images], 'UploadedImage')
+  create_tipline_requests(team, image_project_medias)
 
   puts 'Making Tipline requests: Videos...'
-  create_tipline_requests(team, project, user, data[:videos], 'UploadedVideo')
+  create_tipline_requests(team, video_project_medias)
 
   puts 'Making Shared Feed'
   saved_search = SavedSearch.create!(title: "#{data[:user_name]}'s list", team: team, filters: {created_by: data[:user_name]})

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -253,8 +253,7 @@ ActiveRecord::Base.transaction do
 
   # 2. Creating Items in different states
   # 2.1 Create medias: claims, audios, images and videos
-  # media_data_collection = [ data['Claim'], data['UploadedAudio'], data['UploadedImage'], data['UploadedVideo']]
-  media_data_collection = [ data['Claim'] ]
+  media_data_collection = [ data['Claim'], data['UploadedAudio'], data['UploadedImage'], data['UploadedVideo']]
   media_data_collection.each do |media_data|
     puts "Making #{data.key(media_data)}..."
     puts "#{data.key(media_data)}: Making Medias and Project Medias..."
@@ -289,45 +288,47 @@ ActiveRecord::Base.transaction do
     project_medias[9..10].each { |pm| verify_fact_check_and_publish_report(pm, '')}
   end
 
-  # # 2.2 Create medias: links
-  # puts 'Making Medias and Project Medias: Links...'
-  # begin
-  #   puts "Making Link..."
-  #   puts "Link: Making Medias and Project Medias..."
-  #   medias = data[:link_media_links].map { |individual_data| create_media(user, individual_data, 'Link')}
-  #   project_medias = create_project_medias_with_channel(user, project, team, medias)
+  # 2.2 Create medias: links
+  puts 'Making Medias and Project Medias: Links...'
+  begin
+    puts "Making Link..."
+    puts "Link: Making Medias and Project Medias..."
+    medias = data[:link_media_links].map { |individual_data| create_media(user, individual_data, 'Link')}
+    project_medias = create_project_medias_with_channel(user, project, team, medias)
     
-  #   puts "Link: Making Claim Descriptions and Fact Checks..."
-  #   # add claim description to all items, don't add fact checks to all
-  #   claim_descriptions = create_claim_descriptions(user, project_medias)
-  #   claim_descriptions_for_fact_checks = claim_descriptions[0..10]
-  #   create_fact_checks(user, claim_descriptions_for_fact_checks)
+    puts "Link: Making Claim Descriptions and Fact Checks..."
+    # add claim description to all items, don't add fact checks to all
+    claim_descriptions = create_claim_descriptions(user, project_medias)
+    claim_descriptions_for_fact_checks = claim_descriptions[0..10]
+    create_fact_checks(user, claim_descriptions_for_fact_checks)
     
-  #   puts "Link: Making Relationship: Confirmed Type and Suggested Type..."
-  #   # because we want a lot of state variety between items, we are not creating relationships for 7..13
-  #   # send parent and child index
-  #   create_confirmed_relationship(project_medias[0], project_medias[1])
-  #   create_confirmed_relationship(project_medias[2], project_medias[3])
-  #   create_confirmed_relationship(project_medias[4], project_medias[5])
-  #   create_confirmed_relationship(project_medias[6], project_medias[1])
-  #   # send parent and children
-  #   create_suggested_relationship(project_medias[6], project_medias[14..19])
+    puts "Link: Making Relationship: Confirmed Type and Suggested Type..."
+    # because we want a lot of state variety between items, we are not creating relationships for 7..13
+    # send parent and child index
+    create_confirmed_relationship(project_medias[0], project_medias[1])
+    create_confirmed_relationship(project_medias[2], project_medias[3])
+    create_confirmed_relationship(project_medias[4], project_medias[5])
+    create_confirmed_relationship(project_medias[6], project_medias[1])
+    # send parent and children
+    create_suggested_relationship(project_medias[6], project_medias[14..19])
     
-  #   puts "Link: Making Tipline requests..."
-  #   # we want different ammounts of requests, so we send the item and the number of requests that should be created
-  #   create_tipline_requests(team, project_medias.values_at(0,3,6,9,12,15,18), 1)
-  #   create_tipline_requests(team, project_medias.values_at(1,4,7,10,13,16,19), 15)
-  #   create_tipline_requests(team, project_medias.values_at(2,5,8,11,14,17), 17)
+    puts "Link: Making Tipline requests..."
+    # we want different ammounts of requests, so we send the item and the number of requests that should be created
+    create_tipline_requests(team, project_medias.values_at(0,3,6,9,12,15,18), 1)
+    create_tipline_requests(team, project_medias.values_at(1,4,7,10,13,16,19), 15)
+    create_tipline_requests(team, project_medias.values_at(2,5,8,11,14,17), 17)
     
-  #   puts "Link: Publishing Reports..."
-  #   verify_fact_check_and_publish_report(project_medias[7..10])
-  # rescue
-  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  # end
+    puts "Link: Publishing Reports..."
+    # we want some published items to have/not have published_article_url, because they behave differently in the feed
+    project_medias[7..8].each { |pm| verify_fact_check_and_publish_report(pm, "https://www.thespruceeats.com/step-by-step-basic-cake-recipe-304553?timestamp=#{Time.now.to_f}")}
+    project_medias[9..10].each { |pm| verify_fact_check_and_publish_report(pm, '')}
+  rescue
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  end
   
-  # # 2.3 Create medias: imported Fact Checks
-  # puts 'Making Imported Fact Checks...'
-  # data[:fact_check_links].map { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
+  # 2.3 Create medias: imported Fact Checks
+  puts 'Making Imported Fact Checks...'
+  data[:fact_check_links].map { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
 
   # 3. Create Shared feed
   puts 'Making Shared Feed'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -67,7 +67,7 @@ end
 
 def add_claim_descriptions_and_fact_checks(user, project_medias)
   claim_descriptions = project_medias.map { |project_media| ClaimDescription.create!(description: create_description(project_media), context: Faker::Lorem.sentence, user: user, project_media: project_media) }
-  claim_descriptions.values_at(0,3,8).each { |claim_description| FactCheck.create!(summary: Faker::Company.catch_phrase, title: Faker::Company.name, user: user, claim_description: claim_description, language: 'en') }
+  claim_descriptions.values_at(0,3,6).each { |claim_description| FactCheck.create!(summary: Faker::Company.catch_phrase, title: Faker::Company.name, user: user, claim_description: claim_description, language: 'en') }
 end
 
 def fact_check_attributes(fact_check_link, user, project, team)
@@ -238,6 +238,13 @@ ActiveRecord::Base.transaction do
   claims = data[:claims].map { |data| create_media(user, data, 'Claim')}
   claim_project_medias = create_project_medias(user, project, team, claims)
   add_claim_descriptions_and_fact_checks(user, claim_project_medias)
+  claim_project_medias.values_at(0,3,6).each do |pm|
+    r = Dynamic.where(annotation_type: 'report_design').find_by(annotated_id: pm)
+    r.set_fields = { status_label: 'verified' }.to_json
+    r.set_fields = { state: 'published' }.to_json
+    r.action = 'publish'
+    r.save!
+  end
 
   puts 'Making Medias and Project Medias: Links...'
   begin

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,7 +32,10 @@ data = {
     'https://meedan.com/post/what-is-gendered-health-misinformation-and-why-is-it-an-equity-problem-worth',
     'https://meedan.com/post/the-case-for-a-public-health-approach-to-moderate-health-misinformation',
   ],
-  claims: Array.new(9) { Faker::Lorem.paragraph(sentence_count: 10) }
+  claims: Array.new(9) { Faker::Lorem.paragraph(sentence_count: 10) },
+  invited_team_name: Faker::Company.name,
+  invited_user_name: Faker::Name.first_name.downcase,
+  invited_user_password: Faker::Internet.password(min_length: 8)
 }
 
 def open_file(file)
@@ -273,7 +276,7 @@ ActiveRecord::Base.transaction do
   begin
     create_relationship(link_project_medias)
   rescue
-    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."    
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
   end
 
   puts 'Making Relationship: Audios / Confirmed Type and Suggested Type...'
@@ -306,14 +309,22 @@ ActiveRecord::Base.transaction do
   create_tipline_requests(team, project, user, data[:videos], 'UploadedVideo')
 
   puts 'Making Shared Feed'
-  Feed.create!(name: "#{data[:team_name]} / Feed Test", user: user, team: team)
+  Feed.create!(name: "#{Faker::Fantasy::Tolkien.location} / Feed Test", user: user, team: team)
 
-  puts 'Making Feed invitee'
-  team = create_team(name: "Feed Invitee")
+  puts 'Making Feed invitee...'
+  puts 'Making invited Team...'
+  invited_team = create_team(name: "#{data[:invited_team_name]} / Invited Team")
+
+  puts 'Making invited User...'
+  invited_user = create_user(name: data[:invited_user_name], login: data[:invited_user_name], password: data[:invited_user_password], password_confirmation: data[:invited_user_password], email: Faker::Internet.safe_email(name: data[:invited_user_name]), is_admin: true)
+
+  puts 'Making invited Team User...'
+  create_team_user(team: invited_team, user: invited_user, role: 'admin')
 
   if answer == "1"
-    puts "Created — user: #{data[:user_name]} — email: #{user.email} — password : #{data[:user_password]}"
+    puts "Created user: name: #{data[:invited_user_name]} — email: #{user.email} — password : #{data[:invited_user_password]}"
   elsif answer == "2"
     puts "Data added to user: #{user.email}"
   end
+  puts "Created invited user: name: #{data[:invited_user_name]} — email: #{invited_user.email} — password : #{data[:invited_user_password]}"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -241,75 +241,76 @@ ActiveRecord::Base.transaction do
   claim_project_medias = create_project_medias(user, project, team, claims)
   add_claim_descriptions_and_fact_checks(user, claim_project_medias)
 
-  puts 'Making Medias and Project Medias: Links...'
-  begin
-    links = data[:link_media_links].map { |data| create_media(user, data, 'Link')}
-    link_project_medias = create_project_medias(user, project, team, links)
-    add_claim_descriptions_and_fact_checks(user, link_project_medias)
-  rescue
-    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  end
+  # puts 'Making Medias and Project Medias: Links...'
+  # begin
+  #   links = data[:link_media_links].map { |data| create_media(user, data, 'Link')}
+  #   link_project_medias = create_project_medias(user, project, team, links)
+  #   add_claim_descriptions_and_fact_checks(user, link_project_medias)
+  # rescue
+  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  # end
 
-  puts 'Making Medias and Project Medias: Audios...'
-  audios = data[:audios].map { |data| create_media(user, data, 'UploadedAudio')}
-  audio_project_medias = create_project_medias(user, project, team, audios)
-  add_claim_descriptions_and_fact_checks(user, audio_project_medias)
+  # puts 'Making Medias and Project Medias: Audios...'
+  # audios = data[:audios].map { |data| create_media(user, data, 'UploadedAudio')}
+  # audio_project_medias = create_project_medias(user, project, team, audios)
+  # add_claim_descriptions_and_fact_checks(user, audio_project_medias)
 
-  puts 'Making Medias and Project Medias: Images...'
-  images = data[:images].map { |data| create_media(user, data, 'UploadedImage')}
-  image_project_medias = create_project_medias(user, project, team, images)
-  add_claim_descriptions_and_fact_checks(user, image_project_medias)
+  # puts 'Making Medias and Project Medias: Images...'
+  # images = data[:images].map { |data| create_media(user, data, 'UploadedImage')}
+  # image_project_medias = create_project_medias(user, project, team, images)
+  # add_claim_descriptions_and_fact_checks(user, image_project_medias)
 
-  puts 'Making Medias and Project Medias: Videos...'
-  videos = data[:videos].map { |data| create_media(user, data, 'UploadedVideo')}
-  video_project_medias = create_project_medias(user, project, team, videos)
-  add_claim_descriptions_and_fact_checks(user, video_project_medias)
+  # puts 'Making Medias and Project Medias: Videos...'
+  # videos = data[:videos].map { |data| create_media(user, data, 'UploadedVideo')}
+  # video_project_medias = create_project_medias(user, project, team, videos)
+  # add_claim_descriptions_and_fact_checks(user, video_project_medias)
 
-  puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
-  data[:fact_check_links].map { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
+  # puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
+  # data[:fact_check_links].map { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
 
-  puts 'Making Relationship...'
-  puts 'Making Relationship: Claims / Confirmed Type and Suggested Type...'
-  create_relationship(claim_project_medias)
+  # puts 'Making Relationship...'
+  # puts 'Making Relationship: Claims / Confirmed Type and Suggested Type...'
+  # create_relationship(claim_project_medias)
 
-  puts 'Making Relationship: Links / Suggested Type...'
-  begin
-    create_relationship(link_project_medias)
-  rescue
-    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  end
+  # puts 'Making Relationship: Links / Suggested Type...'
+  # begin
+  #   create_relationship(link_project_medias)
+  # rescue
+  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  # end
 
-  puts 'Making Relationship: Audios / Confirmed Type and Suggested Type...'
-  create_relationship(audio_project_medias)
+  # puts 'Making Relationship: Audios / Confirmed Type and Suggested Type...'
+  # create_relationship(audio_project_medias)
 
-  puts 'Making Relationship: Images / Confirmed Type and Suggested Type...'
-  create_relationship(image_project_medias)
+  # puts 'Making Relationship: Images / Confirmed Type and Suggested Type...'
+  # create_relationship(image_project_medias)
 
-  puts 'Making Relationship: Videos / Confirmed Type and Suggested Type...'
-  create_relationship(video_project_medias)
+  # puts 'Making Relationship: Videos / Confirmed Type and Suggested Type...'
+  # create_relationship(video_project_medias)
 
-  puts 'Making Tipline requests...'
-  puts 'Making Tipline requests: Claims...'
-  create_tipline_requests(team, project, user, data[:claims], 'Claim')
+  # puts 'Making Tipline requests...'
+  # puts 'Making Tipline requests: Claims...'
+  # create_tipline_requests(team, project, user, data[:claims], 'Claim')
 
-  puts 'Making Tipline requests: Links...'
-  begin
-    create_tipline_requests(team, project, user, data[:link_media_links], 'Link')
-  rescue
-    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  end
+  # puts 'Making Tipline requests: Links...'
+  # begin
+  #   create_tipline_requests(team, project, user, data[:link_media_links], 'Link')
+  # rescue
+  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  # end
 
-  puts 'Making Tipline requests: Audios...'
-  create_tipline_requests(team, project, user, data[:audios], 'UploadedAudio')
+  # puts 'Making Tipline requests: Audios...'
+  # create_tipline_requests(team, project, user, data[:audios], 'UploadedAudio')
 
-  puts 'Making Tipline requests: Images...'
-  create_tipline_requests(team, project, user, data[:images], 'UploadedImage')
+  # puts 'Making Tipline requests: Images...'
+  # create_tipline_requests(team, project, user, data[:images], 'UploadedImage')
 
-  puts 'Making Tipline requests: Videos...'
-  create_tipline_requests(team, project, user, data[:videos], 'UploadedVideo')
+  # puts 'Making Tipline requests: Videos...'
+  # create_tipline_requests(team, project, user, data[:videos], 'UploadedVideo')
 
   puts 'Making Shared Feed'
-  Feed.create!(name: "#{Faker::Fantasy::Tolkien.location} / Feed Test", user: user, team: team)
+  saved_search = SavedSearch.create!(title: 'Unpublished Items', team: team, filters: {report_status: ['published']})
+  shared_feed = Feed.create!(name: "#{Faker::Fantasy::Tolkien.location} / Feed Test", user: user, team: team, published: true, saved_search: saved_search)
 
   puts 'Making Feed invitee...'
   puts 'Making invited Team...'
@@ -320,6 +321,10 @@ ActiveRecord::Base.transaction do
 
   puts 'Making invited Team User...'
   create_team_user(team: invited_team, user: invited_user, role: 'admin')
+
+  puts 'Inviting to feed...'
+  invitation = FeedInvitation.create!(email: invited_user.email, feed: shared_feed, user: invited_user)
+  invitation.accept(invited_team)
 
   if answer == "1"
     puts "Created user: name: #{data[:invited_user_name]} — email: #{user.email} — password : #{data[:invited_user_password]}"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,9 +33,6 @@ data = {
     'https://meedan.com/post/the-case-for-a-public-health-approach-to-moderate-health-misinformation',
   ],
   claims: Array.new(9) { Faker::Lorem.paragraph(sentence_count: 10) },
-  invited_team_name: Faker::Company.name,
-  invited_user_name: Faker::Name.first_name.downcase,
-  invited_user_password: Faker::Internet.password(min_length: 8)
 }
 
 def open_file(file)
@@ -241,95 +238,80 @@ ActiveRecord::Base.transaction do
   claim_project_medias = create_project_medias(user, project, team, claims)
   add_claim_descriptions_and_fact_checks(user, claim_project_medias)
 
-  # puts 'Making Medias and Project Medias: Links...'
-  # begin
-  #   links = data[:link_media_links].map { |data| create_media(user, data, 'Link')}
-  #   link_project_medias = create_project_medias(user, project, team, links)
-  #   add_claim_descriptions_and_fact_checks(user, link_project_medias)
-  # rescue
-  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  # end
+  puts 'Making Medias and Project Medias: Links...'
+  begin
+    links = data[:link_media_links].map { |data| create_media(user, data, 'Link')}
+    link_project_medias = create_project_medias(user, project, team, links)
+    add_claim_descriptions_and_fact_checks(user, link_project_medias)
+  rescue
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  end
 
-  # puts 'Making Medias and Project Medias: Audios...'
-  # audios = data[:audios].map { |data| create_media(user, data, 'UploadedAudio')}
-  # audio_project_medias = create_project_medias(user, project, team, audios)
-  # add_claim_descriptions_and_fact_checks(user, audio_project_medias)
+  puts 'Making Medias and Project Medias: Audios...'
+  audios = data[:audios].map { |data| create_media(user, data, 'UploadedAudio')}
+  audio_project_medias = create_project_medias(user, project, team, audios)
+  add_claim_descriptions_and_fact_checks(user, audio_project_medias)
 
-  # puts 'Making Medias and Project Medias: Images...'
-  # images = data[:images].map { |data| create_media(user, data, 'UploadedImage')}
-  # image_project_medias = create_project_medias(user, project, team, images)
-  # add_claim_descriptions_and_fact_checks(user, image_project_medias)
+  puts 'Making Medias and Project Medias: Images...'
+  images = data[:images].map { |data| create_media(user, data, 'UploadedImage')}
+  image_project_medias = create_project_medias(user, project, team, images)
+  add_claim_descriptions_and_fact_checks(user, image_project_medias)
 
-  # puts 'Making Medias and Project Medias: Videos...'
-  # videos = data[:videos].map { |data| create_media(user, data, 'UploadedVideo')}
-  # video_project_medias = create_project_medias(user, project, team, videos)
-  # add_claim_descriptions_and_fact_checks(user, video_project_medias)
+  puts 'Making Medias and Project Medias: Videos...'
+  videos = data[:videos].map { |data| create_media(user, data, 'UploadedVideo')}
+  video_project_medias = create_project_medias(user, project, team, videos)
+  add_claim_descriptions_and_fact_checks(user, video_project_medias)
 
-  # puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
-  # data[:fact_check_links].map { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
+  puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
+  data[:fact_check_links].map { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
 
-  # puts 'Making Relationship...'
-  # puts 'Making Relationship: Claims / Confirmed Type and Suggested Type...'
-  # create_relationship(claim_project_medias)
+  puts 'Making Relationship...'
+  puts 'Making Relationship: Claims / Confirmed Type and Suggested Type...'
+  create_relationship(claim_project_medias)
 
-  # puts 'Making Relationship: Links / Suggested Type...'
-  # begin
-  #   create_relationship(link_project_medias)
-  # rescue
-  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  # end
+  puts 'Making Relationship: Links / Suggested Type...'
+  begin
+    create_relationship(link_project_medias)
+  rescue
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  end
 
-  # puts 'Making Relationship: Audios / Confirmed Type and Suggested Type...'
-  # create_relationship(audio_project_medias)
+  puts 'Making Relationship: Audios / Confirmed Type and Suggested Type...'
+  create_relationship(audio_project_medias)
 
-  # puts 'Making Relationship: Images / Confirmed Type and Suggested Type...'
-  # create_relationship(image_project_medias)
+  puts 'Making Relationship: Images / Confirmed Type and Suggested Type...'
+  create_relationship(image_project_medias)
 
-  # puts 'Making Relationship: Videos / Confirmed Type and Suggested Type...'
-  # create_relationship(video_project_medias)
+  puts 'Making Relationship: Videos / Confirmed Type and Suggested Type...'
+  create_relationship(video_project_medias)
 
-  # puts 'Making Tipline requests...'
-  # puts 'Making Tipline requests: Claims...'
-  # create_tipline_requests(team, project, user, data[:claims], 'Claim')
+  puts 'Making Tipline requests...'
+  puts 'Making Tipline requests: Claims...'
+  create_tipline_requests(team, project, user, data[:claims], 'Claim')
 
-  # puts 'Making Tipline requests: Links...'
-  # begin
-  #   create_tipline_requests(team, project, user, data[:link_media_links], 'Link')
-  # rescue
-  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  # end
+  puts 'Making Tipline requests: Links...'
+  begin
+    create_tipline_requests(team, project, user, data[:link_media_links], 'Link')
+  rescue
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  end
 
-  # puts 'Making Tipline requests: Audios...'
-  # create_tipline_requests(team, project, user, data[:audios], 'UploadedAudio')
+  puts 'Making Tipline requests: Audios...'
+  create_tipline_requests(team, project, user, data[:audios], 'UploadedAudio')
 
-  # puts 'Making Tipline requests: Images...'
-  # create_tipline_requests(team, project, user, data[:images], 'UploadedImage')
+  puts 'Making Tipline requests: Images...'
+  create_tipline_requests(team, project, user, data[:images], 'UploadedImage')
 
-  # puts 'Making Tipline requests: Videos...'
-  # create_tipline_requests(team, project, user, data[:videos], 'UploadedVideo')
+  puts 'Making Tipline requests: Videos...'
+  create_tipline_requests(team, project, user, data[:videos], 'UploadedVideo')
 
   puts 'Making Shared Feed'
-  saved_search = SavedSearch.create!(title: 'Unpublished Items', team: team, filters: {report_status: ['published']})
-  shared_feed = Feed.create!(name: "#{Faker::Fantasy::Tolkien.location} / Feed Test", user: user, team: team, published: true, saved_search: saved_search)
-
-  puts 'Making Feed invitee...'
-  puts 'Making invited Team...'
-  invited_team = create_team(name: "#{data[:invited_team_name]} / Invited Team")
-
-  puts 'Making invited User...'
-  invited_user = create_user(name: data[:invited_user_name], login: data[:invited_user_name], password: data[:invited_user_password], password_confirmation: data[:invited_user_password], email: Faker::Internet.safe_email(name: data[:invited_user_name]), is_admin: true)
-
-  puts 'Making invited Team User...'
-  create_team_user(team: invited_team, user: invited_user, role: 'admin')
-
-  puts 'Inviting to feed...'
-  invitation = FeedInvitation.create!(email: invited_user.email, feed: shared_feed, user: invited_user)
-  invitation.accept(invited_team)
+  saved_search = SavedSearch.create!(title: "#{data[:user_name]}'s list", team: team, filters: {created_by: data[:user_name]})
+  Feed.create!(name: "Feed Test #{Faker::Alphanumeric.alpha(number: 10)}", user: user, team: team, published: true, saved_search: saved_search)
 
   if answer == "1"
-    puts "Created user: name: #{data[:invited_user_name]} — email: #{user.email} — password : #{data[:invited_user_password]}"
+    puts "Created user: name: #{data[:user_name]} — email: #{user.email} — password : #{data[:user_password]}"
   elsif answer == "2"
     puts "Data added to user: #{user.email}"
   end
-  puts "Created invited user: name: #{data[:invited_user_name]} — email: #{invited_user.email} — password : #{data[:invited_user_password]}"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -319,7 +319,7 @@ ActiveRecord::Base.transaction do
 
   puts 'Making Shared Feed'
   saved_search = SavedSearch.create!(title: "#{data[:user_name]}'s list", team: team, filters: {created_by: data[:user_name]})
-  Feed.create!(name: "Feed Test #{Faker::Alphanumeric.alpha(number: 10)}", user: user, team: team, published: true, saved_search: saved_search)
+  Feed.create!(name: "Feed Test: #{Faker::Alphanumeric.alpha(number: 10)}", user: user, team: team, published: true, saved_search: saved_search, licenses: [1])
 
   if answer == "1"
     puts "Created user: name: #{data[:user_name]} — email: #{user.email} — password : #{data[:user_password]}"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -53,7 +53,7 @@ def create_media(user, data, model_string)
 end
 
 def create_project_medias(user, project, team, data)
-  data.map { |media| ProjectMedia.create!(user_id: user.id, project: project, team: team, media: media, channel: { main: CheckChannels::ChannelCodes::WHATSAPP }) }
+  data.map { |media| ProjectMedia.create!(user_id: user.id, project: project, team: team, media: media) }
 end
 
 def humanize_link(link)
@@ -113,7 +113,7 @@ def create_relationship(project_medias)
   project_medias[4..9].each { |pm| Relationship.create!(source_id: project_medias[2].id, target_id: pm.id, relationship_type: Relationship.suggested_type)}    
 end
 
-def create_tipline_project_media(user, project, team, data)
+def create_tipline_project_medias(user, project, team, data)
   data.map { |media| ProjectMedia.create!(user_id: user.id, project: project, team: team, media: media, channel: { main: CheckChannels::ChannelCodes::WHATSAPP })}
 end
 
@@ -244,91 +244,78 @@ ActiveRecord::Base.transaction do
   puts 'Making Medias...'
   puts 'Making Medias and Project Medias: Claims...'
   claims = data[:claims].map { |data| create_media(user, data, 'Claim')}
-  claim_project_medias = create_project_medias(user, project, team, claims)
+  claim_project_medias = create_tipline_project_medias(user, project, team, claims)
   add_claim_descriptions_and_fact_checks(user, claim_project_medias)
 
-  # puts 'Making Medias and Project Medias: Links...'
-  # begin
-  #   links = data[:link_media_links].map { |data| create_media(user, data, 'Link')}
-  #   link_project_medias = create_project_medias(user, project, team, links)
-  #   add_claim_descriptions_and_fact_checks(user, link_project_medias)
-  # rescue
-  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  # end
+  puts 'Making Medias and Project Medias: Links...'
+  begin
+    links = data[:link_media_links].map { |data| create_media(user, data, 'Link')}
+    link_project_medias = create_tipline_project_medias(user, project, team, links)
+    add_claim_descriptions_and_fact_checks(user, link_project_medias)
+  rescue
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  end
 
-  # puts 'Making Medias and Project Medias: Audios...'
-  # audios = data[:audios].map { |data| create_media(user, data, 'UploadedAudio')}
-  # audio_project_medias = create_project_medias(user, project, team, audios)
-  # add_claim_descriptions_and_fact_checks(user, audio_project_medias)
+  puts 'Making Medias and Project Medias: Audios...'
+  audios = data[:audios].map { |data| create_media(user, data, 'UploadedAudio')}
+  audio_project_medias = create_tipline_project_medias(user, project, team, audios)
+  add_claim_descriptions_and_fact_checks(user, audio_project_medias)
 
-  # puts 'Making Medias and Project Medias: Images...'
-  # images = data[:images].map { |data| create_media(user, data, 'UploadedImage')}
-  # image_project_medias = create_project_medias(user, project, team, images)
-  # add_claim_descriptions_and_fact_checks(user, image_project_medias)
+  puts 'Making Medias and Project Medias: Images...'
+  images = data[:images].map { |data| create_media(user, data, 'UploadedImage')}
+  image_project_medias = create_tipline_project_medias(user, project, team, images)
+  add_claim_descriptions_and_fact_checks(user, image_project_medias)
 
-  # puts 'Making Medias and Project Medias: Videos...'
-  # videos = data[:videos].map { |data| create_media(user, data, 'UploadedVideo')}
-  # video_project_medias = create_project_medias(user, project, team, videos)
-  # add_claim_descriptions_and_fact_checks(user, video_project_medias)
+  puts 'Making Medias and Project Medias: Videos...'
+  videos = data[:videos].map { |data| create_media(user, data, 'UploadedVideo')}
+  video_project_medias = create_tipline_project_medias(user, project, team, videos)
+  add_claim_descriptions_and_fact_checks(user, video_project_medias)
 
-  # puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
-  # data[:fact_check_links].map { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
+  puts 'Making Claim Descriptions and Fact Checks: Imported Fact Checks...'
+  data[:fact_check_links].map { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
 
-  # puts 'Making Relationship...'
-  # puts 'Making Relationship: Claims / Confirmed Type and Suggested Type...'
-  # create_relationship(claim_project_medias)
-
-  # puts 'Making Relationship: Links / Suggested Type...'
-  # begin
-  #   create_relationship(link_project_medias)
-  # rescue
-  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  # end
-
-  # puts 'Making Relationship: Audios / Confirmed Type and Suggested Type...'
-  # create_relationship(audio_project_medias)
-
-  # puts 'Making Relationship: Images / Confirmed Type and Suggested Type...'
-  # create_relationship(image_project_medias)
-
-  # puts 'Making Relationship: Videos / Confirmed Type and Suggested Type...'
-  # create_relationship(video_project_medias)
+  puts 'Making Relationship...'
+  puts 'Making Relationship: Claims / Confirmed Type and Suggested Type...'
+  create_relationship(claim_project_medias)
+    create_relationship(link_project_medias)
+  puts 'Making Relationship: Links / Suggested Type...'
+  begin
+  rescue
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  end
+  puts 'Making Relationship: Audios / Confirmed Type and Suggested Type...'
+  create_relationship(audio_project_medias)
+  puts 'Making Relationship: Images / Confirmed Type and Suggested Type...'
+  create_relationship(image_project_medias)
+  puts 'Making Relationship: Videos / Confirmed Type and Suggested Type...'
+  create_relationship(video_project_medias)
 
   puts 'Publishing Reports...'
   verify_fact_check_and_publish_report(claim_project_medias)
-  # begin
-  #   verify_fact_check_and_publish_report(link_project_medias)
-  # rescue
-  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  # end
-  # verify_fact_check_and_publish_report(audio_project_medias)
-  # verify_fact_check_and_publish_report(image_project_medias)
-  # verify_fact_check_and_publish_report(video_project_medias)
+  begin
+    verify_fact_check_and_publish_report(link_project_medias)
+  rescue
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  end
+  verify_fact_check_and_publish_report(audio_project_medias)
+  verify_fact_check_and_publish_report(image_project_medias)
+  verify_fact_check_and_publish_report(video_project_medias)
 
   puts 'Making Tipline requests...'
   puts 'Making Tipline requests: Claims...'
-  # tipline_claims = data[:claims].map { |data| create_media(user, data, 'Claim')}
-  # tipline_claim_project_medias = create_tipline_project_media(user, project, team, tipline_claims)
-  # add_claim_descriptions_and_fact_checks(user, tipline_claim_project_medias)
-  # create_relationship(tipline_claim_project_medias)
-  # verify_fact_check_and_publish_report(tipline_claim_project_medias)
   create_tipline_requests(team, claim_project_medias)
-
-  # puts 'Making Tipline requests: Links...'
-  # begin
-  #   create_tipline_requests(team, link_project_medias)
-  # rescue
-  #   puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  # end
-
-  # puts 'Making Tipline requests: Audios...'
-  # create_tipline_requests(team, audio_project_medias)
-
-  # puts 'Making Tipline requests: Images...'
-  # create_tipline_requests(team, image_project_medias)
-
-  # puts 'Making Tipline requests: Videos...'
-  # create_tipline_requests(team, video_project_medias)
+  puts 'Making Tipline requests: Links...'
+  begin
+    create_tipline_requests(team, link_project_medias)
+  rescue
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  end
+  puts 'Making Tipline requests: Audios...'
+  create_tipline_requests(team, audio_project_medias)
+  puts 'Making Tipline requests: Images...'
+  create_tipline_requests(team, image_project_medias)
+  puts 'Making Tipline requests: Videos...'
+  create_tipline_requests(team, video_project_medias)
 
   puts 'Making Shared Feed'
   saved_search = SavedSearch.create!(title: "#{data[:user_name]}'s list", team: team, filters: {created_by: data[:user_name]})

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -277,9 +277,9 @@ ActiveRecord::Base.transaction do
   puts 'Making Relationship...'
   puts 'Making Relationship: Claims / Confirmed Type and Suggested Type...'
   create_relationship(claim_project_medias)
-    create_relationship(link_project_medias)
   puts 'Making Relationship: Links / Suggested Type...'
   begin
+    create_relationship(link_project_medias)
   rescue
     puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -238,7 +238,13 @@ ActiveRecord::Base.transaction do
   claims = data[:claims].map { |data| create_media(user, data, 'Claim')}
   claim_project_medias = create_project_medias(user, project, team, claims)
   add_claim_descriptions_and_fact_checks(user, claim_project_medias)
+
   claim_project_medias.values_at(0,3,6).each do |pm|
+    a = Dynamic.where(annotation_type: 'verification_status').find_by(annotated_id: pm)
+    a.set_fields = { verification_status_status: 'verified' }.to_json
+    a.reload
+    a.save!
+
     r = Dynamic.where(annotation_type: 'report_design').find_by(annotated_id: pm)
     r.set_fields = { status_label: 'verified' }.to_json
     r.set_fields = { state: 'published' }.to_json

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -67,7 +67,7 @@ end
 
 def add_claim_descriptions_and_fact_checks(user, project_medias)
   claim_descriptions = project_medias.map { |project_media| ClaimDescription.create!(description: create_description(project_media), context: Faker::Lorem.sentence, user: user, project_media: project_media) }
-  claim_descriptions.values_at(0,3,8).each { |claim_description| FactCheck.create!(summary: Faker::Company.catch_phrase, title: Faker::Company.name, user: user, claim_description: claim_description) }
+  claim_descriptions.values_at(0,3,8).each { |claim_description| FactCheck.create!(summary: Faker::Company.catch_phrase, title: Faker::Company.name, user: user, claim_description: claim_description, language: 'en') }
 end
 
 def fact_check_attributes(fact_check_link, user, project, team)
@@ -204,6 +204,7 @@ ActiveRecord::Base.transaction do
   if answer == "1"
     puts 'Making Team / Workspace...'
     team = create_team(name: "#{data[:team_name]} / Feed Creator")
+    team.set_language('en')
 
     puts 'Making User...'
     user = create_user(name: data[:user_name], login: data[:user_name], password: data[:user_password], password_confirmation: data[:user_password], email: Faker::Internet.safe_email(name: data[:user_name]), is_admin: true)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -72,19 +72,18 @@ end
 
 def verify_fact_check_and_publish_report(project_medias)
   project_medias.values_at(0,1,3,4,6,7).each do |pm|
-    annotations = Dynamic.where(annotated_id: pm)
     status = ['verified', 'false'].sample
 
-    v = annotations.find_by(annotation_type: 'verification_status')
-    v.set_fields = { verification_status_status: status }.to_json
-    v.reload
-    v.save!
+    verification_status = pm.get_dynamic_annotation('verification_status')
+    verification_status.set_fields = { verification_status_status: status }.to_json
+    verification_status.reload
+    verification_status.save!
 
-    r = annotations.find_by(annotation_type: 'report_design')
-    r.set_fields = { status_label: status }.to_json
-    r.set_fields = { state: 'published' }.to_json
-    r.action = 'publish'
-    r.save!
+    report_design = pm.get_dynamic_annotation('report_design')
+    report_design.set_fields = { status_label: status }.to_json
+    report_design.set_fields = { state: 'published' }.to_json
+    report_design.action = 'publish'
+    report_design.save!
   end
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -203,7 +203,7 @@ answer = STDIN.gets.chomp
 ActiveRecord::Base.transaction do
   if answer == "1"
     puts 'Making Team / Workspace...'
-    team = create_team(name: Faker::Company.name)
+    team = create_team(name: "#{data[:team_name]} / Feed Creator")
 
     puts 'Making User...'
     user = create_user(name: data[:user_name], login: data[:user_name], password: data[:user_password], password_confirmation: data[:user_password], email: Faker::Internet.safe_email(name: data[:user_name]), is_admin: true)
@@ -222,7 +222,7 @@ ActiveRecord::Base.transaction do
     user = User.find_by(email: email)
 
     if user.team_users.first.nil?
-      team = create_team(name: Faker::Company.name)
+      team = create_team(name: data[:team_name])
       project = create_project(title: team.name, team_id: team.id, user: user, description: '')
       create_team_user(team: team, user: user, role: 'admin')
     else 
@@ -294,7 +294,7 @@ ActiveRecord::Base.transaction do
     create_tipline_requests(team, project, user, data[:link_media_links], 'Link')
   rescue
     puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
-  end  
+  end
 
   puts 'Making Tipline requests: Audios...'
   create_tipline_requests(team, project, user, data[:audios], 'UploadedAudio')
@@ -304,6 +304,12 @@ ActiveRecord::Base.transaction do
 
   puts 'Making Tipline requests: Videos...'
   create_tipline_requests(team, project, user, data[:videos], 'UploadedVideo')
+
+  puts 'Making Shared Feed'
+  Feed.create!(name: "#{data[:team_name]} / Feed Test", user: user, team: team)
+
+  puts 'Making Feed invitee'
+  team = create_team(name: "Feed Invitee")
 
   if answer == "1"
     puts "Created — user: #{data[:user_name]} — email: #{user.email} — password : #{data[:user_password]}"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -296,7 +296,11 @@ ActiveRecord::Base.transaction do
 
   puts 'Publishing Reports...'
   verify_fact_check_and_publish_report(claim_project_medias)
-  verify_fact_check_and_publish_report(link_project_medias)
+  begin
+    verify_fact_check_and_publish_report(link_project_medias)
+  rescue
+    puts "Couldn't create Links. Other medias will still be created. \nIn order to create Links make sure Pender is running."
+  end
   verify_fact_check_and_publish_report(audio_project_medias)
   verify_fact_check_and_publish_report(image_project_medias)
   verify_fact_check_and_publish_report(video_project_medias)


### PR DESCRIPTION
## Description

We are now creating a feed with published items (randomized verified and false items).
Important: It can take a bit of time for the items to appear in the published list and on the feed (and even when they appear, the count on the published list stays at 0)

## Images
<img width="1114" alt="Screenshot 2023-11-13 at 13 25 11" src="https://github.com/meedan/check-api/assets/87862340/b6595f92-e3dc-41e6-898d-a4e938204b9f">
<img width="1466" alt="Screenshot 2023-11-10 at 13 37 55" src="https://github.com/meedan/check-api/assets/87862340/f5fdaa0c-2152-4072-a0cd-eea520216bc7">

References: 3384

## How has this been tested?

Ran seed script, created and added to user.

## Things to pay attention to during code review

1. When verifying and publishing fact checks we get a lot of logs, I couldn't figure out how to pause logging for the seed file.
2. I decided to create everything with channel: Whatsapp, instead of duplicating everything

## Documentation
I will update the documentation to include:
1. running with elasticsearch_log set to 0, so it doesn't output the logs
    a. `elasticsearch_log=0 bundle exec rake db:seed`
3. Things might take sometime to update in the UI, but if there are any issues with the Feed not displaying the clickable items (items with `published_article_url`), one should log into the rails console, clear the cache, and refresh the browser
    b. `Rails.cache.clear`