### PR TITLE
Small changes to feed permissions

### DIFF
--- a/app/graph/types/feed_type.rb
+++ b/app/graph/types/feed_type.rb
@@ -43,6 +43,13 @@ class FeedType < DefaultObject
   end
 
   field :feed_invitations, FeedInvitationType.connection_type, null: false
+
+  def feed_invitations
+    ability = context[:ability] || Ability.new
+    return FeedInvitation.none unless ability.can?(:read_feed_invitations, object)
+    object.feed_invitations
+  end
+
   field :teams, TeamType.connection_type, null: false
   field :feed_teams, FeedTeamType.connection_type, null: false
 end

--- a/app/lib/check_permissions.rb
+++ b/app/lib/check_permissions.rb
@@ -54,7 +54,7 @@ module CheckPermissions
       if self.class.name == 'Team'
         role = User.current.role(self)
         role ||= 'authenticated'
-        cache_key = "team_permissions_#{self.private.to_i}_#{role}_role"
+        cache_key = "team_permissions_#{self.private.to_i}_#{role}_role_202311221222"
         perms = Rails.cache.read(cache_key) if Rails.cache.exist?(cache_key)
       end
       if perms.blank?
@@ -77,7 +77,7 @@ module CheckPermissions
 
   def get_create_permissions
     {
-      'Team' => [Project, Account, TeamUser, User, TagText, ProjectMedia, TiplineNewsletter, Feed],
+      'Team' => [Project, Account, TeamUser, User, TagText, ProjectMedia, TiplineNewsletter, Feed, FeedTeam, FeedInvitation],
       'Account' => [Media, Link, Claim],
       'Media' => [ProjectMedia, Comment, Tag, Dynamic, Task],
       'Link' => [ProjectMedia, Comment, Tag, Dynamic, Task],

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -59,6 +59,7 @@ class Ability
     can [:update, :destroy], TeamUser, team_id: @context_team.id
     can :duplicate, Team, :id => @context_team.id
     can :set_privacy, Project, :team_id => @context_team.id
+    can :read_feed_invitations, Feed, :team_id => @context_team.id
   end
 
   def editor_perms

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -714,7 +714,8 @@ class AbilityTest < ActiveSupport::TestCase
       "bulk_create Tag", "bulk_update ProjectMedia", "create TagText", "read Team", "update Team", "destroy Team", "empty Trash",
       "create Project", "create Account", "create TeamUser", "create User", "create ProjectMedia", "invite Members",
       "not_spam ProjectMedia", "restore ProjectMedia", "confirm ProjectMedia", "update ProjectMedia", "duplicate Team", "create Feed",
-      "manage TagText", "manage TeamTask", "set_privacy Project", "update Relationship", "destroy Relationship", "create TiplineNewsletter"
+      "manage TagText", "manage TeamTask", "set_privacy Project", "update Relationship", "destroy Relationship", "create TiplineNewsletter",
+      "create FeedInvitation", "create FeedTeam"
     ]
     project_perms = [
       "read Project", "update Project", "destroy Project", "create Source", "create Media", "create ProjectMedia",

--- a/test/models/ability_test.rb
+++ b/test/models/ability_test.rb
@@ -1323,16 +1323,19 @@ class AbilityTest < ActiveSupport::TestCase
       ability = Ability.new
       assert ability.can?(:destroy, ft2)
       assert ability.can?(:destroy, ft3)
+      assert ability.can?(:destroy, f)
     end
     with_current_user_and_team(u2, t2) do
       ability = Ability.new
       assert ability.can?(:destroy, ft2)
       assert ability.cannot?(:destroy, ft3)
+      assert ability.cannot?(:destroy, f)
     end
     with_current_user_and_team(u3, t3) do
       ability = Ability.new
       assert ability.cannot?(:destroy, ft2)
       assert ability.can?(:destroy, ft3)
+      assert ability.cannot?(:destroy, f)
     end
   end
 end

--- a/test/models/team_2_test.rb
+++ b/test/models/team_2_test.rb
@@ -292,7 +292,7 @@ class Team2Test < ActiveSupport::TestCase
       "destroy Team", "empty Trash", "create Project", "create ProjectMedia", "create Account", "create TeamUser",
       "create User", "invite Members", "not_spam ProjectMedia", "restore ProjectMedia", "confirm ProjectMedia", "update ProjectMedia",
       "duplicate Team", "manage TagText", "manage TeamTask", "set_privacy Project", "update Relationship",
-      "destroy Relationship", "create TiplineNewsletter", "create Feed"
+      "destroy Relationship", "create TiplineNewsletter", "create Feed", "create FeedTeam", "create FeedInvitation"
     ].sort
 
     # load permissions as owner


### PR DESCRIPTION
## Description

- Expose `FeedTeam` and `FeedInvitation` permissions
- Invalidate team permissions cache
- Do not return feed invitations to users that are not admins in the feed creator organization

Reference: CV2-4027.

## How has this been tested?

Automated tests.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

