### PR TITLE
CV2-4126 flag origin of sentry error explicitly

### DIFF
--- a/app/models/concerns/alegre_webhooks.rb
+++ b/app/models/concerns/alegre_webhooks.rb
@@ -28,7 +28,7 @@ module AlegreWebhooks
         doc_id = body.dig('data', 'item', 'id') if doc_id.nil?
         # search for doc_id on completed short-circuit callbacks (i.e. items already known to Alegre but added context TODO make these the same structure)
         doc_id = body.dig('data', 'item', 'raw', 'doc_id') if doc_id.nil?
-        CheckSentry.notify(AlegreCallbackError.new("Tracing Webhook NOT AN ERROR"), params: {doc_id: doc_id, is_not_a_bug_is_a_temporary_log_to_sentry: true, alegre_response: request.params, body: body })
+        CheckSentry.notify(AlegreCallbackError.new("Tracing Webhook NOT AN ERROR"), params: {is_raised_from_error: false, doc_id: doc_id, is_not_a_bug_is_a_temporary_log_to_sentry: true, alegre_response: request.params, body: body })
         raise 'Unexpected params format' if doc_id.blank?
         if is_from_alegre_search_result_callback(body)
           Bot::Alegre.process_alegre_callback(body)
@@ -37,7 +37,7 @@ module AlegreWebhooks
           redis.lpush(key, body.to_json)
         end
       rescue StandardError => e
-        CheckSentry.notify(AlegreCallbackError.new(e.message), params: { alegre_response: request.params })
+        CheckSentry.notify(AlegreCallbackError.new(e.message), params: { is_raised_from_error: true, alegre_response: request.params })
       ensure
         redis.expire(key, 1.day.to_i) if !key.nil?
       end


### PR DESCRIPTION
## Description

Some weirdness around potentially confused origins of raised sentry errors - flagging them explicitly as a sanity check during extended QA issues.

References: CV2-4126

## How has this been tested?

Not tested yet - pushing for better instrumentation on existing tests

## Things to pay attention to during code review

NA

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

