### PR TITLE
CV2-4508: include unconfirmed items when add new team task

### DIFF
--- a/app/models/team_task.rb
+++ b/app/models/team_task.rb
@@ -150,7 +150,7 @@ class TeamTask < ApplicationRecord
   end
 
   def add_to_project_medias
-    ProjectMedia.where({ team_id: self.team_id, archived: CheckArchivedFlags::FlagCodes::NONE })
+    ProjectMedia.where({ team_id: self.team_id, archived: [CheckArchivedFlags::FlagCodes::NONE, CheckArchivedFlags::FlagCodes::UNCONFIRMED] })
     .joins("LEFT JOIN annotations a ON a.annotation_type = 'task' AND a.annotated_type = 'ProjectMedia'
       AND a.annotated_id = project_medias.id
       AND task_team_task_id(a.annotation_type, a.data) = #{self.id}")

--- a/test/models/team_task_test.rb
+++ b/test/models/team_task_test.rb
@@ -119,7 +119,7 @@ class TeamTaskTest < ActiveSupport::TestCase
     Team.stubs(:current).returns(t)
     Sidekiq::Testing.inline! do
       pm = create_project_media team: t
-      pm2 = create_project_media team: t
+      pm2 = create_project_media team: t, archived: CheckArchivedFlags::FlagCodes::UNCONFIRMED
       tt = create_team_task team_id: t.id, order: 2, description: 'Foo', options: [{ label: 'Foo' }]
       tt2 = create_team_task team_id: t.id, order: 1, description: 'Foo2', options: [{ label: 'Foo2' }]
       pm_tt = pm.annotations('task').select{|t| t.team_task_id == tt.id}.last


### PR DESCRIPTION
## Description

Adding new team task should reflect on unconfirmed items.

References: CV2-4508

## How has this been tested?

Implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

