### PR TITLE
Fixing how media and requests are counted for each workspace in a feed cluster

### DIFF
--- a/lib/cluster_team.rb
+++ b/lib/cluster_team.rb
@@ -47,8 +47,8 @@ class ClusterTeam
         fact_check_title: fact_check&.title,
         fact_check_summary: fact_check&.summary,
         rating: item.status_i18n,
-        media_count: item.linked_items_count,
-        requests_count: item.demand,
+        media_count: Relationship.where(source_id: item.id, relationship_type: Relationship.confirmed_type).where('created_at < ?', @cluster.created_at).count + 1,
+        requests_count: TiplineRequest.where(associated_type: 'ProjectMedia', associated_id: item.id).where('created_at < ?', @cluster.created_at).count,
         claim_description: claim_description
       })
     end


### PR DESCRIPTION
## Description

Calculate the number of requests and media created until the time the cluster was created instead of using cached fields. That should be fine since feeds should never contain too many teams anyway.

Fixes: CV2-4177.

## How has this been tested?

Existing tests should cover this.

## Things to pay attention to during code review

Performance shouldn't be affected since a cluster will never contain more than 5 or 10 teams.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

