### PR TITLE
CV2-4529 initial review on missing / uncovered lines

### DIFF
--- a/app/models/concerns/alegre_similarity.rb
+++ b/app/models/concerns/alegre_similarity.rb
@@ -286,18 +286,6 @@ module AlegreSimilarity
       params
     end
 
-    def get_items_with_similar_media(media_url, threshold, team_id, path)
-      self.get_similar_items_from_api(
-        path,
-        self.similar_media_content_from_api_conditions(
-          team_id,
-          media_url,
-          threshold
-        ),
-        threshold
-      )
-    end
-
     def similar_media_content_from_api_conditions(team_id, media_url, threshold, match_across_content_types=true)
       {
         url: media_url,

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -439,8 +439,6 @@ module AlegreV2
         response = get_similar_items_v2_callback(project_media, nil)
         delete(project_media, nil) if project_media.is_a?(TemporaryProjectMedia)
         return response
-      else
-        self.get_items_with_similar_media("#{media_url||media_file_url(project_media)}?hash=#{SecureRandom.hex}", threshold, team_ids, "/#{type}/similarity/search/")
       end
     end
 

--- a/test/models/bot/alegre_3_test.rb
+++ b/test/models/bot/alegre_3_test.rb
@@ -237,7 +237,7 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
   end
 
   test "should extract project medias from context as array" do
-    assert_equal Bot::Alegre.extract_project_medias_from_context({"_score" => 2, "_source" => {"context" => [{"project_media_id" => 1}]}}), {1=>{:score=>2, :context=>{"project_media_id"=>1}, :model=>nil}}
+    assert_equal Bot::Alegre.extract_project_medias_from_context({"_score" => 2, "_source" => {"context" => [{"project_media_id" => 1}]}}), {1=>{:score=>2, :context=>[{"project_media_id"=>1}], :model=>nil}}
   end
 
   test "should update on alegre" do

--- a/test/models/bot/alegre_3_test.rb
+++ b/test/models/bot/alegre_3_test.rb
@@ -232,22 +232,12 @@ class Bot::Alegre3Test < ActiveSupport::TestCase
     end
   end
 
-  def self.extract_project_medias_from_context(search_result)
-    # We currently have two cases of context:
-    # - a straight hash with project_media_id
-    # - an array of hashes, each with project_media_id
-    context = search_result.dig('_source', 'context')
-    pms = []
-    if context.kind_of?(Array)
-      context.each{ |c| pms.push(c.with_indifferent_access.dig('project_media_id')) }
-    elsif context.kind_of?(Hash)
-      pms.push(context.with_indifferent_access.dig('project_media_id'))
-    end
-    Hash[pms.flatten.collect{|pm| [pm.to_i, search_result.with_indifferent_access.dig('_score')]}]
+  test "should extract project medias from context as dict" do
+    assert_equal Bot::Alegre.extract_project_medias_from_context({"_score" => 2, "_source" => {"context" => {"project_media_id" => 1}}}), {1=>{:score=>2, :context=>{"project_media_id"=>1}, :model=>nil}}
   end
 
-  test "should extract project medias from context" do
-    assert_equal Bot::Alegre.extract_project_medias_from_context({"_score" => 2, "_source" => {"context" => {"project_media_id" => 1}}}), {1=>{:score=>2, :context=>{"project_media_id"=>1}, :model=>nil}}
+  test "should extract project medias from context as array" do
+    assert_equal Bot::Alegre.extract_project_medias_from_context({"_score" => 2, "_source" => {"context" => [{"project_media_id" => 1}]}}), {1=>{:score=>2, :context=>{"project_media_id"=>1}, :model=>nil}}
   end
 
   test "should update on alegre" do


### PR DESCRIPTION
## Description

Once we merged video changes, some lines started showing as uncovered. Upon initial review, some of those lines were obviously no longer in use and should just be removed (https://github.com/meedan/check-api/blob/662f023463a05b37120547d38d6eb2043304d9c3/app/models/concerns/alegre_similarity.rb#L289-L299 and https://github.com/meedan/check-api/blob/662f023463a05b37120547d38d6eb2043304d9c3/app/models/concerns/alegre_v2.rb#L442-L443) - also some weird dangling function declared in a test nonsensically. It shouldn't be there, so lets see if something breaks if its removed... Also add another test for array based contexts and leave that line in as that could still theoretically be a valid case.

References: CV2-4529

## How has this been tested?

Added another test for the only uncovered line, otherwise I'm removing code.

## Things to pay attention to during code review

Help me double check why that stray function was wandering around the test file I suppose?

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

