### PR TITLE
React to the Smooch trigger related to story mention.

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -302,7 +302,7 @@ class Bot::Smooch < BotUser
       when 'message:delivery:failure'
         self.resend_message(json)
         true
-      when 'conversation:start'
+      when 'conversation:start', 'conversation:referral'
         message = {
           '_id': json['conversation']['_id'],
           authorId: json['appUser']['_id'],


### PR DESCRIPTION
## Description

The tipline bot should react to the Smooch trigger that happens when a connected Instagram account is mentioned in a story. This is required in order for the Facebook app to be approved.

Fixes: CV2-3727.

## How has this been tested?

Manually. When a public Instagram account mentions in a story an Instagram account that is connected to a Check tipline, the tipline bot should respond.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

