### PR TITLE
Exposing `team_avatar` in item's `feed_columns_values` method.

### DIFF
--- a/app/models/concerns/project_media_getters.rb
+++ b/app/models/concerns/project_media_getters.rb
@@ -209,4 +209,8 @@ module ProjectMediaGetters
     end
     user_name
   end
+
+  def team_avatar
+    self.team.avatar
+  end
 end

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -347,7 +347,8 @@ class ProjectMedia < ApplicationRecord
       'tags_as_sentence',
       'team_name',
       'updated_at_timestamp',
-      'status'
+      'status',
+      'team_avatar'
     ]
     columns.each do |column|
       values[column] = self.send(column)

--- a/test/models/project_media_6_test.rb
+++ b/test/models/project_media_6_test.rb
@@ -510,4 +510,12 @@ class ProjectMedia6Test < ActiveSupport::TestCase
     assert_match /^text-/, pm.get_title # Uncached
     assert_match /^text-/, pm.title # Cached
   end
+
+  test "should avoid N + 1 queries problem when loading the team avatar of many items at once" do
+    t = create_team
+    create_project_media team: t
+    create_project_media team: t
+    pms = ProjectMedia.where(team: t).to_a
+    assert_queries(1, '=') { pms.map(&:team_avatar) }
+  end
 end


### PR DESCRIPTION
## Description

Exposing `team_avatar` in item's `feed_columns_values` method.

Reference: CV2-3989.

## How has this been tested?

I added a unit test to be sure that we won't fall into a N + 1 queries problem.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

