### PR TITLE
Double devise failed attempts

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -54,7 +54,7 @@ Devise.setup do |config|
   config.lock_strategy = :failed_attempts
   config.unlock_strategy = :time
   config.unlock_keys = [ :time ]
-  config.maximum_attempts = CheckConfig.get('devise_maximum_attempts', 5)
+  config.maximum_attempts = CheckConfig.get('devise_maximum_attempts', 5) * 2
   config.unlock_in = CheckConfig.get('devise_unlock_accounts_after', 1).hour
 end
 


### PR DESCRIPTION

## Description

Due to https://github.com/devise-two-factor/devise-two-factor/issues/28, devise doubles the count stored in the failed_attempts column when 2FA is enabled.

In this PR we are doubling the value set in devise_maximum_attempts in CheckConfig, so that devise always doubles it, at least until the issue referred to above is fixed

Due to this, user's will no longer get a warning before the last login attempt, so we are increasing the default number of attempts before an account is locked to 5.

References: CV2-4164

## How has this been tested?

Confirmed that the user's account will always be locked after 5(default value) tries.


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

