### PR TITLE
Return placeholder values for report introduction settings in GraphQL `TeamType.get_report` field

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GIT
 
 GIT
   remote: https://github.com/meedan/rails-i18n.git
-  revision: 130e65e148b13fb166e041bc2df4c4d03f202ea1
+  revision: ba4b3a267ff09b58a29fe8fc9eb002f9b75d7cba
   branch: rails-6-x
   specs:
     rails-i18n (6.0.0)
@@ -1036,4 +1036,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.4.19
+   2.5.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1036,4 +1036,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.5.7
+   2.4.19

--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -101,13 +101,9 @@ class TeamType < DefaultObject
   field :get_report, JsonStringType, null: true
 
   def get_report
-    report_settings = object.get_report.to_h
-    report_settings.each do |language, settings|
-      settings[:placeholders] = {
-        query_date: Dynamic.new.report_design_date(Time.now, language)
-      }
-    end
-    report_settings
+    placeholders = {}
+    object.get_languages.to_a.each { |language| placeholders[language] = { 'placeholders' => { 'query_date' => Dynamic.new.report_design_date(Time.now, language) } } }
+    object.get_report.to_h.deep_merge(placeholders)
   end
 
   field :get_fieldsets, JsonStringType, null: true

--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -101,7 +101,13 @@ class TeamType < DefaultObject
   field :get_report, JsonStringType, null: true
 
   def get_report
-    object.get_report
+    report_settings = object.get_report.to_h
+    report_settings.each do |language, settings|
+      settings[:placeholders] = {
+        query_date: Dynamic.new.report_design_date(Time.now, language)
+      }
+    end
+    report_settings
   end
 
   field :get_fieldsets, JsonStringType, null: true

--- a/config/application.rb
+++ b/config/application.rb
@@ -47,7 +47,7 @@ module Check
 
     locale = ENV['locale'] || cfg['locale']
     if locale.blank?
-      config.i18n.available_locales = ["ar","bho","bn","fil","fr","de","hi","id","kn","ml","mr","pa","pt","ro","ru","es","sw","ta","te","ur","en","am","as","bn_BD","gu","ks","ne","si","tl"] # Do not change manually! Use `rake transifex:languages` instead, or set the `locale` key in your `config/config.yml`
+      config.i18n.available_locales = ["ar","bho","bn","fil","fr","de","hi","id","kn","mk","ml","mn","mr","pa","pt","ro","ru","es","sw","ta","te","ur","en","am","as","bn_BD","gu","ks","ne","si","tl"] # Do not change manually! Use `rake transifex:languages` instead, or set the `locale` key in your `config/config.yml`
     else
       config.i18n.available_locales = [locale].flatten
     end

--- a/test/controllers/graphql_controller_8_test.rb
+++ b/test/controllers/graphql_controller_8_test.rb
@@ -878,8 +878,8 @@ class GraphqlController8Test < ActionController::TestCase
   test "should get team settings fields" do
     u = create_user is_admin: true
     authenticate_with_user(u)
-    t = create_team
-    fields = %w(get_slack_notifications_enabled get_slack_webhook get_embed_whitelist get_report_design_image_template get_status_target_turnaround get_rules get_languages get_language get_report get_data_report_url get_outgoing_urls_utm_code get_shorten_outgoing_urls)
+    t = create_team set_report: { en: { use_introduction: true, introduction: 'Test' } }
+    fields = %w(get_slack_notifications_enabled get_slack_webhook get_embed_whitelist get_report_design_image_template get_status_target_turnaround get_rules get_languages get_language get_report get_data_report_url get_outgoing_urls_utm_code get_shorten_outgoing_urls get_report)
     post :create, params: { query: "query Team { team { join_requests(first: 10) { edges { node { id } } }, #{fields.join(', ')} } }", team: t.slug }
     assert_response :success
   end

--- a/test/controllers/graphql_controller_test.rb
+++ b/test/controllers/graphql_controller_test.rb
@@ -503,14 +503,14 @@ class GraphqlControllerTest < ActionController::TestCase
 
   test "should get default if language is not supported" do
     authenticate_with_user
-    @request.headers['Accept-Language'] = 'mk-MK'
+    @request.headers['Accept-Language'] = 'xx-XX'
     post :create, params: { query: 'query Query { me { name } }' }
     assert_equal :en, I18n.locale
   end
 
   test "should get closest language" do
     authenticate_with_user
-    @request.headers['Accept-Language'] = 'mk-MK, fr-FR'
+    @request.headers['Accept-Language'] = 'xx-XX, fr-FR'
     post :create, params: { query: 'query Query { me { name } }' }
     assert_equal :fr, I18n.locale
   end


### PR DESCRIPTION
## Description

This way, API clients can know how we format (and can even use) the placeholder values for the report introduction.

Reference: CV2-4424.

## How has this been tested?

Existing tests should cover this. But in GraphiQL:

![Captura de tela de 2024-04-05 11-19-08](https://github.com/meedan/check-api/assets/117518/08bb2331-a6b3-4960-8bb1-ec07d0e098e0)

## Things to pay attention to during code review

I didn't include `status` since it's per item.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

