### PR TITLE
A couple of fixes for some shared feed attributes computation

### DIFF
--- a/app/graph/types/claim_description_type.rb
+++ b/app/graph/types/claim_description_type.rb
@@ -14,6 +14,8 @@ class ClaimDescriptionType < DefaultObject
 
   def fact_check(report_status:)
     ability = context[:ability] || Ability.new
-    (ability.can?(:read, object) && (!report_status || object.project_media.report_status == report_status)) ? object.fact_check : nil
+    status = object.project_media.report_status
+    can_read = ability.can?(:read, object) || status == 'published'
+    (can_read && (!report_status || status == report_status)) ? object.fact_check : nil
   end
 end

--- a/app/graph/types/claim_description_type.rb
+++ b/app/graph/types/claim_description_type.rb
@@ -12,7 +12,7 @@ class ClaimDescriptionType < DefaultObject
     argument :report_status, GraphQL::Types::String, required: false, camelize: false
   end
 
-  def fact_check(report_status:)
+  def fact_check(report_status: nil)
     ability = context[:ability] || Ability.new
     status = object.project_media.report_status
     can_read = ability.can?(:read, object) || status == 'published'

--- a/app/graph/types/claim_description_type.rb
+++ b/app/graph/types/claim_description_type.rb
@@ -13,6 +13,7 @@ class ClaimDescriptionType < DefaultObject
   end
 
   def fact_check(report_status:)
-    (!report_status || object.project_media.report_status == report_status) ? object.fact_check : nil
+    ability = context[:ability] || Ability.new
+    (ability.can?(:read, object) && (!report_status || object.project_media.report_status == report_status)) ? object.fact_check : nil
   end
 end

--- a/app/graph/types/claim_description_type.rb
+++ b/app/graph/types/claim_description_type.rb
@@ -8,5 +8,11 @@ class ClaimDescriptionType < DefaultObject
   field :context, GraphQL::Types::String, null: true, resolver_method: :claim_context
   field :user, UserType, null: true
   field :project_media, ProjectMediaType, null: true
-  field :fact_check, FactCheckType, null: true
+  field :fact_check, FactCheckType, null: true do
+    argument :report_status, GraphQL::Types::String, required: false, camelize: false
+  end
+
+  def fact_check(report_status:)
+    (!report_status || object.project_media.report_status == report_status) ? object.fact_check : nil
+  end
 end

--- a/lib/cluster_team.rb
+++ b/lib/cluster_team.rb
@@ -18,8 +18,13 @@ class ClusterTeam
     @cluster.project_medias.where(team_id: @team.id)
   end
 
+  def requests
+    TiplineRequest.where(associated_type: 'ProjectMedia', associated_id: self.project_medias.map(&:id)).where('created_at < ?', @cluster.created_at)
+  end
+
   def last_request_date
-    self.project_medias.map(&:last_seen).sort.last # FIXME: We don't expect thousands of items per team in a cluster, but if so, this can be a performance issue
+    return nil if self.requests.count == 0
+    self.requests.order('created_at DESC').first.created_at.to_i
   end
 
   def media_count
@@ -27,7 +32,7 @@ class ClusterTeam
   end
 
   def requests_count
-    self.project_medias.map(&:requests_count).sum
+    self.requests.count
   end
 
   def fact_checks
@@ -35,11 +40,12 @@ class ClusterTeam
     list = []
     ClaimDescription.where(project_media_id: self.project_medias.map(&:id)).each do |claim_description|
       item = claim_description.project_media
+      fact_check = claim_description.fact_check if item.report_status == 'published'
       list << OpenStruct.new({
         id: claim_description.id,
         claim: claim_description.description,
-        fact_check_title: claim_description.fact_check&.title,
-        fact_check_summary: claim_description.fact_check&.summary,
+        fact_check_title: fact_check&.title,
+        fact_check_summary: fact_check&.summary,
         rating: item.status_i18n,
         media_count: item.linked_items_count,
         requests_count: item.demand,

--- a/lib/cluster_team.rb
+++ b/lib/cluster_team.rb
@@ -23,8 +23,8 @@ class ClusterTeam
   end
 
   def last_request_date
-    return nil if self.requests.count == 0
-    self.requests.order('created_at DESC').first.created_at.to_i
+    last_request = self.requests.order('created_at DESC').first
+    last_request ? last_request.created_at.to_i : nil
   end
 
   def media_count

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -627,7 +627,7 @@ type ClaimDescription implements Node {
   created_at: String
   dbid: Int
   description: String
-  fact_check: FactCheck
+  fact_check(report_status: String): FactCheck
   id: ID!
   permissions: String
   project_media: ProjectMedia
@@ -13318,7 +13318,6 @@ type TiplineRequest implements Node {
   smooch_request_type: String
   smooch_user_external_identifier: String
   smooch_user_request_language: String
-  smooch_user_slack_channel_url: String
   updated_at: String
 }
 

--- a/lib/tasks/check_khousheh.rake
+++ b/lib/tasks/check_khousheh.rake
@@ -251,7 +251,7 @@ namespace :check do
                   # Fact-checks
                   pm_fc_mapping = {} # Project Media ID => Fact-Check Updated At
                   ProjectMedia.select('project_medias.id as id, fc.updated_at as fc_updated_at')
-                  .where(id: pms.map(&:id))
+                  .where(id: pms.select{ |pm| pm.report_status == 'published' }.map(&:id))
                   .joins("INNER JOIN claim_descriptions cd ON project_medias.id = cd.project_media_id")
                   .joins("INNER JOIN fact_checks fc ON cd.id = fc.claim_description_id")
                   .find_each do |pm_fc|

--- a/public/relay.json
+++ b/public/relay.json
@@ -3139,7 +3139,18 @@
               "name": "fact_check",
               "description": null,
               "args": [
-
+                {
+                  "name": "report_status",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
               ],
               "type": {
                 "kind": "OBJECT",
@@ -70230,20 +70241,6 @@
             },
             {
               "name": "smooch_user_request_language",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "smooch_user_slack_channel_url",
               "description": null,
               "args": [
 

--- a/test/controllers/graphql_controller_5_test.rb
+++ b/test/controllers/graphql_controller_5_test.rb
@@ -56,9 +56,10 @@ class GraphqlController5Test < ActionController::TestCase
     m2 = create_claim_media quote: 'Foo bar'
     pm = create_project_media project: p, media: m
     pm2 = create_project_media project: p, media: m2
+    create_claim_description project_media: pm2
     Bot::Alegre.stubs(:get_similar_texts).returns({ pm2.id => 0.9, pm.id => 0.8 })
 
-    query = 'query { project_media(ids: "' + [pm.id, p.id, t.id].join(',') + '") { similar_items(first: 10000) { edges { node { dbid, claim_description { id } } } } } }'
+    query = 'query { project_media(ids: "' + [pm.id, p.id, t.id].join(',') + '") { similar_items(first: 10000) { edges { node { dbid, claim_description { id, fact_check { id } } } } } } }'
     post :create, params: { query: query, team: t.slug }
     assert_response :success
     assert_equal pm2.id, JSON.parse(@response.body)['data']['project_media']['similar_items']['edges'][0]['node']['dbid']


### PR DESCRIPTION
## Description

A couple of fixes for some shared feed attributes computation:

(1) Only requests created before the cluster was created should be included

(2) Only published fact-checks should be included

Fixes: CV2-4177.

## How has this been tested?

Existing tests should cover this.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)