### PR TITLE
CV2-3405 - Update statistics rake task to factor all bot users

### DIFF
--- a/lib/tasks/data/statistics.rake
+++ b/lib/tasks/data/statistics.rake
@@ -16,75 +16,80 @@ namespace :check do
       ActiveRecord::Base.logger = nil
 
       errors = []
-      team_ids = Team.joins(:project_medias).where(project_medias: { user: BotUser.smooch_user }).distinct.pluck(:id)
+      team_ids = Team.joins(:project_medias).where(project_medias: { user: BotUser.pluck(:id) }).distinct.pluck(:id)
       current_time = DateTime.now
       puts "[#{Time.now}] Detected #{team_ids.length} teams with tipline data"
       team_ids.each_with_index do |team_id, index|
-        tipline_bot = TeamBotInstallation.where(team_id: team_id, user: BotUser.smooch_user).last
-        if tipline_bot.nil?
-          puts "[#{Time.now}] No tipline bot installed for team #{team_id}; skipping team"
-          next
-        end
+        TeamBotInstallation.where(team_id: team_id, user: BotUser.pluck(:id)).find_each do |bot|
+          tipline_message_statistics = Check::TiplineMessageStatistics.new(team_id)
+          date = ProjectMedia.where(team_id: team_id, user: bot.user).order('created_at ASC').first&.created_at&.beginning_of_day
 
-        tipline_message_statistics = Check::TiplineMessageStatistics.new(team_id)
-        date = ProjectMedia.where(team_id: team_id, user: BotUser.smooch_user).order('created_at ASC').first&.created_at&.beginning_of_day
-        team = Team.find(team_id)
-        languages = team.get_languages.to_a
-        platforms = tipline_bot.smooch_enabled_integrations.keys
+          next if date.nil?
 
-        team_stats = Hash.new(0)
-        puts "[#{Time.now}] Generating month tipline statistics for team with ID #{team_id}. (#{index + 1} / #{team_ids.length})"
-        begin
-          month_start = date.beginning_of_month
-          month_end = date.end_of_month
+          team = Team.find(team_id)
+          languages = team.get_languages.to_a
+          if bot.user == BotUser.smooch_user
+            platforms = bot.smooch_enabled_integrations.keys 
+          else
+            platforms = Bot::Smooch::SUPPORTED_INTEGRATION_NAMES.keys
+          end
 
-          platforms.each do |platform|
-            languages.each do |language|
-              if MonthlyTeamStatistic.where(team_id: team_id, platform: platform, language: language, start_date: month_start, end_date: month_end).any?
-                team_stats[:skipped] += 1
-                next
-              end
+          team_stats = Hash.new(0)
+          puts "[#{Time.now}] Generating month tipline statistics for team with ID #{team_id}. (#{index + 1} / #{team_ids.length})"
+          begin
+            month_start = date.beginning_of_month
+            month_end = date.end_of_month
 
-              period_end = current_time < month_end ? current_time : month_end
-              tracing_attributes = { "app.team.id" => team_id, "app.attr.platform" => platform, "app.attr.language" => language}
+            platforms.each do |platform|
+              languages.each do |language|
+                if MonthlyTeamStatistic.where(team_id: team_id, platform: platform, language: language, start_date: month_start, end_date: month_end).any?
+                  team_stats[:skipped] += 1
+                  next
+                end
 
-              row_attributes = {}
-              begin
-                row_attributes = CheckStatistics.get_statistics(month_start.to_date, period_end, team_id, platform, language)
+                period_end = current_time < month_end ? current_time : month_end
+                tracing_attributes = { "app.team.id" => team_id, "app.attr.platform" => platform, "app.attr.language" => language}
 
-                # Start date for new conversation calculation, with optional override for testing
-                if args.ignore_convo_cutoff || month_start >= DateTime.new(2023,4,1)
-                  CheckTracer.in_span("Check::TiplineMessageStatistics.monthly_conversations", attributes: tracing_attributes) do
-                    row_attributes[:conversations_24hr] = tipline_message_statistics.monthly_conversations(
-                      Bot::Smooch::SUPPORTED_INTEGRATION_NAMES[platform],
-                      language,
-                      month_start,
-                      period_end
-                    )
+                row_attributes = {}
+                begin
+                  row_attributes = CheckStatistics.get_statistics(month_start.to_date, period_end, team_id, platform, language)
+
+                  # Start date for new conversation calculation, with optional override for testing
+                  if args.ignore_convo_cutoff || month_start >= DateTime.new(2023,4,1)
+                    CheckTracer.in_span("Check::TiplineMessageStatistics.monthly_conversations", attributes: tracing_attributes) do
+                      row_attributes[:conversations_24hr] = tipline_message_statistics.monthly_conversations(
+                        Bot::Smooch::SUPPORTED_INTEGRATION_NAMES[platform],
+                        language,
+                        month_start,
+                        period_end
+                      )
+                    end
                   end
-                end
 
-                partial_month = MonthlyTeamStatistic.find_by(team_id: team_id, platform: platform, language: language, start_date: month_start)
-                if partial_month.present?
-                  partial_month.update!(row_attributes.merge!(team_id: team_id))
-                  team_stats[:updated] += 1
-                else
-                  MonthlyTeamStatistic.create!(row_attributes.merge!(team_id: team_id))
-                  team_stats[:created] += 1
+                  partial_month = MonthlyTeamStatistic.find_by(team_id: team_id, platform: platform, language: language, start_date: month_start)
+                  if partial_month.present?
+                    partial_month.update!(row_attributes.merge!(team_id: team_id))
+                    team_stats[:updated] += 1
+                  else
+                    MonthlyTeamStatistic.create!(row_attributes.merge!(team_id: team_id))
+                    team_stats[:created] += 1
+                  end
+
+                rescue StandardError => e
+                  error = Check::Statistics::CalculationError.new(e)
+                  errors.push(error)
+                  puts "Error #{error}"
+                  CheckSentry.notify(error, team_id: team_id, platform: platform, language: language, start_date: month_start, end_date: period_end)
+                  team_stats[:errored] += 1
                 end
-              rescue StandardError => e
-                error = Check::Statistics::CalculationError.new(e)
-                errors.push(error)
-                CheckSentry.notify(error, team_id: team_id, platform: platform, language: language, start_date: month_start, end_date: period_end)
-                team_stats[:errored] += 1
               end
             end
-          end
-          date += 1.month
-        # Protect against generating stats for the future, by bailing if start of the start of first day of month is later than time rake task was run
-        end while date.beginning_of_month <= current_time
+            date += 1.month
+          # Protect against generating stats for the future, by bailing if start of the start of first day of month is later than time rake task was run
+          end while date.beginning_of_month <= current_time
 
-        puts "[#{Time.now}] Stats summary for team with ID #{team_id}: #{team_stats.map{|k,v| "#{k} - #{v}" }.join("; ") }. Platforms: #{platforms.join(',')}. Languages: #{languages.join(', ')}"
+          puts "[#{Time.now}] Stats summary for team with ID #{team_id} : #{team_stats.map{|k,v| "#{k} - #{v}" }.join("; ") }. Platforms: #{platforms.join(',')}. Languages: #{languages.join(', ')}"
+        end
       end
 
       ActiveRecord::Base.logger = old_logger


### PR DESCRIPTION
## Description

Update the statistics rake task to include media imported by all bot users, not just tipline data.

References: CV2-3405

## How has this been tested?

Steps to test:

 - Create a bot in a workspace
 - Create some ProjectMedia using that bot via the api
 - When you run the statistics rake job (`bundle exec rake check:data:statistics`), if you navigate to the workspace and go to `settings/data` you should see statistics for media from all bot users

## Things to pay attention to during code review

- Confirm that the generated statistics are what we expect
- We do not update existing stats, so in case you want to re-generate statistics for a specific month, you have to delete them from the database first.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

