### PR TITLE
NLU Rate Limits

### DIFF
--- a/app/lib/smooch_nlu.rb
+++ b/app/lib/smooch_nlu.rb
@@ -64,9 +64,6 @@ class SmoochNlu
   def self.alegre_matches_from_message(message, language, context, alegre_result_key, uid)
     # FIXME: Raise exception if not in a tipline context (so, if Bot::Smooch.config is nil)
     matches = []
-    team_slug = Team.find(Bot::Smooch.config['team_id']).slug
-    params = nil
-    response = nil
     unless Bot::Smooch.config.to_h['nlu_enabled']
       return []
     end
@@ -80,6 +77,7 @@ class SmoochNlu
     end
     begin
       self.increment_global_counter
+      team_slug = Team.find(Bot::Smooch.config['team_id']).slug
       # FIXME: In the future we could consider matches across all languages when options is nil
       # FIXME: No need to call Alegre if it's an exact match to one of the keywords
       # FIXME: No need to call Alegre if message has no word characters

--- a/app/lib/smooch_nlu_menus.rb
+++ b/app/lib/smooch_nlu_menus.rb
@@ -67,13 +67,13 @@ module SmoochNluMenus
   end
 
   module ClassMethods
-    def menu_options_from_message(message, language, options)
+    def menu_options_from_message(message, language, options, uid)
       return [{ 'smooch_menu_option_value' => 'main_state' }] if message == 'cancel_nlu'
       return [] if options.blank?
       context = {
         context: ALEGRE_CONTEXT_KEY_MENU
       }
-      matches = SmoochNlu.alegre_matches_from_message(message, language, context, 'menu_option_id')
+      matches = SmoochNlu.alegre_matches_from_message(message, language, context, 'menu_option_id', uid)
       # Select the top two menu options that exists in `options`
       top_options = []
       matches.each do |r|

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -295,8 +295,8 @@ class Bot::Smooch < BotUser
         'capi:verification'
       when 'message:appUser'
         json['messages'].each do |message|
-          self.parse_message(message, json['app']['_id'], json)
           SmoochTiplineMessageWorker.perform_async(message, json)
+          self.parse_message(message, json['app']['_id'], json)
         end
         true
       when 'message:delivery:failure'
@@ -570,12 +570,12 @@ class Bot::Smooch < BotUser
     end
     # ...if nothing is matched, try using the NLU feature
     if state != 'query'
-      options = SmoochNlu.menu_options_from_message(typed, language, options)
+      options = SmoochNlu.menu_options_from_message(typed, language, options, uid)
       unless options.blank?
         SmoochNlu.process_menu_options(uid, options, message, language, workflow, app_id)
         return true
       end
-      resource = TiplineResource.resource_from_message(typed, language)
+      resource = TiplineResource.resource_from_message(typed, language, uid)
       unless resource.nil?
         CheckStateMachine.new(uid).reset
         resource = self.send_resource_to_user(uid, workflow, resource.uuid, language)

--- a/app/models/concerns/tipline_resource_nlu.rb
+++ b/app/models/concerns/tipline_resource_nlu.rb
@@ -32,11 +32,11 @@ module TiplineResourceNlu
   end
 
   module ClassMethods
-    def resource_from_message(message, language)
+    def resource_from_message(message, language, uid)
       context = {
         context: ALEGRE_CONTEXT_KEY_RESOURCE
       }
-      matches = SmoochNlu.alegre_matches_from_message(message, language, context, 'resource_id').collect{ |m| m['key'] }
+      matches = SmoochNlu.alegre_matches_from_message(message, language, context, 'resource_id', uid).collect{ |m| m['key'] }
       # Select the top resource that exists
       resource_id = matches.find { |id| TiplineResource.where(id: id).exists? }
       Rails.logger.info("[Smooch NLU] [Resource From Message] Resource ID: #{resource_id} | Message: #{message}")

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -259,12 +259,14 @@ development: &default
   otel_traces_sampler:
   otel_custom_sampling_rate:
 
-  # Rate limit for tipline submissions, tipline users are blocked after reaching this limit
+  # Rate limits for tiplines
   #
   # OPTIONAL
-  # When not set, a default number will be used.
+  # When not set, default values are used.
   #
   tipline_user_max_messages_per_day: 1500
+  nlu_global_rate_limit: 100
+  nlu_user_rate_limit: 30
 
 test:
   <<: *default

--- a/test/lib/smooch_nlu_test.rb
+++ b/test/lib/smooch_nlu_test.rb
@@ -122,4 +122,29 @@ class SmoochNluTest < ActiveSupport::TestCase
     Bot::Smooch.get_installation('smooch_id', 'test')
     assert_not_nil SmoochNlu.menu_options_from_message('I want to subscribe to the newsletter', 'en', @menu_options, random_string)
   end
+
+  test 'should return empty list of matches if global rate limit is reached' do
+    Bot::Smooch.stubs(:config).returns({ 'nlu_enabled' => true })
+    Bot::Alegre.stubs(:request).never
+    SmoochNlu.increment_global_counter
+    SmoochNlu.increment_global_counter
+    stub_configs({ 'nlu_global_rate_limit' => 1 }) do
+      assert_equal [], SmoochNlu.alegre_matches_from_message('test', 'en', {}, 'test', 'test')
+    end
+  end
+
+  test 'should return empty list of matches if user rate limit is reached' do
+    Bot::Smooch.stubs(:config).returns({ 'nlu_enabled' => true })
+    Bot::Alegre.stubs(:request).never
+    2.times { create_tipline_message uid: '123', state: 'received' }
+    stub_configs({ 'nlu_user_rate_limit' => 1 }) do
+      assert_equal [], SmoochNlu.alegre_matches_from_message('test', 'en', {}, 'test', '123')
+    end
+  end
+
+  test 'should return empty list of matches if exception happens' do
+    Bot::Smooch.stubs(:config).returns({ 'nlu_enabled' => true })
+    Bot::Alegre.stubs(:request).never
+    assert_equal [], SmoochNlu.alegre_matches_from_message('test', 'en', {}, 'test', 'test')
+  end
 end

--- a/test/lib/smooch_nlu_test.rb
+++ b/test/lib/smooch_nlu_test.rb
@@ -110,7 +110,7 @@ class SmoochNluTest < ActiveSupport::TestCase
     team = create_team_with_smooch_bot_installed
     SmoochNlu.new(team.slug).disable!
     Bot::Smooch.get_installation('smooch_id', 'test')
-    assert_equal [], SmoochNlu.menu_options_from_message('I want to subscribe to the newsletter', 'en', @menu_options)
+    assert_equal [], SmoochNlu.menu_options_from_message('I want to subscribe to the newsletter', 'en', @menu_options, random_string)
   end
 
   test 'should return a menu option if NLU is enabled' do
@@ -120,6 +120,6 @@ class SmoochNluTest < ActiveSupport::TestCase
     team = create_team_with_smooch_bot_installed
     SmoochNlu.new(team.slug).enable!
     Bot::Smooch.get_installation('smooch_id', 'test')
-    assert_not_nil SmoochNlu.menu_options_from_message('I want to subscribe to the newsletter', 'en', @menu_options)
+    assert_not_nil SmoochNlu.menu_options_from_message('I want to subscribe to the newsletter', 'en', @menu_options, random_string)
   end
 end

--- a/test/models/bot/smooch_8_test.rb
+++ b/test/models/bot/smooch_8_test.rb
@@ -3,6 +3,7 @@ require 'sidekiq/testing'
 
 class Bot::Smooch8Test < ActiveSupport::TestCase
   def setup
+    WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
   end
 
   def teardown

--- a/test/models/bot_user_2_test.rb
+++ b/test/models/bot_user_2_test.rb
@@ -127,4 +127,12 @@ class BotUser2Test < ActiveSupport::TestCase
       b.call({})
     end
   end
+
+  test "should capture error if bot can't be called" do
+    Bot::Alegre.stubs(:run).raises(StandardError)
+    b = create_bot_user login: 'alegre'
+    assert_nothing_raised do
+      b.call({})
+    end
+  end
 end


### PR DESCRIPTION
**Description**

As part of the ongoing development of the Natural Language Understanding (NLU) feature, it has been identified that the current implementation of the text similarity service lacks robust handling of concurrent requests. The absence of efficient concurrency management may lead to degraded performance and potential service disruptions when multiple requests are made simultaneously.

**Issue**

The primary issue is the lack of a concurrency control mechanism, resulting in potential race conditions and suboptimal response times during peak usage periods. It is imperative to enhance the system's capability to handle concurrent requests seamlessly to ensure a smooth and responsive user experience.

**Objective**

The goal of this ticket is to implement rate limits as a concurrent request handling mechanism for the NLU feature. 

**Changes**

- Store messages even before they are parsed
- Keep a global NLU counter and increment/decrement it in a thread-safe way as NLU operations start and finish
- Global rate limit: do not process using NLU when the current number of NLU operations is greater than the limit defined in a configuration key
- User rate limit: do not process using NLU when the user who sent the message has sent more messages in the last seconds than the limit defined in a configuration key