### PR TITLE
CV2-4597 rework how cached responses are returned to re-differentiate between empty responses and non-responses

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -400,6 +400,7 @@ class Bot::Alegre < BotUser
   def self.media_file_url(pm)
     # FIXME Ugly hack to get a usable URL in docker-compose development environment.
     if pm.is_a?(TemporaryProjectMedia)
+      print("HELLO")
       url = pm.url
     else
       url = (ENV['RAILS_ENV'] != 'development' ? pm.media.file.file.public_url : "#{CheckConfig.get('storage_endpoint')}/#{CheckConfig.get('storage_bucket')}/#{pm.media.file.file.path}")

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -435,6 +435,7 @@ module AlegreV2
       type = args[:type]
       if ['audio', 'image', 'video'].include?(type)
         if project_media.nil?
+          print("hello")
           project_media = TemporaryProjectMedia.new
           project_media.url = media_url
           project_media.id = Digest::MD5.hexdigest(project_media.url).to_i(16)

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -384,12 +384,11 @@ module AlegreV2
     end
 
     def get_parsed_cached_data_for_key(key)
-      value = redis.get(key)
+      value = Redis.new(REDIS_CONFIG).get(key)
       Hash[YAML.load(value).collect{|kk,vv| [kk.to_i, vv]}] if value
     end
 
     def get_cached_data(required_keys)
-      redis = Redis.new(REDIS_CONFIG)
       # For a given project media, we expect a set of keys to be set by the webhook callbacks sent from alegre back to check-api.
       # For each callback response (which is set via #process_alegre_callback), we store the value as serialized YAML to persist
       # the data such that symbolized keys return as symbols (as opposed to JSON, which loses the distinction). Here, in effect,

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -40,8 +40,56 @@ class ReportsControllerTest < ActionController::TestCase
     pm5 = create_project_media team: @t, media: create_uploaded_video
     create_project_media team: @t
 
-    Bot::Alegre.stubs(:request).returns({ 'result' => [from_alegre(@pm), from_alegre(pm), from_alegre(pm2), from_alegre(pm3), from_alegre(pm4), from_alegre(pm5)] })
-
+    Bot::Alegre.stubs(:get_items_with_similar_media_v2).returns({
+      @pm.id => {
+        score: 1.0,
+        context: {"team_id" => @pm.team_id, "project_media_id" => @pm.id, "temporary_media" => false},
+        model: Bot::Alegre.get_type(@pm),
+        source_field: Bot::Alegre.get_type(@pm),
+        target_field: Bot::Alegre.get_type(@pm),
+        relationship_type: {:source=>"confirmed_sibling", :target=>"confirmed_sibling"}
+      },
+      pm.id => {
+        score: 1.0,
+        context: {"team_id" => pm.team_id, "project_media_id" => pm.id, "temporary_media" => false},
+        model: Bot::Alegre.get_type(pm),
+        source_field: Bot::Alegre.get_type(pm),
+        target_field: Bot::Alegre.get_type(pm),
+        relationship_type: {:source=>"confirmed_sibling", :target=>"confirmed_sibling"}
+      },
+      pm2.id => {
+        score: 1.0,
+        context: {"team_id" => pm2.team_id, "project_media_id" => pm2.id, "temporary_media" => false},
+        model: Bot::Alegre.get_type(pm2),
+        source_field: Bot::Alegre.get_type(pm2),
+        target_field: Bot::Alegre.get_type(pm2),
+        relationship_type: {:source=>"confirmed_sibling", :target=>"confirmed_sibling"}
+      },
+      pm3.id => {
+        score: 1.0,
+        context: {"team_id" => pm3.team_id, "project_media_id" => pm3.id, "temporary_media" => false},
+        model: Bot::Alegre.get_type(pm3),
+        source_field: Bot::Alegre.get_type(pm3),
+        target_field: Bot::Alegre.get_type(pm3),
+        relationship_type: {:source=>"confirmed_sibling", :target=>"confirmed_sibling"}
+      },
+      pm4.id => {
+        score: 1.0,
+        context: {"team_id" => pm4.team_id, "project_media_id" => pm4.id, "temporary_media" => false},
+        model: Bot::Alegre.get_type(pm4),
+        source_field: Bot::Alegre.get_type(pm4),
+        target_field: Bot::Alegre.get_type(pm4),
+        relationship_type: {:source=>"confirmed_sibling", :target=>"confirmed_sibling"}
+      },
+      pm5.id => {
+        score: 1.0,
+        context: {"team_id" => pm5.team_id, "project_media_id" => pm5.id, "temporary_media" => false},
+        model: Bot::Alegre.get_type(pm5),
+        source_field: Bot::Alegre.get_type(pm5),
+        target_field: Bot::Alegre.get_type(pm5),
+        relationship_type: {:source=>"confirmed_sibling", :target=>"confirmed_sibling"}
+      },
+    })
     post :index, params: {}
     assert_response :success
     assert_equal 7, json_response['data'].size

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -833,7 +833,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     params = {
         "model_type": "image",
         "data": {
-            "is_shortcircuited_callback": true,
+            "is_shortcircuited_search_result_callback": true,
             "item": {
                 "callback_url": "http://alegre:3100/presto/receive/add_item/image",
                 "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -847,8 +847,56 @@ class Bot::AlegreTest < ActiveSupport::TestCase
                         "temporary_media": false,
                     },
                     "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
-                    "threshold": 0.73,
+                    "threshold": 0.85,
                     "confirmed": true,
+                    "created_at": "2024-03-14T22:05:47.588975",
+                    "limit": 200,
+                    "requires_callback": true,
+                    "final_task": "search"
+                },
+                "hash_value": "1110101010001011110100000011110010101000000010110101101010100101101111110101101001011010100001011111110101011010010000101010010110101101010110100000001010100101101010111110101000010101011100001110101010101111100001010101001011101010101011010001010101010010"
+            },
+            "results": {
+                "result": [
+                    {
+                        "id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
+                        "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
+                        "pdq": "1110101010001011110100000011110010101000000010110101101010100101101111110101101001011010100001011111110101011010010000101010010110101101010110100000001010100101101010111110101000010101011100001110101010101111100001010101001011101010101011010001010101010010",
+                        "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+                        "context": [
+                            {
+                                "team_id": pm2.team_id,
+                                "has_custom_id": true,
+                                "project_media_id": pm2.id,
+                                "temporary_media": false,
+                            }
+                        ],
+                        "score": 1.0,
+                        "model": "image/pdq"
+                    }
+                ]
+            }
+        }
+    }
+    unconfirmed_params = {
+        "model_type": "image",
+        "data": {
+            "is_shortcircuited_search_result_callback": true,
+            "item": {
+                "callback_url": "http://alegre:3100/presto/receive/add_item/image",
+                "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+                "text": nil,
+                "raw": {
+                    "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
+                    "context": {
+                        "team_id": pm1.team_id,
+                        "project_media_id": pm1.id,
+                        "has_custom_id": true,
+                        "temporary_media": false,
+                    },
+                    "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+                    "threshold": 0.73,
+                    "confirmed": false,
                     "created_at": "2024-03-14T22:05:47.588975",
                     "limit": 200,
                     "requires_callback": true,
@@ -880,6 +928,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     }
     assert_difference 'Relationship.count' do
       # Simulate the webhook hitting the server and being executed....
+      Bot::Alegre.process_alegre_callback(JSON.parse(unconfirmed_params.to_json)) #hack to force into stringed keys
       relationship = Bot::Alegre.process_alegre_callback(JSON.parse(params.to_json)) #hack to force into stringed keys
     end
     assert_equal relationship.source, pm2

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -816,8 +816,57 @@ class Bot::AlegreTest < ActiveSupport::TestCase
             }
         }
     }
+    unconfirmed_params = {
+        "model_type": "image",
+        "data": {
+            "item": {
+                "id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
+                "callback_url": "http://alegre:3100/presto/receive/add_item/image",
+                "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+                "text": nil,
+                "raw": {
+                    "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
+                    "context": {
+                        "team_id": pm1.team_id,
+                        "project_media_id": pm1.id,
+                        "has_custom_id": true,
+                        "temporary_media": false,
+                    },
+                    "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+                    "threshold": 0.63,
+                    "confirmed": false,
+                    "created_at": "2024-03-14T22:05:47.588975",
+                    "limit": 200,
+                    "requires_callback": true,
+                    "final_task": "search"
+                },
+                "hash_value": "1110101010001011110100000011110010101000000010110101101010100101101111110101101001011010100001011111110101011010010000101010010110101101010110100000001010100101101010111110101000010101011100001110101010101111100001010101001011101010101011010001010101010010"
+            },
+            "results": {
+                "result": [
+                    {
+                        "id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
+                        "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
+                        "pdq": "1110101010001011110100000011110010101000000010110101101010100101101111110101101001011010100001011111110101011010010000101010010110101101010110100000001010100101101010111110101000010101011100001110101010101111100001010101001011101010101011010001010101010010",
+                        "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+                        "context": [
+                            {
+                                "team_id": pm2.team_id,
+                                "has_custom_id": true,
+                                "project_media_id": pm2.id,
+                                "temporary_media": false,
+                            }
+                        ],
+                        "score": 1.0,
+                        "model": "image/pdq"
+                    }
+                ]
+            }
+        }
+    }
     assert_difference 'Relationship.count' do
       # Simulate the webhook hitting the server and being executed....
+      Bot::Alegre.process_alegre_callback(JSON.parse(unconfirmed_params.to_json))
       relationship = Bot::Alegre.process_alegre_callback(JSON.parse(params.to_json)) #hack to force into stringed keys
     end
     assert_equal relationship.source, pm2
@@ -997,7 +1046,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
 
   test "should get_cached_data with right fallbacks" do
     pm1 = create_project_media team: @team, media: create_uploaded_audio
-    assert_equal Bot::Alegre.get_cached_data(Bot::Alegre.get_required_keys(pm1, nil)), {confirmed_results: [], suggested_or_confirmed_results: []}
+    assert_equal Bot::Alegre.get_cached_data(Bot::Alegre.get_required_keys(pm1, nil)), {confirmed_results: nil, suggested_or_confirmed_results: nil}
   end
 
   test "should relate project media for audio" do


### PR DESCRIPTION
## Description

With the latest 4126 changes we observed that there were many many cases where we hit the timeout in alegre's cached response logic - I think its because we don't differentiate between getting *nothing* from alegre versus getting an affirmative *no results* from alegre. Tested locally with temporary log files and this is confirmed to solve for that difference!

References: CV2-4126 and CV2-4597

## How has this been tested?

Tested locally - may need to tweak existing unit tests, tbd

## Things to pay attention to during code review

None come to mind!

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

