### PR TITLE
Add initial tests for image via sync endpoint

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -151,7 +151,7 @@ class Bot::Alegre < BotUser
       if body.dig(:event) == 'create_project_media' && !pm.nil?
         Rails.logger.info("[Alegre Bot] [ProjectMedia ##{pm.id}] This item was just created, processing...")
         self.get_language(pm)
-        if self.get_pm_type(pm) == "audio" || self.get_pm_type(pm) == "image"
+        if self.get_pm_type(pm) == "audio"
           self.relate_project_media(pm)
         else
           self.send_to_media_similarity_index(pm)

--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -151,7 +151,7 @@ class Bot::Alegre < BotUser
       if body.dig(:event) == 'create_project_media' && !pm.nil?
         Rails.logger.info("[Alegre Bot] [ProjectMedia ##{pm.id}] This item was just created, processing...")
         self.get_language(pm)
-        if self.get_pm_type(pm) == "audio"
+        if self.get_pm_type(pm) == "audio" || self.get_pm_type(pm) == "image"
           self.relate_project_media(pm)
         else
           self.send_to_media_similarity_index(pm)

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -8,12 +8,12 @@ module AlegreV2
       CheckConfig.get('alegre_host')
     end
 
-    def sync_path
-      "/similarity/sync/audio"
+    def sync_path(project_media)
+      "/similarity/sync/#{get_type(project_media)}"
     end
 
-    def async_path
-      "/similarity/async/audio"
+    def async_path(project_media)
+      "/similarity/async/#{get_type(project_media)}"
     end
 
     def delete_path(project_media)
@@ -119,10 +119,22 @@ module AlegreV2
       ).merge(params)
     end
 
-    def generic_package_audio(project_media, params)
+    def generic_package_media(project_media, params)
       generic_package(project_media, nil).merge(
         url: media_file_url(project_media),
       ).merge(params)
+    end
+
+    def generic_package_image(project_media, params)
+      generic_package_media(project_media, params)
+    end
+
+    def delete_package_image(project_media, _field, params)
+      generic_package_image(project_media, params)
+    end
+
+    def generic_package_audio(project_media, params)
+      generic_package_media(project_media, params)
     end
 
     def delete_package_audio(project_media, _field, params)

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -82,12 +82,12 @@ module AlegreV2
       request("delete", delete_path(project_media), data)
     end
 
-    def request_sync(data)
-      request("post", sync_path, data)
+    def request_sync(data, project_media)
+      request("post", sync_path(project_media), data)
     end
 
-    def request_async(data)
-      request("post", async_path, data)
+    def request_async(data, project_media)
+      request("post", async_path(project_media), data)
     end
 
     def get_type(project_media)
@@ -161,19 +161,25 @@ module AlegreV2
       context
     end
 
+    def store_package_image(project_media, _field, params)
+      generic_package_image(project_media, params)
+    end
+
     def store_package_audio(project_media, _field, params)
       generic_package_audio(project_media, params)
     end
 
     def get_sync(project_media, field=nil, params={})
       request_sync(
-        store_package(project_media, field, params)
+        store_package(project_media, field, params),
+        project_media
       )
     end
 
     def get_async(project_media, field=nil, params={})
       request_async(
-        store_package(project_media, field, params)
+        store_package(project_media, field, params),
+        project_media
       )
     end
 

--- a/test/contract/alegre_contract_test.rb
+++ b/test/contract/alegre_contract_test.rb
@@ -25,8 +25,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
     WebMock.stub_request(:delete, 'http://localhost:3100/text/similarity/').to_return(body: { success: true }.to_json)
     WebMock.stub_request(:post, 'http://localhost:3100/image/similarity/').to_return(body: { 'success': true }.to_json)
     WebMock.stub_request(:post, 'http://localhost:3100/image/classification/').with(body: { uri: url}).to_return(body:{ result: @flags }.to_json)
-    WebMock.stub_request(:post, 'http://localhost:3100/image/similarity/search/').with(body: {:url=>"https://i.imgur.com/ewGClFQ.png", :context=>{:has_custom_id=>true, :team_id=>pm.team_id}, :match_across_content_types=>true, :threshold=>0.89}).to_return(body: { "result": [] }.to_json)
-    WebMock.stub_request(:post, 'http://localhost:3100/image/similarity/search/').with(body: {:url=>"https://i.imgur.com/ewGClFQ.png", :context=>{:has_custom_id=>true, :team_id=>pm.team_id}, :match_across_content_types=>true, :threshold=>0.95}).to_return(body: { "result": [] }.to_json)
+    WebMock.stub_request(:post, 'http://localhost:3100/similarity/sync/image').to_return(body: { "result": [] }.to_json)
   end
 
   # def teardown
@@ -101,7 +100,6 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
         },
         body: { text: @extracted_text },
       )
-
       pm2 = create_project_media team: @pm.team, media: create_uploaded_image
       stub_similarity_requests(@url, pm2)
       Bot::Alegre.stubs(:media_file_url).with(pm2).returns(@url)
@@ -125,7 +123,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
       upon_receiving('a request to link similar images').
       with(
         method: :post,
-        path: '/image/similarity/search/',
+        path: '/similarity/sync/image',
         body: {url: @url,threshold: 0.89}
       ).
       will_respond_with(
@@ -147,7 +145,7 @@ class Bot::AlegreContractTest < ActiveSupport::TestCase
         }
       )
       conditions = {url: @url, threshold: 0.89}
-      Bot::Alegre.get_similar_items_from_api('/image/similarity/search/', conditions, 0.89)
+      Bot::Alegre.get_similar_items_from_api('/similarity/sync/image', conditions, 0.89)
     end
   end
 end

--- a/test/controllers/elastic_search_9_test.rb
+++ b/test/controllers/elastic_search_9_test.rb
@@ -134,10 +134,10 @@ class ElasticSearch9Test < ActionController::TestCase
       # Text extraction
       Bot::Alegre.unstub(:media_file_url)
       pm = create_project_media team: team, media: create_uploaded_image, disable_es_callbacks: false
-      WebMock.stub_request(:post, 'http://alegre/image/similarity/search/').with(body: {context: {:has_custom_id=>true, :team_id=>pm.team_id}, match_across_content_types: true, threshold: 0.89, url: "some/path"}).to_return(body: {
+      WebMock.stub_request(:post, 'http://alegre/similarity/sync/image').with(body: {doc_id: Bot::Alegre.item_doc_id(pm), context: {:has_custom_id=>true, :project_media_id=>pm.id, :team_id=>pm.team_id}, threshold: 0.89, url: "some/path"}).to_return(body: {
         "result": []
       }.to_json)
-      WebMock.stub_request(:post, 'http://alegre/image/similarity/search/').with(body: {context: {:has_custom_id=>true, :team_id=>pm.team_id}, match_across_content_types: true, threshold: 0.95, url: "some/path"}).to_return(body: {
+      WebMock.stub_request(:post, 'http://alegre/similarity/sync/image').with(body: {doc_id: Bot::Alegre.item_doc_id(pm), context: {:has_custom_id=>true, :project_media_id=>pm.id, :team_id=>pm.team_id}, threshold: 0.95, url: "some/path"}).to_return(body: {
         "result": []
       }.to_json)
       Bot::Alegre.stubs(:media_file_url).with(pm).returns("some/path")

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -61,7 +61,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     assert_equal Bot::Alegre.host, CheckConfig.get('alegre_host')
     assert_equal Bot::Alegre.sync_path(pm1), "/similarity/sync/image"
     assert_equal Bot::Alegre.async_path(pm1), "/similarity/async/image"
-    assert_equal Bot::Alegre.delete_path(pm1), "/audio/similarity/"
+    assert_equal Bot::Alegre.delete_path(pm1), "/image/similarity/"
   end
 
   test "should release and reconnect db" do


### PR DESCRIPTION
## Description
Updates check api / alegre integration to use the sync endpoint in lieu of the old / sunsetting on-alegre fingerprinting, and instead route through presto


References: 4044

## How has this been tested?

Most of the work should just be adding test coverage for different states of image uploads - the code itself should be a one liner.

## Things to pay attention to during code review


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

