### PR TITLE
If a user declines a feed invitation, they can be invited again.

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -85,7 +85,7 @@ class Ability
       obj.annotation.team&.id == @context_team.id
     end
     can [:create, :update, :read, :destroy], [Account, Source, TiplineNewsletter, TiplineResource, Feed, FeedTeam], :team_id => @context_team.id
-    can [:create, :update, :destroy], FeedInvitation, { feed: { team_id: @context_team.id } }
+    can [:create, :update], FeedInvitation, { feed: { team_id: @context_team.id } }
     can :destroy, FeedTeam do |obj|
       obj.team.id == @context_team.id || obj.feed.team.id == @context_team.id
     end

--- a/app/models/feed_invitation.rb
+++ b/app/models/feed_invitation.rb
@@ -18,7 +18,8 @@ class FeedInvitation < ApplicationRecord
   end
 
   def reject!
-    self.update_column(:state, :rejected)
+    # self.update_column(:state, :rejected)
+    self.destroy!
   end
 
   private

--- a/lib/check_basic_abilities.rb
+++ b/lib/check_basic_abilities.rb
@@ -125,8 +125,8 @@ module CheckBasicAbilities
       !(@user.cached_teams & obj.feed.team_ids).empty?
     end
 
-    can :read, FeedInvitation do |obj|
-      @user.email == obj.email || @user.id == obj.user_id
+    can [:read, :destroy], FeedInvitation do |obj|
+      @user.email == obj.email || @user.id == obj.user_id || TeamUser.where(user_id: @user.id, team_id: obj.feed.team_id, role: 'admin').exists?
     end
   end
 


### PR DESCRIPTION
## Description

If a user declines a feed invitation, they can be invited again.

In practice, this means really deleting the invitation from the database when it's rejected.

Fixes CV2-3802.

## How has this been tested?

Existing unit tests will be fixed to cover this.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

