### PR TITLE
Fixing Alegre path for tipline image search.

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -33,7 +33,7 @@ class Bot::Alegre < BotUser
           'UploadedImage' => 'image',
         }[self.media.type].to_s
         threshold = [{value: thresholds.dig(media_type.to_sym, :value)}] || Bot::Alegre.get_threshold_for_query(media_type, self, true)
-        ids_and_scores = Bot::Alegre.get_items_with_similar_media(Bot::Alegre.media_file_url(self), threshold, team_ids, "/#{media_type}/similarity/search/").to_h
+        ids_and_scores = Bot::Alegre.get_items_with_similar_media_v2(Bot::Alegre.media_file_url(self), threshold, team_ids, media_type).to_h
       elsif self.is_text?
         ids_and_scores = {}
         threads = []

--- a/app/models/concerns/alegre_similarity.rb
+++ b/app/models/concerns/alegre_similarity.rb
@@ -39,7 +39,7 @@ module AlegreSimilarity
       if type == 'text'
         self.get_merged_items_with_similar_text(pm, threshold)
       else
-        results = self.get_items_with_similar_media(self.media_file_url(pm), threshold, pm.team_id, "/#{type}/similarity/search/").reject{ |id, _score_with_context| pm.id == id }
+        results = self.get_items_with_similar_media_v2(self.media_file_url(pm), threshold, pm.team_id, type).reject{ |id, _score_with_context| pm.id == id }
         self.merge_response_with_source_and_target_fields(results, type)
       end
     end

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -9,7 +9,11 @@ module AlegreV2
     end
 
     def sync_path(project_media)
-      "/similarity/sync/#{get_type(project_media)}"
+      self.sync_path_for_type(get_type(project_media))
+    end
+
+    def sync_path_for_type(type)
+      "/similarity/sync/#{type}"
     end
 
     def async_path(project_media)
@@ -255,6 +259,13 @@ module AlegreV2
 
     def relate_project_media(project_media, field=nil)
       self.add_relationships(project_media, self.get_similar_items_v2(project_media, field)) unless project_media.is_blank?
+    end
+
+    def get_items_with_similar_media_v2(media_url, threshold, team_ids, type)
+      alegre_path = ['audio', 'image'].include?(type) ? self.sync_path_for_type(type) : "/#{type}/similarity/search/"
+      # FIXME: Stop using this method from v1 once all media types are supported by v2
+      # FIXME: Alegre crashes if `media_url` was already requested before, this is why I append a hash
+      self.get_items_with_similar_media("#{media_url}?hash=#{SecureRandom.hex}", threshold, team_ids, alegre_path)
     end
   end
 end

--- a/app/resources/api/v2/report_resource.rb
+++ b/app/resources/api/v2/report_resource.rb
@@ -100,7 +100,7 @@ module Api
         unless media.blank?
           media[0].rewind
           CheckS3.write(media_path, media[0].content_type.gsub(/^video/, 'application'), media[0].read)
-          ids_and_scores = Bot::Alegre.get_items_with_similar_media(CheckS3.public_url(media_path), [{ value: threshold }], organization_ids, "/#{media_type}/similarity/search/")
+          ids_and_scores = Bot::Alegre.get_items_with_similar_media_v2(CheckS3.public_url(media_path), [{ value: threshold }], organization_ids, media_type)
           RequestStore.store[:scores] = ids_and_scores # Store the scores so we can return them
           ids = ids_and_scores.keys.uniq || [0]
           CheckS3.delete(media_path)

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -262,7 +262,7 @@ class CheckSearch
       file_path = "check_search/#{hash}"
     end
     threshold = Bot::Alegre.get_threshold_for_query(@options['file_type'], ProjectMedia.new(team_id: Team.current.id))[0][:value]
-    results = Bot::Alegre.get_items_with_similar_media(CheckS3.public_url(file_path), [{ value: threshold }], @options['team_id'].first, "/#{@options['file_type']}/similarity/search/")
+    results = Bot::Alegre.get_items_with_similar_media_v2(CheckS3.public_url(file_path), [{ value: threshold }], @options['team_id'].first, @options['file_type'])
     results.blank? ? [0] : results.keys
   end
 

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -17,8 +17,10 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
     Sidekiq::Testing.inline!
     Bot::Alegre.stubs(:should_get_similar_items_of_type?).returns(true)
     Bot::Alegre.unstub(:media_file_url)
+    hex = SecureRandom.hex
+    SecureRandom.stubs(:hex).returns(hex)
     @media_path = random_url
-    @params = { url: @media_path, context: { has_custom_id: true, team_id: @team.id }, threshold: 0.9, match_across_content_types: true }
+    @params = { url: "#{@media_path}?hash=#{hex}", context: { has_custom_id: true, team_id: @team.id }, threshold: 0.9, match_across_content_types: true }
   end
 
   def teardown
@@ -64,7 +66,7 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
     pm1 = create_project_media team: @team, media: create_uploaded_audio
     pm2 = create_project_media team: @team, media: create_uploaded_audio
     pm3 = create_project_media team: @team, media: create_uploaded_audio
-    Bot::Alegre.stubs(:request).with('post', '/audio/similarity/search/', @params).returns({
+    Bot::Alegre.stubs(:request).with('post', '/similarity/sync/audio', @params).returns({
       result: [
         {
           id: 1,
@@ -105,7 +107,7 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
     pm1 = create_project_media team: @team, media: create_uploaded_video
     pm2 = create_project_media team: @team, media: create_uploaded_audio
     pm3 = create_project_media team: @team, media: create_uploaded_audio
-    Bot::Alegre.stubs(:request).with('post', '/audio/similarity/search/', @params).returns({
+    Bot::Alegre.stubs(:request).with('post', '/similarity/sync/audio', @params).returns({
       result: [
         {
           id: 2,
@@ -171,8 +173,8 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
         }
       ]
     }.with_indifferent_access
-    Bot::Alegre.stubs(:request).with('post', '/image/similarity/search/', @params.merge({ threshold: 0.89 })).returns(result)
-    Bot::Alegre.stubs(:request).with('post', '/image/similarity/search/', @params.merge({ threshold: 0.95 })).returns(result)
+    Bot::Alegre.stubs(:request).with('post', '/similarity/sync/image', @params.merge({ threshold: 0.89 })).returns(result)
+    Bot::Alegre.stubs(:request).with('post', '/similarity/sync/image', @params.merge({ threshold: 0.95 })).returns(result)
     Bot::Alegre.stubs(:media_file_url).with(pm3).returns(@media_path)
     assert_difference 'Relationship.count' do
       Bot::Alegre.relate_project_media_to_similar_items(pm3)
@@ -222,8 +224,8 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
       ]
     }.with_indifferent_access
     Bot::Alegre.stubs(:media_file_url).with(pm1a).returns(@media_path)
-    Bot::Alegre.stubs(:request).with('post', '/image/similarity/search/', @params.merge({ threshold: 0.89 })).returns(response)
-    Bot::Alegre.stubs(:request).with('post', '/image/similarity/search/', @params.merge({ threshold: 0.95 })).returns(response)
+    Bot::Alegre.stubs(:request).with('post', '/similarity/sync/image', @params.merge({ threshold: 0.89 })).returns(response)
+    Bot::Alegre.stubs(:request).with('post', '/similarity/sync/image', @params.merge({ threshold: 0.95 })).returns(response)
     assert_difference 'Relationship.count' do
       Bot::Alegre.relate_project_media_to_similar_items(pm1a)
     end
@@ -232,170 +234,65 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
     assert_equal pm1a, Relationship.last.target
   end
 
-  test "should link similar images, get flags and extract text zzz" do
+  test "should link similar images, get flags and extract text" do
     image_path = random_url
     ft = create_field_type field_type: 'image_path', label: 'Image Path'
     at = create_annotation_type annotation_type: 'reverse_image', label: 'Reverse Image'
     create_field_instance annotation_type_object: at, name: 'reverse_image_path', label: 'Reverse Image', field_type_object: ft, optional: false
     stub_configs({ 'alegre_host' => 'http://alegre.test', 'alegre_token' => 'test' }) do
-      WebMock.stub_request(:post, 'http://alegre.test/text/langid/').to_return(body: { 'result' => { 'language' => 'es' }}.to_json)
-      WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
-      WebMock.stub_request(:post, 'http://alegre.test/text/similarity/').to_return(body: 'success')
-      WebMock.stub_request(:delete, 'http://alegre.test/text/similarity/').to_return(body: {success: true}.to_json)
-      WebMock.stub_request(:post, 'http://alegre.test/text/similarity/search/').to_return(body: {success: true}.to_json)
-      WebMock.stub_request(:post, 'http://alegre.test/image/similarity/').to_return(body: {
-        "success": true
-      }.to_json)
-      WebMock.stub_request(:post, 'http://alegre.test/image/classification/').with({ body: { uri: image_path } }).to_return(body: {
-        "result": valid_flags_data
-      }.to_json)
-      WebMock.stub_request(:post, 'http://alegre.test/image/ocr/').with({ body: { url: image_path } }).to_return(body: {
-        "text": "Foo bar"
-      }.to_json)
-      WebMock.stub_request(:post, 'http://alegre.test/image/similarity/').to_return(body: 'success')
-
-      # Similarity
       t = create_team
-      pm1 = create_project_media team: t, media: create_uploaded_image
-      context = [{
-        "team_id" => pm1.team.id.to_s,
-        "project_media_id" => pm1.id.to_s
-      }]
-      WebMock.stub_request(:post, "http://alegre.test/image/similarity/search/").with(body: {:context=>{:team_id=>pm1.team_id, :has_custom_id=>true}, :match_across_content_types => true, :url=>image_path, :threshold=>0.89}).to_return(body: {
-        "result": [
-          {
-            "id": pm1.id,
-            "sha256": "1782b1d1993fcd9f6fd8155adc6009a9693a8da7bb96d20270c4bc8a30c97570",
-            "phash": 17399941807326929,
-            "url": "https:\/\/www.gstatic.com\/webp\/gallery3\/1.png",
-            "context": context,
-            "score": 0
-          }
-        ]
-      }.to_json)
-      WebMock.stub_request(:post, "http://alegre.test/image/similarity/search/").with(body: {:context=>{:team_id=>pm1.team_id, :has_custom_id=>true}, :match_across_content_types => true, :url=>image_path, :threshold=>0.95}).to_return(body: {
-        "result": [
-          {
-            "id": pm1.id,
-            "sha256": "1782b1d1993fcd9f6fd8155adc6009a9693a8da7bb96d20270c4bc8a30c97570",
-            "phash": 17399941807326929,
-            "url": "https:\/\/www.gstatic.com\/webp\/gallery3\/1.png",
-            "context": context,
-            "score": 0
-          }
-        ]
-      }.to_json)
-      WebMock.stub_request(:post, "http://alegre.test/similarity/sync/image").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>image_path, :threshold=>0.89}).to_return(body: {
-        "result": [
-          {
-            "id": pm1.id,
-            "sha256": "1782b1d1993fcd9f6fd8155adc6009a9693a8da7bb96d20270c4bc8a30c97570",
-            "phash": 17399941807326929,
-            "url": "https:\/\/www.gstatic.com\/webp\/gallery3\/1.png",
-            "context": context,
-            "score": 0
-          }
-        ]
-      }.to_json)
-      WebMock.stub_request(:post, "http://alegre.test/similarity/sync/image").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>image_path, :threshold=>0.95}).to_return(body: {
-        "result": [
-          {
-            "id": pm1.id,
-            "sha256": "1782b1d1993fcd9f6fd8155adc6009a9693a8da7bb96d20270c4bc8a30c97570",
-            "phash": 17399941807326929,
-            "url": "https:\/\/www.gstatic.com\/webp\/gallery3\/1.png",
-            "context": context,
-            "score": 0
-          }
-        ]
-      }.to_json)
       Bot::Alegre.stubs(:media_file_url).returns(image_path)
-      assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
-      Bot::Alegre.unstub(:media_file_url)
-      WebMock.stub_request(:post, 'http://alegre.test/similarity/sync/image').with(body: {url: image_path}.to_json).to_return(body: {
-        "result": [
+      WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
+      WebMock.stub_request(:post, 'http://alegre.test/text/langid/').to_return(body: { 'result' => { 'language' => 'es' }}.to_json)
+      WebMock.stub_request(:post, 'http://alegre.test/text/similarity/').to_return(body: 'success')
+      WebMock.stub_request(:delete, 'http://alegre.test/text/similarity/').to_return(body: { success: true }.to_json)
+      WebMock.stub_request(:post, 'http://alegre.test/text/similarity/search/').to_return(body: { success: true }.to_json)
+      WebMock.stub_request(:post, 'http://alegre.test/image/ocr/').to_return(body: { text: 'Foo bar' }.to_json)
+      WebMock.stub_request(:post, 'http://alegre.test/similarity/sync/image').to_return(body: {
+        result: [
           {
-            "id": 1,
-            "sha256": "1782b1d1993fcd9f6fd8155adc6009a9693a8da7bb96d20270c4bc8a30c97570",
-            "phash": 17399941807326929,
-            "url": "https:\/\/www.gstatic.com\/webp\/gallery3\/1.png",
-            "context": context,
-            "score": 0
+            id: random_number,
+            sha256: random_string,
+            phash: random_string,
+            url: image_path,
+            context: { team_id: t.id },
+            score: 0
           }
         ]
       }.to_json)
-      pm2 = create_project_media team: t, media: create_uploaded_image
-      response = {pm1.id => {:score => 0, :context => context, :model=>nil, :source_field=>"image", :target_field => "image"}}
-      Bot::Alegre.stubs(:media_file_url).returns(image_path)
-      assert_equal response, Bot::Alegre.get_items_with_similarity('image', pm2, Bot::Alegre.get_threshold_for_query('image', pm2))
 
       # Flags
       Bot::Alegre.unstub(:media_file_url)
-      WebMock.stub_request(:post, 'http://alegre.test/image/classification/').to_return(body: {
-        "result": valid_flags_data
-      }.to_json)
+      WebMock.stub_request(:post, 'http://alegre.test/image/classification/').to_return(body: { result: valid_flags_data }.to_json)
       pm3 = create_project_media team: t, media: create_uploaded_image
-      WebMock.stub_request(:post, "http://alegre.test/similarity/sync/image").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm3), :context=>{:team_id=>pm3.team_id, :project_media_id=>pm3.id, :has_custom_id=>true}, :url=>image_path, :threshold=>0.89}).to_return(body: {
-        "result": [
-          {
-            "id": pm1.id,
-            "sha256": "1782b1d1993fcd9f6fd8155adc6009a9693a8da7bb96d20270c4bc8a30c97570",
-            "phash": 17399941807326929,
-            "url": "https:\/\/www.gstatic.com\/webp\/gallery3\/1.png",
-            "context": context,
-            "score": 0
-          }
-        ]
-      }.to_json)
-      WebMock.stub_request(:post, "http://alegre.test/similarity/sync/image").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm3), :context=>{:team_id=>pm3.team_id, :project_media_id=>pm3.id, :has_custom_id=>true}, :url=>image_path, :threshold=>0.95}).to_return(body: {
-        "result": [
-          {
-            "id": pm1.id,
-            "sha256": "1782b1d1993fcd9f6fd8155adc6009a9693a8da7bb96d20270c4bc8a30c97570",
-            "phash": 17399941807326929,
-            "url": "https:\/\/www.gstatic.com\/webp\/gallery3\/1.png",
-            "context": context,
-            "score": 0
-          }
-        ]
-      }.to_json)
-      Bot::Alegre.stubs(:media_file_url).returns(image_path)
       assert Bot::Alegre.run({ data: { dbid: pm3.id }, event: 'create_project_media' })
       assert_not_nil pm3.get_annotations('flag').last
-      Bot::Alegre.unstub(:media_file_url)
 
       # Text extraction
-      Bot::Alegre.unstub(:media_file_url)
       pm4 = create_project_media team: t, media: create_uploaded_image
-      WebMock.stub_request(:post, "http://alegre.test/similarity/sync/image").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm4), :context=>{:team_id=>pm4.team_id, :project_media_id=>pm4.id, :has_custom_id=>true}, :url=>image_path, :threshold=>0.89}).to_return(body: {
-        "result": [
-          {
-            "id": pm1.id,
-            "sha256": "1782b1d1993fcd9f6fd8155adc6009a9693a8da7bb96d20270c4bc8a30c97570",
-            "phash": 17399941807326929,
-            "url": "https:\/\/www.gstatic.com\/webp\/gallery3\/1.png",
-            "context": context,
-            "score": 0
-          }
-        ]
-      }.to_json)
-      WebMock.stub_request(:post, "http://alegre.test/similarity/sync/image").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm4), :context=>{:team_id=>pm4.team_id, :project_media_id=>pm4.id, :has_custom_id=>true}, :url=>image_path, :threshold=>0.95}).to_return(body: {
-        "result": [
-          {
-            "id": pm1.id,
-            "sha256": "1782b1d1993fcd9f6fd8155adc6009a9693a8da7bb96d20270c4bc8a30c97570",
-            "phash": 17399941807326929,
-            "url": "https:\/\/www.gstatic.com\/webp\/gallery3\/1.png",
-            "context": context,
-            "score": 0
-          }
-        ]
-      }.to_json)
-      Bot::Alegre.stubs(:media_file_url).returns(image_path)
       assert Bot::Alegre.run({ data: { dbid: pm4.id }, event: 'create_project_media' })
       extracted_text_annotation = pm4.get_annotations('extracted_text').last
       assert_equal 'Foo bar', extracted_text_annotation.data['text']
-      Bot::Alegre.unstub(:media_file_url)
+
+      # Similarity
+      pm1 = create_project_media team: t, media: create_uploaded_image
+      assert Bot::Alegre.run({ data: { dbid: pm1.id }, event: 'create_project_media' })
+      
+      pm2 = create_project_media team: t, media: create_uploaded_image
+      WebMock.stub_request(:post, 'http://alegre.test/similarity/sync/image').to_return(body: {
+        result: [
+          {
+            id: pm1.id,
+            sha256: '1782b1d1993fcd9f6fd8155adc6009a9693a8da7bb96d20270c4bc8a30c97570',
+            phash: '17399941807326929',
+            url: image_path,
+            context: { team_id: t.id, project_media_id: pm1.id },
+            score: 0.8
+          }
+        ]
+      }.to_json)
+      response = { pm1.id => { score: 0.8, context: { team_id: t.id, project_media_id: pm1.id, contexts_count: 1, field: ''}, model: nil, source_field: 'image', target_field: 'image' } }
+      assert_equal response.to_json, Bot::Alegre.get_items_with_similarity('image', pm2, Bot::Alegre.get_threshold_for_query('image', pm2)).to_json
     end
   end
 
@@ -605,7 +502,7 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
     pm = create_project_media quote: "Blah", team: p.team
     pm.analysis = { title: 'Title 1' }
     pm.save!
-    tbi.settings = {"text_similarity_model": "paraphrase-filipino-mpnet-base-v2", "text_similarity_model": ["indian-sbert", "xlm-r-bert-base-nli-stsb-mean-tokens"], "alegre_model_in_use": "paraphrase-filipino-mpnet-base-v2", "alegre_model_in_use": ["indian-sbert", "xlm-r-bert-base-nli-stsb-mean-tokens"], "text_vector_matching_threshold" => 0.92, "text_vector_xlm-r-bert-base-nli-stsb-mean-tokens_suggestion_threshold" => 0.97}
+    tbi.settings = {"text_similarity_model": ["indian-sbert", "xlm-r-bert-base-nli-stsb-mean-tokens"], "alegre_model_in_use": ["indian-sbert", "xlm-r-bert-base-nli-stsb-mean-tokens"], "text_vector_matching_threshold" => 0.92, "text_vector_xlm-r-bert-base-nli-stsb-mean-tokens_suggestion_threshold" => 0.97}
     tbi.save!
     assert_equal Bot::Alegre.get_threshold_for_query("text", pm, true), [{:value=>0.875, :key=>"text_elasticsearch_matching_threshold", :automatic=>true, :model=>"elasticsearch"}, {:value=>0.92, :key=>"text_vector_matching_threshold", :automatic=>true, :model=>"indian-sbert"}, {:value=>0.92, :key=>"text_vector_matching_threshold", :automatic=>true, :model=>"xlm-r-bert-base-nli-stsb-mean-tokens"}]
     assert_equal Bot::Alegre.get_threshold_for_query("text", pm, false), [{:value=>0.7, :key=>"text_elasticsearch_suggestion_threshold", :automatic=>false, :model=>"elasticsearch"}, {:value=>0.75, :key=>"text_vector_suggestion_threshold", :automatic=>false, :model=>"indian-sbert"}, {:value=>0.97, :key=>"text_vector_xlm-r-bert-base-nli-stsb-mean-tokens_suggestion_threshold", :automatic=>false, :model=>"xlm-r-bert-base-nli-stsb-mean-tokens"}]

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -258,6 +258,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     ProjectMedia.any_instance.stubs(:analysis_published_article_url).returns(random_url)
     Bot::Alegre.stubs(:get_items_with_similar_media).returns({ @search_result.id => { score: 0.9 } })
     Bot::Smooch.stubs(:bundle_list_of_messages).returns({ 'type' => 'image', 'mediaUrl' => image_url })
+    CheckS3.stubs(:rewrite_url).returns(random_url)
     Sidekiq::Testing.inline! do
       send_message 'hello', '1', '1', 'Image here', '1'
       assert_state 'search_result'
@@ -266,10 +267,6 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
       end
       assert_state 'main'
     end
-    Bot::Alegre.unstub(:get_merged_similar_items)
-    Bot::Smooch.unstub(:bundle_list_of_messages)
-    ProjectMedia.any_instance.unstub(:report_status)
-    ProjectMedia.any_instance.unstub(:analysis_published_article_url)
   end
 
   test "should submit query and handle search error on tipline bot v2" do

--- a/test/models/bot/smooch_7_test.rb
+++ b/test/models/bot/smooch_7_test.rb
@@ -263,6 +263,7 @@ class Bot::Smooch7Test < ActiveSupport::TestCase
     ProjectMedia.any_instance.stubs(:report_status).returns('published')
     ProjectMedia.any_instance.stubs(:analysis_published_article_url).returns(random_url)
     Bot::Alegre.stubs(:get_items_with_similar_media).returns({ pm.id => { score: 0.9, model: 'elasticsearch' } })
+    CheckS3.stubs(:rewrite_url).returns(random_url)
 
     assert_equal [pm], Bot::Smooch.get_search_results(random_string, {}, pm.team_id, 'en')
 


### PR DESCRIPTION
## Description

Tipline image search, and actually other places of the code, were still hitting a deprecated path of Alegre API, `:type/similarity/search`, while (AFAIU) it should be `/similarity/sync/:type` (for audio and image, only). This PR fixes it by creating a `get_items_with_similar_media_v2` method that hits the new endpoint for image and audio and the old endpoint for video and text. This is not the ideal and I also noticed another problem, but I added a couple of `#FIXME`'s to the code to handle that later.

Reference: CV2-4044.

## How has this been tested?

Existing tests should cover this, they broke as expected and I fixed them.

## Things to pay attention to during code review

I added a couple of `FIXME`'s to the code, please check them.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)