### PR TITLE
Filter items by Tipline search result feedback

### DIFF
--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -468,6 +468,20 @@ module ProjectMediaCachedFields
           }
         }
       ]
+    cached_field :negative_tipline_search_results_count,
+      update_es: true,
+      recalculate: :recalculate_negative_tipline_search_results_count,
+      update_on: [
+        {
+          model: TiplineRequest,
+          if: proc { |tr| tr.smooch_request_type == 'relevant_search_result_requests' },
+          affected_ids: proc { |tr| [tr.associated_id] },
+          events: {
+            save: :recalculate,
+            destroy: :recalculate,
+          }
+        }
+      ]
 
     cached_field :tipline_search_results_count,
       update_es: true,
@@ -656,6 +670,10 @@ module ProjectMediaCachedFields
 
     def recalculate_positive_tipline_search_results_count
       TiplineRequest.where(associated_type: 'ProjectMedia', associated_id: self.id, smooch_request_type: 'relevant_search_result_requests').count
+    end
+
+    def recalculate_negative_tipline_search_results_count
+      TiplineRequest.where(associated_type: 'ProjectMedia', associated_id: self.id, smooch_request_type: 'irrelevant_search_result_requests').count
     end
 
     def recalculate_tipline_search_results_count

--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -468,13 +468,14 @@ module ProjectMediaCachedFields
           }
         }
       ]
+
     cached_field :negative_tipline_search_results_count,
       update_es: true,
       recalculate: :recalculate_negative_tipline_search_results_count,
       update_on: [
         {
           model: TiplineRequest,
-          if: proc { |tr| tr.smooch_request_type == 'relevant_search_result_requests' },
+          if: proc { |tr| tr.smooch_request_type == 'irrelevant_search_result_requests' },
           affected_ids: proc { |tr| [tr.associated_id] },
           events: {
             save: :recalculate,

--- a/app/repositories/media_search.rb
+++ b/app/repositories/media_search.rb
@@ -139,6 +139,8 @@ class MediaSearch
 
     indexes :positive_tipline_search_results_count, { type: 'long' }
 
+    indexes :negative_tipline_search_results_count, { type: 'long' }
+
     indexes :tipline_search_results_count, { type: 'long' }
   end
 end

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -361,7 +361,7 @@ class CheckSearch
 
   def adjust_numeric_range_filter
     @options['range_numeric'] = {}
-    [:linked_items_count, :suggestions_count, :demand].each do |field|
+    [:linked_items_count, :suggestions_count, :demand, :positive_tipline_search_results_count, :negative_tipline_search_results_count].each do |field|
       if @options.has_key?(field) && !@options[field].blank?
         @options['range_numeric'][field] = @options[field]
       end

--- a/test/controllers/graphql_controller_2_test.rb
+++ b/test/controllers/graphql_controller_2_test.rb
@@ -144,7 +144,7 @@ class GraphqlController2Test < ActionController::TestCase
   test "should get cached values for list columns" do
     RequestStore.store[:skip_cached_field_update] = false
     t = create_team
-    t.set_list_columns = ["updated_at_timestamp", "last_seen", "demand", "share_count", "folder", "linked_items_count", "suggestions_count", "type_of_media", "status", "created_at_timestamp", "report_status", "tags_as_sentence", "media_published_at", "comment_count", "reaction_count", "related_count"]
+    t.set_list_columns = ["updated_at_timestamp", "last_seen", "demand", "share_count", "folder", "linked_items_count", "suggestions_count", "type_of_media", "status", "created_at_timestamp", "report_status", "tags_as_sentence", "media_published_at", "comment_count", "reaction_count", "related_count", "positive_tipline_search_results_count", "negative_tipline_search_results_count"]
     t.save!
     5.times { create_project_media team: t }
     u = create_user is_admin: true

--- a/test/models/bot/smooch_7_test.rb
+++ b/test/models/bot/smooch_7_test.rb
@@ -491,8 +491,9 @@ class Bot::Smooch7Test < ActiveSupport::TestCase
       Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'relevant_search_result_requests', pm)
       Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'relevant_search_result_requests', pm)
       Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'timeout_search_requests', pm)
-      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests')
-      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests')
+      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests', pm)
+      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests', pm)
+      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests', pm)
       message = lambda do
         {
           type: 'text',
@@ -512,24 +513,30 @@ class Bot::Smooch7Test < ActiveSupport::TestCase
         }
       end
       Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'relevant_search_result_requests', pm2)
-      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests')
+      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests', pm2)
+      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests', pm2)
       # Verify cached field
-      assert_equal 5, pm.tipline_search_results_count
+      assert_equal 6, pm.tipline_search_results_count
       assert_equal 2, pm.positive_tipline_search_results_count
-      assert_equal 2, pm2.tipline_search_results_count
+      assert_equal 3, pm.negative_tipline_search_results_count
+      assert_equal 3, pm2.tipline_search_results_count
       assert_equal 1, pm2.positive_tipline_search_results_count
+      assert_equal 2, pm2.negative_tipline_search_results_count
       # Verify ES values
       es = $repository.find(pm.get_es_doc_id)
-      assert_equal 5, es['tipline_search_results_count']
+      assert_equal 6, es['tipline_search_results_count']
       assert_equal 2, es['positive_tipline_search_results_count']
+      assert_equal 3, es['negative_tipline_search_results_count']
       es2 = $repository.find(pm2.get_es_doc_id)
-      assert_equal 2, es2['tipline_search_results_count']
+      assert_equal 3, es2['tipline_search_results_count']
       assert_equal 1, es2['positive_tipline_search_results_count']
+      assert_equal 2, es2['negative_tipline_search_results_count']
       # Verify destroy
       types = ["irrelevant_search_result_requests", "timeout_search_requests"]
       TiplineRequest.where(associated_type: 'ProjectMedia', associated_id: pm.id, smooch_request_type: types).destroy_all
       assert_equal 2, pm.tipline_search_results_count
       assert_equal 2, pm.positive_tipline_search_results_count
+      assert_equal 0, pm.negative_tipline_search_results_count
     end
   end
 


### PR DESCRIPTION
## Description

Here, we are adding the ability to filter items by tipline search result feedback (negative and positive). This will
allow `CheckSearch` to be called with `:positive_tipline_search_results_count` and `:negative_tipline_search_results_count` as search fields with  numeric range filter.

References: https://meedan.atlassian.net/browse/CV2-4309

## How has this been tested?

1: Added tests in `test/controllers/elastic_search_10_test.rb:483` to simulate and validate this search.
2: Directly calling GraphQL with the positive and negative filters, for example:

```
query {
  search(query: "{\"negative_tipline_search_results_count\":{\"min\":1, \"max\":2}}" {
    number_of_results
  }
}
```

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

