### PR TITLE
When a user leaves a feed, any previous feed invitation they received for that feed should be deleted.

### DIFF
--- a/test/models/feed_team_test.rb
+++ b/test/models/feed_team_test.rb
@@ -65,4 +65,19 @@ class FeedTeamTest < ActiveSupport::TestCase
     ft.save!
     assert_equal 'bar', ft.reload.get_requests_filters[:foo]
   end
+
+  test "should delete invitations when leaving feed" do
+    u = create_user
+    ft = create_feed_team
+    create_team_user user: u, team: ft.team, role: 'admin'
+    create_feed_invitation feed: ft.feed
+    fi = create_feed_invitation email: u.email, feed: ft.feed
+    assert_not_nil FeedInvitation.find_by_id(fi.id)
+    User.current = u
+    assert_difference 'FeedInvitation.count', -1 do
+      ft.destroy!
+    end
+    User.current = nil
+    assert_nil FeedInvitation.find_by_id(fi.id)
+  end
 end


### PR DESCRIPTION
## Description

When a user leaves a feed, any previous feed invitation they received for that feed should be deleted.

This way, they can be invited again in the future.

Fixes: CV2-3802.

## How has this been tested?

I added a unit test for this case.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

