### PR TITLE
Do not send a report to a tipline user for relationships created by Alegre Bot

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -63,9 +63,9 @@ class Bot::Smooch < BotUser
 
     def self.inherit_status_and_send_report(rid)
       relationship = Relationship.find_by_id(rid)
-      # A relationship created by the Smooch Bot is related to search results, so the user has already received the report as a search result
-      return if relationship&.user && relationship.user == BotUser.smooch_user
       unless relationship.nil?
+        # A relationship created by the Smooch Bot or Alegre Bot is related to search results, so the user has already received the report as a search result
+        return if [BotUser.smooch_user&.id, BotUser.alegre_user&.id].include?(relationship.user_id)
         target = relationship.target
         parent = relationship.source
         if ::Bot::Smooch.team_has_smooch_bot_installed(target) && relationship.is_confirmed?

--- a/test/models/bot/smooch_2_test.rb
+++ b/test/models/bot/smooch_2_test.rb
@@ -100,7 +100,7 @@ class Bot::Smooch2Test < ActiveSupport::TestCase
 
     child = create_project_media project: @project
     create_dynamic_annotation annotation_type: 'smooch', annotated: child, set_fields: { smooch_message_id: random_string, smooch_data: { app_id: @app_id, authorId: random_string, language: 'en' }.to_json }.to_json
-    r = create_relationship source_id: parent.id, target_id: child.id, relationship_type: Relationship.confirmed_type
+    r = create_relationship source_id: parent.id, target_id: child.id, relationship_type: Relationship.confirmed_type, user: create_user
     s = child.annotations.where(annotation_type: 'verification_status').last.load
     assert_equal 'verified', s.status
 


### PR DESCRIPTION
## Description

Expand the current condition so that reports are not sent for relationships saved by not only by Smooch Bot, but also by Alegre Bot. The rationale is that medias are created only through tipline requests, so they already received search results and gave feedback, so they don't need to receive additional reports.

Fixes CV2-4068.

## How has this been tested?

A fixed a test that broke because of this change.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

