### PR TITLE
CV2-4508: apply team task order to item tasks

### DIFF
--- a/app/models/team_task.rb
+++ b/app/models/team_task.rb
@@ -100,8 +100,8 @@ class TeamTask < ApplicationRecord
     task2.update_column(:order, task1_order)
     # Apply new order to item annotations
     fields = { order: true }
-    TeamTaskWorker.perform_in(1.second, 'update', task1.id, YAML::dump(User.current), YAML::dump(fields))
-    TeamTaskWorker.perform_in(1.second, 'update', task2.id, YAML::dump(User.current), YAML::dump(fields))
+    TeamTaskWorker.perform_in(1.second, 'update', task1.id, User.current&.id, YAML::dump(fields))
+    TeamTaskWorker.perform_in(1.second, 'update', task2.id, User.current&.id, YAML::dump(fields))
     task2_order
   end
 
@@ -117,7 +117,7 @@ class TeamTask < ApplicationRecord
 
   def add_teamwide_tasks
     self.team&.clear_list_columns_cache
-    TeamTaskWorker.perform_in(1.second, 'add', self.id, YAML::dump(User.current))
+    TeamTaskWorker.perform_in(1.second, 'add', self.id, User.current&.id)
   end
 
   def update_teamwide_tasks
@@ -130,13 +130,13 @@ class TeamTask < ApplicationRecord
       order: self.saved_change_to_order?
     }
     fields.delete_if{|_k, v| v == false || v.nil?}
-    TeamTaskWorker.perform_in(1.second, 'update', self.id, YAML::dump(User.current), YAML::dump(fields), false, self.options_diff) unless fields.blank?
+    TeamTaskWorker.perform_in(1.second, 'update', self.id, User.current&.id, YAML::dump(fields), false, self.options_diff) unless fields.blank?
   end
 
   def delete_teamwide_tasks
     self.team&.clear_list_columns_cache
     self.keep_completed_tasks = self.keep_completed_tasks.nil? ? false : self.keep_completed_tasks
-    TeamTaskWorker.perform_in(1.second, 'destroy', self.id, YAML::dump(User.current), YAML::dump({}), self.keep_completed_tasks)
+    TeamTaskWorker.perform_in(1.second, 'destroy', self.id, User.current&.id, YAML::dump({}), self.keep_completed_tasks)
   end
 
   def add_to_sources

--- a/app/workers/team_task_worker.rb
+++ b/app/workers/team_task_worker.rb
@@ -3,12 +3,12 @@ class TeamTaskWorker
 
   sidekiq_options :queue => :tsqueue
 
-  def perform(action, id, author, fields = YAML::dump({}), keep_completed_tasks = false, options_diff = {})
+  def perform(action, id, author_id, fields = YAML::dump({}), keep_completed_tasks = false, options_diff = {})
     RequestStore.store[:skip_notifications] = true
     user_current = User.current
     team_current = Team.current
     fields = YAML::load(fields)
-    author = YAML::load(author)
+    author = User.find_by_id(author_id)
     User.current = author
     if action == 'update' || action == 'add'
       team_task = TeamTask.find_by_id(id)

--- a/test/models/team_task_test.rb
+++ b/test/models/team_task_test.rb
@@ -233,6 +233,15 @@ class TeamTaskTest < ActiveSupport::TestCase
       assert_equal 'update desc', pm2_tt.description
       assert_equal 'multiple_choice', pm2_tt.type
       assert_equal([{ 'label' => 'Test' }], pm2_tt.options)
+      # update order
+      order = pm2_tt.order + 1
+      tt.order = order; tt.save!
+      pm2_tt = pm2_tt.reload
+      assert_equal 'update label', pm2_tt.label
+      assert_equal 'update desc', pm2_tt.description
+      assert_equal 'multiple_choice', pm2_tt.type
+      assert_equal([{ 'label' => 'Test' }], pm2_tt.options)
+      assert_equal order, pm2_tt.order
       # update title/description/type/options
       tt.label = 'update label2'
       tt.description = 'update desc2'


### PR DESCRIPTION
## Description

Apply re-order for team annotations to item annotations.

References: CV2-4508

## How has this been tested?

Implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

