### PR TITLE
Delete the `set_cluster` method definition and calls from Alegre Bot

### DIFF
--- a/app/models/concerns/relationship_bulk.rb
+++ b/app/models/concerns/relationship_bulk.rb
@@ -73,7 +73,7 @@ module RelationshipBulk
       index_alias = CheckElasticSearchModel.get_index_alias
       es_body = []
       versions = []
-      callbacks = [:reset_counters, :update_counters, :set_cluster, :propagate_inversion]
+      callbacks = [:reset_counters, :update_counters, :propagate_inversion]
       target_ids = []
       Relationship.where(id: ids, source_id: extra_options['source_id']).find_each do |r|
         target_ids << r.target_id

--- a/lib/tasks/check_clusters.rake
+++ b/lib/tasks/check_clusters.rake
@@ -138,11 +138,6 @@ namespace :check do
       team = Team.find_by_slug(slug)
       n = ProjectMedia.where(team_id: team.id).count
       i = 0
-      ProjectMedia.where(team_id: team.id).order('id ASC').find_each do |pm|
-        i += 1
-        c = Bot::Alegre.set_cluster(pm, true)
-        log "[#{i}/#{n}] [#{Time.now}] Adding item #{pm.id} to the clusters... added to cluster #{c.id}"
-      end
     end
   end
 end

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -665,26 +665,6 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
     Bot::Alegre.unstub(:get_items_with_similar_description)
   end
 
-  test "should set cluster" do
-    c1 = create_cluster
-    c2 = create_cluster
-    pm1 = create_project_media team: @team, cluster_id: c1.id
-    pm2 = create_project_media team: @team, cluster_id: c2.id
-
-    ProjectMedia.any_instance.stubs(:similar_items_ids_and_scores).returns({ pm1.id => { score: 0.9 }, pm2.id => { score: 0.8 } })
-    pm3 = create_project_media team: @team
-    Bot::Alegre.set_cluster(pm3)
-    assert_equal c1.id, pm3.reload.cluster_id
-
-    ProjectMedia.any_instance.stubs(:similar_items_ids_and_scores).returns({})
-    pm4 = create_project_media team: @team
-    assert_difference 'Cluster.count' do
-      Bot::Alegre.set_cluster(pm4)
-    end
-
-    ProjectMedia.any_instance.unstub(:similar_items_ids_and_scores)
-  end
-
   test "should get number of words" do
     assert_equal 4, Bot::Alegre.get_number_of_words('58 This   is a test !!! 123 😊')
     assert_equal 1, Bot::Alegre.get_number_of_words(random_url)

--- a/test/models/cluster_test.rb
+++ b/test/models/cluster_test.rb
@@ -87,17 +87,6 @@ class ClusterTest < ActiveSupport::TestCase
     end
   end
 
-  test "should set cluster" do
-    t = create_team
-    pm1 = create_project_media team: t
-    c = create_cluster
-    c.project_medias << pm1
-    pm2 = create_project_media team: t
-    ProjectMedia.any_instance.stubs(:similar_items_ids_and_scores).returns({ pm1.id => { score: 0.9, context: {} }, random_number => { score: 0.8, context: { foo: 'bar' } } })
-    assert_equal c, Bot::Alegre.set_cluster(pm2)
-    ProjectMedia.any_instance.unstub(:similar_items_ids_and_scores)
-  end
-
   test "should get requests count" do
     RequestStore.store[:skip_cached_field_update] = false
     t = create_team

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -61,23 +61,6 @@ class RelationshipTest < ActiveSupport::TestCase
     assert_equal pm_t.id, es_t['parent_id']
   end
 
-  test "should set cluster" do
-    t = create_team
-    u = create_user
-    create_team_user team: t, user: u, role: 'admin'
-    s = create_project_media team: t
-    t = create_project_media team: t
-    s_c = create_cluster project_media: s
-    s_c.project_medias << s
-    t_c = create_cluster project_media: t
-    t_c.project_medias << t
-    User.stubs(:current).returns(u)
-    create_relationship source_id: s.id, target_id: t.id, relationship_type: Relationship.confirmed_type
-    assert_nil Cluster.where(id: t_c.id).last
-    assert_equal [s.id, t.id].sort, s_c.reload.project_media_ids.sort
-    User.unstub(:current)
-  end
-
   test "should remove suggested relation when same items added as similar" do
     team = create_team
     b = create_bot name: 'Alegre', login: 'alegre'


### PR DESCRIPTION
For FactsFirstPH, elections project we run in the Philippines in early 2022, we implemented the very first version of shared feeds and global clusters. Part of that logic included adding new items to clusters automatically. We’re changing this logic, so before proceeding with the new logic, it’s important to get rid of the previous one.

## Description

References: CV2-4173

## How has this been tested?

Confirmed that all tests pass locally.

## Things to pay attention to during code review

Confirm that all removed methods are no longer needed.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

