### PR TITLE
Item custom title feature

### DIFF
--- a/app/graph/mutations/project_media_mutations.rb
+++ b/app/graph/mutations/project_media_mutations.rb
@@ -56,6 +56,8 @@ module ProjectMediaMutations
     argument :project_id, GraphQL::Types::Int, required: false, camelize: false
     argument :source_id, GraphQL::Types::Int, required: false, camelize: false
     argument :read, GraphQL::Types::Boolean, required: false
+    argument :custom_title, GraphQL::Types::String, required: false, camelize: false
+    argument :title_field, GraphQL::Types::String, required: false, camelize: false
   end
 
   class Destroy < Mutations::DestroyMutation; end

--- a/app/graph/types/project_media_type.rb
+++ b/app/graph/types/project_media_type.rb
@@ -43,6 +43,8 @@ class ProjectMediaType < DefaultObject
   field :is_confirmed, GraphQL::Types::Boolean, null: true
   field :positive_tipline_search_results_count, GraphQL::Types::Int, null: true
   field :tipline_search_results_count, GraphQL::Types::Int, null: true
+  field :custom_title, GraphQL::Types::String, null: true
+  field :title_field, GraphQL::Types::String, null: true
 
   field :claim_description, ClaimDescriptionType, null: true
 

--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -44,6 +44,14 @@ module ProjectMediaCachedFields
           events: {
             save: :recalculate
           }
+        },
+        {
+          model: ProjectMedia,
+          if: proc { |pm| pm.saved_changes[:custom_title].present? || pm.saved_changes[:title_field].present? },
+          affected_ids: proc { |pm| [pm.id] },
+          events: {
+            save: :recalculate
+          }
         }
       ]
     end

--- a/app/models/concerns/project_media_getters.rb
+++ b/app/models/concerns/project_media_getters.rb
@@ -145,6 +145,17 @@ module ProjectMediaGetters
   end
 
   def get_title
+    # Maps the value of the `ProjectMedia` `title_field` column to a `ProjectMedia` method that returns that value
+    title_mapping = {
+      custom_title: :custom_title,
+      pinned_media_id: :media_slug,
+      claim_title: :claim_description_content,
+      fact_check_title: :fact_check_title
+    }
+    title_field = self.title_field&.to_sym
+    if !title_field.blank? && title_mapping.keys.include?(title_field)
+      return self.send(title_mapping[title_field]).to_s
+    end
     title = self.original_title
     [self.analysis['file_title'], self.analysis['title'], self.fact_check_title, self.claim_description_content].each do |value|
       title = value if !value.blank? && value != '-' && value != '​'

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -23,6 +23,8 @@ class ProjectMedia < ApplicationRecord
   validate :channel_in_allowed_values, on: :create
   validate :channel_not_changed, on: :update
   validate :rate_limit_not_exceeded, on: :create
+  validates_inclusion_of :title_field, in: ['custom_title', 'pinned_media_id', 'claim_title', 'fact_check_title'], allow_nil: true, allow_blank: true
+  validates_presence_of :custom_title, if: proc { |pm| pm.title_field == 'custom_title' }
 
   before_validation :set_team_id, :set_channel, :set_project_id, on: :create
   after_create :create_annotation, :create_metrics_annotation, :send_slack_notification, :create_relationship, :create_team_tasks, :create_claim_description_and_fact_check, :create_tags

--- a/db/migrate/20231210015830_add_custom_title_fields_to_project_media.rb
+++ b/db/migrate/20231210015830_add_custom_title_fields_to_project_media.rb
@@ -1,0 +1,6 @@
+class AddCustomTitleFieldsToProjectMedia < ActiveRecord::Migration[6.1]
+  def change
+    add_column :project_medias, :custom_title, :string, null: true
+    add_column :project_medias, :title_field, :string, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -268,7 +268,7 @@ ActiveRecord::Schema.define(version: 2023_12_10_015830) do
     t.jsonb "value_json", default: "{}"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY (ARRAY[('external_id'::character varying)::text, ('smooch_user_id'::character varying)::text, ('verification_status_status'::character varying)::text]))"
+    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
     t.index ["annotation_id"], name: "index_dynamic_annotation_fields_on_annotation_id"
     t.index ["annotation_type"], name: "index_dynamic_annotation_fields_on_annotation_type"
@@ -666,7 +666,6 @@ ActiveRecord::Schema.define(version: 2023_12_10_015830) do
     t.datetime "updated_at", null: false
     t.string "state"
     t.index ["external_id", "state"], name: "index_tipline_messages_on_external_id_and_state", unique: true
-    t.index ["external_id"], name: "index_tipline_messages_on_external_id"
     t.index ["team_id"], name: "index_tipline_messages_on_team_id"
     t.index ["uid"], name: "index_tipline_messages_on_uid"
   end
@@ -807,7 +806,8 @@ ActiveRecord::Schema.define(version: 2023_12_10_015830) do
   end
 
   create_table "versions", id: :serial, force: :cascade do |t|
-    t.string "item_type", null: false
+    t.string "item_type"
+    t.string "{:null=>false}"
     t.string "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_10_26_162554) do
+ActiveRecord::Schema.define(version: 2023_12_10_015830) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -268,7 +268,7 @@ ActiveRecord::Schema.define(version: 2023_10_26_162554) do
     t.jsonb "value_json", default: "{}"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
+    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY (ARRAY[('external_id'::character varying)::text, ('smooch_user_id'::character varying)::text, ('verification_status_status'::character varying)::text]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
     t.index ["annotation_id"], name: "index_dynamic_annotation_fields_on_annotation_id"
     t.index ["annotation_type"], name: "index_dynamic_annotation_fields_on_annotation_type"
@@ -460,6 +460,8 @@ ActiveRecord::Schema.define(version: 2023_10_26_162554) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "unmatched", default: 0
+    t.string "custom_title"
+    t.string "title_field"
     t.index ["channel"], name: "index_project_medias_on_channel"
     t.index ["cluster_id"], name: "index_project_medias_on_cluster_id"
     t.index ["last_seen"], name: "index_project_medias_on_last_seen"

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -10557,6 +10557,7 @@ type ProjectMedia implements Node {
   ): RelationshipConnection
   created_at: String
   creator_name: String
+  custom_title: String
   dbid: Int
   default_relationships(
     """
@@ -11573,6 +11574,7 @@ type ProjectMedia implements Node {
   team_name: String
   tipline_search_results_count: Int
   title: String
+  title_field: String
   type: String
   updated_at: String
   url: String
@@ -15518,6 +15520,7 @@ input UpdateProjectMediaInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  custom_title: String
   id: ID
   media_id: Int
   previous_project_id: Int
@@ -15526,6 +15529,7 @@ input UpdateProjectMediaInput {
   refresh_media: Int
   related_to_id: Int
   source_id: Int
+  title_field: String
 }
 
 """

--- a/public/relay.json
+++ b/public/relay.json
@@ -56646,6 +56646,20 @@
               "deprecationReason": null
             },
             {
+              "name": "custom_title",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "dbid",
               "description": null,
               "args": [
@@ -60639,6 +60653,20 @@
             },
             {
               "name": "title",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title_field",
               "description": null,
               "args": [
 
@@ -84608,6 +84636,30 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "custom_title",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title_field",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "defaultValue": null,


### PR DESCRIPTION
## Description

Items (`ProjectMedia`'s) can now have custom titles. Summary of changes:

- Added fields `custom_title` and `title_field` to the `ProjectMedia` model (new columns for the `project_medias` table in PostgreSQL)
- Expose these fields in GraphQL API for `ProjectMedia` mutations and type
- Changed the logic of the item `get_title` methodIf there is a value for title_field, use that field for the title
- Updated the events that trigger an update for the `title` cached field

Reference: CV2-3983.

## How has this been tested?

Automated tests were implemented for all these new features.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)