### PR TITLE
Exposing new GraphQL field `suggestions_count` in `ProjectMediaType`.

### DIFF
--- a/app/graph/types/project_media_type.rb
+++ b/app/graph/types/project_media_type.rb
@@ -45,6 +45,7 @@ class ProjectMediaType < DefaultObject
   field :tipline_search_results_count, GraphQL::Types::Int, null: true
   field :custom_title, GraphQL::Types::String, null: true
   field :title_field, GraphQL::Types::String, null: true
+  field :suggestions_count, GraphQL::Types::Int, null: true
 
   field :claim_description, ClaimDescriptionType, null: true
 

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -11526,6 +11526,7 @@ type ProjectMedia implements Node {
     """
     last: Int
   ): RelationshipConnection
+  suggestions_count: Int
   tags(
     """
     Returns the elements in the list that come after the specified cursor.

--- a/public/relay.json
+++ b/public/relay.json
@@ -60462,6 +60462,20 @@
               "deprecationReason": null
             },
             {
+              "name": "suggestions_count",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "tags",
               "description": null,
               "args": [


### PR DESCRIPTION
## Description

Exposing new GraphQL field `suggestions_count` in `ProjectMediaType`.

Reference: CV2-3988.

## How has this been tested?

The underlying method is already unit-tested.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

