### PR TITLE
Disable GraphQL Query Introspection

### DIFF
--- a/app/graph/relay_on_rails_schema.rb
+++ b/app/graph/relay_on_rails_schema.rb
@@ -13,6 +13,8 @@ class RelayOnRailsSchema < GraphQL::Schema
 
   lazy_resolve(Concurrent::Future, :value)
 
+  disable_introspection_entry_points
+
   class << self
     def resolve_type(_type, object, _ctx)
       klass = (object.respond_to?(:type) && object.type) ? object.type : object.class_name

--- a/test/controllers/graphql_controller_12_test.rb
+++ b/test/controllers/graphql_controller_12_test.rb
@@ -289,4 +289,23 @@ class GraphqlController12Test < ActionController::TestCase
     data = JSON.parse(@response.body)['data']['updateUser']['me']
     assert_equal user.id, data['dbid']
   end
+
+  test "should ensure graphql introspection is disabled" do
+    user = create_user
+    authenticate_with_user(user)
+    INTROSPECTION_QUERY = <<-GRAPHQL
+      {
+        __schema {
+          queryType {
+            name
+          }
+        }
+      }
+    GRAPHQL
+
+    post :create, params: { query: INTROSPECTION_QUERY }
+    assert_response :success
+    response_body = JSON.parse(response.body)
+    assert_equal response_body['errors'][0]['message'], "Field '__schema' doesn't exist on type 'Query'"
+  end
 end


### PR DESCRIPTION
## Description

GraphQL query introspection allows users to browse all graphql endpoints along with their descriptions.

Since this is considered to be a security risk, here we are disabling that access.

References: CV2-4171

## How has this been tested?

While on `develop` (or any other branch that doesn't have this fix), run the following query in GraphiQL (Can be accessed via `http://localhost:3000/graphiql`):

```graphql
{
  __schema {
    types {
      name
      description
    }
  }
}
```

This should return a list of all available queries and their descriptions. 

---

When you switch to this branch, the same query should result in an error.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

