### PR TITLE
Adding Mongolian as a supported language for tiplines.

### DIFF
--- a/config/tipline_strings.yml
+++ b/config/tipline_strings.yml
@@ -1042,3 +1042,42 @@ vi:
   subscribed: Bạn hiện đã ghi danh nhận bản tin của chúng tôi.
   unsubscribe_button_label: Ngừng Ghi Danh
   unsubscribed: Bạn hiện không còn ghi danh nhận bản tin của chúng tôi.
+mn:
+  add_more_details_state_button_label: "Нэмэх"
+  ask_if_ready_state_button_label: "Цуцлах"
+  cancelled: "Амжилттай цуцаллаа"
+  confirm_preferred_language: "Сонгосон хэлээ баталгаажуулна уу"
+  invalid_format: "Уучлаарай, таны илгээсэн файлын формат ажиллахгүй байна."
+  keep_subscription_button_label: "Бүртгэлээ хадгалах"
+  languages: "Хэл сонгох"
+  languages_and_privacy_title: "Хэл болон Нууцлал"
+  main_menu: "Үндсэн цэс"
+  main_state_button_label: "Цуцлах"
+  navigation_button: "Шилжих товч дарах"
+  no_results_in_language: "Монгол хэл дээр илэрц олдсонгүй. Бусад хэл дээрх холбоотой байж болох зарим үр дүнг энд оруулав."
+  privacy_and_purpose: |-
+    Нууцлал ба зорилго
+  
+    Монголын баримт шалгах төвийн хуурамч мэдээллийн эсрэг Баримт нэн тэргүүнд сувагт тавтай морилно уу.
+  
+    Та энэ дугаарыг ашиглан мэдээлэл нягтлуулахаар илгээх боломжтой.
+  
+    Таны өгөгдөл аюулгүй байна. Бид таны хувийн мэдээллийг хамгаалах, Баримт нэн тэргүүнд сувгийг нууцалж, аюулгүй байлгах болно; Энэ үйлчилгээг үзүүлэх, сайжруулахаас бусад тохиолдолд таны хувийн мэдээллийг (PII) хуваалцахгүй, худалдахгүй, ашиглахгүй.
+  
+    Хуурамч, ташаа мэдээллийг аль болох эрт илрүүлэхийн тулд бид энэ PII бус контентыг шалгасан судлаачид болон баримт шалгах түншүүдтэй хуваалцаж болно.
+  
+    Бидний холбосон вэбсайтууд өөрсдийн нууцлалын бодлоготой байх болно гэдгийг анхаарна уу.
+  
+    Хэрэв та өөрийн хүсэлтийг энэ ажилд ашиглуулахыг хүсэхгүй байгаа бол манай системд оруулахгүй байхыг хүсье.
+  privacy_statement: "Нууцлалын мэдэгдэл"
+  privacy_title: "Нууцлал"
+  report_updated: "Дараах баримт шалгалт ингэж шинэчлэгдлээ"
+  search_result_is_not_relevant_button_label: "Үгүй"
+  search_result_is_relevant_button_label: "Тийм"
+  search_state_button_label: "Илгээх"
+  subscribe_button_label: "Бүртгүүлэх"
+  subscribed: "Та мэдээллийн товхимолд бүртгүүллээ"
+  unsubscribe_button_label: "Бүртгэлээс хасах"
+  unsubscribed: "Та одоогоор мэдээллийн товхимолд бүртгэгдээгүй байна"
+  nlu_disambiguation: "Дараах сонголтуудаас нэгийг сонгоно уу:"
+  nlu_cancel: "Цэс рүү буцах"


### PR DESCRIPTION
## Description

Adding Mongolian as a supported language for tiplines. I followed Meedan's documentation "How to localize (l10n) in Check" in order to do this.

Reference: CV2-4394.

## How has this been tested?

Manually: Configured a tipline in Mongolian and tested the bot in that language.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

