### PR TITLE
3995 – Invite a new user to a shared feed

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -354,8 +354,12 @@ ActiveRecord::Base.transaction do
 
   # 3. Create Shared feed
   puts 'Making Shared Feed'
-  saved_search = SavedSearch.create!(title: "#{user.name}'s list #{random_number}", team: team, filters: {created_by: user})
-  feed = Feed.create!(name: "Feed Test ##{user.feeds.count + 1} [User: #{user.name} / Team: #{team.name}]", user: user, team: team, published: true, saved_search: saved_search, licenses: [1])
+  if team.saved_searches.empty?
+    saved_search = SavedSearch.create!(title: "#{user.name.capitalize}'s list", team: team, filters: {created_by: user})
+  else
+    saved_search = team.saved_searches.first
+  end
+  feed = Feed.create!(name: "Feed Test ##{user.feeds.count + 1} [User: #{user.name.capitalize} / Team: #{team.name}]", user: user, team: team, published: true, saved_search: saved_search, licenses: [1])
 
   # 4.1 Create new user with two empty workspaces
   puts 'Making invited user and their 2 empty workspaces...'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -355,7 +355,7 @@ ActiveRecord::Base.transaction do
   # 3. Create Shared feed
   puts 'Making Shared Feed'
   saved_search = SavedSearch.create!(title: "#{user.name}'s list #{random_number}", team: team, filters: {created_by: user})
-  feed = Feed.create!(name: "Feed Test: #{Faker::Alphanumeric.alpha(number: 10)}", user: user, team: team, published: true, saved_search: saved_search, licenses: [1])
+  feed = Feed.create!(name: "Feed Test ##{user.feeds.count + 1} [User: #{user.name} / Team: #{team.name}]", user: user, team: team, published: true, saved_search: saved_search, licenses: [1])
 
   # 4.1 Create new user with two empty workspaces
   puts 'Making invited user and their 2 empty workspaces...'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,7 +10,7 @@ data_users = {
     password: Faker::Internet.password(min_length: 8),
   },
   invited_empty_user: {
-    team: ["#{Faker::Company.name}", "#{Faker::Company.name}"],
+    team: [Faker::Company.name, Faker::Company.name],
     name: Faker::Name.first_name.downcase,
     password: Faker::Internet.password(min_length: 8),
   }
@@ -343,16 +343,13 @@ ActiveRecord::Base.transaction do
   saved_search = SavedSearch.create!(title: "#{user.name}'s list #{random_number}", team: team, filters: {created_by: user})
   feed = Feed.create!(name: "Feed Test: #{Faker::Alphanumeric.alpha(number: 10)}", user: user, team: team, published: true, saved_search: saved_search, licenses: [1])
 
-  # 4.1 Create new user with an empty workspace
-  puts 'Making a new user, their new empty workspace'
-  # _team_invited_empty, user_invited_empty, _project_invited_empty = create_user_with_team_and_project(data_users[:invited_empty_user])
-  puts 'Making User...'
+  # 4.1 Create new user with two empty workspaces
+  puts 'Making invited user and their 2 empty workspaces...'
   invited_empty_user = create_user(name: data_users[:invited_empty_user][:name], login: data_users[:invited_empty_user][:name], password: data_users[:invited_empty_user][:password], password_confirmation: data_users[:invited_empty_user][:password], email: Faker::Internet.safe_email(name: data_users[:invited_empty_user][:name]), is_admin: true)
-
-  # 4.2 Create invited user's two empty workspaces with projects
   data_users[:invited_empty_user][:team].each  { |team_name| create_team_and_project_related_to_user(invited_empty_user, team_name) }
 
   # 4.2 Invite new user/empty workspace
+  puts 'Inviting user to main user\'s feed...'
   create_feed_invitation(email: invited_empty_user.email, feed: feed, user: user)
 
   # FINAL. Return user information

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -47,15 +47,16 @@ data_items = {
   'UploadedAudio' => ['e-item.mp3', 'rails.mp3', 'with_cover.mp3', 'with_cover.ogg', 'with_cover.wav']*4,
   'UploadedImage' =>  ['large-image.jpg', 'maçã.png', 'rails-photo.jpg', 'rails.png', 'ruby-small.png']*4,
   'UploadedVideo' =>  ['d-item.mp4', 'rails.mp4', 'd-item.mp4', 'rails.mp4', 'd-item.mp4']*4,
-  fact_check_links: [
-    'https://meedan.com/post/welcome-haramoun-hamieh-our-program-manager-for-nawa',
-    'https://meedan.com/post/strengthening-fact-checking-with-media-literacy-technology-and-collaboration',
-    'https://meedan.com/post/highlights-from-the-work-of-meedans-partners-on-international-fact-checking',
-    'https://meedan.com/post/what-is-gendered-health-misinformation-and-why-is-it-an-equity-problem-worth',
-    'https://meedan.com/post/the-case-for-a-public-health-approach-to-moderate-health-misinformation',
-  ],
   'Claim' => Array.new(20) { Faker::Lorem.paragraph(sentence_count: 10) },
 }
+
+data_imported_fact_checks =  [
+  'https://meedan.com/post/welcome-haramoun-hamieh-our-program-manager-for-nawa',
+  'https://meedan.com/post/strengthening-fact-checking-with-media-literacy-technology-and-collaboration',
+  'https://meedan.com/post/highlights-from-the-work-of-meedans-partners-on-international-fact-checking',
+  'https://meedan.com/post/what-is-gendered-health-misinformation-and-why-is-it-an-equity-problem-worth',
+  'https://meedan.com/post/the-case-for-a-public-health-approach-to-moderate-health-misinformation',
+]
 
 def open_file(file)
   File.open(File.join(Rails.root, 'test', 'data', file))
@@ -288,13 +289,11 @@ ActiveRecord::Base.transaction do
 
   # 2. Creating Items in different states
   # 2.1 Create medias: claims, audios, images, videos and links
-  media_data_collection = [ data_items['Claim'], data_items['UploadedAudio'], data_items['UploadedImage'], data_items['UploadedVideo'], data_items['Link']]
-  media_data_collection.each do |media_data|
+  data_items.each do |media_type, medias_data|
     begin
-      media_type = data_items.key(media_data)
       puts "Making #{media_type}..."
       puts "#{media_type}: Making Medias and Project Medias..."
-      medias = media_data.map { |individual_data| create_media(user, individual_data, media_type)}
+      medias = medias_data.map { |individual_data| create_media(user, individual_data, media_type)}
       project_medias = create_project_medias_with_channel(user, project, team, medias)
       
       puts "#{media_type}: Making Claim Descriptions and Fact Checks..."
@@ -347,7 +346,7 @@ ActiveRecord::Base.transaction do
   
   # 2.2 Create medias: imported Fact Checks
   puts 'Making Imported Fact Checks...'
-  data_items[:fact_check_links].map { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
+  data_imported_fact_checks.map { |fact_check_link| create_fact_check(fact_check_attributes(fact_check_link, user, project, team)) }
 
   # 3. Create Shared feed
   puts 'Making Shared Feed'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,11 +13,6 @@ data_users = {
     team: Faker::Company.name,
     name: Faker::Name.first_name.downcase,
     password: Faker::Internet.password(min_length: 8),
-  },
-  invited_published_user: {
-    team: Faker::Company.name,
-    name: Faker::Name.first_name.downcase,
-    password: Faker::Internet.password(min_length: 8),
   }
 }
 
@@ -360,23 +355,6 @@ ActiveRecord::Base.transaction do
   # 4.2 Invite new user/empty workspace
   create_feed_invitation(email: user_invited_empty.email, feed: feed, user: user_invited_empty)
 
-  # 5.1 Create a new user with published items
-  puts 'Making a new user, their new workspace with published item'
-  team_invited_published, user_invited_published, project_invited_published = create_user_with_team_and_project(data_users[:invited_published_user])
-
-  # 5.2 Create published Items
-  medias_invited_published = data_items['Claim'].map { |individual_data| create_media(user_invited_published, individual_data, 'Claim')}
-  project_medias_invited_published = create_project_medias_with_channel(user_invited_published, project_invited_published, team_invited_published, medias_invited_published)
-  claim_descriptions_invited_published = create_claim_descriptions(user_invited_published, project_medias_invited_published)
-  claim_descriptions_for_fact_checks_invited_published = claim_descriptions_invited_published[0..10]
-  create_fact_checks(user_invited_published, claim_descriptions_for_fact_checks_invited_published)
-  project_medias_invited_published[7..8].each { |pm| verify_fact_check_and_publish_report(pm, "https://www.thespruceeats.com/step-by-step-basic-cake-recipe-304553?timestamp=#{Time.now.to_f}")}
-  project_medias_invited_published[9..10].each { |pm| verify_fact_check_and_publish_report(pm)}
-  SavedSearch.create!(title: "#{user_invited_published.name}'s list #{random_number}", team: team_invited_published, filters: {created_by: user_invited_published})
-
-  # 5.3 Invite new user/published workspace
-  create_feed_invitation(email: user_invited_published.email, feed: feed, user: user_invited_published)
-
   # FINAL. Return user information
   if answer == "1"
     puts "Created user: name: #{data_users[:main_user][:name]} — email: #{user.email} — password : #{data_users[:main_user][:password]}"
@@ -384,7 +362,6 @@ ActiveRecord::Base.transaction do
     puts "Data added to user: #{user.email}"
   end
   puts "Created invited user / empty workspace: name: #{data_users[:invited_empty_user][:name]} — email: #{user_invited_empty.email} — password : #{data_users[:invited_empty_user][:password]}"
-  puts "Created invited user / workspace with published items: name: #{data_users[:invited_published_user][:name]} — email: #{user_invited_published.email} — password : #{data_users[:invited_published_user][:password]}"
 end
 
 Rails.cache.clear

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,12 +5,26 @@ Rails.env.development? || raise('To run the seeds file you should be in the deve
 
 data_users = {
   main_user: {
-    team: Faker::Company.name,
+    team:
+      {
+        name: "#{Faker::Company.name} / Main User: Main Team",
+        logo: 'rails.png'
+      },
     name: Faker::Name.first_name.downcase,
     password: Faker::Internet.password(min_length: 8),
   },
   invited_empty_user: {
-    team: [Faker::Company.name, Faker::Company.name],
+    team:
+    [
+      {
+      name: "#{Faker::Company.name} / Invited User: Team #1",
+      logo: 'maçã.png'
+    },
+    {
+      name: "#{Faker::Company.name} / Invited User: Team #2",
+      logo: 'ruby-small.png'
+    }
+  ],
     name: Faker::Name.first_name.downcase,
     password: Faker::Internet.password(min_length: 8),
   }
@@ -233,9 +247,9 @@ def verify_fact_check_and_publish_report(project_media, url = '')
   report_design.save!
 end
 
-def create_team_and_project_related_to_user(user, team_name)
+def create_team_and_project_related_to_user(user, team_data)
   puts 'Making Team / Workspace...'
-  team = create_team(name: team_name)
+  team = create_team(team_data)
   team.set_language('en')
 
   puts 'Making Project...'
@@ -346,7 +360,7 @@ ActiveRecord::Base.transaction do
   # 4.1 Create new user with two empty workspaces
   puts 'Making invited user and their 2 empty workspaces...'
   invited_empty_user = create_user(name: data_users[:invited_empty_user][:name], login: data_users[:invited_empty_user][:name], password: data_users[:invited_empty_user][:password], password_confirmation: data_users[:invited_empty_user][:password], email: Faker::Internet.safe_email(name: data_users[:invited_empty_user][:name]), is_admin: true)
-  data_users[:invited_empty_user][:team].each  { |team_name| create_team_and_project_related_to_user(invited_empty_user, team_name) }
+  data_users[:invited_empty_user][:team].each  { |team| create_team_and_project_related_to_user(invited_empty_user, team) }
 
   # 4.2 Invite new user/empty workspace
   puts 'Inviting user to main user\'s feed...'


### PR DESCRIPTION
## Description

We are improving feed invitation and inviting a new user who is part of 2 different workspaces to a shared feed.
The new user's workspaces are both empty.

References: 3995, 3884

## How has this been tested?

By running the seed's script.

## Notes

- Once this is merged, I'll update the confluence page.
- I split the big data hash we had with everything into smaller groups (2 hashes and 1 array): data_users, data_items and data_imported_fact_checks. I thought this made it easier to reason with. 

