### PR TITLE
Replace item by parent when sending tipline keyword search results.

### DIFF
--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -15,7 +15,7 @@ module SmoochSearch
           pm = Relationship.confirmed_parent(pm)
           report = pm.get_dynamic_annotation('report_design')
           !report.nil? && !!report.should_send_report_in_this_language?(language)
-        end.uniq
+        end.collect{ |pm| Relationship.confirmed_parent(pm) }.uniq
         if results.empty?
           self.bundle_messages(uid, '', app_id, 'default_requests', nil, true)
           self.send_final_message_to_user(uid, self.get_custom_string('search_no_results', language), workflow, language, 'no_results')


### PR DESCRIPTION
## Description

Replace item by parent when sending tipline keyword search results.

Fixes CV2-4071.

## How has this been tested?

Existing tests should cover this.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

