### PR TITLE
use gitlab-provided aws base image for ci build steps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
   - deploy
 
 build_qa:
-  image: docker:latest
+  image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest
   services:
     - docker:dind
   tags:
@@ -15,9 +15,7 @@ build_qa:
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
 
   script:
-    - apk add --no-cache curl python3 py3-pip
-    - pip install awscli==1.29.59
-    - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+    - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_API_BASE_URL
     - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA" .
     - docker push "$ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
@@ -58,7 +56,7 @@ deploy_qa:
     - develop
 
 build_batch:
-  image: docker:latest
+  image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest
   services:
     - docker:dind
   tags:
@@ -69,16 +67,14 @@ build_batch:
     AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
   script:
-    - apk add --no-cache curl python3 py3-pip git
-    - pip install awscli==1.29.59
-    - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+    - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_API_BASE_URL
     - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/batch/check/api:$CI_COMMIT_SHA" .
     - docker push "$ECR_API_BASE_URL/batch/check/api:$CI_COMMIT_SHA"
   only:
     - master
 
 build_live:
-  image: docker:latest
+  image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest
   services:
     - docker:dind
   tags:
@@ -89,9 +85,7 @@ build_live:
     AWS_ACCESS_KEY_ID: $AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY: $AWS_SECRET_ACCESS_KEY
   script:
-    - apk add --no-cache curl python3 py3-pip git
-    - pip install awscli==1.29.59
-    - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+    - aws ecr get-login-password --region $AWS_DEFAULT_REGION | docker login --username AWS --password-stdin $ECR_API_BASE_URL
     - docker build -f production/Dockerfile -t "$ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA" .
     - docker push "$ECR_API_BASE_URL/live/check/api:$CI_COMMIT_SHA"
   only:


### PR DESCRIPTION
## Description

replaces image used in ci with gitlab-provided aws-base image and updates aws ecr command to reflect syntax used in new awscli version. fixes gitlab issue around installing awscli v1