### PR TITLE
Should not allow feed to be deleted if it still has collaborators.

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -4,7 +4,7 @@ class Feed < ApplicationRecord
   check_settings
 
   has_many :requests
-  has_many :feed_teams, dependent: :destroy
+  has_many :feed_teams, dependent: :restrict_with_error
   has_many :teams, through: :feed_teams
   has_many :feed_invitations, dependent: :destroy
   belongs_to :user, optional: true

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -162,26 +162,29 @@ class FeedTest < ActiveSupport::TestCase
     CheckSearch.any_instance.unstub(:medias)
   end
 
-  test "should delete feed teams and invitation when feed is deleted" do
+  test "should not delete feed if it has teams" do
     f = create_feed
-    f.teams << create_team
     ft = create_feed_team team: create_team, feed: f
     assert_no_difference 'Feed.count' do
-      assert_difference 'FeedTeam.count', -1 do
-        ft.destroy!
-      end
-    end
-    assert_difference 'Feed.count', -1 do
-      assert_difference 'FeedTeam.count', -1 do
+      assert_raises ActiveRecord::RecordNotDestroyed do
         f.destroy!
       end
     end
+    ft.destroy!
+    assert_difference 'Feed.count', -1 do
+      f.reload.destroy!
+    end
+  end
+
+  test "should delete invites when feed is deleted" do
     f = create_feed
-    create_feed_invitation feed: f
-    assert_difference 'Feed.count', -1 do
-      assert_difference 'FeedInvitation.count', -1 do
-        f.destroy!
-      end
+    fi1 = create_feed_invitation feed: f
+    fi2 = create_feed_invitation feed: f
+    assert_no_difference 'Feed.count' do
+      fi1.destroy!
+    end
+    assert_difference 'FeedInvitation.count', -1 do
+      f.destroy!
     end
   end
 end


### PR DESCRIPTION
## Description

Should not allow feed to be deleted if it still has collaborators.

Fixes CV2-3952.

## How has this been tested?

Unit tests.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

