### PR TITLE
Changing the shared feed invitation email url to match check-web

### DIFF
--- a/app/mailers/feed_invitation_mailer.rb
+++ b/app/mailers/feed_invitation_mailer.rb
@@ -8,7 +8,7 @@ class FeedInvitationMailer < ApplicationMailer
     @user = record.user
     @feed = record.feed
     @due_at = record.created_at + CheckConfig.get('feed_invitation_due_to', 30).to_i.days
-    @accept_feed_url = "#{CheckConfig.get('checkdesk_client')}/#{team.slug}/feed/#{record.id}/accept_invitation"
+    @accept_feed_url = "#{CheckConfig.get('checkdesk_client')}/#{team.slug}/feed-invitation/#{record.id}"
     subject = I18n.t("mails_notifications.feed_invitation.subject", user: @user.name, feed: @feed.name)
     Rails.logger.info "Sending a feed invitation e-mail to #{@recipient}"
     mail(to: @recipient, email_type: 'feed_invitation', subject: subject)


### PR DESCRIPTION
Just changing the slug for the shared feed invitation url in the mailer to match the work done in https://github.com/meedan/check-web/pull/1730