### PR TITLE
CV2-4126 alter webhook to use body instead of params

### DIFF
--- a/app/models/concerns/alegre_webhooks.rb
+++ b/app/models/concerns/alegre_webhooks.rb
@@ -11,21 +11,26 @@ module AlegreWebhooks
     end
 
     def is_from_alegre_search_result_callback(request)
-      request.params.dig('data', 'is_shortcircuited_search_result_callback') || request.params.dig('data', 'is_search_result_callback')
+      params.dig('data', 'is_shortcircuited_search_result_callback') || params.dig('data', 'is_search_result_callback')
+    end
+
+    def parse_body(request)
+      JSON.parse(request.body.read)
     end
 
     def webhook(request)
       key = nil
+      body = parse_body(request)
       begin
         doc_id = request.params.dig('data', 'requested', 'id')
         # search for doc_id on completed full-circuit callbacks
         doc_id = request.params.dig('data', 'item', 'id') if doc_id.nil?
         # search for doc_id on completed short-circuit callbacks (i.e. items already known to Alegre but added context TODO make these the same structure)
         doc_id = request.params.dig('data', 'item', 'raw', 'doc_id') if doc_id.nil?
-        CheckSentry.notify(AlegreCallbackError.new("Tracing Webhook NOT AN ERROR"), params: {doc_id: doc_id, is_not_a_bug_is_a_temporary_log_to_sentry: true, alegre_response: request.params })
+        CheckSentry.notify(AlegreCallbackError.new("Tracing Webhook NOT AN ERROR"), params: {doc_id: doc_id, is_not_a_bug_is_a_temporary_log_to_sentry: true, alegre_response: request.params, body: body })
         raise 'Unexpected params format' if doc_id.blank?
-        if is_from_alegre_search_result_callback(request)
-          Bot::Alegre.process_alegre_callback(request.params)
+        if is_from_alegre_search_result_callback(body)
+          Bot::Alegre.process_alegre_callback(body)
         else
           redis = Redis.new(REDIS_CONFIG)
           key = "alegre:webhook:#{doc_id}"

--- a/app/models/concerns/alegre_webhooks.rb
+++ b/app/models/concerns/alegre_webhooks.rb
@@ -21,20 +21,20 @@ module AlegreWebhooks
     def webhook(request)
       key = nil
       body = parse_body(request)
+      redis = Redis.new(REDIS_CONFIG)
       begin
-        doc_id = request.params.dig('data', 'requested', 'id')
+        doc_id = body.dig('data', 'requested', 'id')
         # search for doc_id on completed full-circuit callbacks
-        doc_id = request.params.dig('data', 'item', 'id') if doc_id.nil?
+        doc_id = body.dig('data', 'item', 'id') if doc_id.nil?
         # search for doc_id on completed short-circuit callbacks (i.e. items already known to Alegre but added context TODO make these the same structure)
-        doc_id = request.params.dig('data', 'item', 'raw', 'doc_id') if doc_id.nil?
+        doc_id = body.dig('data', 'item', 'raw', 'doc_id') if doc_id.nil?
         CheckSentry.notify(AlegreCallbackError.new("Tracing Webhook NOT AN ERROR"), params: {doc_id: doc_id, is_not_a_bug_is_a_temporary_log_to_sentry: true, alegre_response: request.params, body: body })
         raise 'Unexpected params format' if doc_id.blank?
         if is_from_alegre_search_result_callback(body)
           Bot::Alegre.process_alegre_callback(body)
         else
-          redis = Redis.new(REDIS_CONFIG)
           key = "alegre:webhook:#{doc_id}"
-          redis.lpush(key, request.params.to_json)
+          redis.lpush(key, body.to_json)
         end
       rescue StandardError => e
         CheckSentry.notify(AlegreCallbackError.new(e.message), params: { alegre_response: request.params })

--- a/app/models/concerns/alegre_webhooks.rb
+++ b/app/models/concerns/alegre_webhooks.rb
@@ -10,7 +10,7 @@ module AlegreWebhooks
       !token.blank? && token == CheckConfig.get('alegre_token')
     end
 
-    def is_from_alegre_search_result_callback(request)
+    def is_from_alegre_search_result_callback(params)
       params.dig('data', 'is_shortcircuited_search_result_callback') || params.dig('data', 'is_search_result_callback')
     end
 

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -233,7 +233,7 @@ class WebhooksControllerTest < ActionController::TestCase
     assert_match /ignored/, response.body
   end
 
-  test "should process Alegre webhook zzz" do
+  test "should process Alegre webhook" do
     CheckSentry.expects(:notify).once
     redis = Redis.new(REDIS_CONFIG)
     redis.del('alegre:webhook:foo')

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -233,18 +233,18 @@ class WebhooksControllerTest < ActionController::TestCase
     assert_match /ignored/, response.body
   end
 
-  test "should process Alegre webhook" do
+  test "should process Alegre webhook zzz" do
     CheckSentry.expects(:notify).once
     redis = Redis.new(REDIS_CONFIG)
-    redis.del('foo')
+    redis.del('alegre:webhook:foo')
     id = random_number
     payload = { 'action' => 'audio', 'data' => {'requested' => { 'id' => 'foo', 'context' => { 'project_media_id' => id } }} }
     assert_nil redis.lpop('alegre:webhook:foo')
 
-    post :index, params: { name: :alegre, token: CheckConfig.get('alegre_token') }.merge(payload)
+    post :index, params: { name: :alegre, token: CheckConfig.get('alegre_token') }, body: payload.to_json
     response = JSON.parse(redis.lpop('alegre:webhook:foo'))
     assert_equal 'foo', response.dig('data', 'requested', 'id')
-    expectation = {"action"=>"index", "data"=>{"requested"=>{"context"=>{"project_media_id"=>id.to_s}, "id"=>"foo"}}, "token"=>"test", "name"=>"alegre", "controller"=>"api/v1/webhooks"}
+    expectation = payload
     assert_equal expectation, response
   end
 
@@ -253,7 +253,7 @@ class WebhooksControllerTest < ActionController::TestCase
     id = random_number
     payload = { 'action' => 'audio', 'data' => {'is_shortcircuited_search_result_callback' => true, 'item' => { 'callback_url' => '/presto/receive/add_item', 'id' => id.to_s }} }
     Bot::Alegre.stubs(:process_alegre_callback).returns({})
-    post :index, params: { name: :alegre, token: CheckConfig.get('alegre_token') }.merge(payload)
+    post :index, params: { name: :alegre, token: CheckConfig.get('alegre_token') }, body: payload.to_json
     assert_equal '200', response.code
     assert_match /success/, response.body
   end
@@ -263,13 +263,13 @@ class WebhooksControllerTest < ActionController::TestCase
     id = random_number
     payload = { 'action' => 'audio', 'data' => {'is_search_result_callback' => true, 'item' => { 'callback_url' => '/presto/receive/add_item', 'id' => id.to_s }} }
     Bot::Alegre.stubs(:process_alegre_callback).returns({})
-    post :index, params: { name: :alegre, token: CheckConfig.get('alegre_token') }.merge(payload)
+    post :index, params: { name: :alegre, token: CheckConfig.get('alegre_token') }, body: payload.to_json
     assert_equal '200', response.code
     assert_match /success/, response.body
   end
 
   test "should report error if can't process Alegre webhook" do
     CheckSentry.expects(:notify).twice
-    post :index, params: { name: :alegre, token: CheckConfig.get('alegre_token') }.merge({ foo: 'bar' })
+    post :index, params: { name: :alegre, token: CheckConfig.get('alegre_token') }, body: {foo: "bar"}.to_json
   end
 end


### PR DESCRIPTION
## Description

Puts alegre webhook in line with other webhooks to use the body rather than params as the accessor for data

References: CV2-4126

## How has this been tested?

We're seeing very weird results that makes us believe that the params coming in from `request.params` get altered in potentially erratic ways - and we are definitely losing variables in params somehow. This is a fix to make Alegre canonical with other webhooks, but also potentially resolve that problem.

## Things to pay attention to during code review

N/A

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

