### PR TITLE
Load `ClusterTeam` class when the application starts

### DIFF
--- a/config/initializers/plugins.rb
+++ b/config/initializers/plugins.rb
@@ -1,2 +1,2 @@
 # Load classes on boot, in production, that otherwise wouldn't be auto-loaded by default
-CcDeville && Bot::Keep && Workflow::Workflow.workflows && CheckS3 && Bot::Tagger && Bot::Fetch && Bot::Smooch && Bot::Slack && Bot::Alegre && CheckChannels && RssFeed && UrlRewriter
+CcDeville && Bot::Keep && Workflow::Workflow.workflows && CheckS3 && Bot::Tagger && Bot::Fetch && Bot::Smooch && Bot::Slack && Bot::Alegre && CheckChannels && RssFeed && UrlRewriter && ClusterTeam


### PR DESCRIPTION
## Description

Load `ClusterTeam` class when the application starts. It just happens in production environment. Fixes an error reported by Sentry on QA.

References: SENTRY event ID 41a7e7cf09924d9dbcf0f31b90f370b0.

## How has this been tested?

Opening a cluster page in Check Web should not return an error 400 from the backend.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

