### PR TITLE
4406 – Seeds: Add multilpe teams' items to clusters

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -348,33 +348,38 @@ class PopulatedWorkspaces
   end
 
   def clusters(feed)
-    feed_project_medias = feed_project_medias(feed)
+    feed_project_medias_groups = feed_project_medias(feed).in_groups(3, false)
 
-    c1_centre = feed_project_medias.first
+    c1_centre = feed_project_medias_groups.first.delete_at(0)
     c1_project_media = [c1_centre]
-    c2_centre = feed_project_medias.second
-    c2_project_medias = feed_project_medias[1..(feed_project_medias.size/2)-1] # first half
-    c3_centre = feed_project_medias.last
-    c3_project_medias = feed_project_medias[feed_project_medias.size/2..-1] # second half
+    c2_centre = feed_project_medias_groups.first.first
+    c2_project_medias = feed_project_medias_groups.first
+    c3_centre = feed_project_medias_groups.second.first
+    c3_project_medias = feed_project_medias_groups.second
+    c4_centre = feed_project_medias_groups.third.first
+    c4_project_medias = feed_project_medias_groups.third
 
     c1 = cluster(c1_centre, feed, c1_centre.team_id)
     c2 = cluster(c2_centre, feed, c2_centre.team_id)
     c3 = cluster(c3_centre, feed, c3_centre.team_id)
+    c4 = cluster(c3_centre, feed, c4_centre.team_id)
 
     cluster_items(c1_project_media, c1)
     cluster_items(c2_project_medias, c2)
     cluster_items(c3_project_medias, c3)
+    cluster_items(c4_project_medias, c4)
 
     updated_cluster(c1)
     updated_cluster(c2)
     updated_cluster(c3)
+    updated_cluster(c4)
   end
 
   def feed_project_medias(feed)
     teams_not_on_feed = teams.reject { |team_name, team| team.is_part_of_feed?(feed.id) }
     teams_project_medias_clone = teams_project_medias.clone
     teams_not_on_feed.each_key { |team_name| teams_project_medias_clone.delete(team_name)}
-    teams_project_medias_clone.compact_blank!.values.flatten!.shuffle
+    teams_project_medias_clone.compact_blank!.values.flatten!
   end
 
   def confirm_relationships

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,9 +31,9 @@ end
 
 MEDIAS_PARAMS = [
   *CLAIMS_PARAMS,
-  # *UPLOADED_AUDIO_PARAMS,
-  # *UPLOADED_IMAGE_PARAMS,
-  # *UPLOADED_VIDEO_PARAMS,
+  *UPLOADED_AUDIO_PARAMS,
+  *UPLOADED_IMAGE_PARAMS,
+  *UPLOADED_VIDEO_PARAMS,
 ].shuffle!
 
 class Setup
@@ -220,7 +220,7 @@ class PopulatedWorkspaces
         title: "#{teams[:main_team_a][:name]} / [a] Main User: Main Team",
         user: users[:main_user_a],
         team: teams[:main_team_a],
-        project_medias_attributes: MEDIAS_PARAMS.map.with_index { |media_params, index|
+        project_medias_attributes: medias_params_with_links.map.with_index { |media_params, index|
           {
             media_attributes: media_params,
             user: users[:main_user_a],
@@ -258,24 +258,24 @@ class PopulatedWorkspaces
             }
           }
         },
-        # {
-        #   title: "#{teams[:invited_team_b2][:name]} / [b] Invited User: Project Team #2",
-        #   user: users[:invited_user_b],
-        #   team: teams[:invited_team_b2],
-        #   project_medias_attributes: MEDIAS_PARAMS.map.with_index { |media_params, index|
-        #     {
-        #       media_attributes: media_params,
-        #       user: users[:invited_user_b],
-        #       team: teams[:invited_team_b2],
-        #       claim_description_attributes: {
-        #         description: claim_title(media_params),
-        #         context: Faker::Lorem.sentence,
-        #         user: users[:invited_user_b],
-        #         fact_check_attributes: fact_check_params_for_half_the_claims(index, users[:invited_user_b]),
-        #       }
-        #     }
-        #   }
-        # },
+        {
+          title: "#{teams[:invited_team_b2][:name]} / [b] Invited User: Project Team #2",
+          user: users[:invited_user_b],
+          team: teams[:invited_team_b2],
+          project_medias_attributes: MEDIAS_PARAMS.map.with_index { |media_params, index|
+            {
+              media_attributes: media_params,
+              user: users[:invited_user_b],
+              team: teams[:invited_team_b2],
+              claim_description_attributes: {
+                description: claim_title(media_params),
+                context: Faker::Lorem.sentence,
+                user: users[:invited_user_b],
+                fact_check_attributes: fact_check_params_for_half_the_claims(index, users[:invited_user_b]),
+              }
+            }
+          }
+        },
         {
           title: "#{teams[:invited_team_c][:name]} / [c] Invited User: Project Team #1",
           user: users[:invited_user_c],
@@ -693,10 +693,10 @@ ActiveRecord::Base.transaction do
     populated_workspaces.share_feed(feed_2)
     puts 'Accepting invitation to a Shared Feed...'
     populated_workspaces.accept_invitation(feed_2, :invited_user_c)
-    # puts 'Making Confirmed Relationships between items...'
-    # populated_workspaces.confirm_relationships
-    # puts 'Making Suggested Relationships between items...'
-    # populated_workspaces.suggest_relationships
+    puts 'Making Confirmed Relationships between items...'
+    populated_workspaces.confirm_relationships
+    puts 'Making Suggested Relationships between items...'
+    populated_workspaces.suggest_relationships
     puts 'Making Tipline requests...'
     populated_workspaces.tipline_requests
     puts 'Publishing half of each user\'s Fact Checks...'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -341,6 +341,12 @@ class PopulatedWorkspaces
     invited_users.each { |invited_user| feed_invitation(feed, invited_user)}
   end
 
+  def accept_invitation(feed, invited_user)
+    team = users[invited_user].teams.first
+    feed_invitation = FeedInvitation.where(feed_id: feed.id).find_by(email: users[invited_user].email)
+    feed_invitation.accept!(team.id)
+  end
+
   def clusters(feed)
     teams_project_medias.compact_blank!.each do |team_name, project_medias|
       next unless teams[team_name].is_part_of_feed?(feed.id)
@@ -673,6 +679,8 @@ ActiveRecord::Base.transaction do
     puts 'Making and inviting to Shared Feed... (won\'t run if you are not creating any invited users)'
     populated_workspaces.share_feed(feed_1)
     populated_workspaces.share_feed(feed_2)
+    puts 'Accepting invitation to a Shared Feed...'
+    populated_workspaces.accept_invitation(feed_2, :invited_user_c)
     # puts 'Making Confirmed Relationships between items...'
     # populated_workspaces.confirm_relationships
     # puts 'Making Suggested Relationships between items...'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -375,13 +375,6 @@ class PopulatedWorkspaces
     updated_cluster(c4)
   end
 
-  def feed_project_medias(feed)
-    teams_not_on_feed = teams.reject { |team_name, team| team.is_part_of_feed?(feed.id) }
-    teams_project_medias_clone = teams_project_medias.clone
-    teams_not_on_feed.each_key { |team_name| teams_project_medias_clone.delete(team_name)}
-    teams_project_medias_clone.compact_blank!.values.flatten!
-  end
-
   def confirm_relationships
     teams_project_medias.each_value do |project_medias|
       confirmed_relationship(project_medias[0],  project_medias[1])
@@ -617,6 +610,13 @@ class PopulatedWorkspaces
         17.times {create_tipline_user_and_data(project_media)}
       end
     end
+  end
+
+  def feed_project_medias(feed)
+    teams_not_on_feed = teams.reject { |team_name, team| team.is_part_of_feed?(feed.id) }
+    teams_project_medias_clone = teams_project_medias.clone
+    teams_not_on_feed.each_key { |team_name| teams_project_medias_clone.delete(team_name)}
+    teams_project_medias_clone.compact_blank!.values.flatten!
   end
 
   def cluster_items(project_medias, cluster)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -31,9 +31,9 @@ end
 
 MEDIAS_PARAMS = [
   *CLAIMS_PARAMS,
-  *UPLOADED_AUDIO_PARAMS,
-  *UPLOADED_IMAGE_PARAMS,
-  *UPLOADED_VIDEO_PARAMS,
+  # *UPLOADED_AUDIO_PARAMS,
+  # *UPLOADED_IMAGE_PARAMS,
+  # *UPLOADED_VIDEO_PARAMS,
 ].shuffle!
 
 class Setup
@@ -220,7 +220,7 @@ class PopulatedWorkspaces
         title: "#{teams[:main_team_a][:name]} / [a] Main User: Main Team",
         user: users[:main_user_a],
         team: teams[:main_team_a],
-        project_medias_attributes: medias_params_with_links.map.with_index { |media_params, index|
+        project_medias_attributes: MEDIAS_PARAMS.map.with_index { |media_params, index|
           {
             media_attributes: media_params,
             user: users[:main_user_a],
@@ -258,24 +258,24 @@ class PopulatedWorkspaces
             }
           }
         },
-        {
-          title: "#{teams[:invited_team_b2][:name]} / [b] Invited User: Project Team #2",
-          user: users[:invited_user_b],
-          team: teams[:invited_team_b2],
-          project_medias_attributes: MEDIAS_PARAMS.map.with_index { |media_params, index|
-            {
-              media_attributes: media_params,
-              user: users[:invited_user_b],
-              team: teams[:invited_team_b2],
-              claim_description_attributes: {
-                description: claim_title(media_params),
-                context: Faker::Lorem.sentence,
-                user: users[:invited_user_b],
-                fact_check_attributes: fact_check_params_for_half_the_claims(index, users[:invited_user_b]),
-              }
-            }
-          }
-        },
+        # {
+        #   title: "#{teams[:invited_team_b2][:name]} / [b] Invited User: Project Team #2",
+        #   user: users[:invited_user_b],
+        #   team: teams[:invited_team_b2],
+        #   project_medias_attributes: MEDIAS_PARAMS.map.with_index { |media_params, index|
+        #     {
+        #       media_attributes: media_params,
+        #       user: users[:invited_user_b],
+        #       team: teams[:invited_team_b2],
+        #       claim_description_attributes: {
+        #         description: claim_title(media_params),
+        #         context: Faker::Lorem.sentence,
+        #         user: users[:invited_user_b],
+        #         fact_check_attributes: fact_check_params_for_half_the_claims(index, users[:invited_user_b]),
+        #       }
+        #     }
+        #   }
+        # },
         {
           title: "#{teams[:invited_team_c][:name]} / [c] Invited User: Project Team #1",
           user: users[:invited_user_c],
@@ -673,10 +673,10 @@ ActiveRecord::Base.transaction do
     puts 'Making and inviting to Shared Feed... (won\'t run if you are not creating any invited users)'
     populated_workspaces.share_feed(feed_1)
     populated_workspaces.share_feed(feed_2)
-    puts 'Making Confirmed Relationships between items...'
-    populated_workspaces.confirm_relationships
-    puts 'Making Suggested Relationships between items...'
-    populated_workspaces.suggest_relationships
+    # puts 'Making Confirmed Relationships between items...'
+    # populated_workspaces.confirm_relationships
+    # puts 'Making Suggested Relationships between items...'
+    # populated_workspaces.suggest_relationships
     puts 'Making Tipline requests...'
     populated_workspaces.tipline_requests
     puts 'Publishing half of each user\'s Fact Checks...'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -348,10 +348,7 @@ class PopulatedWorkspaces
   end
 
   def clusters(feed)
-    teams_not_on_feed = teams.reject { |team_name, team| team.is_part_of_feed?(feed.id) }
-    teams_not_on_feed.each_key { |team_name| teams_project_medias.delete(team_name)}
-
-    feed_project_medias = teams_project_medias.compact_blank!.values.flatten!.shuffle
+    feed_project_medias = feed_project_medias(feed)
 
     c1_centre = feed_project_medias.first
     c1_project_media = [c1_centre]
@@ -371,6 +368,13 @@ class PopulatedWorkspaces
     updated_cluster(c1)
     updated_cluster(c2)
     updated_cluster(c3)
+  end
+
+  def feed_project_medias(feed)
+    teams_not_on_feed = teams.reject { |team_name, team| team.is_part_of_feed?(feed.id) }
+    teams_project_medias_clone = teams_project_medias.clone
+    teams_not_on_feed.each_key { |team_name| teams_project_medias_clone.delete(team_name)}
+    teams_project_medias_clone.compact_blank!.values.flatten!.shuffle
   end
 
   def confirm_relationships


### PR DESCRIPTION
## Description

**Issues**
1. All of the clusters only had one team: because we were iterating and creating the clusters per team.
2. Only from the cluster creator team: because we where inviting the other teams, but not accepting. When we would check if a team was part of the feed, only the cluster creator (`team a`) was returned. 

**How this was fixed**
I had to fix issue 2 first. I added a method `accept_invitation(feed, team)`. This way we can accept it on the script as needed, so we are still able to test the invitation acceptance process. Currently `team c` accepts the invitation to `feed 2` (our feed with clusters). 

To fix issue 1: instead of iterating per team project medias, I’m removing the teams that aren’t part of the feed, adding all the project medias to a `feed_projects_medias` array. This array I divided into 3 groups:
- I took one item out to create the solo cluster
- The first third has only items from one team
- The second third from both
- The third from the other team

References: 4406, 4346

## How has this been tested?

By running the script to create new users from scratch and to add to an user.

## Things to pay attention to during code review

I'm not too sure about the `feed_project_medias` method. I feel it could be simpler and I'm missing something.
https://github.com/meedan/check-api/blob/71d21a5a5d80379935129eb40c3bb68c3a754b64/db/seeds.rb#L615-L620

## Flow per team (images)
### Team A (Feed creator)
<img width="1392" alt="0 team_a" src="https://github.com/meedan/check-api/assets/87862340/fe6fed3f-bd29-4b48-ae2f-22336a14e1f0">
<img width="1392" alt="1 team_a" src="https://github.com/meedan/check-api/assets/87862340/d5775696-f138-4f6d-8088-120894438ed9">
<img width="1392" alt="2 team_a" src="https://github.com/meedan/check-api/assets/87862340/ab2ced92-6e60-42e1-bae6-7961cc7706e0">
<img width="1392" alt="3 team_a" src="https://github.com/meedan/check-api/assets/87862340/4af42489-48d5-4be5-932b-2b82c18331d8">

### Team C (Invited team, accepts the invitation through the script)
<img width="1392" alt="0 team_c" src="https://github.com/meedan/check-api/assets/87862340/28709cdc-41f8-4a95-92e2-84b455782165">
<img width="1392" alt="1 team_c" src="https://github.com/meedan/check-api/assets/87862340/e2161e3b-5b67-40c2-9e75-d5bfc9b9690a">

### Team B1/B2 (Invited teams, accepts through the UI)
<img width="1392" alt="Screenshot 2024-03-28 at 11 18 49" src="https://github.com/meedan/check-api/assets/87862340/a1125e03-b43f-4aeb-9a7c-c914d549df99">
<img width="1392" alt="Screenshot 2024-03-28 at 11 18 58" src="https://github.com/meedan/check-api/assets/87862340/69a5d218-bd10-403b-b244-813261839ec0">
<img width="1392" alt="Screenshot 2024-03-28 at 11 19 07" src="https://github.com/meedan/check-api/assets/87862340/c30c91c0-7158-49c9-ae44-1561b1628b50">

