### PR TITLE
Do not crash if link metadata contains invalid JSON when parsing Keep request

### DIFF
--- a/app/mailers/feed_invitation_mailer.rb
+++ b/app/mailers/feed_invitation_mailer.rb
@@ -1,9 +1,8 @@
 class FeedInvitationMailer < ApplicationMailer
   layout nil
 
-  def notify(record_id, team_id)
+  def notify(record_id)
     record = FeedInvitation.find_by_id record_id
-    team = Team.find_by_id team_id
     @recipient = record.email
     @user = record.user
     @feed = record.feed

--- a/app/models/bot/keep.rb
+++ b/app/models/bot/keep.rb
@@ -60,6 +60,15 @@ class Bot::Keep < BotUser
     end
   end
 
+  def self.save_archive_information(link, response, payload)
+    m = link.metadata_annotation
+    data = begin JSON.parse(m.get_field_value('metadata_value')) rescue {} end
+    data['archives'] ||= {}
+    data['archives'][payload['type']] = response
+    m.set_fields = { metadata_value: data.to_json }.to_json
+    m.save!
+  end
+
   def self.webhook(request)
     payload = JSON.parse(request.raw_post)
     if payload['url']
@@ -71,12 +80,7 @@ class Bot::Keep < BotUser
       else
         type = Bot::Keep.archiver_to_annotation_type(payload['type'])
         response = Bot::Keep.set_response_based_on_pender_data(type, payload) || { error: true }
-        m = link.metadata_annotation
-        data = begin JSON.parse(m.get_field_value('metadata_value')) rescue {} end
-        data['archives'] ||= {}
-        data['archives'][payload['type']] = response
-        m.set_fields = { metadata_value: data.to_json }.to_json
-        m.save!
+        Bot::Keep.save_archive_information(link, response, payload)
 
         project_media = ProjectMedia.where(media_id: link.id)
         raise ObjectNotReadyError.new('ProjectMedia') unless project_media.count > 0

--- a/app/models/bot/keep.rb
+++ b/app/models/bot/keep.rb
@@ -72,7 +72,7 @@ class Bot::Keep < BotUser
         type = Bot::Keep.archiver_to_annotation_type(payload['type'])
         response = Bot::Keep.set_response_based_on_pender_data(type, payload) || { error: true }
         m = link.metadata_annotation
-        data = JSON.parse(m.get_field_value('metadata_value'))
+        data = begin JSON.parse(m.get_field_value('metadata_value')) rescue {} end
         data['archives'] ||= {}
         data['archives'][payload['type']] = response
         m.set_fields = { metadata_value: data.to_json }.to_json

--- a/app/models/feed_invitation.rb
+++ b/app/models/feed_invitation.rb
@@ -28,6 +28,6 @@ class FeedInvitation < ApplicationRecord
   end
 
   def send_feed_invitation_mail
-    FeedInvitationMailer.delay.notify(self.id, Team.current.id)
+    FeedInvitationMailer.delay.notify(self.id)
   end
 end

--- a/test/mailers/feed_invitation_mailer_test.rb
+++ b/test/mailers/feed_invitation_mailer_test.rb
@@ -1,15 +1,12 @@
-require "test_helper"
+require_relative '../test_helper'
 
 class FeedInvitationMailerTest < ActionMailer::TestCase
-  test "should notify about feed invitation" do
+  test 'should notify about feed invitation' do
     fi = create_feed_invitation
-    t = create_team
-    Team.stubs(:current).returns(t)
-    email = FeedInvitationMailer.notify(fi.id, t.id)
+    email = FeedInvitationMailer.notify(fi.id)
     assert_emails 1 do
       email.deliver_now
     end
     assert_equal [fi.email], email.to
-    Team.unstub(:current)
   end
 end


### PR DESCRIPTION
## Description

Do not crash if link metadata contains invalid JSON when parsing Keep request.

References: CV2-3966.

## How has this been tested?

TDD. I added a unit test that reproduced the bug.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

