### PR TITLE
Use item status instead of report status label in the introduction when sending a report

### DIFF
--- a/config/initializers/report_designer.rb
+++ b/config/initializers/report_designer.rb
@@ -56,7 +56,7 @@ Dynamic.class_eval do
   def report_design_introduction(data, language)
     if self.annotation_type == 'report_design'
       introduction = self.report_design_field_value('introduction').to_s
-      introduction = introduction.gsub('{{status}}', self.report_design_field_value('status_label').to_s)
+      introduction = introduction.gsub('{{status}}', self.annotated&.status_i18n(nil, { locale: language }))
       introduction = introduction.gsub('{{query_date}}', self.report_design_date(Time.at(data['received']).to_date, language)) if data['received']
       introduction
     end


### PR DESCRIPTION
## Description

Use item status instead of report status label in the introduction when sending a report.

Fixes: CV2-4180

## How has this been tested?

Existing tests should cover this. This is an edge case.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

