### PR TITLE
CV2-4126 add more explicit flagging to avoid sending stray callback params into callback consumption function

### DIFF
--- a/app/models/concerns/alegre_webhooks.rb
+++ b/app/models/concerns/alegre_webhooks.rb
@@ -24,7 +24,7 @@ module AlegreWebhooks
         doc_id = request.params.dig('data', 'item', 'raw', 'doc_id') if doc_id.nil?
         CheckSentry.notify(AlegreCallbackError.new("Tracing Webhook NOT AN ERROR"), params: {doc_id: doc_id, is_not_a_bug_is_a_temporary_log_to_sentry: true, alegre_response: request.params })
         raise 'Unexpected params format' if doc_id.blank?
-        if is_from_alegre_callback(request)
+        if is_from_alegre_search_result_callback(request)
           Bot::Alegre.process_alegre_callback(request.params)
         else
           redis = Redis.new(REDIS_CONFIG)

--- a/app/models/concerns/alegre_webhooks.rb
+++ b/app/models/concerns/alegre_webhooks.rb
@@ -10,8 +10,8 @@ module AlegreWebhooks
       !token.blank? && token == CheckConfig.get('alegre_token')
     end
 
-    def is_from_alegre_callback(request)
-      request.params.dig('data', 'item', 'callback_url').to_s.include?("/presto/receive/add_item") || request.params.dig('data', 'is_shortcircuited_callback')
+    def is_from_alegre_search_result_callback(request)
+      request.params.dig('data', 'is_shortcircuited_search_result_callback') || request.params.dig('data', 'is_shortcircuited_callback')
     end
 
     def webhook(request)

--- a/app/models/concerns/alegre_webhooks.rb
+++ b/app/models/concerns/alegre_webhooks.rb
@@ -11,7 +11,7 @@ module AlegreWebhooks
     end
 
     def is_from_alegre_search_result_callback(request)
-      request.params.dig('data', 'is_shortcircuited_search_result_callback') || request.params.dig('data', 'is_shortcircuited_callback')
+      request.params.dig('data', 'is_shortcircuited_search_result_callback') || request.params.dig('data', 'is_search_result_callback')
     end
 
     def webhook(request)

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -234,7 +234,7 @@ class WebhooksControllerTest < ActionController::TestCase
   end
 
   test "should process Alegre webhook" do
-    CheckSentry.expects(:notify).once
+    CheckSentry.expects(:notify).twice
     redis = Redis.new(REDIS_CONFIG)
     redis.del('foo')
     id = random_number
@@ -249,7 +249,7 @@ class WebhooksControllerTest < ActionController::TestCase
   end
 
   test "should process Alegre callback webhook" do
-    CheckSentry.expects(:notify).once
+    CheckSentry.expects(:notify).twice
     id = random_number
     payload = { 'action' => 'audio', 'data' => {'item' => { 'callback_url' => '/presto/receive/add_item', 'id' => id.to_s }} }
     Bot::Alegre.stubs(:process_alegre_callback).returns({})

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -233,7 +233,7 @@ class WebhooksControllerTest < ActionController::TestCase
     assert_match /ignored/, response.body
   end
 
-  test "should process Alegre webhook zzz" do
+  test "should process Alegre webhook" do
     CheckSentry.expects(:notify).once
     redis = Redis.new(REDIS_CONFIG)
     redis.del('foo')
@@ -249,7 +249,7 @@ class WebhooksControllerTest < ActionController::TestCase
   end
 
   test "should process Alegre callback webhook" do
-    CheckSentry.expects(:notify).twice
+    CheckSentry.expects(:notify).once
     id = random_number
     payload = { 'action' => 'audio', 'data' => {'item' => { 'callback_url' => '/presto/receive/add_item', 'id' => id.to_s }} }
     Bot::Alegre.stubs(:process_alegre_callback).returns({})

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -233,8 +233,8 @@ class WebhooksControllerTest < ActionController::TestCase
     assert_match /ignored/, response.body
   end
 
-  test "should process Alegre webhook" do
-    CheckSentry.expects(:notify).twice
+  test "should process Alegre webhook zzz" do
+    CheckSentry.expects(:notify).once
     redis = Redis.new(REDIS_CONFIG)
     redis.del('foo')
     id = random_number


### PR DESCRIPTION


## Description
New theory is that all webhooks are getting accidentally consumed including ones where its just reporting back that we stored an object. Forcing responses to only be consumed when explicitly flagged as such.

References: CV2-4126

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

