### PR TITLE
adding `user_id` to f.write({...}) dictionary in `similarity.rake` an…

### DIFF
--- a/lib/tasks/data/similarity.rake
+++ b/lib/tasks/data/similarity.rake
@@ -20,6 +20,7 @@ def write_similarity_relationships_to_disk(query, filename)
       created_at: r.created_at,
       source_text_fields: Hash[Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS.collect{|f| [f, (r.source.send(f) rescue nil)]}],
       target_text_fields: Hash[Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS.collect{|f| [f, (r.target.send(f) rescue nil)]}],
+      user_id: r.user_id,
     }.to_json+"\n")
   end
   f.close

--- a/lib/tasks/data/similarityunc.rake
+++ b/lib/tasks/data/similarityunc.rake
@@ -26,6 +26,7 @@ def write_archived_similarity_relationships_to_disk(object_change, filename)
         created_at: r["created_at"],
         source_text_fields: Hash[Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS.collect{|f| [f, (source.send(f) rescue nil)]}],
         target_text_fields: Hash[Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS.collect{|f| [f, (target.send(f) rescue nil)]}],
+        user_id: r["user_id"],
       }.to_json+"\n")
     end
   end


### PR DESCRIPTION
adding `user_id` to f.write({...}) dictionary in `similarity.rake` an…

## Description

 add a line to the f.write({...}) dictionary like:
```
user_id: r["user_id"]     #for write_archived_similarity_relationships_to_disk
user_id: r.user_id     #for write_similarity_relationships_to_disk
 ```
in 
`write_archived_similarity_relationships_to_disk`  and `write_similarity_relationships_to_disk`

References: CV2-4200

## How has this been tested?

this needs to be code-reviewed and tested on QA. 