### PR TITLE
Show list of existing media URLs in validation message when trying to import media from feed that already exist in the workspace.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -822,6 +822,7 @@ en:
   send_every_must_be_a_list_of_days_of_the_week: must be a list of days of the week.
   send_on_must_be_in_the_future: can't be in the past.
   cant_delete_default_folder: The default folder can't be deleted
+  shared_feed_imported_media_already_exist: "No media to import. All media items from this item already exist in your workspace: %{urls}"
   info:
     messages:
       sent_to_trash_by_rule: '"%{item_title}" has been sent to trash by an automation


### PR DESCRIPTION
## Description

Show list of existing media URLs in validation message when trying to import media from feed that already exist in the workspace.

Fixes: CV2-4631.

## How has this been tested?

This needs to be properly tested using the frontend.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

