### PR TITLE
4346 – Seeds script: create cluster data with real values

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,9 +31,9 @@ end
 
 MEDIAS_PARAMS = [
   *CLAIMS_PARAMS,
-  *UPLOADED_AUDIO_PARAMS,
-  *UPLOADED_IMAGE_PARAMS,
-  *UPLOADED_VIDEO_PARAMS,
+  # *UPLOADED_AUDIO_PARAMS,
+  # *UPLOADED_IMAGE_PARAMS,
+  # *UPLOADED_VIDEO_PARAMS,
 ].shuffle!
 
 class Setup
@@ -220,7 +220,7 @@ class PopulatedWorkspaces
         title: "#{teams[:main_team_a][:name]} / [a] Main User: Main Team",
         user: users[:main_user_a],
         team: teams[:main_team_a],
-        project_medias_attributes: medias_params_with_links.map.with_index { |media_params, index|
+        project_medias_attributes: MEDIAS_PARAMS.map.with_index { |media_params, index|
           {
             media_attributes: media_params,
             user: users[:main_user_a],
@@ -258,24 +258,24 @@ class PopulatedWorkspaces
             }
           }
         },
-        {
-          title: "#{teams[:invited_team_b2][:name]} / [b] Invited User: Project Team #2",
-          user: users[:invited_user_b],
-          team: teams[:invited_team_b2],
-          project_medias_attributes: MEDIAS_PARAMS.map.with_index { |media_params, index|
-            {
-              media_attributes: media_params,
-              user: users[:invited_user_b],
-              team: teams[:invited_team_b2],
-              claim_description_attributes: {
-                description: claim_title(media_params),
-                context: Faker::Lorem.sentence,
-                user: users[:invited_user_b],
-                fact_check_attributes: fact_check_params_for_half_the_claims(index, users[:invited_user_b]),
-              }
-            }
-          }
-        },
+        # {
+        #   title: "#{teams[:invited_team_b2][:name]} / [b] Invited User: Project Team #2",
+        #   user: users[:invited_user_b],
+        #   team: teams[:invited_team_b2],
+        #   project_medias_attributes: MEDIAS_PARAMS.map.with_index { |media_params, index|
+        #     {
+        #       media_attributes: media_params,
+        #       user: users[:invited_user_b],
+        #       team: teams[:invited_team_b2],
+        #       claim_description_attributes: {
+        #         description: claim_title(media_params),
+        #         context: Faker::Lorem.sentence,
+        #         user: users[:invited_user_b],
+        #         fact_check_attributes: fact_check_params_for_half_the_claims(index, users[:invited_user_b]),
+        #       }
+        #     }
+        #   }
+        # },
         {
           title: "#{teams[:invited_team_c][:name]} / [c] Invited User: Project Team #1",
           user: users[:invited_user_c],
@@ -644,10 +644,10 @@ ActiveRecord::Base.transaction do
     puts 'Making and inviting to Shared Feed... (won\'t run if you are not creating any invited users)'
     populated_workspaces.share_feed(feed_1)
     populated_workspaces.share_feed(feed_2)
-    puts 'Making Confirmed Relationships between items...'
-    populated_workspaces.confirm_relationships
-    puts 'Making Suggested Relationships between items...'
-    populated_workspaces.suggest_relationships
+    # puts 'Making Confirmed Relationships between items...'
+    # populated_workspaces.confirm_relationships
+    # puts 'Making Suggested Relationships between items...'
+    # populated_workspaces.suggest_relationships
     puts 'Making Tipline requests...'
     populated_workspaces.tipline_requests
     puts 'Publishing half of each user\'s Fact Checks...'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -344,12 +344,20 @@ class PopulatedWorkspaces
   def clusters(feed)
     teams_project_medias.compact_blank!.each do |team_name, project_medias|
       next unless teams[team_name].is_part_of_feed?(feed.id)
-      c1 = cluster(project_medias.first, feed, teams[team_name])
-      c2 = cluster(project_medias.second, feed, teams[team_name])
-      c3 = cluster(project_medias.last, feed, teams[team_name])
+      c1_centre = project_medias.first
+      c1_project_media = c1_centre
+      c2_centre = project_medias.second
+      c2_project_medias = project_medias[1..(project_medias.size/2)-1] # first half
+      c3_centre = project_medias.last
+      c3_project_medias = project_medias[project_medias.size/2..-1] # second half
 
-      project_medias[2..(project_medias.size/2)-1].each { |pm| ClusterProjectMedia.create!(cluster_id: c2.id, project_media_id: pm.id) }
-      project_medias[project_medias.size/2..-2].each { |pm| ClusterProjectMedia.create!(cluster_id: c3.id, project_media_id: pm.id) }
+      c1 = cluster(c1_centre, feed, teams[team_name])
+      c2 = cluster(c2_centre, feed, teams[team_name])
+      c3 = cluster(c3_centre, feed, teams[team_name])
+
+      cluster_items(c1_project_media, c1)
+      cluster_items(c2_project_medias, c2)
+      cluster_items(c3_project_medias, c3)
 
       updated_cluster(c1)
       updated_cluster(c2)
@@ -357,37 +365,48 @@ class PopulatedWorkspaces
     end
   end
 
+  ###### tbd: move to private
+  def cluster_items(project_medias, cluster)
+    [project_medias].flatten.each { |pm| ClusterProjectMedia.create!(cluster_id: cluster.id, project_media_id: pm.id) }
+  end
+
   def updated_cluster(cluster)
     cluster_project_medias = cluster.items
     cluster_fact_checks = cluster_project_medias.map { |project_media| project_media.claim_description.fact_check }.compact!
+    cluster_tipline_requests = cluster_project_medias.map { |project_media| project_media.get_requests }.flatten!
 
-    cluster.last_item_at = Time.now
-    unless cluster.items.blank?
-      cluster.media_count = cluster_project_medias.size
-      cluster.requests_count = cluster_requests_count(cluster_project_medias)
-      cluster.fact_checks_count = cluster_fact_checks_count(cluster_fact_checks)
-      cluster.last_request_date = cluster_last_request_date(cluster_project_medias)
-      cluster.last_fact_check_date = cluster_last_fact_check_date(cluster_fact_checks)
+    cluster.media_count = cluster_project_medias.size
+    cluster.last_item_at = cluster_project_medias.last.created_at
+    unless cluster_fact_checks.nil?
+      cluster.fact_checks_count = cluster_fact_checks.size
+      cluster.last_fact_check_date = last_date(cluster_fact_checks)
+    end
+    unless cluster_tipline_requests.nil?
+      cluster.requests_count = cluster_tipline_requests.size
+      cluster.last_request_date = last_date(cluster_tipline_requests)
     end
     cluster.save!
   end
 
-  ###### tbd: move to private
-  def cluster_requests_count(cluster_project_medias)
-    cluster_project_medias.map { |project_media| project_media.requests_count }.sum
+  def last_date(collection)
+    collection.sort { |a,b| a.created_at <=> b.created_at }.last.created_at
   end
 
-  def cluster_fact_checks_count(cluster_fact_checks)
-    cluster_fact_checks.size
+  def random_channels
+    channels = [5, 6, 7, 8, 9, 10, 13]
+    channels.sample(rand(channels.size))
   end
 
-  def cluster_last_request_date(cluster_project_medias)
-    tipline_requests = cluster_project_medias.map { |project_media| TiplineRequest.where(associated_id: project_media.id) }
-    tipline_requests.flatten!.sort { |a,b| a.created_at <=> b.created_at }.last.created_at
-  end
-
-  def cluster_last_fact_check_date(cluster_fact_checks)
-    cluster_fact_checks.sort { |a,b| a.created_at <=> b.created_at }.last.created_at
+  def cluster(project_media, feed, team)
+    cluster_params = {
+      project_media_id: project_media.id,
+      first_item_at: project_media.created_at,
+      feed_id: feed.id,
+      team_ids: [team.id],
+      channels: random_channels,
+      title: project_media.title
+    }
+    Cluster.create!(cluster_params)
   end
   #####
 
@@ -626,23 +645,6 @@ class PopulatedWorkspaces
         17.times {create_tipline_user_and_data(project_media)}
       end
     end
-  end
-
-  def random_channels
-    channels = [5, 6, 7, 8, 9, 10, 13]
-    channels.sample(rand(channels.size))
-  end
-
-  def cluster(project_media, feed, team)
-    cluster_params = {
-      project_media_id: project_media.id,
-      first_item_at: Time.now,
-      feed_id: feed.id,
-      team_ids: [team.id],
-      channels: random_channels,
-      title: project_media.title
-    }
-    Cluster.create!(cluster_params)
   end
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,9 +31,9 @@ end
 
 MEDIAS_PARAMS = [
   *CLAIMS_PARAMS,
-  # *UPLOADED_AUDIO_PARAMS,
-  # *UPLOADED_IMAGE_PARAMS,
-  # *UPLOADED_VIDEO_PARAMS,
+  *UPLOADED_AUDIO_PARAMS,
+  *UPLOADED_IMAGE_PARAMS,
+  *UPLOADED_VIDEO_PARAMS,
 ].shuffle!
 
 class Setup
@@ -220,7 +220,7 @@ class PopulatedWorkspaces
         title: "#{teams[:main_team_a][:name]} / [a] Main User: Main Team",
         user: users[:main_user_a],
         team: teams[:main_team_a],
-        project_medias_attributes: MEDIAS_PARAMS.map.with_index { |media_params, index|
+        project_medias_attributes: medias_params_with_links.map.with_index { |media_params, index|
           {
             media_attributes: media_params,
             user: users[:main_user_a],
@@ -258,24 +258,24 @@ class PopulatedWorkspaces
             }
           }
         },
-        # {
-        #   title: "#{teams[:invited_team_b2][:name]} / [b] Invited User: Project Team #2",
-        #   user: users[:invited_user_b],
-        #   team: teams[:invited_team_b2],
-        #   project_medias_attributes: MEDIAS_PARAMS.map.with_index { |media_params, index|
-        #     {
-        #       media_attributes: media_params,
-        #       user: users[:invited_user_b],
-        #       team: teams[:invited_team_b2],
-        #       claim_description_attributes: {
-        #         description: claim_title(media_params),
-        #         context: Faker::Lorem.sentence,
-        #         user: users[:invited_user_b],
-        #         fact_check_attributes: fact_check_params_for_half_the_claims(index, users[:invited_user_b]),
-        #       }
-        #     }
-        #   }
-        # },
+        {
+          title: "#{teams[:invited_team_b2][:name]} / [b] Invited User: Project Team #2",
+          user: users[:invited_user_b],
+          team: teams[:invited_team_b2],
+          project_medias_attributes: MEDIAS_PARAMS.map.with_index { |media_params, index|
+            {
+              media_attributes: media_params,
+              user: users[:invited_user_b],
+              team: teams[:invited_team_b2],
+              claim_description_attributes: {
+                description: claim_title(media_params),
+                context: Faker::Lorem.sentence,
+                user: users[:invited_user_b],
+                fact_check_attributes: fact_check_params_for_half_the_claims(index, users[:invited_user_b]),
+              }
+            }
+          }
+        },
         {
           title: "#{teams[:invited_team_c][:name]} / [c] Invited User: Project Team #1",
           user: users[:invited_user_c],
@@ -668,15 +668,15 @@ ActiveRecord::Base.transaction do
     puts 'Creating saved searches for all teams...'
     populated_workspaces.saved_searches
     puts 'Creating feed...'
-    # feed_1 = populated_workspaces.main_user_feed("share_factchecks")
+    feed_1 = populated_workspaces.main_user_feed("share_factchecks")
     feed_2 = populated_workspaces.main_user_feed("share_everything")
     puts 'Making and inviting to Shared Feed... (won\'t run if you are not creating any invited users)'
-    # populated_workspaces.share_feed(feed_1)
+    populated_workspaces.share_feed(feed_1)
     populated_workspaces.share_feed(feed_2)
-    # puts 'Making Confirmed Relationships between items...'
-    # populated_workspaces.confirm_relationships
-    # puts 'Making Suggested Relationships between items...'
-    # populated_workspaces.suggest_relationships
+    puts 'Making Confirmed Relationships between items...'
+    populated_workspaces.confirm_relationships
+    puts 'Making Suggested Relationships between items...'
+    populated_workspaces.suggest_relationships
     puts 'Making Tipline requests...'
     populated_workspaces.tipline_requests
     puts 'Publishing half of each user\'s Fact Checks...'


### PR DESCRIPTION
## Description

We updated how we create the clusters in the seeds script, so it will:
- add all the cluster values (some were missing from the prior version)
- add the real values (some were random values, now only channel is random)

References: 4346

## How has this been tested?

By running the script to create all the data, and then running it to add data to an user.

## Things to pay attention to during code review

- Currently all the cluster's items are from the same team. We decide to finish this first version first, and update it to add the other team's items to the cluster on a next ticket/PR.

## Images

### User A / Team A*
<img width="1392" alt="Screenshot 2024-03-22 at 16 25 57" src="https://github.com/meedan/check-api/assets/87862340/4ce8997d-a8c9-4569-81b1-f0c80bcb5672">
<img width="1392" alt="Screenshot 2024-03-22 at 16 26 10" src="https://github.com/meedan/check-api/assets/87862340/c0c1e8e8-f965-479e-a650-864fa766f19a">
<img width="1392" alt="Screenshot 2024-03-22 at 16 34 51" src="https://github.com/meedan/check-api/assets/87862340/109b87a4-1f67-48e1-95e6-34b89361d415">
<img width="1392" alt="Screenshot 2024-03-22 at 16 35 06" src="https://github.com/meedan/check-api/assets/87862340/fb896d4a-88d4-488b-a27f-6ac09ebf7900">

_* I ran the script twice, so that is why User A has 4 feeds instead of 2._

### User C / Team C
<img width="1120" alt="Screenshot 2024-03-22 at 16 26 49" src="https://github.com/meedan/check-api/assets/87862340/10d72c96-310f-4f51-b753-122216609b08">
<img width="1120" alt="Screenshot 2024-03-22 at 16 27 09" src="https://github.com/meedan/check-api/assets/87862340/960fa9c8-b16d-469e-9428-56cbdbbabdba">
