### PR TITLE
CV2-4223 readd condition for checking if we should even search for the type

### DIFF
--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -252,9 +252,13 @@ module AlegreV2
     end
 
     def get_similar_items_v2(project_media, field)
-      suggested_or_confirmed = get_suggested_items(project_media, field)
-      confirmed = get_confirmed_items(project_media, field)
-      Bot::Alegre.merge_suggested_and_confirmed(suggested_or_confirmed, confirmed, project_media)
+      if !Bot::Alegre.should_get_similar_items_of_type?('master', project_media.team_id) || !Bot::Alegre.should_get_similar_items_of_type?(type, project_media.team_id)
+        {}
+      else
+        suggested_or_confirmed = get_suggested_items(project_media, field)
+        confirmed = get_confirmed_items(project_media, field)
+        Bot::Alegre.merge_suggested_and_confirmed(suggested_or_confirmed, confirmed, project_media)
+      end
     end
 
     def relate_project_media(project_media, field=nil)

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -252,6 +252,7 @@ module AlegreV2
     end
 
     def get_similar_items_v2(project_media, field)
+      type = get_type(project_media)
       if !Bot::Alegre.should_get_similar_items_of_type?('master', project_media.team_id) || !Bot::Alegre.should_get_similar_items_of_type?(type, project_media.team_id)
         {}
       else

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -652,32 +652,20 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   end
 
   test "should not relate project media for audio if disabled on workspace" do
-    tbi = @team.team_bot_installations.select{|x| x.user_id == @bot.id}
+    tbi = @team.team_bot_installations.select{ |x| x.user_id == @bot.id }
     tbi.set_audio_similarity_enabled = false
     tbi.save!
-    pm1 = create_project_media team: @team, media: create_uploaded_audio
-    pm2 = create_project_media team: @team, media: create_uploaded_audio
-    relationship = nil
-    assert_no_difference 'Relationship.count' do
-      relationship = Bot::Alegre.relate_project_media(pm1)
-    end
-    assert_equal relationship, nil
-    tbi.set_audio_similarity_enabled = true
-    tbi.save!
+    Bot::Alegre.stubs(:merge_suggested_and_confirmed).never
+    pm = create_project_media team: @team, media: create_uploaded_audio
+    assert_equal {}, Bot::Alegre.get_similar_items_v2(pm)
   end
 
   test "should not relate project media for image if disabled on workspace" do
-    tbi = @team.team_bot_installations.select{|x| x.user_id == @bot.id}
+    tbi = @team.team_bot_installations.select{ |x| x.user_id == @bot.id }
     tbi.set_image_similarity_enabled = false
     tbi.save!
-    pm1 = create_project_media team: @team, media: create_uploaded_image
-    pm2 = create_project_media team: @team, media: create_uploaded_image
-    relationship = nil
-    assert_no_difference 'Relationship.count' do
-      relationship = Bot::Alegre.relate_project_media(pm1)
-    end
-    assert_equal relationship, nil
-    tbi.set_image_similarity_enabled = true
-    tbi.save!
+    Bot::Alegre.stubs(:merge_suggested_and_confirmed).never
+    pm = create_project_media team: @team, media: create_uploaded_image
+    assert_equal {}, Bot::Alegre.get_similar_items_v2(pm)
   end
 end

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -654,34 +654,30 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   test "should not relate project media for audio if disabled on workspace" do
     tbi = @team.team_bot_installations.select{|x| x.user_id == @bot.id}
     tbi.set_audio_similarity_enabled = false
-    tb.save!
+    tbi.save!
     pm1 = create_project_media team: @team, media: create_uploaded_audio
     pm2 = create_project_media team: @team, media: create_uploaded_audio
-    Bot::Alegre.stubs(:get_similar_items_v2).returns({pm2.id=>{:score=>0.91, :context=>{"team_id"=>pm2.team_id, "has_custom_id"=>true, "project_media_id"=>pm2.id}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.suggested_type}})
     relationship = nil
     assert_no_difference 'Relationship.count' do
       relationship = Bot::Alegre.relate_project_media(pm1)
     end
     assert_equal relationship, nil
-    Bot::Alegre.unstub(:get_similar_items_v2)
     tbi.set_audio_similarity_enabled = true
-    tb.save!
+    tbi.save!
   end
 
   test "should not relate project media for image if disabled on workspace" do
     tbi = @team.team_bot_installations.select{|x| x.user_id == @bot.id}
     tbi.set_image_similarity_enabled = false
-    tb.save!
+    tbi.save!
     pm1 = create_project_media team: @team, media: create_uploaded_image
     pm2 = create_project_media team: @team, media: create_uploaded_image
-    Bot::Alegre.stubs(:get_similar_items_v2).returns({pm2.id=>{:score=>0.91, :context=>{"team_id"=>pm2.team_id, "has_custom_id"=>true, "project_media_id"=>pm2.id}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.suggested_type}})
     relationship = nil
     assert_no_difference 'Relationship.count' do
       relationship = Bot::Alegre.relate_project_media(pm1)
     end
     assert_equal relationship, nil
-    Bot::Alegre.unstub(:get_similar_items_v2)
     tbi.set_image_similarity_enabled = true
-    tb.save!
+    tbi.save!
   end
 end

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -652,20 +652,20 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   end
 
   test "should not relate project media for audio if disabled on workspace" do
-    tbi = @team.team_bot_installations.select{ |x| x.user_id == @bot.id }
+    tbi = TeamBotInstallation.where(team: @team, user: @bot).last
     tbi.set_audio_similarity_enabled = false
     tbi.save!
     Bot::Alegre.stubs(:merge_suggested_and_confirmed).never
     pm = create_project_media team: @team, media: create_uploaded_audio
-    assert_equal {}, Bot::Alegre.get_similar_items_v2(pm)
+    assert_equal({}, Bot::Alegre.get_similar_items_v2(pm, nil))
   end
 
   test "should not relate project media for image if disabled on workspace" do
-    tbi = @team.team_bot_installations.select{ |x| x.user_id == @bot.id }
+    tbi = TeamBotInstallation.where(team: @team, user: @bot).last
     tbi.set_image_similarity_enabled = false
     tbi.save!
     Bot::Alegre.stubs(:merge_suggested_and_confirmed).never
     pm = create_project_media team: @team, media: create_uploaded_image
-    assert_equal {}, Bot::Alegre.get_similar_items_v2(pm)
+    assert_equal({}, Bot::Alegre.get_similar_items_v2(pm, nil))
   end
 end


### PR DESCRIPTION
## Description

In `Bot::Alegre.get_similar_items(pm)` (i.e. the original similarity matching function in alegre), we run a conditional check of `!Bot::Alegre.should_get_similar_items_of_type?('master', pm.team_id) || !Bot::Alegre.should_get_similar_items_of_type?(type, pm.team_id)` - this effectively checks the team to ensure that similarity searching is enabled at all, and specifically, similarity searching for that media modality is enabled. In the massive simplification/refactor, we lost that condition for V2. Adding that back in at the point of search, which should be all that's needed to get Alegre back to spec.
References: CV2-4223

## How has this been tested?

Strange that we didn't have a unit test for this - I will be writing one for this test case, but I want to see test results for just the change itself with no alterations to tests first to see if there's breaks in existing tests - will serve as the jumping off point for rewriting those tests or adding new ones.

## Things to pay attention to during code review

Are we missing any other "core" features? This would be a good time to check!

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

