### PR TITLE
Don't confirm user when testing account lockout

### DIFF
--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -73,7 +73,6 @@ class SessionsControllerTest < ActionController::TestCase
 
   test "should lock user after excessive login requests" do
     u = create_user login: 'test', password: '12345678', password_confirmation: '12345678', email: 'test@test.com'
-    u.confirm
     Devise.maximum_attempts = 2
 
     2.times do
@@ -87,7 +86,6 @@ class SessionsControllerTest < ActionController::TestCase
 
   test "should unlock locked user accounts after specified time" do
     u = create_user login: 'test', password: '12345678', password_confirmation: '12345678', email: 'test@test.com'
-    u.confirm
     maximum_attempts = Devise.maximum_attempts
 
     maximum_attempts.times do


### PR DESCRIPTION


## Description

Confirming triggers the DeviseMailer.invitation_instructions job, which isn't intended, and leads to failed jobs such as
https://app.travis-ci.com/github/meedan/check-api/jobs/617009352#L2868

References: CV2-4164

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

