### PR TITLE
add condition to verify if list is shared on a feed

### DIFF
--- a/app/graph/types/saved_search_type.rb
+++ b/app/graph/types/saved_search_type.rb
@@ -17,7 +17,7 @@ class SavedSearchType < DefaultObject
   field :is_part_of_feeds, GraphQL::Types::Boolean, null: true
 
   def is_part_of_feeds
-    Feed.where(saved_search_id: object.id).exists?
+    Feed.where(saved_search_id: object.id).exists? || FeedTeam.where(saved_search_id: object.id).exists?
   end
 
   field :feeds, FeedType.connection_type, null: true


### PR DESCRIPTION
## Description

Modify the code to include a check for any FeedTeams associated with the same saved_search_id. This change ensures that the list is considered part of a shared feed when either a Feed or a FeedTeam is linked to the saved_search_id

## How has this been tested?
Checked that the param is correctly being set to true and ran the integration tests on check-web: https://app.travis-ci.com/github/meedan/check-web/builds/269722027

Reference: CV2-4413

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

