### PR TITLE
Adding one more `team_id` filter to `CheckSearch`.

### DIFF
--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -117,7 +117,7 @@ class CheckSearch
     else
       @medias = get_pg_results
     end
-    @medias
+    @medias.where(team_id: @options['team_id']) # Safe check: Be sure that `team_id` filter is always applied
   end
 
   def project_medias


### PR DESCRIPTION
## Description

Just to be safe and avoid regressions from other parts of the code, be sure that at the end, the `team_id` filter is always applied on `CheckSearch` `media` queries.

Reference: CV2-4062.

## How has this been tested?

I added an automated test for this case.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)