### PR TITLE
Stop storing search results as suggestions

### DIFF
--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -343,9 +343,6 @@ module SmoochMessages
       elsif ['relevant_search_result_requests', 'timeout_search_requests'].include?(request_type)
         message['archived'] = (request_type == 'relevant_search_result_requests' ? self.default_archived_flag : CheckArchivedFlags::FlagCodes::UNCONFIRMED)
         associated = self.create_project_media_from_message(message)
-        if associated != associated_obj && associated.is_a?(ProjectMedia)
-          Relationship.create(relationship_type: Relationship.suggested_type, source: associated_obj, target: associated, user: BotUser.smooch_user)
-        end
       end
 
       return if associated.nil?

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -19,7 +19,6 @@ class Relationship < ApplicationRecord
   validates :relationship_type, uniqueness: { scope: [:source_id, :target_id], message: :already_exists }, on: :create
 
   before_create :destroy_same_suggested_item, if: proc { |r| r.is_confirmed? }
-  before_update :destroy_other_suggested_items, if: proc { |r| r.is_confirmed? }
   after_create :move_to_same_project_as_main, prepend: true
   after_create :point_targets_to_new_source, :update_counters, prepend: true
   after_update :reset_counters, prepend: true
@@ -312,14 +311,6 @@ class Relationship < ApplicationRecord
     Relationship.where(source_id: self.source_id, target_id: self.target_id)
     .joins(:user).where('users.type' => 'BotUser')
     .where('relationship_type = ?', Relationship.suggested_type.to_yaml)
-    .destroy_all
-  end
-
-  def destroy_other_suggested_items
-    # If created by Smooch Bot, destroy other suggestions to the same media
-    Relationship.where(target_id: self.target_id, user: BotUser.smooch_user)
-    .where('relationship_type = ?', Relationship.suggested_type.to_yaml)
-    .where('id != ?', self.id)
     .destroy_all
   end
 

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -223,7 +223,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     Sidekiq::Testing.inline! do
       send_message 'hello', '1', '1', 'Foo bar', '1'
       assert_state 'search_result'
-      assert_difference 'TiplineRequest.count + ProjectMedia.count + Relationship.where(relationship_type: Relationship.suggested_type).count', 3 do
+      assert_difference 'TiplineRequest.count + ProjectMedia.count', 2 do
         send_message '1'
       end
       assert_state 'main'
@@ -240,7 +240,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     Sidekiq::Testing.inline! do
       send_message 'hello', '1', '1', 'Foo bar foo bar foo bar', '1'
       assert_state 'search_result'
-      assert_difference 'TiplineRequest.count + ProjectMedia.count + Relationship.where(relationship_type: Relationship.suggested_type).count', 3 do
+      assert_difference 'TiplineRequest.count + ProjectMedia.count', 2 do
         send_message '1'
       end
       assert_state 'main'
@@ -262,12 +262,8 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     Sidekiq::Testing.inline! do
       send_message 'hello', '1', '1', 'Image here', '1'
       assert_state 'search_result'
-      assert_difference 'TiplineRequest.count' do
-        assert_difference 'ProjectMedia.count' do
-          assert_difference 'Relationship.where(relationship_type: Relationship.suggested_type).count' do
-            send_message '1'
-          end
-        end
+      assert_difference 'TiplineRequest.count + ProjectMedia.count', 2 do
+        send_message '1'
       end
       assert_state 'main'
     end


### PR DESCRIPTION

## Description

Stop manually-creating suggestions between the item created from the user request and search results.

REFERENCES: CV2-4206

## How has this been tested?

Ensure that all tests and checks are passing.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

