### PR TITLE
A couple of updates for the GraphQL feed API

### DIFF
--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -202,6 +202,27 @@ class QueryType < BaseObject
     end
   end
 
+  field :feed_invitation, FeedInvitationType, description: 'Information about a feed invitation, given its database ID or feed database ID (and then the current user email is used)', null: true do
+    argument :id, GraphQL::Types::Int, required: false
+    argument :feed_id, GraphQL::Types::Int, required: false
+  end
+
+  def feed_invitation(id: nil, feed_id: nil)
+    feed_invitation_id = id || FeedInvitation.where(feed_id: feed_id, email: User.current.email).last&.id
+    GraphqlCrudOperations.load_if_can(FeedInvitation, feed_invitation_id, context)
+  end
+
+  field :feed_team, FeedTeamType, description: 'Information about a feed team, given its database ID or the combo feed database ID plus team slug', null: true do
+    argument :id, GraphQL::Types::Int, required: false
+    argument :feed_id, GraphQL::Types::Int, required: false
+    argument :team_slug, GraphQL::Types::String, required: false
+  end
+
+  def feed_team(id: nil, feed_id: nil, team_slug: nil)
+    feed_team_id = id || FeedTeam.where(feed_id: feed_id, team_id: Team.find_by_slug(team_slug).id).last&.id
+    GraphqlCrudOperations.load_if_can(FeedTeam, feed_team_id, context)
+  end
+
   # Getters by ID
   %i[
     source
@@ -214,8 +235,6 @@ class QueryType < BaseObject
     cluster
     feed
     request
-    feed_invitation
-    feed_team
     tipline_message
   ].each do |type|
     field type,

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -11728,14 +11728,14 @@ type Query {
   feed(id: ID!): Feed
 
   """
-  Information about the feed_invitation with given id
+  Information about a feed invitation, given its database ID or feed database ID (and then the current user email is used)
   """
-  feed_invitation(id: ID!): FeedInvitation
+  feed_invitation(feedId: Int, id: Int): FeedInvitation
 
   """
-  Information about the feed_team with given id
+  Information about a feed team, given its database ID or the combo feed database ID plus team slug
   """
-  feed_team(id: ID!): FeedTeam
+  feed_team(feedId: Int, id: Int, teamSlug: String): FeedTeam
 
   """
   Find whether a team exists

--- a/public/relay.json
+++ b/public/relay.json
@@ -61648,19 +61648,27 @@
             },
             {
               "name": "feed_invitation",
-              "description": "Information about the feed_invitation with given id",
+              "description": "Information about a feed invitation, given its database ID or feed database ID (and then the current user email is used)",
               "args": [
                 {
                   "name": "id",
                   "description": null,
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "feedId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
                   },
                   "defaultValue": null,
                   "isDeprecated": false,
@@ -61677,19 +61685,39 @@
             },
             {
               "name": "feed_team",
-              "description": "Information about the feed_team with given id",
+              "description": "Information about a feed team, given its database ID or the combo feed database ID plus team slug",
               "args": [
                 {
                   "name": "id",
                   "description": null,
                   "type": {
-                    "kind": "NON_NULL",
-                    "name": null,
-                    "ofType": {
-                      "kind": "SCALAR",
-                      "name": "ID",
-                      "ofType": null
-                    }
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "feedId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "teamSlug",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
                   },
                   "defaultValue": null,
                   "isDeprecated": false,

--- a/test/controllers/graphql_controller_12_test.rb
+++ b/test/controllers/graphql_controller_12_test.rb
@@ -175,4 +175,64 @@ class GraphqlController12Test < ActionController::TestCase
     assert_response :success
     assert_nil JSON.parse(@response.body).dig('data', 'feed_invitation')
   end
+
+  test "should read feed invitation based on feed ID and current user email" do
+    fi = create_feed_invitation email: @u.email
+
+    authenticate_with_user(@u)
+    query = 'query { feed_invitation(feedId: ' + fi.feed_id.to_s + ') { id } }'
+    post :create, params: { query: query }
+    assert_response :success
+    assert_not_nil JSON.parse(@response.body).dig('data', 'feed_invitation')
+  end
+
+  test "should not read feed invitation based on feed ID and current user email" do
+    fi = create_feed_invitation
+
+    authenticate_with_user(@u)
+    query = 'query { feed_invitation(feedId: ' + fi.feed_id.to_s + ') { id } }'
+    post :create, params: { query: query }
+    assert_response :success
+    assert_nil JSON.parse(@response.body).dig('data', 'feed_invitation')
+  end
+
+  test "should read feed team" do
+    ft = create_feed_team team: @t
+
+    authenticate_with_user(@u)
+    query = 'query { feed_team(id: ' + ft.id.to_s + ') { id } }'
+    post :create, params: { query: query }
+    assert_response :success
+    assert_not_nil JSON.parse(@response.body).dig('data', 'feed_team')
+  end
+
+  test "should not read feed team" do
+    ft = create_feed_team
+
+    authenticate_with_user(@u)
+    query = 'query { feed_team(id: ' + ft.id.to_s + ') { id } }'
+    post :create, params: { query: query }
+    assert_response :success
+    assert_nil JSON.parse(@response.body).dig('data', 'feed_team')
+  end
+
+  test "should read feed team based on feed ID and team slug" do
+    ft = create_feed_team team: @t
+
+    authenticate_with_user(@u)
+    query = 'query { feed_team(feedId: ' + ft.feed_id.to_s + ', teamSlug: "' + @t.slug + '") { id } }'
+    post :create, params: { query: query }
+    assert_response :success
+    assert_not_nil JSON.parse(@response.body).dig('data', 'feed_team')
+  end
+
+  test "should not read feed team based on feed ID and team slug" do
+    ft = create_feed_team
+
+    authenticate_with_user(@u)
+    query = 'query { feed_team(feedId: ' + ft.feed_id.to_s + ', teamSlug: "' + ft.team.slug + '") { id } }'
+    post :create, params: { query: query }
+    assert_response :success
+    assert_nil JSON.parse(@response.body).dig('data', 'feed_team')
+  end
 end


### PR DESCRIPTION
## Description

A couple of updates for the GraphQL root query fields `feed_team` and `feed_invitation`:

* `feed_team`: Adding the ability to query by `feedId` and `teamSlug` in addition to `id`
* `feed_invitation`: Adding the ability to query by `feedId` (and then the current logged in user email is assumed) in addition to `id`

Reference: CV2-3801.

## How has this been tested?

Automated tests were implemented for all cases.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

