### PR TITLE
CV2-4233 add retry looper for alegre requests that intermittently fail

### DIFF
--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -234,7 +234,7 @@ module AlegreV2
     def safe_get_sync(project_media, field, params={})
       response = get_sync(project_media, field, params)
       retries = 0
-      while (response == nil or response["result"] == nil) and retries < 3
+      while (response.nil? || response["result"].nil?) && retries < 3
         response = get_sync(project_media, field, params)
         retries += 1
       end

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -231,6 +231,16 @@ module AlegreV2
       }.reject{ |k,_| k == project_media.id }]
     end
 
+    def safe_get_sync(project_media, field, threshold)
+      response = get_sync(project_media, field, threshold)
+      retries = 0
+      while (response == nil or response["result"] == nil) and retries < 3
+        response = get_sync(project_media, field, threshold)
+        retries += 1
+      end
+      response
+    end
+
     def get_items(project_media, field, confirmed=false)
       relationship_type = confirmed ? Relationship.confirmed_type : Relationship.suggested_type
       type = get_type(project_media)
@@ -238,7 +248,7 @@ module AlegreV2
       parse_similarity_results(
         project_media,
         field,
-        get_sync(project_media, field, threshold)["result"],
+        safe_get_sync(project_media, field, threshold)["result"],
         relationship_type
       )
     end

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -231,11 +231,11 @@ module AlegreV2
       }.reject{ |k,_| k == project_media.id }]
     end
 
-    def safe_get_sync(project_media, field, threshold)
-      response = get_sync(project_media, field, threshold)
+    def safe_get_sync(project_media, field, params={})
+      response = get_sync(project_media, field, params)
       retries = 0
       while (response == nil or response["result"] == nil) and retries < 3
-        response = get_sync(project_media, field, threshold)
+        response = get_sync(project_media, field, params)
         retries += 1
       end
       response

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -287,7 +287,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     pm1 = create_project_media team: @team, media: create_uploaded_audio
     response = {}
     WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)}).to_return(body: response.to_json)
-    assert_equal Bot::Alegre.safe_get_sync(pm1, "blah", 0.9), {}
+    assert_equal Bot::Alegre.safe_get_sync(pm1, "audio", 0.9), {}
   end
 
   test "should run delete request" do

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -283,6 +283,13 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     assert_equal JSON.parse(Bot::Alegre.get_sync(pm1).to_json), JSON.parse(response.to_json)
   end
 
+  test "should safe_get_sync" do
+    pm1 = create_project_media team: @team, media: create_uploaded_audio
+    response = {}
+    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)}).to_return(body: response.to_json)
+    assert_equal Bot::Alegre.safe_get_sync(pm1), {}
+  end
+
   test "should run delete request" do
     pm1 = create_project_media team: @team, media: create_uploaded_audio
     response = {"requested"=>

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -285,9 +285,8 @@ class Bot::AlegreTest < ActiveSupport::TestCase
 
   test "should safe_get_sync" do
     pm1 = create_project_media team: @team, media: create_uploaded_audio
-    response = {}
-    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)}).to_return(body: response.to_json)
-    assert_equal Bot::Alegre.safe_get_sync(pm1, "audio", {}), {}
+    WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").to_return(body: '{}')
+    assert_equal {}, Bot::Alegre.safe_get_sync(pm1, "audio", {})
   end
 
   test "should run delete request" do

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -287,7 +287,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     pm1 = create_project_media team: @team, media: create_uploaded_audio
     response = {}
     WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)}).to_return(body: response.to_json)
-    assert_equal Bot::Alegre.safe_get_sync(pm1), {}
+    assert_equal Bot::Alegre.safe_get_sync(pm1, "blah", 0.9), {}
   end
 
   test "should run delete request" do

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -287,7 +287,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     pm1 = create_project_media team: @team, media: create_uploaded_audio
     response = {}
     WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").with(body: {:doc_id=>Bot::Alegre.item_doc_id(pm1), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)}).to_return(body: response.to_json)
-    assert_equal Bot::Alegre.safe_get_sync(pm1, "audio", 0.9), {}
+    assert_equal Bot::Alegre.safe_get_sync(pm1, "audio", {}), {}
   end
 
   test "should run delete request" do

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -286,7 +286,9 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   test "should safe_get_sync" do
     pm1 = create_project_media team: @team, media: create_uploaded_audio
     WebMock.stub_request(:post, "#{CheckConfig.get('alegre_host')}/similarity/sync/audio").to_return(body: '{}')
-    assert_equal {}, Bot::Alegre.safe_get_sync(pm1, "audio", {})
+    expected = {}
+    actual = Bot::Alegre.safe_get_sync(pm1, "audio", {})
+    assert_equal expected, actual
   end
 
   test "should run delete request" do

--- a/test/models/fact_check_test.rb
+++ b/test/models/fact_check_test.rb
@@ -30,9 +30,11 @@ class FactCheckTest < ActiveSupport::TestCase
   end
 
   test "should create fact check without optional fields" do
+    Bot::Alegre.stubs(:send_field_to_similarity_index).returns({"success": true})
     assert_difference 'FactCheck.count' do
       create_fact_check url: nil, title: random_string, summary: nil
     end
+    Bot::Alegre.unstub(:send_field_to_similarity_index)
   end
 
   test "should not create fact check without user" do

--- a/test/models/project_media_2_test.rb
+++ b/test/models/project_media_2_test.rb
@@ -75,6 +75,7 @@ class ProjectMedia2Test < ActiveSupport::TestCase
     Sidekiq::Testing.inline! do
       pm = create_project_media quote: 'Title 0'
       assert_equal 'Title 0', pm.title
+      Bot::Alegre.stubs(:send_field_to_similarity_index).returns({"success": true})
       cd = create_claim_description project_media: pm, description: 'Title 1'
       assert_queries 0, '=' do
         assert_equal 'Title 1', pm.title
@@ -86,6 +87,7 @@ class ProjectMedia2Test < ActiveSupport::TestCase
       assert_queries(0, '>') do
         assert_equal 'Title 1', pm.reload.title(true)
       end
+      Bot::Alegre.unstub(:send_field_to_similarity_index)
     end
   end
 


### PR DESCRIPTION
## Description

When running via smooch, every once in a while, a request from Check-API to Alegre fails. There is every indication that this is some sort of intermittent, non-serious issue. When trying to reproduce them, even at large scales with lots of attempts to recreate the issue, Alegre responds correctly consistently. When looking at Alegre and Presto, neither show any indication that there is an issue. The response itself doesn't seem to be loud or fundamentally broken. For the time being, we're introducing a retry - and if that fails, we'll be much more confident that something more fundamental is happening that requires a deeper dive.

References: CV2-4233

## How has this been tested?

I've added a direct test that should yield a proper null output after retrying multiple times, and ran a local script with side-effecting printouts to ensure it is doing what is intended.

## Things to pay attention to during code review

Nothing really - fairly straightforward retry cycle

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

