### PR TITLE
CV2-4126 Rebase then continuing video via presto

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -151,7 +151,7 @@ class Bot::Alegre < BotUser
       if body.dig(:event) == 'create_project_media' && !pm.nil?
         Rails.logger.info("[Alegre Bot] [ProjectMedia ##{pm.id}] This item was just created, processing...")
         self.get_language(pm)
-        if ['audio', 'image'].include?(self.get_pm_type(pm))
+        if ['audio', 'image', 'video'].include?(self.get_pm_type(pm))
           self.relate_project_media_async(pm)
         else
           Bot::Alegre.send_to_media_similarity_index(pm)

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -474,5 +474,12 @@ module AlegreV2
         ]
       }]
     end
+
+    def get_items_with_similar_media_v2(media_url, threshold, team_ids, type)
+      alegre_path = ['audio', 'image', 'video'].include?(type) ? self.sync_path_for_type(type) : "/#{type}/similarity/search/"
+      # FIXME: Stop using this method from v1 once all media types are supported by v2
+      # FIXME: Alegre crashes if `media_url` was already requested before, this is why I append a hash
+      self.get_items_with_similar_media("#{media_url}?hash=#{SecureRandom.hex}", threshold, team_ids, alegre_path)
+    end
   end
 end

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -169,6 +169,14 @@ module AlegreV2
       ).merge(params)
     end
 
+    def generic_package_video(project_media, params)
+      generic_package_media(project_media, params)
+    end
+
+    def delete_package_video(project_media, _field, params)
+      generic_package_video(project_media, params)
+    end
+
     def generic_package_image(project_media, params)
       generic_package_media(project_media, params)
     end
@@ -204,6 +212,10 @@ module AlegreV2
       context[:field] = field if field && is_not_generic_field(field)
       context[:temporary_media] = project_media.is_a?(TemporaryProjectMedia)
       context
+    end
+
+    def store_package_video(project_media, _field, params)
+      generic_package_video(project_media, params)
     end
 
     def store_package_image(project_media, _field, params)

--- a/test/models/bot/alegre_2_test.rb
+++ b/test/models/bot/alegre_2_test.rb
@@ -32,7 +32,7 @@ class Bot::Alegre2Test < ActiveSupport::TestCase
     pm1 = create_project_media team: @team, media: create_uploaded_video
     pm2 = create_project_media team: @team, media: create_uploaded_video
     pm3 = create_project_media team: @team, media: create_uploaded_video
-    Bot::Alegre.stubs(:request).with('post', '/video/similarity/search/', @params.merge(context: { has_custom_id: true, team_id: @team.id})).returns({
+    Bot::Alegre.stubs(:request).with('post', '/similarity/sync/video', @params).returns({
       result: [
         {
           context: [

--- a/test/models/bot/alegre_test.rb
+++ b/test/models/bot/alegre_test.rb
@@ -101,6 +101,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   end
 
   test "should unarchive item after running" do
+    WebMock.stub_request(:delete, 'http://alegre/text/similarity/').to_return(body: {success: true}.to_json)
     stub_configs({ 'alegre_host' => 'http://alegre', 'alegre_token' => 'test' }) do
       WebMock.stub_request(:delete, 'http://alegre/text/similarity/').to_return(status: 200, body: '{}')
       pm = create_project_media

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -951,7 +951,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
 
   test "should not relate project media for video if disabled on workspace" do
     tbi = TeamBotInstallation.where(team: @team, user: @bot).last
-    tbi.set_image_similarity_enabled = false
+    tbi.set_video_similarity_enabled = false
     tbi.save!
     Bot::Alegre.stubs(:merge_suggested_and_confirmed).never
     pm = create_project_media team: @team, media: create_uploaded_video

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -82,7 +82,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     assert_equal Bot::Alegre.delete_path(pm1), "/image/similarity/"
   end
 
-  test "should have host and paths for image" do
+  test "should have host and paths for video" do
     pm1 = create_project_media team: @team, media: create_uploaded_video
     assert_equal Bot::Alegre.host, CheckConfig.get('alegre_host')
     assert_equal Bot::Alegre.sync_path(pm1), "/similarity/sync/video"

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -82,6 +82,14 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     assert_equal Bot::Alegre.delete_path(pm1), "/image/similarity/"
   end
 
+  test "should have host and paths for image" do
+    pm1 = create_project_media team: @team, media: create_uploaded_video
+    assert_equal Bot::Alegre.host, CheckConfig.get('alegre_host')
+    assert_equal Bot::Alegre.sync_path(pm1), "/similarity/sync/video"
+    assert_equal Bot::Alegre.async_path(pm1), "/similarity/async/video"
+    assert_equal Bot::Alegre.delete_path(pm1), "/video/similarity/"
+  end
+
   test "should release and reconnect db" do
     RequestStore.store[:pause_database_connection] = true
     assert_equal Bot::Alegre.release_db.class, Thread::ConditionVariable
@@ -849,7 +857,21 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   test "should relate project media for image" do
     pm1 = create_project_media team: @team, media: create_uploaded_image
     pm2 = create_project_media team: @team, media: create_uploaded_image
-    Bot::Alegre.stubs(:get_similar_items_v2).returns({pm2.id=>{:score=>0.91, :context=>{"team_id"=>pm2.team_id, "has_custom_id"=>true, "project_media_id"=>pm2.id, "temporary_media"=>false}, :model=>"audio", :source_field=>"audio", :target_field=>"audio", :relationship_type=>Relationship.suggested_type}})
+    Bot::Alegre.stubs(:get_similar_items_v2).returns({pm2.id=>{:score=>0.91, :context=>{"team_id"=>pm2.team_id, "has_custom_id"=>true, "project_media_id"=>pm2.id, "temporary_media"=>false}, :model=>"image", :source_field=>"image", :target_field=>"image", :relationship_type=>Relationship.suggested_type}})
+    relationship = nil
+    assert_difference 'Relationship.count' do
+      relationship = Bot::Alegre.relate_project_media(pm1)
+    end
+    assert_equal relationship.source, pm2
+    assert_equal relationship.target, pm1
+    assert_equal relationship.relationship_type, Relationship.suggested_type
+    Bot::Alegre.unstub(:get_similar_items_v2)
+  end
+
+  test "should relate project media for video" do
+    pm1 = create_project_media team: @team, media: create_uploaded_video
+    pm2 = create_project_media team: @team, media: create_uploaded_video
+    Bot::Alegre.stubs(:get_similar_items_v2).returns({pm2.id=>{:score=>0.91, :context=>{"team_id"=>pm2.team_id, "has_custom_id"=>true, "project_media_id"=>pm2.id, "temporary_media"=>false}, :model=>"video", :source_field=>"video", :target_field=>"video", :relationship_type=>Relationship.suggested_type}})
     relationship = nil
     assert_difference 'Relationship.count' do
       relationship = Bot::Alegre.relate_project_media(pm1)

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -107,6 +107,11 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     assert_equal Bot::Alegre.generic_package(pm1, "image"), {:doc_id=>Bot::Alegre.item_doc_id(pm1, "image"), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true, :temporary_media=>false}}
   end
 
+  test "should create a generic_package for video" do
+    pm1 = create_project_media team: @team, media: create_uploaded_video
+    assert_equal Bot::Alegre.generic_package(pm1, "video"), {:doc_id=>Bot::Alegre.item_doc_id(pm1, "video"), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}}
+  end
+
   test "should create a generic_package_audio" do
     pm1 = create_project_media team: @team, media: create_uploaded_audio
     assert_equal Bot::Alegre.generic_package_audio(pm1, {}), {:doc_id=>Bot::Alegre.item_doc_id(pm1, nil), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true, :temporary_media=>false}, :url=>Bot::Alegre.media_file_url(pm1)}
@@ -121,6 +126,13 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     assert_equal Bot::Alegre.store_package(pm1, "image", {}), {:doc_id=>Bot::Alegre.item_doc_id(pm1, nil), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true, :temporary_media=>false}, :url=>Bot::Alegre.media_file_url(pm1)}
   end
 
+  test "should create a generic_package_video" do
+    pm1 = create_project_media team: @team, media: create_uploaded_video
+    assert_equal Bot::Alegre.generic_package_image(pm1, {}), {:doc_id=>Bot::Alegre.item_doc_id(pm1, nil), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)}
+    assert_equal Bot::Alegre.store_package_image(pm1, "video", {}), {:doc_id=>Bot::Alegre.item_doc_id(pm1, nil), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)}
+    assert_equal Bot::Alegre.store_package(pm1, "video", {}), {:doc_id=>Bot::Alegre.item_doc_id(pm1, nil), :context=>{:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}, :url=>Bot::Alegre.media_file_url(pm1)}
+  end
+
   test "should create a context for audio" do
     pm1 = create_project_media team: @team, media: create_uploaded_audio
     assert_equal Bot::Alegre.get_context(pm1, "audio"), {:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true, :temporary_media=>false}
@@ -129,6 +141,11 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   test "should create a context for image" do
     pm1 = create_project_media team: @team, media: create_uploaded_image
     assert_equal Bot::Alegre.get_context(pm1, "image"), {:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true, :temporary_media=>false}
+  end
+
+  test "should create a context for video" do
+    pm1 = create_project_media team: @team, media: create_uploaded_video
+    assert_equal Bot::Alegre.get_context(pm1, "video"), {:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}
   end
 
   test "should create a delete_package for audio" do
@@ -145,6 +162,15 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     package = Bot::Alegre.delete_package(pm1, "image")
     assert_equal package[:doc_id], Bot::Alegre.item_doc_id(pm1, nil)
     assert_equal package[:context], {:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true, :temporary_media=>false}
+    assert_equal package[:url].class, String
+    assert_equal package[:quiet], false
+  end
+
+  test "should create a delete_package for video" do
+    pm1 = create_project_media team: @team, media: create_uploaded_video
+    package = Bot::Alegre.delete_package(pm1, "video")
+    assert_equal package[:doc_id], Bot::Alegre.item_doc_id(pm1, nil)
+    assert_equal package[:context], {:team_id=>pm1.team_id, :project_media_id=>pm1.id, :has_custom_id=>true}
     assert_equal package[:url].class, String
     assert_equal package[:quiet], false
   end
@@ -189,6 +215,11 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     assert_equal Bot::Alegre.isolate_relevant_context(pm1, {"context"=>[{"team_id"=>pm1.team_id}]}), {"team_id"=>pm1.team_id}
   end
 
+  test "should isolate relevant_context for video" do
+    pm1 = create_project_media team: @team, media: create_uploaded_video
+    assert_equal Bot::Alegre.isolate_relevant_context(pm1, {"context"=>[{"team_id"=>pm1.team_id}]}), {"team_id"=>pm1.team_id}
+  end
+
   test "should return field or type on get_target_field for audio" do
     pm1 = create_project_media team: @team, media: create_uploaded_audio
     Bot::Alegre.stubs(:get_type).returns(nil)
@@ -198,6 +229,13 @@ class Bot::AlegreTest < ActiveSupport::TestCase
 
   test "should return field or type on get_target_field for image" do
     pm1 = create_project_media team: @team, media: create_uploaded_image
+    Bot::Alegre.stubs(:get_type).returns(nil)
+    assert_equal Bot::Alegre.get_target_field(pm1, "blah"), "blah"
+    Bot::Alegre.unstub(:get_type)
+  end
+
+  test "should return field or type on get_target_field for video" do
+    pm1 = create_project_media team: @team, media: create_uploaded_video
     Bot::Alegre.stubs(:get_type).returns(nil)
     assert_equal Bot::Alegre.get_target_field(pm1, "blah"), "blah"
     Bot::Alegre.unstub(:get_type)
@@ -222,6 +260,12 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     assert_equal Bot::Alegre.get_per_model_threshold(pm1, sample), {:threshold=>0.9}
   end
 
+  test "should generate per model threshold for video" do
+    pm1 = create_project_media team: @team, media: create_uploaded_video
+    sample = [{:value=>0.9, :key=>"video_hash_suggestion_threshold", :automatic=>false, :model=>"hash"}]
+    assert_equal Bot::Alegre.get_per_model_threshold(pm1, sample), {:threshold=>0.9}
+  end
+
   test "should get target field for audio" do
     pm1 = create_project_media team: @team, media: create_uploaded_audio
     assert_equal Bot::Alegre.get_target_field(pm1, nil), "audio"
@@ -230,6 +274,11 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   test "should get target field for image" do
     pm1 = create_project_media team: @team, media: create_uploaded_image
     assert_equal Bot::Alegre.get_target_field(pm1, nil), "image"
+  end
+
+  test "should get target field for video" do
+    pm1 = create_project_media team: @team, media: create_uploaded_video
+    assert_equal Bot::Alegre.get_target_field(pm1, nil), "video"
   end
 
   test "should parse similarity results" do
@@ -897,6 +946,15 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     tbi.save!
     Bot::Alegre.stubs(:merge_suggested_and_confirmed).never
     pm = create_project_media team: @team, media: create_uploaded_image
+    assert_equal({}, Bot::Alegre.get_similar_items_v2(pm, nil))
+  end
+
+  test "should not relate project media for video if disabled on workspace" do
+    tbi = TeamBotInstallation.where(team: @team, user: @bot).last
+    tbi.set_image_similarity_enabled = false
+    tbi.save!
+    Bot::Alegre.stubs(:merge_suggested_and_confirmed).never
+    pm = create_project_media team: @team, media: create_uploaded_video
     assert_equal({}, Bot::Alegre.get_similar_items_v2(pm, nil))
   end
 end


### PR DESCRIPTION
## Description

Shifts video to use the new sync endpoints in lieu of legacy code path

References: 4126

## How has this been tested?

No tests yet - will require extensive testing against alegre and in integration tests

## Things to pay attention to during code review

Does it even do video matching? Will need to confirm other modalities as well during integration tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

