### PR TITLE
Better Sentry error for WhatsApp Insights API exception in statistics job

### DIFF
--- a/lib/check_statistics.rb
+++ b/lib/check_statistics.rb
@@ -112,7 +112,7 @@ module CheckStatistics
 
         rescue StandardError => e
           error_info = { error_message: e.message, response_code: response.code, response_body: response.body, team_id: team_id, start_date: start_date, end_date: end_date }
-          CheckSentry.notify(WhatsAppInsightsApiError.new('Could not get WhatsApp conversations statistics'), **error_info)
+          CheckSentry.notify(WhatsAppInsightsApiError.new("Could not get WhatsApp conversations statistics for workspace #{Team.find(team_id).name}"), **error_info)
           nil
         end
       end


### PR DESCRIPTION
## Description

Add the workspace name to the error message so we can better handle it in Sentry (for example, archive the ones that are expected to fail).

Fixes CV2-4281.

## How has this been tested?

By executing the rake task `rake check:data:statistics`.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

