### PR TITLE
Tipline history pagination

### DIFF
--- a/app/graph/mutations/tipline_messages_pagination.rb
+++ b/app/graph/mutations/tipline_messages_pagination.rb
@@ -1,50 +1,50 @@
 class TiplineMessagesPagination < GraphQL::Pagination::ArrayConnection
-#  def cursor_for(item)
-#    encode(item.id.to_i.to_s)
-#  end
-#
-#  def load_nodes
-#    @nodes ||= begin
-#      sliced_nodes =  if before && after
-#                        end_idx = index_from_cursor(before)
-#                        start_idx = index_from_cursor(after)
-#                        items.where(id: start_idx..end_idx)
-#                      elsif before
-#                        end_idx = index_from_cursor(before)
-#                        items.where('id < ?', end_idx)
-#                      elsif after
-#                        start_idx = index_from_cursor(after)
-#                        items.where('id > ?', start_idx)
-#                      else
-#                        items
-#                      end
-#
-#      @has_previous_page =  if last
-#                              # There are items preceding the ones in this result
-#                              sliced_nodes.count > last
-#                            elsif after
-#                              # We've paginated into the Array a bit, there are some behind us
-#                              index_from_cursor(after) > items.map(&:id).min
-#                            else
-#                              false
-#                            end
-#
-#      @has_next_page =  if first
-#                          # There are more items after these items
-#                          sliced_nodes.count > first
-#                        elsif before
-#                          # The original array is longer than the `before` index
-#                          index_from_cursor(before) < items.map(&:id).max
-#                        else
-#                          false
-#                        end
-#
-#      limited_nodes = sliced_nodes
-#
-#      limited_nodes = limited_nodes.first(first) if first
-#      limited_nodes = limited_nodes.last(last) if last
-#
-#      limited_nodes
-#    end
-#  end
+  def cursor_for(item)
+    encode(item.id.to_i.to_s)
+  end
+
+  def load_nodes
+    @nodes ||= begin
+      sliced_nodes =  if before && after
+                        end_idx = index_from_cursor(before)
+                        start_idx = index_from_cursor(after)
+                        items.where(id: start_idx..end_idx)
+                      elsif before
+                        end_idx = index_from_cursor(before)
+                        items.where('id < ?', end_idx)
+                      elsif after
+                        start_idx = index_from_cursor(after)
+                        items.where('id > ?', start_idx)
+                      else
+                        items
+                      end
+
+      @has_previous_page =  if last
+                              # There are items preceding the ones in this result
+                              sliced_nodes.count > last
+                            elsif after
+                              # We've paginated into the Array a bit, there are some behind us
+                              index_from_cursor(after) > items.map(&:id).min
+                            else
+                              false
+                            end
+
+      @has_next_page =  if first
+                          # There are more items after these items
+                          sliced_nodes.count > first
+                        elsif before
+                          # The original array is longer than the `before` index
+                          index_from_cursor(before) < items.map(&:id).max
+                        else
+                          false
+                        end
+
+      limited_nodes = sliced_nodes
+
+      limited_nodes = limited_nodes.first(first) if first
+      limited_nodes = limited_nodes.last(last) if last
+
+      limited_nodes
+    end
+  end
 end

--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -299,9 +299,14 @@ class TeamType < DefaultObject
 
   field :tipline_messages, TiplineMessageType.connection_type, null: true do
     argument :uid, GraphQL::Types::String, required: true
+    argument :external_id, GraphQL::Types::String, required: false
   end
 
-  def tipline_messages(uid:)
-    TiplineMessagesPagination.new(object.tipline_messages.where(uid: uid).order('id ASC'))
+  def tipline_messages(uid:, external_id: nil)
+    if external_id
+      TiplineMessagesPagination.new(object.tipline_messages.where(uid: uid, external_id: external_id).order('id ASC'))
+    else
+      TiplineMessagesPagination.new(object.tipline_messages.where(uid: uid).order('id ASC'))
+    end
   end
 end

--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -302,6 +302,6 @@ class TeamType < DefaultObject
   end
 
   def tipline_messages(uid:)
-    TiplineMessagesPagination.new(object.tipline_messages.where(uid: uid).order('sent_at DESC'))
+    TiplineMessagesPagination.new(object.tipline_messages.where(uid: uid).order('id ASC'))
   end
 end

--- a/app/graph/types/tipline_message_type.rb
+++ b/app/graph/types/tipline_message_type.rb
@@ -22,7 +22,7 @@ class TiplineMessageType < DefaultObject
     object.sent_at.to_i.to_s
   end
 
-  # def cursor
-  #   GraphQL::Schema::Base64Encoder.encode(object.id.to_i.to_s)
-  # end
+  def cursor
+    GraphQL::Schema::Base64Encoder.encode(object.id.to_i.to_s)
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -664,6 +664,7 @@ ActiveRecord::Schema.define(version: 2023_10_26_162554) do
     t.datetime "updated_at", null: false
     t.string "state"
     t.index ["external_id", "state"], name: "index_tipline_messages_on_external_id_and_state", unique: true
+    t.index ["external_id"], name: "index_tipline_messages_on_external_id"
     t.index ["team_id"], name: "index_tipline_messages_on_team_id"
     t.index ["uid"], name: "index_tipline_messages_on_uid"
   end
@@ -804,8 +805,7 @@ ActiveRecord::Schema.define(version: 2023_10_26_162554) do
   end
 
   create_table "versions", id: :serial, force: :cascade do |t|
-    t.string "item_type"
-    t.string "{:null=>false}"
+    t.string "item_type", null: false
     t.string "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -664,7 +664,6 @@ ActiveRecord::Schema.define(version: 2023_10_26_162554) do
     t.datetime "updated_at", null: false
     t.string "state"
     t.index ["external_id", "state"], name: "index_tipline_messages_on_external_id_and_state", unique: true
-    t.index ["external_id"], name: "index_tipline_messages_on_external_id"
     t.index ["team_id"], name: "index_tipline_messages_on_team_id"
     t.index ["uid"], name: "index_tipline_messages_on_uid"
   end
@@ -805,7 +804,8 @@ ActiveRecord::Schema.define(version: 2023_10_26_162554) do
   end
 
   create_table "versions", id: :serial, force: :cascade do |t|
-    t.string "item_type", null: false
+    t.string "item_type"
+    t.string "{:null=>false}"
     t.string "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -13229,6 +13229,7 @@ type Team implements Node {
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    externalId: String
 
     """
     Returns the first _n_ elements from the list.

--- a/public/relay.json
+++ b/public/relay.json
@@ -69033,6 +69033,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "externalId",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {

--- a/test/controllers/graphql_controller_9_test.rb
+++ b/test/controllers/graphql_controller_9_test.rb
@@ -409,28 +409,7 @@ class GraphqlController9Test < ActionController::TestCase
     assert_equal "Not Found", JSON.parse(@response.body)['errors'][0]['message']
   end
 
-  test "should get latest tipline messages" do
-    t = create_team slug: 'test', private: true
-    u = create_user
-    create_team_user user: u, team: t, role: 'admin'
-    uid = random_string
-
-    tm1 = create_tipline_message team_id: t.id, uid: uid, sent_at: Time.now.ago(2.hours)
-    tm2 = create_tipline_message team_id: t.id, uid: uid, sent_at: Time.now.ago(1.hour)
-
-    authenticate_with_user(u)
-
-    query = 'query latest { team(slug: "test") { tipline_messages(first: 1, uid:"' + uid + '") { edges { node { dbid } } } } }'
-    post :create, params: { query: query }
-    assert_response :success
-    data = JSON.parse(@response.body)['data']['team']['tipline_messages']
-    results = data['edges'].to_a.collect{ |e| e['node']['dbid'] }
-    assert_equal 1, results.size
-    assert_equal tm2.id, results[0]
-  end
-
   test "should paginate tipline messages" do
-    skip 'Pagination disabled in this commit'
     t = create_team slug: 'test', private: true
     u = create_user
     create_team_user user: u, team: t, role: 'admin'


### PR DESCRIPTION
I had to add an optional `external_id` filter to the `tipline_messages` function. This is required because I need to be able to associate `TiplineRequest` with `TiplineMessages` and I can't derive a cursor value for `TiplineMessages` from `TiplineRequest` because it's a totally different object so graphql wouldn't track that. The `value_json` in `TiplineRequest` contains a reference to `_id` which matches `external_id` on `TiplineMessages`. This lets me do a filter like the following, where `externalId` is derived from `TiplineRequest` is derived from `ProjectMedia`:

```graphql
tipline_messages(uid:"abc123",externalId:"def456") {
    edges {
      node {
        cursor
        dbid,
      }
    }
}
```

Things to consider:

 - not sure I did this correctly, please let me know
 - I don't understand why rails removed the index on `external_id` -- seems like we would want it since we are searching by it?