### PR TITLE
Delete old tipline request and fix sentry issue

### DIFF
--- a/app/models/concerns/team_rules.rb
+++ b/app/models/concerns/team_rules.rb
@@ -50,7 +50,7 @@ module TeamRules
 
     def get_smooch_message(pm)
       smooch_message = pm.smooch_message
-      smooch_message.nil? ? pm.tipline_requests.last.smooch_data : smooch_message
+      smooch_message.nil? ? pm.tipline_requests.last&.smooch_data : smooch_message
     end
 
     def title_matches_regexp(pm, value, _rule_id)

--- a/lib/tasks/migrate/20231122054128_migrate_tipline_requests.rake
+++ b/lib/tasks/migrate/20231122054128_migrate_tipline_requests.rake
@@ -448,5 +448,19 @@ namespace :check do
       minutes = ((Time.now.to_i - started) / 60).to_i
       puts "[#{Time.now}] Done in #{minutes} minutes."
     end
+
+    # Remove old tipline requests (annotations of type smooch)
+    # bundle exec rails check:migrate:remove_old_tipline_requests
+    task remove_old_tipline_requests: :environment do
+      started = Time.now.to_i
+      Annotation.where(annotation_type: 'smooch').find_in_batches(:batch_size => 200) do |annotations|
+        print '.'
+        ids = annotations.map(&:id)
+        DynamicAnnotation::Field.where(annotation_type: 'smooch', annotation_id: ids).delete_all
+        Annotation.where(id: ids).delete_all
+      end
+      minutes = ((Time.now.to_i - started) / 60).to_i
+      puts "[#{Time.now}] Done in #{minutes} minutes."
+    end
   end
 end

--- a/lib/tasks/migrate/20231122054128_migrate_tipline_requests.rake
+++ b/lib/tasks/migrate/20231122054128_migrate_tipline_requests.rake
@@ -453,11 +453,14 @@ namespace :check do
     # bundle exec rails check:migrate:remove_old_tipline_requests
     task remove_old_tipline_requests: :environment do
       started = Time.now.to_i
-      Annotation.where(annotation_type: 'smooch').find_in_batches(:batch_size => 200) do |annotations|
-        print '.'
+      total = Annotation.where(annotation_type: 'smooch').count
+      deleted = 0
+      Annotation.where(annotation_type: 'smooch').find_in_batches(:batch_size => 2000) do |annotations|
         ids = annotations.map(&:id)
+        deleted += ids.count
         DynamicAnnotation::Field.where(annotation_type: 'smooch', annotation_id: ids).delete_all
         Annotation.where(id: ids).delete_all
+        puts "\nDeleted #{deleted} / #{total}\n"
       end
       minutes = ((Time.now.to_i - started) / 60).to_i
       puts "[#{Time.now}] Done in #{minutes} minutes."


### PR DESCRIPTION
## Description

- Add rake task to remove old tipline requests (annotation of type smooch).
- Fix sentry issue

References: CV2-4351, CV2-4352

## How has this been tested?

Locally against live DB .

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

