### PR TITLE
Fallback to custom title with previous value if item title gets blank.

### DIFF
--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -548,8 +548,15 @@ module ProjectMediaCachedFields
     def recalculate_title
       title = self.get_title
       # Always save the title as a custom title so we can fallback to it in case the title gets blank (for example, title_field is claim title and claim is deleted)
-      title.blank? ? self.update_column(:title_field, 'custom_title') : self.update_column(:custom_title, title)
-      title.blank? ? self.custom_title&.to_s : title
+      if title.blank?
+        unless self.custom_title.blank?
+          self.update_column(:title_field, 'custom_title')
+          title = self.custom_title
+        end
+      else
+        self.update_column(:custom_title, title)
+      end
+      title.to_s
     end
 
     def recalculate_status

--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -546,7 +546,10 @@ module ProjectMediaCachedFields
     end
 
     def recalculate_title
-      self.get_title
+      title = self.get_title
+      # Always save the title as a custom title so we can fallback to it in case the title gets blank (for example, title_field is claim title and claim is deleted)
+      title.blank? ? self.update_column(:title_field, 'custom_title') : self.update_column(:custom_title, title)
+      title.blank? ? self.custom_title&.to_s : title
     end
 
     def recalculate_status

--- a/app/models/concerns/project_media_getters.rb
+++ b/app/models/concerns/project_media_getters.rb
@@ -150,7 +150,7 @@ module ProjectMediaGetters
       custom_title: :custom_title,
       pinned_media_id: :media_slug,
       claim_title: :claim_description_content,
-      fact_check_title: :fact_check_title
+      fact_check_title: :recalculate_fact_check_title
     }
     title_field = self.title_field&.to_sym
     if !title_field.blank? && title_mapping.keys.include?(title_field)

--- a/test/models/project_media_6_test.rb
+++ b/test/models/project_media_6_test.rb
@@ -487,6 +487,7 @@ class ProjectMedia6Test < ActiveSupport::TestCase
     assert_equal 'The Claim', pm.title
 
     pm.title_field = 'custom_title'
+    pm.custom_title = 'Custom Title'
     pm.save!
     assert_equal 'Custom Title', pm.get_title # Uncached
     assert_equal 'Custom Title', pm.title # Cached


### PR DESCRIPTION
## Description

If an item has the title field set to claim title or fact-check title and one of those is deleted, then in order to avoid that the title gets blank, the title field is set to "custom_title" and the value is set to the previous title value.

Reference: CV2-3986.

## How has this been tested?

This is a very edge case so I didn't add a specific test for it. I'm mostly concerned about keeping the previous behavior, so existing tests should pass.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

