### PR TITLE
Reverting conversation history sort order until pagination is implemented on the frontend side

### DIFF
--- a/app/graph/mutations/tipline_messages_pagination.rb
+++ b/app/graph/mutations/tipline_messages_pagination.rb
@@ -1,50 +1,50 @@
 class TiplineMessagesPagination < GraphQL::Pagination::ArrayConnection
-  def cursor_for(item)
-    encode(item.id.to_i.to_s)
-  end
-
-  def load_nodes
-    @nodes ||= begin
-      sliced_nodes =  if before && after
-                        end_idx = index_from_cursor(before)
-                        start_idx = index_from_cursor(after)
-                        items.where(id: start_idx..end_idx)
-                      elsif before
-                        end_idx = index_from_cursor(before)
-                        items.where('id < ?', end_idx)
-                      elsif after
-                        start_idx = index_from_cursor(after)
-                        items.where('id > ?', start_idx)
-                      else
-                        items
-                      end
-
-      @has_previous_page =  if last
-                              # There are items preceding the ones in this result
-                              sliced_nodes.count > last
-                            elsif after
-                              # We've paginated into the Array a bit, there are some behind us
-                              index_from_cursor(after) > items.map(&:id).min
-                            else
-                              false
-                            end
-
-      @has_next_page =  if first
-                          # There are more items after these items
-                          sliced_nodes.count > first
-                        elsif before
-                          # The original array is longer than the `before` index
-                          index_from_cursor(before) < items.map(&:id).max
-                        else
-                          false
-                        end
-
-      limited_nodes = sliced_nodes
-
-      limited_nodes = limited_nodes.first(first) if first
-      limited_nodes = limited_nodes.last(last) if last
-
-      limited_nodes
-    end
-  end
+#  def cursor_for(item)
+#    encode(item.id.to_i.to_s)
+#  end
+#
+#  def load_nodes
+#    @nodes ||= begin
+#      sliced_nodes =  if before && after
+#                        end_idx = index_from_cursor(before)
+#                        start_idx = index_from_cursor(after)
+#                        items.where(id: start_idx..end_idx)
+#                      elsif before
+#                        end_idx = index_from_cursor(before)
+#                        items.where('id < ?', end_idx)
+#                      elsif after
+#                        start_idx = index_from_cursor(after)
+#                        items.where('id > ?', start_idx)
+#                      else
+#                        items
+#                      end
+#
+#      @has_previous_page =  if last
+#                              # There are items preceding the ones in this result
+#                              sliced_nodes.count > last
+#                            elsif after
+#                              # We've paginated into the Array a bit, there are some behind us
+#                              index_from_cursor(after) > items.map(&:id).min
+#                            else
+#                              false
+#                            end
+#
+#      @has_next_page =  if first
+#                          # There are more items after these items
+#                          sliced_nodes.count > first
+#                        elsif before
+#                          # The original array is longer than the `before` index
+#                          index_from_cursor(before) < items.map(&:id).max
+#                        else
+#                          false
+#                        end
+#
+#      limited_nodes = sliced_nodes
+#
+#      limited_nodes = limited_nodes.first(first) if first
+#      limited_nodes = limited_nodes.last(last) if last
+#
+#      limited_nodes
+#    end
+#  end
 end

--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -302,6 +302,6 @@ class TeamType < DefaultObject
   end
 
   def tipline_messages(uid:)
-    TiplineMessagesPagination.new(object.tipline_messages.where(uid: uid).order('id ASC'))
+    TiplineMessagesPagination.new(object.tipline_messages.where(uid: uid).order('sent_at DESC'))
   end
 end

--- a/app/graph/types/tipline_message_type.rb
+++ b/app/graph/types/tipline_message_type.rb
@@ -22,7 +22,7 @@ class TiplineMessageType < DefaultObject
     object.sent_at.to_i.to_s
   end
 
-  def cursor
-    GraphQL::Schema::Base64Encoder.encode(object.id.to_i.to_s)
-  end
+  # def cursor
+  #   GraphQL::Schema::Base64Encoder.encode(object.id.to_i.to_s)
+  # end
 end

--- a/test/controllers/graphql_controller_9_test.rb
+++ b/test/controllers/graphql_controller_9_test.rb
@@ -409,6 +409,26 @@ class GraphqlController9Test < ActionController::TestCase
     assert_equal "Not Found", JSON.parse(@response.body)['errors'][0]['message']
   end
 
+  test "should get latest tipline messages" do
+    t = create_team slug: 'test', private: true
+    u = create_user
+    create_team_user user: u, team: t, role: 'admin'
+    uid = random_string
+
+    tm1 = create_tipline_message team_id: t.id, uid: uid, sent_at: Time.now.ago(2.hours)
+    tm2 = create_tipline_message team_id: t.id, uid: uid, sent_at: Time.now.ago(1.hour)
+
+    authenticate_with_user(u)
+
+    query = 'query latest { team(slug: "test") { tipline_messages(first: 1, uid:"' + uid + '") { edges { node { dbid } } } } }'
+    post :create, params: { query: query }
+    assert_response :success
+    data = JSON.parse(@response.body)['data']['team']['tipline_messages']
+    results = data['edges'].to_a.collect{ |e| e['node']['dbid'] }
+    assert_equal 1, results.size
+    assert_equal tm2.id, results[0]
+  end
+
   test "should paginate tipline messages" do
     skip 'Pagination disabled in this commit'
     t = create_team slug: 'test', private: true

--- a/test/controllers/graphql_controller_9_test.rb
+++ b/test/controllers/graphql_controller_9_test.rb
@@ -410,6 +410,7 @@ class GraphqlController9Test < ActionController::TestCase
   end
 
   test "should paginate tipline messages" do
+    skip 'Pagination disabled in this commit'
     t = create_team slug: 'test', private: true
     u = create_user
     create_team_user user: u, team: t, role: 'admin'

--- a/test/models/feed_invitation_test.rb
+++ b/test/models/feed_invitation_test.rb
@@ -61,7 +61,7 @@ class FeedInvitationTest < ActiveSupport::TestCase
     end
     assert_equal 'accepted', fi.reload.state
     fi.reject!
-    assert_equal 'rejected', fi.reload.state
+    assert_nil FeedInvitation.find_by_id(fi.id)
   end
 
   test "should send email after create feed invitation" do


### PR DESCRIPTION
## Description

Until conversation history pagination is implemented in Check Web, Check API must return the latest messages. This PR is for that. Once pagination is implemented in Check Web, this PR should be reverted.

References: CV2-3776 and CV2-3703.

## How has this been tested?

Existing tests should cover this.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

