### PR TITLE
Language option in tipline menu can be both in English and regional languages

### DIFF
--- a/app/models/concerns/smooch_menus.rb
+++ b/app/models/concerns/smooch_menus.rb
@@ -120,10 +120,14 @@ module SmoochMenus
     def adjust_language_options(rows, language, number_of_options)
       # WhatsApp just supports up to 10 options, so if we already have 10, we need to replace the
       # individual language options by a single "Languages" option (because we still have the "Privacy and Policy" option)
+      # We can display this single "Languages" option in two languages: the current one and the default one
+      title = [self.get_string('languages', language)]
+      default_language = Team.find_by_id(self.config['team_id'].to_i)&.default_language || 'en'
+      title << self.get_string('languages', default_language) if language != default_language
       new_rows = rows.dup
       new_rows = [{
         id: { state: 'main', keyword: JSON.parse(rows.first[:id])['keyword'] }.to_json,
-        title: '🌐 ' + self.get_string('languages', language, 24)
+        title: '🌐 ' + title.join(' / ').truncate(21) # Maximum is 24
       }] if number_of_options >= 10
       new_rows
     end


### PR DESCRIPTION
## Description

For WhatsApp tiplines that have more than 10 menu options and more than one language, a "Languages" option is displayed in the menu. That option is always localized to the current tipline language. If users select the wrong language, it can be hard for them to find the "Languages" option again. This commit fixes it by adding two labels for the "Languages" option: one in the current language and another one in the default workspace language (if they are different).

Reference: CV2-4554.

## How has this been tested?

- Configure a WhatsApp tipline with more than one language and more than 10 menu options in total
- Send a message to the tipline and open the main menu
- If the current language is different from the default one, you should see the "Languages" option in two languages:

![Captura de tela de 2024-05-07 22-02-52](https://github.com/meedan/check-api/assets/117518/4d0a4ae4-cd40-40f9-8ea9-daf59b6b4f54)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

