### PR TITLE
Only deliver fact-check title and URL for Facebook Messenger tipline search results

### DIFF
--- a/config/initializers/report_designer.rb
+++ b/config/initializers/report_designer.rb
@@ -84,13 +84,13 @@ Dynamic.class_eval do
     footer.join("\n")
   end
 
-  def report_design_text(language = nil)
+  def report_design_text(language = nil, hide_body = false)
     if self.annotation_type == 'report_design'
       team = self.annotated.team
       text = []
       title = self.report_design_field_value('title')
       text << "*#{title.strip}*" unless title.blank?
-      text << self.report_design_field_value('text').to_s
+      text << self.report_design_field_value('text').to_s unless hide_body
       url = self.report_design_field_value('published_article_url')
       text << url unless url.blank?
       text = text.collect do |part|


### PR DESCRIPTION
## Description

Messenger changed the way it formats messages... now it breaks a single long message into smaller messages, so for long fact-checks, messages can be delivered out of order, which is super weird (like, a title in one message, the link in another message, etc.). This commit changes how tipline search results are delivered for Facebook Messenger: no fact-check summary, only title and URL.

Fixes CV2-4287.

## How has this been tested?

![Captura de tela de 2024-02-15 08-38-56](https://github.com/meedan/check-api/assets/117518/269a0fb4-0231-424c-b448-9ea8177a0ab1)

## Things to pay attention to during code review

The change should affect ONLY Facebook Messenger.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)