### PR TITLE
Add negative feedback to tipline's smooch request type

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -468,7 +468,7 @@ ActiveRecord::Schema.define(version: 2024_02_28_203460) do
     t.index ["user_id"], name: "index_project_media_users_on_user_id"
   end
 
-  create_table "project_medias", force: :cascade do |t|
+  create_table "project_medias", id: :serial, force: :cascade do |t|
     t.integer "project_id"
     t.integer "media_id"
     t.integer "user_id"
@@ -860,7 +860,8 @@ ActiveRecord::Schema.define(version: 2024_02_28_203460) do
   end
 
   create_table "versions", id: :serial, force: :cascade do |t|
-    t.string "item_type", null: false
+    t.string "item_type"
+    t.string "{:null=>false}"
     t.string "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -560,11 +560,15 @@ class PopulatedWorkspaces
     TiplineRequest.create!(
       associated: project_media,
       team_id: project_media.team_id,
-      smooch_request_type: ['default_requests', 'timeout_search_requests', 'relevant_search_result_requests'].sample,
+      smooch_request_type: smooch_request_type,
       smooch_data: smooch_data,
       smooch_report_received_at: [Time.now.to_i, nil].sample,
       user_id:  BotUser.smooch_user&.id
     )
+  end
+
+  def smooch_request_type
+    ['default_requests', 'timeout_search_requests', ['relevant_search_result_requests', 'irrelevant_search_result_requests']*3].flatten.sample
   end
 
   def create_tipline_requests(team_project_medias)


### PR DESCRIPTION
## Description

We are going to start working on a feature to filter the tipline request:
- Filter by items that received positive feedback
- Filter by items that received negative feedback

When creating the seeds we were not adding the **negative feedback** (`irrelevant_search_result_requests`). Before we were adding only: `default_requests`, `timeout_search_requests` and `relevant_search_result_requests`. So this PR changes that.

References: 4309

## How has this been tested?

By running the seeds script and checking if the requests type were added.

## Things to pay attention to during code review

- To make it more likely that we will get `relevant_search_result_requests` and `irrelevant_search_result_requests`, I added them a few more times to the array in `smooch_request_type`.
- The negative feedback is **not** displayed in the UI.
- If a request report has been received. That information will show on the UI, you'll be able to see the history on mouseover (if it has a positive or no feedback, again, a negative feedback is not displayed).

![Screenshot 2024-03-05 at 16 48 12](https://github.com/meedan/check-api/assets/87862340/b7a4b4f4-e683-4e37-a00b-191d51781c36)


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

