### PR TITLE
Change devise unlock strategy from `:both` to `:time`

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -52,7 +52,7 @@ Devise.setup do |config|
 
   # Account lockout
   config.lock_strategy = :failed_attempts
-  config.unlock_strategy = :both
+  config.unlock_strategy = :time
   config.unlock_keys = [ :time ]
   config.maximum_attempts = CheckConfig.get('devise_maximum_attempts', 5)
   config.unlock_in = CheckConfig.get('devise_unlock_accounts_after', 1).hour


### PR DESCRIPTION
## Description

Currently, we are using an unlock strategy of `:both`, which allows both time based unlocking and email based unlocking. This leads to an email being sent to the user when their account is locked, which us currently not intended.

References: CV2-4164

## How has this been tested?

Confirmed that all tests are passing

## Things to pay attention to during code review

Ensure that locking and unlocking of user accounts works as expected.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

