### PR TITLE
Better error handling for `unblock_user` method

### DIFF
--- a/app/models/concerns/smooch_blocking.rb
+++ b/app/models/concerns/smooch_blocking.rb
@@ -29,9 +29,10 @@ module SmoochBlocking
     end
 
     def unblock_user(uid)
-      BlockedTiplineUser.where(uid: uid).last.destroy!
-      Rails.logger.info("[Smooch Bot] Unblocked user #{uid}")
       Rails.cache.delete("smooch:banned:#{uid}")
+      blocked_user = BlockedTiplineUser.where(uid: uid).last
+      blocked_user.destroy! unless blocked_user.nil?
+      Rails.logger.info("[Smooch Bot] Unblocked user #{uid}")
     end
 
     def user_blocked?(uid)


### PR DESCRIPTION
## Description

When trying to unblock a tipline user, don't crash if there is no related instance in the `blocked_tipline_users` table.

## How has this been tested?

Existing tests should cover this.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

