### PR TITLE
Inverting the logic of the feed workspace filter for clusters

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -143,7 +143,7 @@ class Feed < ApplicationRecord
     query = self.clusters
 
     # Filter by workspace
-    query = query.where("ARRAY[?] && team_ids", team_ids.to_a.map(&:to_i)) unless team_ids.blank?
+    query = query.where.not("ARRAY[?] && team_ids", self.team_ids - team_ids.to_a.map(&:to_i)) if !team_ids.blank? && team_ids != self.team_ids
     query = query.where(team_ids: []) if team_ids&.empty? # Invalidate the query
 
     # Filter by channel


### PR DESCRIPTION
## Description

It should exclude unselected workspaces, instead of returning clusters with all other selected workspaces.

Fixes CV2-4601.

## How has this been tested?

Automated tests should be updated to cover this.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

