### PR TITLE
Remove the hardcoded minimum number of words to run a full similarity search

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -221,8 +221,8 @@ class Bot::Alegre < BotUser
 
   def self.get_items_from_similar_text(team_id, text, fields = nil, threshold = nil, models = nil, fuzzy = false)
     team_ids = [team_id].flatten
-    if text.blank? || self.get_number_of_words(text) < 3
-      Rails.logger.info("[Alegre Bot] get_items_from_similar_text returning early due to blank/short text #{text}")
+    if text.blank?
+      Rails.logger.info("[Alegre Bot] get_items_from_similar_text returning early due to blank text #{text}")
       return {}
     end
     fields ||= ALL_TEXT_SIMILARITY_FIELDS

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -553,8 +553,8 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
     TeamBotInstallation.unstub(:find_by_team_id_and_user_id)
   end
 
-  test "should not get similar texts for texts with up to 2 words" do
-    assert_equal({}, Bot::Alegre.get_items_from_similar_text(random_number, 'Foo bar'))
+  test "should not get similar texts for blank string" do
+    assert_equal({}, Bot::Alegre.get_items_from_similar_text(random_number, ''))
   end
 
   test "should match rule by extracted text" do


### PR DESCRIPTION
## Description

We have a setting in Check Web that specifies the number of words below which we should run a keyword search rather than a full similarity search with Alegre. Unfortunately, we also hardcode a limit in Check API as three words. This leads to the bad experience where when the Check Web setting is lower than three no results are returned. 

E.g., if the Check Web setting is set at 1, then two word queries return no results. 

This ticket removes the hardcoded minimum.

References: CV2-4085

## How has this been tested?

Updated automated tests. Will test end-to-end after merge

## Things to pay attention to during code review


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

