### PR TITLE
Expose in GraphQL API the previous feed list 

### DIFF
--- a/app/graph/types/feed_team_type.rb
+++ b/app/graph/types/feed_team_type.rb
@@ -18,4 +18,5 @@ class FeedTeamType < DefaultObject
   end
 
   field :saved_search, SavedSearchType, null: true
+  field :saved_search_was, SavedSearchType, null: true
 end

--- a/app/graph/types/feed_type.rb
+++ b/app/graph/types/feed_type.rb
@@ -23,6 +23,7 @@ class FeedType < DefaultObject
 
   field :team, PublicTeamType, null: true
   field :saved_search, SavedSearchType, null: true
+  field :saved_search_was, SavedSearchType, null: true
 
   field :requests, RequestType.connection_type, null: true do
     argument :request_id, GraphQL::Types::Int, required: false, camelize: false

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -168,6 +168,10 @@ class Feed < ApplicationRecord
     query
   end
 
+  def saved_search_was
+    SavedSearch.find_by_id(self.saved_search_id_before_last_save)
+  end
+
   # This takes some time to run because it involves external HTTP requests and writes to the database:
   # 1) If the query contains a media URL, it will be downloaded... if it contains some other URL, it will be sent to Pender
   # 2) Requests will be made to Alegre in order to index the request media and to look for similar requests

--- a/app/models/feed_team.rb
+++ b/app/models/feed_team.rb
@@ -19,6 +19,10 @@ class FeedTeam < ApplicationRecord
     self.saved_search&.filters.to_h
   end
 
+  def saved_search_was
+    SavedSearch.find_by_id(self.saved_search_id_was)
+  end
+
   private
 
   def saved_search_belongs_to_feed_team

--- a/app/models/feed_team.rb
+++ b/app/models/feed_team.rb
@@ -20,7 +20,7 @@ class FeedTeam < ApplicationRecord
   end
 
   def saved_search_was
-    SavedSearch.find_by_id(self.saved_search_id_was)
+    SavedSearch.find_by_id(self.saved_search_id_before_last_save)
   end
 
   private

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -8314,6 +8314,7 @@ type FeedTeam implements Node {
   requests_filters: JsonStringType
   saved_search: SavedSearch
   saved_search_id: Int
+  saved_search_was: SavedSearch
   shared: Boolean
   team: PublicTeam
   team_id: Int

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -8181,6 +8181,7 @@ type Feed implements Node {
   root_requests_count: Int
   saved_search: SavedSearch
   saved_search_id: Int
+  saved_search_was: SavedSearch
   tags: [String]
   team: PublicTeam
   team_id: Int

--- a/public/relay.json
+++ b/public/relay.json
@@ -44618,6 +44618,20 @@
               "deprecationReason": null
             },
             {
+              "name": "saved_search_was",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SavedSearch",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "tags",
               "description": null,
               "args": [

--- a/public/relay.json
+++ b/public/relay.json
@@ -45401,6 +45401,20 @@
               "deprecationReason": null
             },
             {
+              "name": "saved_search_was",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "SavedSearch",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "shared",
               "description": null,
               "args": [

--- a/test/models/feed_team_test.rb
+++ b/test/models/feed_team_test.rb
@@ -81,4 +81,14 @@ class FeedTeamTest < ActiveSupport::TestCase
     User.current = nil
     assert_nil FeedInvitation.find_by_id(fi.id)
   end
+
+  test "should return previous list" do
+    t = create_team
+    ss1 = create_saved_search team: t
+    ss2 = create_saved_search team: t
+    ft = create_feed_team team: t, saved_search: ss1
+    ft.saved_search = ss2
+    ft.save!
+    assert_equal ss1, ft.saved_search_was
+  end
 end

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -208,4 +208,14 @@ class FeedTest < ActiveSupport::TestCase
     f = create_feed data_points: [2], published: true
     assert_equal({}, f.get_feed_filters(:media))
   end
+
+  test "should return previous list" do
+    t = create_team
+    ss1 = create_saved_search team: t
+    ss2 = create_saved_search team: t
+    f = create_feed team: t, saved_search: ss1
+    f.saved_search = ss2
+    f.save!
+    assert_equal ss1, f.saved_search_was
+  end
 end


### PR DESCRIPTION
## Description

This PR adds a new field `saved_search_was` to the GraphQL types `FeedType` and `FeedTeamType`. When the list (saved search) is updated for a given `Feed` or `FeedTeam`, this new field returns the previous object. This allows the frontend to update the Relay store for the previous and new lists.

References: CV2-4413.

## How has this been tested?

Unit tests added.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

