### PR TITLE
Bugfix: Title should be updated in ElasticSearch when item is updated

### DIFF
--- a/app/models/concerns/project_association.rb
+++ b/app/models/concerns/project_association.rb
@@ -100,7 +100,8 @@ module ProjectAssociation
         'project_id' => obj.project_id,
         'unmatched' => obj.unmatched,
         'channel' => obj.channel.values.flatten.map(&:to_i),
-        'updated_at' => obj.updated_at.utc
+        'updated_at' => obj.updated_at.utc,
+        'title' => obj.title
       }
       options = { keys: data.keys, data: data, pm_id: obj.id }
       model = { klass: obj.class.name, id: obj.id }


### PR DESCRIPTION
## Description

While working on the "edit title" feature (see referenced ticket for details), I noticed that the `title` was not updated in ElasticSearch when a `ProjectMedia` was updated. This PR fixes this. Only `title_index` was being updated.

Reference: CV2-3986.

## How has this been tested?

Manually, using the edit title feature:

- Type a custom title for an item
- Search by that custom title
- You should find the item

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

