### PR TITLE
Shared feed import validation message: Format URLs using Markdown

### DIFF
--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -38,7 +38,7 @@ class Cluster < ApplicationRecord
       existing_items << existing_item
       existing_item.nil?
     end
-    raise ActiveRecord::RecordNotUnique.new(I18n.t(:shared_feed_imported_media_already_exist, urls: "\n" + existing_items.uniq.compact_blank.collect{ |pm| "•︎ [#{pm.title}](#{pm.full_url})" }.join("\n"))) if from_project_media.nil?
+    raise ActiveRecord::RecordNotUnique.new(I18n.t(:shared_feed_imported_media_already_exist, urls: existing_items.uniq.compact_blank.collect{ |pm| "•︎ [#{pm.title}](#{pm.full_url})" }.join("\n"))) if from_project_media.nil?
     parent = nil
     if parent_id.nil?
       parent = self.import_media_to_team(team, from_project_media, claim_title, claim_context)

--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -38,7 +38,7 @@ class Cluster < ApplicationRecord
       existing_items << existing_item
       existing_item.nil?
     end
-    raise ActiveRecord::RecordNotUnique.new(I18n.t(:shared_feed_imported_media_already_exist, urls: existing_items.map(&:full_url).uniq.compact_blank.join(', '))) if from_project_media.nil?
+    raise ActiveRecord::RecordNotUnique.new(I18n.t(:shared_feed_imported_media_already_exist, urls: "\n" + existing_items.uniq.compact_blank.collect{ |pm| "•︎ [#{pm.title}](#{pm.full_url})" }.join("\n"))) if from_project_media.nil?
     parent = nil
     if parent_id.nil?
       parent = self.import_media_to_team(team, from_project_media, claim_title, claim_context)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -822,7 +822,10 @@ en:
   send_every_must_be_a_list_of_days_of_the_week: must be a list of days of the week.
   send_on_must_be_in_the_future: can't be in the past.
   cant_delete_default_folder: The default folder can't be deleted
-  shared_feed_imported_media_already_exist: "No media to import. All media items from this item already exist in your workspace: %{urls}"
+  shared_feed_imported_media_already_exist: |-
+    No media eligible to be imported into your workspace.
+    The media selected to import already exist in your workspace in the following items:
+    %{urls}
   info:
     messages:
       sent_to_trash_by_rule: '"%{item_title}" has been sent to trash by an automation


### PR DESCRIPTION
## Description

When trying to import media from a shared feed that already exist in the target workspace, return the existing item URLs in the error message as Markdown, so they can be better displayed on the frontend.

Reference: CV2-4631.

## How has this been tested?

On the frontend side (Check Web branch with same name as this):

![Captura de tela de 2024-05-22 15-26-44](https://github.com/meedan/check-api/assets/117518/4664c95b-a28d-4fbe-bacf-9f2c89d813a0)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

