### PR TITLE
Exposing a new argument `skip_send_report` for the mutation `ProjectMediaReplace`

### DIFF
--- a/app/graph/mutations/project_media_mutations.rb
+++ b/app/graph/mutations/project_media_mutations.rb
@@ -67,11 +67,12 @@ module ProjectMediaMutations
 
     argument :project_media_to_be_replaced_id, GraphQL::Types::ID, required: true, camelize: false
     argument :new_project_media_id, GraphQL::Types::ID, required: true, camelize: false
+    argument :skip_send_report, GraphQL::Types::Boolean, required: false, camelize: false
 
     field :old_project_media_deleted_id, GraphQL::Types::ID, null: true, camelize: false
     field :new_project_media, ProjectMediaType, null: true, camelize: false
 
-    def resolve(project_media_to_be_replaced_id:, new_project_media_id:)
+    def resolve(project_media_to_be_replaced_id:, new_project_media_id:, skip_send_report: false)
       old_object = GraphqlCrudOperations.object_from_id_if_can(
         project_media_to_be_replaced_id,
         context[:ability]
@@ -80,7 +81,7 @@ module ProjectMediaMutations
         new_project_media_id,
         context[:ability]
       )
-      old_object.replace_by(new_object)
+      old_object.replace_by(new_object, skip_send_report)
       {
         old_project_media_deleted_id: old_object.graphql_id,
         new_project_media: new_object

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -11946,6 +11946,7 @@ input ReplaceProjectMediaInput {
   clientMutationId: String
   new_project_media_id: ID!
   project_media_to_be_replaced_id: ID!
+  skip_send_report: Boolean
 }
 
 """

--- a/public/relay.json
+++ b/public/relay.json
@@ -62767,6 +62767,18 @@
               "deprecationReason": null
             },
             {
+              "name": "skip_send_report",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
               "type": {


### PR DESCRIPTION
## Description

When an item is replaced by another one (for example, when accepting a suggestion to an imported item, which has no media), in some cases we don't want a report to be sent since the tipline users may have already received those through search results. This PR adds a `skip_send_report` argument to the `ProjectMediaReplace` mutation, which is `false` by default (so, same as current behavior) but that when `true` doesn't send a report.

Reference: CV2-4132.

## How has this been tested?

Existing tests should cover this. The default behavior is the same.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

