### PR TITLE
Don't pause reports automatically when a fact-check is updated.

### DIFF
--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -70,7 +70,7 @@ class FactCheck < ApplicationRecord
     })
     report.merge!({ use_introduction: default_use_introduction, introduction: default_introduction }) if language != report_language
     data[:options] = report
-    data[:state] = (self.publish_report ? 'published' : 'paused')
+    data[:state] = (self.publish_report ? 'published' : 'paused') if data[:state].blank? || !self.publish_report.nil?
     reports.annotator = self.user || User.current
     reports.set_fields = data.to_json
     reports.skip_check_ability = true


### PR DESCRIPTION
## Description

Don't pause reports automatically when a fact-check is updated.

Update the report status when a fact-check is updated only if:

- There is no status set
- The API call explicitly sends a publish_report parameter

Fixes CV2-4620.

## How has this been tested?

TDD. I implemented a test that reproduces the issue.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

