### PR TITLE
Apply content warning screens for banned users

### DIFF
--- a/app/models/concerns/smooch_blocking.rb
+++ b/app/models/concerns/smooch_blocking.rb
@@ -49,14 +49,18 @@ module SmoochBlocking
       RequestStore.store[:skip_rules] = true
       ProjectMedia.joins(:tipline_requests)
           .where(tipline_requests: { tipline_user_uid: uid }).find_each do |pm|
-            flags = { 'spam': 1, 'adult': 0, 'spoof': 0, 'medical': 0, 'violence': 0, 'racy': 0 }
-            # Add a flag
-            flag = Dynamic.new
-            flag.annotation_type = 'flag'
-            flag.annotated = pm
-            flag.skip_check_ability = true
-            flag.set_fields = { show_cover: true, flags: flags }.to_json
-            flag.save!
+            begin
+              flags = { 'spam': 1, 'adult': 0, 'spoof': 0, 'medical': 0, 'violence': 0, 'racy': 0 }
+              # Add a flag
+              flag = Dynamic.new
+              flag.annotation_type = 'flag'
+              flag.annotated = pm
+              flag.skip_check_ability = true
+              flag.set_fields = { show_cover: true, flags: flags }.to_json
+              flag.save!
+            rescue  StandardError => e
+              Rails.logger.info "[Smooch Bot] Exception when flagging blocked user's media: #{e.message}"
+            end
           end
       RequestStore.store[:skip_rules] = false
     end

--- a/app/models/concerns/smooch_blocking.rb
+++ b/app/models/concerns/smooch_blocking.rb
@@ -50,7 +50,13 @@ module SmoochBlocking
       ProjectMedia.joins(:tipline_requests)
           .where(tipline_requests: { tipline_user_uid: uid }).find_each do |pm|
             flags = { 'spam': 1, 'adult': 0, 'spoof': 0, 'medical': 0, 'violence': 0, 'racy': 0 }
-            Dynamic.create!(annotation_type: 'flag', annotated: pm, annotator: User.current, skip_check_ability: true, set_fields: { show_cover: true, flags: flags }.to_json)
+            # Add a flag
+            flag = Dynamic.new
+            flag.annotation_type = 'flag'
+            flag.annotated = pm
+            flag.skip_check_ability = true
+            flag.set_fields = { show_cover: true, flags: flags }.to_json
+            flag.save!
           end
       RequestStore.store[:skip_rules] = false
     end

--- a/app/models/concerns/smooch_blocking.rb
+++ b/app/models/concerns/smooch_blocking.rb
@@ -22,7 +22,7 @@ module SmoochBlocking
         block.save!
         Rails.logger.info("[Smooch Bot] Blocked user #{uid}")
         Rails.cache.write("smooch:banned:#{uid}", Time.now.to_i)
-        apply_content_warning_to_user_content(uid)
+        self.delay.apply_content_warning_to_user_content(uid)
       rescue ActiveRecord::RecordNotUnique
         # User already blocked
         Rails.logger.info("[Smooch Bot] User #{uid} already blocked")
@@ -57,7 +57,7 @@ module SmoochBlocking
               'racy': 0,
               'spam': 1
             }
-            Dynamic.delay.create!(annotation_type: 'flag', annotated: pm, annotator: current_user, skip_check_ability: true, set_fields: { show_cover: true, flags: flags }.to_json)
+            Dynamic.create!(annotation_type: 'flag', annotated: pm, annotator: User.current, skip_check_ability: true, set_fields: { show_cover: true, flags: flags }.to_json)
           end
       RequestStore.store[:skip_rules] = false
     end

--- a/app/models/concerns/smooch_blocking.rb
+++ b/app/models/concerns/smooch_blocking.rb
@@ -49,14 +49,7 @@ module SmoochBlocking
       RequestStore.store[:skip_rules] = true
       ProjectMedia.joins(:tipline_requests)
           .where(tipline_requests: { tipline_user_uid: uid }).find_each do |pm|
-            flags = {
-              'adult': 0,
-              'spoof': 0,
-              'medical': 0,
-              'violence': 0,
-              'racy': 0,
-              'spam': 1
-            }
+            flags = { 'spam': 1, 'adult': 0, 'spoof': 0, 'medical': 0, 'violence': 0, 'racy': 0 }
             Dynamic.create!(annotation_type: 'flag', annotated: pm, annotator: User.current, skip_check_ability: true, set_fields: { show_cover: true, flags: flags }.to_json)
           end
       RequestStore.store[:skip_rules] = false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -293,6 +293,7 @@ ActiveRecord::Schema.define(version: 2024_03_04_160338) do
     t.index ["field_type"], name: "index_dynamic_annotation_fields_on_field_type"
     t.index ["value"], name: "fetch_unique_id", unique: true, where: "(((field_name)::text = 'external_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
     t.index ["value"], name: "index_status", where: "((field_name)::text = 'verification_status_status'::text)"
+    t.index ["value"], name: "smooch_request_message_id_unique_id", unique: true, where: "(((field_name)::text = 'smooch_message_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
     t.index ["value"], name: "smooch_user_unique_id", unique: true, where: "(((field_name)::text = 'smooch_user_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
     t.index ["value"], name: "translation_request_id", unique: true, where: "((field_name)::text = 'translation_request_id'::text)"
     t.index ["value_json"], name: "index_dynamic_annotation_fields_on_value_json", using: :gin

--- a/test/models/bot/smooch_2_test.rb
+++ b/test/models/bot/smooch_2_test.rb
@@ -214,6 +214,7 @@ class Bot::Smooch2Test < ActiveSupport::TestCase
   end
 
   test "should ban user that sends unsafe URL" do
+    create_flag_annotation_type
     uid = random_string
     url = 'http://unsafe.com/'
     pender_url = CheckConfig.get('pender_url_private') + '/api/medias'

--- a/test/models/bot/smooch_3_test.rb
+++ b/test/models/bot/smooch_3_test.rb
@@ -485,6 +485,7 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
   end
 
   test "should apply content warning after blocking user" do
+    create_flag_annotation_type
     create_annotation_type_and_fields('Smooch User', { 'Id' => ['Text', false], 'App Id' => ['Text', false], 'Data' => ['JSON', false] })
     Bot::Smooch.unstub(:save_user_information)
     SmoochApi::AppApi.any_instance.stubs(:get_app).returns(OpenStruct.new(app: OpenStruct.new(name: random_string)))

--- a/test/models/bot/smooch_3_test.rb
+++ b/test/models/bot/smooch_3_test.rb
@@ -483,4 +483,41 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
     WebMock.stub_request(:get, url).to_return(status: 200, body: File.read(File.join(Rails.root, 'test', 'data', 'rails.png')))
     assert_not_nil Bot::Smooch.turnio_send_message_to_user('test:123456', 'Test', { 'type' => 'image', 'mediaUrl' => url })
   end
+
+  test "should apply content warning after blocking user" do
+    create_annotation_type_and_fields('Smooch User', { 'Id' => ['Text', false], 'App Id' => ['Text', false], 'Data' => ['JSON', false] })
+    Bot::Smooch.unstub(:save_user_information)
+    SmoochApi::AppApi.any_instance.stubs(:get_app).returns(OpenStruct.new(app: OpenStruct.new(name: random_string)))
+    { 'whatsapp' => '', 'messenger' => 'http://facebook.com/psid=1234', 'twitter' => 'http://twitter.com/profile_images/1234/image.jpg', 'other' => '' }.each do |platform, url|
+      SmoochApi::AppUserApi.any_instance.stubs(:get_app_user).returns(OpenStruct.new(appUser: { clients: [{ displayName: random_string, platform: platform, info: { avatarUrl: url } }] }))
+      uid = random_string
+      messages = [
+        {
+          '_id': random_string,
+          authorId: uid,
+          type: 'text',
+          source: { type: "whatsapp" },
+          text: random_string
+        }
+      ]
+      payload = {
+        trigger: 'message:appUser',
+        app: {
+          '_id': @app_id
+        },
+        version: 'v1.1',
+        messages: messages,
+        appUser: {
+          '_id': random_string,
+          'conversationStarted': true
+        }
+      }.to_json
+      redis = Redis.new(REDIS_CONFIG)
+      Bot::Smooch.run(payload)
+      pm = ProjectMedia.last
+      Bot::Smooch.block_user(uid)
+      assert Dynamic.where(annotation_type: 'flag', annotated_id: pm.id).exists?, 'Content warning flags should be applied'
+    end
+    Bot::Smooch.stubs(:save_user_information).returns(nil)
+  end
 end

--- a/test/models/bot/smooch_3_test.rb
+++ b/test/models/bot/smooch_3_test.rb
@@ -131,6 +131,7 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
   end
 
   test "should delete cache entries when user annotation is deleted" do
+    create_flag_annotation_type
     create_annotation_type_and_fields('Smooch User', { 'Id' => ['Text', false], 'App Id' => ['Text', false], 'Data' => ['JSON', false] })
     Bot::Smooch.unstub(:save_user_information)
     SmoochApi::AppApi.any_instance.stubs(:get_app).returns(OpenStruct.new(app: OpenStruct.new(name: random_string)))

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -698,9 +698,8 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
   end
 
   test "should not reply to banned user" do
-    create_flag_annotation_type
-    Sidekiq::Worker.clear_all
     Bot::Smooch.ban_user({ 'authorId' => @uid })
+    Sidekiq::Worker.clear_all
     Sidekiq::Testing.fake! do
       send_message 'hello'
       assert_equal 0, Sidekiq::Worker.jobs.size

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -698,6 +698,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
   end
 
   test "should not reply to banned user" do
+    create_flag_annotation_type
     Sidekiq::Worker.clear_all
     Bot::Smooch.ban_user({ 'authorId' => @uid })
     Sidekiq::Testing.fake! do


### PR DESCRIPTION
## Description

When a user is banned and their submissions are still being consumed by other users, we will now automatically apply content warning screens to their ProjectMedia.

References: CV2-3582

## How has this been tested?

- Confirmed that banned users' content will be marked as 'Spam'

## Things to pay attention to during code review

Ban a user and confirm that all of their project media will be flagged as 'Spam'

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

