### PR TITLE
Removing the "default" from the migration just to see if this is the problem

### DIFF
--- a/db/migrate/20240304160338_add_last_received_terms_email_at_to_users.rb
+++ b/db/migrate/20240304160338_add_last_received_terms_email_at_to_users.rb
@@ -1,5 +1,5 @@
 class AddLastReceivedTermsEmailAtToUsers < ActiveRecord::Migration[6.1]
   def change
-    add_column :users, :last_received_terms_email_at, :datetime, default: -> { 'CURRENT_TIMESTAMP' }
+    add_column :users, :last_received_terms_email_at, :datetime
   end
 end


### PR DESCRIPTION
Maybe the "default" value in this migration is making it take longer for big databases.