### PR TITLE
Fix failing test in SessionsControllerTest

### DIFF
--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -94,7 +94,7 @@ class SessionsControllerTest < ActionController::TestCase
       post :create, params: { api_user: { email: 'test@test.com', password: '12345679' } }
     end
 
-    travel_to CheckConfig.get('devise_unlock_accounts_after', 5, :integer) + 1.hours.from_now do
+    travel_to  CheckConfig.get('devise_unlock_accounts_after', 5, :integer).hours.from_now + 1.hour do
       u.reload
       assert !u.access_locked?
       assert_nil u.locked_at


### PR DESCRIPTION
There is a failing test in SessionsController where travel_to is behaving differently in CI vs dev. This PR contains a fix for it.

## Description

In https://github.com/meedan/check-api/pull/1777, a new test was introduced in SessionsControllerTest, but it is bugging out in CI.

References: CV2-4164

## How has this been tested?

Verified that the test passes successfully.


## Things to pay attention to during code review

Run: `rails test test/controllers/sessions_controller_test.rb:88`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

