### PR TITLE
Adding a `data_points` field to `Feed` and exposing it on GraphQL API

### DIFF
--- a/app/graph/mutations/feed_mutations.rb
+++ b/app/graph/mutations/feed_mutations.rb
@@ -19,6 +19,7 @@ module FeedMutations
 
     argument :name, GraphQL::Types::String, required: true
     argument :licenses, [GraphQL::Types::Int, null: true], required: true
+    argument :data_points, [GraphQL::Types::Int, null: true], required: false
   end
 
   class Update < Mutations::UpdateMutation

--- a/app/graph/types/feed_type.rb
+++ b/app/graph/types/feed_type.rb
@@ -52,4 +52,5 @@ class FeedType < DefaultObject
 
   field :teams, TeamType.connection_type, null: false
   field :feed_teams, FeedTeamType.connection_type, null: false
+  field :data_points, [GraphQL::Types::Int, null: true], null: true
 end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -22,6 +22,8 @@ class Feed < ApplicationRecord
   PROHIBITED_FILTERS = ['team_id', 'feed_id', 'clusterize']
   LICENSES = { 1 => 'academic', 2 => 'commercial', 3 => 'open_source' }
   validates_inclusion_of :licenses, in: LICENSES.keys, if: proc { |feed| feed.discoverable }
+  DATA_POINTS = { 1 => 'published_fact_checks', 2 => 'media_claim_requests', 3 => 'tags' }
+  validates_inclusion_of :data_points, in: DATA_POINTS.keys
 
   # Filters for the whole feed: applies to all data from all teams
   def get_feed_filters

--- a/db/migrate/20240107223820_add_data_points_to_feeds.rb
+++ b/db/migrate/20240107223820_add_data_points_to_feeds.rb
@@ -1,0 +1,5 @@
+class AddDataPointsToFeeds < ActiveRecord::Migration[6.1]
+  def change
+    add_column :feeds, :data_points, :integer, array: true, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_10_015830) do
+ActiveRecord::Schema.define(version: 2024_01_07_223820) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -337,6 +337,7 @@ ActiveRecord::Schema.define(version: 2023_12_10_015830) do
     t.string "tags", default: [], array: true
     t.integer "licenses", default: [], array: true
     t.boolean "discoverable", default: false
+    t.integer "data_points", default: [], array: true
     t.index ["saved_search_id"], name: "index_feeds_on_saved_search_id"
     t.index ["team_id"], name: "index_feeds_on_team_id"
     t.index ["user_id"], name: "index_feeds_on_user_id"
@@ -666,6 +667,7 @@ ActiveRecord::Schema.define(version: 2023_12_10_015830) do
     t.datetime "updated_at", null: false
     t.string "state"
     t.index ["external_id", "state"], name: "index_tipline_messages_on_external_id_and_state", unique: true
+    t.index ["external_id"], name: "index_tipline_messages_on_external_id"
     t.index ["team_id"], name: "index_tipline_messages_on_team_id"
     t.index ["uid"], name: "index_tipline_messages_on_uid"
   end
@@ -806,8 +808,7 @@ ActiveRecord::Schema.define(version: 2023_12_10_015830) do
   end
 
   create_table "versions", id: :serial, force: :cascade do |t|
-    t.string "item_type"
-    t.string "{:null=>false}"
+    t.string "item_type", null: false
     t.string "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -2311,6 +2311,7 @@ input CreateFeedInput {
   A unique identifier for the client performing the mutation.
   """
   clientMutationId: String
+  dataPoints: [Int]
   description: String
   discoverable: Boolean
   licenses: [Int]!
@@ -8053,6 +8054,7 @@ Feed type
 type Feed implements Node {
   created_at: String
   current_feed_team: FeedTeam
+  data_points: [Int]
   dbid: Int
   description: String
   discoverable: Boolean

--- a/public/relay.json
+++ b/public/relay.json
@@ -14295,6 +14295,22 @@
               "deprecationReason": null
             },
             {
+              "name": "dataPoints",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
               "type": {
@@ -43757,6 +43773,24 @@
                 "kind": "OBJECT",
                 "name": "FeedTeam",
                 "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "data_points",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "Int",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -187,4 +187,20 @@ class FeedTest < ActiveSupport::TestCase
       f.destroy!
     end
   end
+
+  test "should create feed without data points" do
+    f = create_feed
+    assert_equal [], f.data_points
+  end
+
+  test "should create feed with valid data points" do
+    f = create_feed data_points: [1, 2]
+    assert_equal [1, 2], f.data_points
+  end
+
+  test "should not create feed with invalid data points" do
+    assert_raises ActiveRecord::RecordInvalid do
+      create_feed data_points: [0, 1]
+    end
+  end
 end


### PR DESCRIPTION
## Description

* Adding a new column/field `data_points` to the `Feed` model, which is an array of integers, empty by default
* Validate that it contains allowed values
* Expose `data_points` on GraphQL API, for feed type and create mutation
* Automated tests added

References: CV2-4034 and CV2-3923.

## How has this been tested?

Unit and functional tests added for all features here.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

