### PR TITLE
Add rate limiting to login requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'graphiql-rails', git: 'https://github.com/meedan/graphiql-rails.git', ref: 
 gem 'graphql-formatter'
 gem 'nokogiri', '1.14.3'
 gem 'puma'
+gem 'rack-attack'
 gem 'rack-cors', '1.0.6', require: 'rack/cors'
 gem 'sidekiq', '5.2.10'
 gem 'sidekiq-cloudwatchmetrics'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -637,6 +637,8 @@ GEM
     raabro (1.4.0)
     racc (1.7.1)
     rack (2.2.6.4)
+    rack-attack (6.7.0)
+      rack (>= 1.0, < 4)
     rack-cors (1.0.6)
       rack (>= 1.6.0)
     rack-protection (2.2.0)
@@ -983,6 +985,7 @@ DEPENDENCIES
   puma
   pusher
   rack (= 2.2.6.4)
+  rack-attack
   rack-cors (= 1.0.6)
   rack-protection (= 2.2.0)
   railroady

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,7 +30,7 @@ class User < ApplicationRecord
 
   devise :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :confirmable,
-         :omniauthable, omniauth_providers: [:twitter, :facebook, :slack, :google_oauth2]
+         :omniauthable, :lockable, omniauth_providers: [:twitter, :facebook, :slack, :google_oauth2]
 
   before_create :skip_confirmation_for_non_email_provider
   after_create :create_source_and_account, :set_source_image, :send_welcome_email

--- a/config/application.rb
+++ b/config/application.rb
@@ -99,5 +99,8 @@ module Check
     })
 
     config.active_record.yaml_column_permitted_classes = [Time, Symbol]
+
+    # Rack Attack Configuration
+    config.middleware.use Rack::Attack
   end
 end

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -266,6 +266,10 @@ development: &default
   #
   tipline_user_max_messages_per_day: 1500
 
+  devise_maximum_attempts: 5
+  devise_unlock_accounts_after: 1
+  login_rate_limit: 10
+  api_rate_limit: 100
 test:
   <<: *default
   checkdesk_base_url_private: http://api:3000

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -83,6 +83,4 @@ Rails.application.configure do
   else
     puts '[WARNING] config.hosts not provided. Only requests from localhost are allowed. To change, update `whitelisted_hosts` in config.yml'
   end
-
-  config.hosts << "api.check.orb.local"
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -83,4 +83,6 @@ Rails.application.configure do
   else
     puts '[WARNING] config.hosts not provided. Only requests from localhost are allowed. To change, update `whitelisted_hosts` in config.yml'
   end
+
+  config.hosts << "api.check.orb.local"
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -78,6 +78,4 @@ Rails.application.configure do
   config.after_initialize do
     PaperTrail.enabled = ENV['PAPERTRAIL_ENABLED'] || false
   end
-
-  config.cache_store = :memory_store
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -78,4 +78,6 @@ Rails.application.configure do
   config.after_initialize do
     PaperTrail.enabled = ENV['PAPERTRAIL_ENABLED'] || false
   end
+
+  config.cache_store = :memory_store
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,7 +23,8 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
+  config.cache_store = :memory_store
 
   # Raise exceptions instead of rendering exception templates.
   config.action_dispatch.show_exceptions = false

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -49,6 +49,13 @@ Devise.setup do |config|
   end
   config.mailer = 'DeviseMailer'
   config.invite_for = 1.month
+
+  # Account lockout
+  config.lock_strategy = :failed_attempts
+  config.unlock_strategy = :both
+  config.unlock_keys = [ :time ]
+  config.maximum_attempts = 5
+  config.unlock_in = 1.hour
 end
 
 AuthTrail.geocode = false

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -54,8 +54,8 @@ Devise.setup do |config|
   config.lock_strategy = :failed_attempts
   config.unlock_strategy = :both
   config.unlock_keys = [ :time ]
-  config.maximum_attempts = CheckConfig.get('devise_maximum_attempts', 5).to_i
-  config.unlock_in = CheckConfig.get('devise_unlock_accounts_after', 1).to_i.hour
+  config.maximum_attempts = CheckConfig.get('devise_maximum_attempts', 5)
+  config.unlock_in = CheckConfig.get('devise_unlock_accounts_after', 1).hour
 end
 
 AuthTrail.geocode = false

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -54,8 +54,8 @@ Devise.setup do |config|
   config.lock_strategy = :failed_attempts
   config.unlock_strategy = :both
   config.unlock_keys = [ :time ]
-  config.maximum_attempts = 5
-  config.unlock_in = 1.hour
+  config.maximum_attempts = CheckConfig.get('devise_maximum_attempts', 5).to_i
+  config.unlock_in = CheckConfig.get('devise_unlock_accounts_after', 1).to_i.hour
 end
 
 AuthTrail.geocode = false

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,13 +1,13 @@
 class Rack::Attack
   # Throttle login attempts by IP address
-  throttle('logins/ip', limit: ChheckConfig.get('login_rate_limit', 10).to_i, period: 60.seconds) do |req|
+  throttle('logins/ip', limit: CheckConfig.get('login_rate_limit', 10, :integer), period: 60.seconds) do |req|
     if req.path == '/api/users/sign_in' && req.post?
       req.ip
     end
   end
 
   # Throttle login attempts by email address
-  throttle('logins/email', limit: ChheckConfig.get('login_rate_limit', 10).to_i, period: 60.seconds) do |req|
+  throttle('logins/email', limit: CheckConfig.get('login_rate_limit', 10, :integer), period: 60.seconds) do |req|
     if req.path == '/api/users/sign_in' && req.post?
       # Return the email if present, nil otherwise
       req.params['user']['email'].presence if req.params['user']
@@ -15,7 +15,7 @@ class Rack::Attack
   end
 
    # Throttle all graphql requests by IP address
-   throttle('api/graphql', limit: ChheckConfig.get('api_rate_limit', 100).to_i, period: 60.seconds) do |req|
+   throttle('api/graphql', limit: CheckConfig.get('api_rate_limit', 100, :integer), period: 60.seconds) do |req|
     req.ip if req.path == '/api/graphql'
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,16 +1,21 @@
 class Rack::Attack
   # Throttle login attempts by IP address
-  throttle('logins/ip', limit: 10, period: 60.seconds) do |req|
+  throttle('logins/ip', limit: ChheckConfig.get('login_rate_limit', 10).to_i, period: 60.seconds) do |req|
     if req.path == '/api/users/sign_in' && req.post?
       req.ip
     end
   end
 
   # Throttle login attempts by email address
-  throttle('logins/email', limit: 10, period: 60.seconds) do |req|
+  throttle('logins/email', limit: ChheckConfig.get('login_rate_limit', 10).to_i, period: 60.seconds) do |req|
     if req.path == '/api/users/sign_in' && req.post?
       # Return the email if present, nil otherwise
       req.params['user']['email'].presence if req.params['user']
     end
+  end
+
+   # Throttle all graphql requests by IP address
+   throttle('api/graphql', limit: ChheckConfig.get('api_rate_limit', 100).to_i, period: 60.seconds) do |req|
+    req.ip if req.path == '/api/graphql'
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,13 +1,13 @@
 class Rack::Attack
   # Throttle login attempts by IP address
-  throttle('logins/ip', limit: 5, period: 60.seconds) do |req|
+  throttle('logins/ip', limit: 10, period: 60.seconds) do |req|
     if req.path == '/api/users/sign_in' && req.post?
       req.ip
     end
   end
 
   # Throttle login attempts by email address
-  throttle('logins/email', limit: 5, period: 60.seconds) do |req|
+  throttle('logins/email', limit: 10, period: 60.seconds) do |req|
     if req.path == '/api/users/sign_in' && req.post?
       # Return the email if present, nil otherwise
       req.params['user']['email'].presence if req.params['user']

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,21 +1,21 @@
 class Rack::Attack
   # Throttle login attempts by IP address
-  throttle('logins/ip', limit: CheckConfig.get('login_rate_limit', 10, :integer), period: 60.seconds) do |req|
+  throttle('logins/ip', limit: proc { CheckConfig.get('login_rate_limit', 10, :integer) }, period: 60.seconds) do |req|
     if req.path == '/api/users/sign_in' && req.post?
       req.ip
     end
   end
 
   # Throttle login attempts by email address
-  throttle('logins/email', limit: CheckConfig.get('login_rate_limit', 10, :integer), period: 60.seconds) do |req|
+  throttle('logins/email', limit: proc { CheckConfig.get('login_rate_limit', 10, :integer) }, period: 60.seconds) do |req|
     if req.path == '/api/users/sign_in' && req.post?
       # Return the email if present, nil otherwise
       req.params['user']['email'].presence if req.params['user']
     end
   end
 
-   # Throttle all graphql requests by IP address
-   throttle('api/graphql', limit: CheckConfig.get('api_rate_limit', 100, :integer), period: 60.seconds) do |req|
+  # Throttle all graphql requests by IP address
+  throttle('api/graphql', limit:  proc { CheckConfig.get('api_rate_limit', 100, :integer) }, period: 60.seconds) do |req|
     req.ip if req.path == '/api/graphql'
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,16 @@
+class Rack::Attack
+  # Throttle login attempts by IP address
+  throttle('logins/ip', limit: 5, period: 60.seconds) do |req|
+    if req.path == '/api/users/sign_in' && req.post?
+      req.ip
+    end
+  end
+
+  # Throttle login attempts by email address
+  throttle('logins/email', limit: 5, period: 60.seconds) do |req|
+    if req.path == '/api/users/sign_in' && req.post?
+      # Return the email if present, nil otherwise
+      req.params['user']['email'].presence if req.params['user']
+    end
+  end
+end

--- a/db/migrate/20240115101312_add_lockable_to_devise.rb
+++ b/db/migrate/20240115101312_add_lockable_to_devise.rb
@@ -1,0 +1,7 @@
+class AddLockableToDevise < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :failed_attempts, :integer, default: 0, null: false
+    add_column :users, :unlock_token, :string
+    add_column :users, :locked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_01_14_024701) do
+ActiveRecord::Schema.define(version: 2024_01_15_101312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -669,7 +669,6 @@ ActiveRecord::Schema.define(version: 2024_01_14_024701) do
     t.datetime "updated_at", null: false
     t.string "state"
     t.index ["external_id", "state"], name: "index_tipline_messages_on_external_id_and_state", unique: true
-    t.index ["external_id"], name: "index_tipline_messages_on_external_id"
     t.index ["team_id"], name: "index_tipline_messages_on_team_id"
     t.index ["uid"], name: "index_tipline_messages_on_uid"
   end
@@ -799,6 +798,9 @@ ActiveRecord::Schema.define(version: 2024_01_14_024701) do
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.string "otp_backup_codes", array: true
+    t.integer "failed_attempts", default: 0, null: false
+    t.string "unlock_token"
+    t.datetime "locked_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true, where: "((email IS NOT NULL) AND ((email)::text <> ''::text))"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
@@ -810,7 +812,8 @@ ActiveRecord::Schema.define(version: 2024_01_14_024701) do
   end
 
   create_table "versions", id: :serial, force: :cascade do |t|
-    t.string "item_type", null: false
+    t.string "item_type"
+    t.string "{:null=>false}"
     t.string "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -71,5 +71,17 @@ class SessionsControllerTest < ActionController::TestCase
     assert_not_nil @controller.current_api_user
   end
 
+  test "should throttle excessive login requests" do
+    u = create_user login: 'test', password: '12345678', password_confirmation: '12345678', email: 'test@test.com'
+
+    20.times do
+      post :create, params: { api_user: { email: 'test@test.com', password: '12345678' }  }
+      assert_not_nil @controller.current_api_user
+    end
+
+    # post :create, params: { api_user: { email: 'user@test.com', password: '12345678' } }
+    # assert_response :too_many_requests
+  end
+
 
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -74,9 +74,9 @@ class SessionsControllerTest < ActionController::TestCase
   test "should lock user after excessive login requests" do
     u = create_user login: 'test', password: '12345678', password_confirmation: '12345678', email: 'test@test.com'
     u.confirm
-    maximum_attempts = Devise.maximum_attempts
+    Devise.maximum_attempts = 2
 
-    maximum_attempts.times do
+    2.times do
       post :create, params: { api_user: { email: 'test@test.com', password: '12345679' } }
     end
 
@@ -94,7 +94,7 @@ class SessionsControllerTest < ActionController::TestCase
       post :create, params: { api_user: { email: 'test@test.com', password: '12345679' } }
     end
 
-    travel_to 2.hours.from_now do
+    travel_to CheckConfig.get('devise_unlock_accounts_after', 5).to_i + 1.hours.from_now do
       u.reload
       assert !u.access_locked?
       assert_nil u.locked_at

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -94,7 +94,7 @@ class SessionsControllerTest < ActionController::TestCase
       post :create, params: { api_user: { email: 'test@test.com', password: '12345679' } }
     end
 
-    travel_to CheckConfig.get('devise_unlock_accounts_after', 5).to_i + 1.hours.from_now do
+    travel_to CheckConfig.get('devise_unlock_accounts_after', 5, :integer) + 1.hours.from_now do
       u.reload
       assert !u.access_locked?
       assert_nil u.locked_at

--- a/test/lib/check_rack_attack_test.rb
+++ b/test/lib/check_rack_attack_test.rb
@@ -6,26 +6,27 @@ class ThrottlingTest < ActionDispatch::IntegrationTest
   end
 
   test "should throttle excessive requests to /api/graphql" do
-    limit = 100
+    stub_configs({ 'api_rate_limit' => 2 }) do
+      2.times do
+        post api_graphql_path
+        assert_response :unauthorized
+      end
 
-    limit.times do
       post api_graphql_path
-      assert_response :unauthorized
+      assert_response :too_many_requests
     end
-
-    get api_graphql_path
-    assert_response :too_many_requests
   end
 
   test "should throttle excessive requests to /api/users/sign_in" do
-    limit = 10
-    user_params = { api_user: { email: 'user@example.com', password: 'password' } }
+    stub_configs({ 'login_rate_limit' => 2 }) do
+      user_params = { api_user: { email: 'user@example.com', password: 'password' } }
 
-    limit.times do
+      2.times do
+        post api_user_session_path, params: user_params, as: :json
+      end
+
       post api_user_session_path, params: user_params, as: :json
+      assert_response :too_many_requests
     end
-
-    post api_user_session_path, params: user_params, as: :json
-    assert_response :too_many_requests
   end
 end

--- a/test/lib/check_rack_attack_test.rb
+++ b/test/lib/check_rack_attack_test.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class ThrottlingTest < ActionDispatch::IntegrationTest
+  setup do
+    Rails.cache.clear
+  end
+
+  test "should throttle excessive requests to /api/graphql" do
+    limit = 100
+
+    limit.times do
+      post api_graphql_path
+      assert_response :unauthorized
+    end
+
+    get api_graphql_path
+    assert_response :too_many_requests
+  end
+
+  test "should throttle excessive requests to /api/users/sign_in" do
+    limit = 10
+    user_params = { api_user: { email: 'user@example.com', password: 'password' } }
+
+    limit.times do
+      post api_user_session_path, params: user_params, as: :json
+    end
+
+    post api_user_session_path, params: user_params, as: :json
+    assert_response :too_many_requests
+  end
+end


### PR DESCRIPTION
## Description

Add rate limiting to login requests using rack-attack. As a starting point, we are setting a limit of 5 request per minute to /api/users/sign_in.

References: CV2-4164

## How has this been tested?

Tested by confirming that:

 - Repeated calls to /api/users/sign_in will result in a `429: Too many requests` error. This can be validated using both the check web application or an api client. . The default limit is 10 requests per minute.
- Repeated calls to /api/graphql will result in a `429` error as well. The default limit is 100 requests per minute.

## Things to pay attention to during code review



## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

