### PR TITLE
4380 – Remove create_report method from the FetchBot

### DIFF
--- a/app/models/bot/fetch.rb
+++ b/app/models/bot/fetch.rb
@@ -184,7 +184,7 @@ class Bot::Fetch < BotUser
       end
     end
 
-    def self.import_claim_review(claim_review, team_id, user_id, status_fallback, status_mapping, auto_publish_reports, force = false)
+    def self.import_claim_review(claim_review, team_id, user_id, status_fallback, status_mapping, _auto_publish_reports, force = false)
       begin
         user = User.find(user_id)
         team = Team.find(team_id)
@@ -303,19 +303,6 @@ class Bot::Fetch < BotUser
         s.status = status_fallback
         s.save!
       end
-    end
-
-    def self.get_image_file(image_url)
-      tmp = nil
-      unless image_url.blank?
-        tmp = File.join(Rails.root, 'tmp', "image-#{SecureRandom.hex}")
-        URI(Addressable::URI.escape(image_url)).open do |i|
-          File.open(tmp, 'wb') do |f|
-            f.write(i.read)
-          end
-        end
-      end
-      tmp
     end
 
     def self.parse_text(text)

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -73,6 +73,7 @@ class FactCheck < ApplicationRecord
     data[:state] = (self.publish_report ? 'published' : 'paused')
     reports.annotator = self.user || User.current
     reports.set_fields = data.to_json
+    reports.skip_check_ability = true
     reports.save!
   end
 end


### PR DESCRIPTION
## Description
This method was causing an issue and is not needed anymore.
We can simply substitute it by `fc.publish_report = true`

## Issue:
When trying to import some Fact Checks, using the `FetchBot`,
with language set to `pt_BR`, the language was still being set as `en`.

That was happening because inside `import_claim_review` after it runs
`set_claim_and_fact_check`, it was running `create_report`.
https://github.com/meedan/check-api/blob/4a44ab093fbae68e25114c4cef0af537daec9f2b/app/models/bot/fetch.rb#L187-L199

Inside `create_report` it was setting the language to the workspace’s
default language. So, we might want to add a language as `pt_BR`,
but if the default language of the workspace is `en`, that gets overwritten.
https://github.com/meedan/check-api/blob/4a44ab093fbae68e25114c4cef0af537daec9f2b/app/models/bot/fetch.rb#L338

References: 4380, 4347

## How has this been tested?

By creating imported fact checks using the Fetch Bot.

## Things to pay attention to

We had one failing test: `"should not import duplicate claim reviews"`. We got an error `#<RuntimeError: No permission to create Dynamic>` when trying to save a `FactCheck`, it was rolled back and didn't create the `FactCheck` and `ProjectMedia`, causing the test to fail. 

This was fixed by adding `reports.skip_check_ability = true` to `update_report`. 
https://github.com/meedan/check-api/blob/e681cf2388da208e7286e7135c82bdb14f7d2c07/app/models/fact_check.rb#L76

Basically, we don’t really need to check for permissions in the `FactCheck` `update_report` method, since it’s a private method that is just called from a `FactCheck` callback.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

