### PR TITLE
CV2-4593: use ApplicationRecord.transaction to save message

### DIFF
--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -333,7 +333,7 @@ module SmoochMessages
     def save_message(message_json, app_id, author = nil, request_type = 'default_requests', associated_obj = nil)
       message = JSON.parse(message_json)
       self.get_installation(self.installation_setting_id_keys, app_id)
-      Team.current = Team.where(id: self.config['team_id']).last
+      Team.current = Team.find self.config['team_id'].to_i
       associated = nil
       if ['default_requests', 'timeout_requests', 'irrelevant_search_result_requests'].include?(request_type)
         message['archived'] = ['default_requests', 'irrelevant_search_result_requests'].include?(request_type) ? self.default_archived_flag : CheckArchivedFlags::FlagCodes::UNCONFIRMED

--- a/test/models/bot/smooch_4_test.rb
+++ b/test/models/bot/smooch_4_test.rb
@@ -596,7 +596,9 @@ class Bot::Smooch4Test < ActiveSupport::TestCase
       medias_count = Media.count
 
       assert_no_difference 'ProjectMedia.count' do
-       Bot::Smooch.save_message(message.to_json, @app_id)
+        assert_raises ActiveRecord::StatementInvalid do
+          Bot::Smooch.save_message(message.to_json, @app_id)
+        end
       end
       assert_equal medias_count, Media.count
     end

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -470,18 +470,18 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
       ProjectMedia.where('id > ?', pm_id).destroy_all
       TiplineRequest.where('id > ?', tr_id).destroy_all
       threads = []
-      # assert_difference 'ProjectMedia.count', 3 do
-        # assert_difference "TiplineRequest.count" do
-          # assert_raises ActiveRecord::StatementInvalid do
-            3.times do |i|
+      assert_difference 'ProjectMedia.count' do
+        assert_difference "TiplineRequest.count" do
+          assert_raises ActiveRecord::StatementInvalid do
+            1.times do |i|
               threads << Thread.new {
                 Bot::Smooch.save_message(message.to_json, @app_id, author, 'timeout_requests', nil)
               }
             end
             threads.map(&:join)
-          # end
-        # end
-      # end
+          end
+        end
+      end
     end
   end
 

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -440,9 +440,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     end
   end
 
-  test "try to reproduce CV2-4593" do
-    pm_id = ProjectMedia.last&.id || 0
-    tr_id = TiplineRequest.last&.id || 0
+  test "should save only one item and one request for same tipline message" do
     text = "This is message is so long that it is considered a media"
     Sidekiq::Testing.inline! do
       message = {
@@ -462,15 +460,6 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
         language: 'en',
       }
       author = BotUser.smooch_user
-      assert_difference 'ProjectMedia.count' do
-        assert_difference "TiplineRequest.count" do
-          assert_raises ActiveRecord::StatementInvalid do
-            3.times { Bot::Smooch.save_message(message.to_json, @app_id, author, 'timeout_requests', nil) }
-          end
-        end
-      end
-      ProjectMedia.where('id > ?', pm_id).destroy_all
-      TiplineRequest.where('id > ?', tr_id).destroy_all
       threads = []
       assert_difference 'ProjectMedia.count' do
         assert_difference "TiplineRequest.count" do

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -464,7 +464,9 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
       author = BotUser.smooch_user
       assert_difference 'ProjectMedia.count' do
         assert_difference "TiplineRequest.count" do
-          3.times { Bot::Smooch.save_message(message.to_json, @app_id, author, 'timeout_requests', nil) }
+          assert_raises ActiveRecord::StatementInvalid do
+            3.times { Bot::Smooch.save_message(message.to_json, @app_id, author, 'timeout_requests', nil) }
+          end
         end
       end
       ProjectMedia.where('id > ?', pm_id).destroy_all
@@ -473,7 +475,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
       assert_difference 'ProjectMedia.count' do
         assert_difference "TiplineRequest.count" do
           assert_raises ActiveRecord::StatementInvalid do
-            1.times do |i|
+            3.times do |i|
               threads << Thread.new {
                 Bot::Smooch.save_message(message.to_json, @app_id, author, 'timeout_requests', nil)
               }

--- a/test/models/bot/smooch_test.rb
+++ b/test/models/bot/smooch_test.rb
@@ -419,67 +419,67 @@ class Bot::SmoochTest < ActiveSupport::TestCase
     URI.unstub(:parse)
   end
 
-  # TODO: fix by Sawy
-  # test "should send report to user" do
-  #   text = random_string
-  #   uid = random_string
-  #   child1 = create_project_media project: @project
-  #   u = create_user
-  #   messages = [
-  #     {
-  #       '_id': random_string,
-  #       authorId: uid,
-  #       type: 'text',
-  #       text: text
-  #     }
-  #   ]
-  #   payload = {
-  #     trigger: 'message:appUser',
-  #     app: {
-  #       '_id': @app_id
-  #     },
-  #     version: 'v1.1',
-  #     messages: messages,
-  #     appUser: {
-  #       '_id': random_string,
-  #       'conversationStarted': true
-  #     }
-  #   }.to_json
-  #   Bot::Smooch.run(payload)
-  #   sleep 1
-  #   pm = ProjectMedia.last
-  #   pm.archived = CheckArchivedFlags::FlagCodes::NONE
-  #   pm.save!
-  #   create_relationship source_id: pm.id, target_id: child1.id, user: u
-  #   r = create_report(pm)
-  #   pa1 = r.reload.get_field_value('last_published')
-  #   assert !r.reload.report_design_field_value('visual_card_url')
-  #   r = Dynamic.find(r.id)
-  #   r.save!
-  #   assert !r.reload.report_design_field_value('visual_card_url')
-  #   publish_report(pm, {}, r)
-  #   assert r.reload.report_design_field_value('visual_card_url')
-  #   pa2 = r.reload.get_field_value('last_published')
-  #   assert_not_equal pa1.to_s, pa2.to_s
-  #   s = pm.annotations.where(annotation_type: 'verification_status').last.load
-  #   s.status = 'in_progress'
-  #   assert_raises RuntimeError do
-  #     s.save!
-  #   end
-  #   r = Dynamic.find(r.id)
-  #   r.set_fields = { state: 'paused' }.to_json
-  #   r.action = 'pause'
-  #   r.save!
-  #   s.reload.save!
-  #   assert_equal 'In Progress', r.reload.report_design_field_value('status_label')
-  #   assert_not_equal 'In Progress', r.reload.report_design_field_value('previous_published_status_label')
-  #   r = Dynamic.find(r.id)
-  #   r.set_fields = { state: 'published' }.to_json
-  #   r.action = 'republish_and_resend'
-  #   r.save!
-  #   pa3 = r.reload.get_field_value('last_published')
-  #   assert_not_equal pa2.to_s, pa3.to_s
-  # end
+  test "should send report to user" do
+    text = random_string
+    uid = random_string
+    child1 = create_project_media project: @project
+    u = create_user
+    messages = [
+      {
+        '_id': random_string,
+        authorId: uid,
+        type: 'text',
+        text: text,
+        source: { type: "whatsapp" },
+      }
+    ]
+    payload = {
+      trigger: 'message:appUser',
+      app: {
+        '_id': @app_id
+      },
+      version: 'v1.1',
+      messages: messages,
+      appUser: {
+        '_id': random_string,
+        'conversationStarted': true
+      }
+    }.to_json
+    Bot::Smooch.run(payload)
+    sleep 1
+    pm = ProjectMedia.last
+    pm.archived = CheckArchivedFlags::FlagCodes::NONE
+    pm.save!
+    create_relationship source_id: pm.id, target_id: child1.id, user: u
+    r = create_report(pm)
+    pa1 = r.reload.get_field_value('last_published')
+    assert !r.reload.report_design_field_value('visual_card_url')
+    r = Dynamic.find(r.id)
+    r.save!
+    assert !r.reload.report_design_field_value('visual_card_url')
+    publish_report(pm, {}, r)
+    assert r.reload.report_design_field_value('visual_card_url')
+    pa2 = r.reload.get_field_value('last_published')
+    assert_not_equal pa1.to_s, pa2.to_s
+    s = pm.annotations.where(annotation_type: 'verification_status').last.load
+    s.status = 'in_progress'
+    assert_raises RuntimeError do
+      s.save!
+    end
+    r = Dynamic.find(r.id)
+    r.set_fields = { state: 'paused' }.to_json
+    r.action = 'pause'
+    r.save!
+    s.reload.save!
+    assert_equal 'In Progress', r.reload.report_design_field_value('status_label')
+    assert_not_equal 'In Progress', r.reload.report_design_field_value('previous_published_status_label')
+    r = Dynamic.find(r.id)
+    r.set_fields = { state: 'published' }.to_json
+    r.action = 'republish_and_resend'
+    r.save!
+    pa3 = r.reload.get_field_value('last_published')
+    assert_not_equal pa2.to_s, pa3.to_s
+  end
 
   test "should get language" do
     stub_request(:post, "http://alegre/text/langid/").

--- a/test/models/bot/smooch_test.rb
+++ b/test/models/bot/smooch_test.rb
@@ -419,66 +419,67 @@ class Bot::SmoochTest < ActiveSupport::TestCase
     URI.unstub(:parse)
   end
 
-  test "should send report to user" do
-    text = random_string
-    uid = random_string
-    child1 = create_project_media project: @project
-    u = create_user
-    messages = [
-      {
-        '_id': random_string,
-        authorId: uid,
-        type: 'text',
-        text: text
-      }
-    ]
-    payload = {
-      trigger: 'message:appUser',
-      app: {
-        '_id': @app_id
-      },
-      version: 'v1.1',
-      messages: messages,
-      appUser: {
-        '_id': random_string,
-        'conversationStarted': true
-      }
-    }.to_json
-    Bot::Smooch.run(payload)
-    sleep 1
-    pm = ProjectMedia.last
-    pm.archived = CheckArchivedFlags::FlagCodes::NONE
-    pm.save!
-    create_relationship source_id: pm.id, target_id: child1.id, user: u
-    r = create_report(pm)
-    pa1 = r.reload.get_field_value('last_published')
-    assert !r.reload.report_design_field_value('visual_card_url')
-    r = Dynamic.find(r.id)
-    r.save!
-    assert !r.reload.report_design_field_value('visual_card_url')
-    publish_report(pm, {}, r)
-    assert r.reload.report_design_field_value('visual_card_url')
-    pa2 = r.reload.get_field_value('last_published')
-    assert_not_equal pa1.to_s, pa2.to_s
-    s = pm.annotations.where(annotation_type: 'verification_status').last.load
-    s.status = 'in_progress'
-    assert_raises RuntimeError do
-      s.save!
-    end
-    r = Dynamic.find(r.id)
-    r.set_fields = { state: 'paused' }.to_json
-    r.action = 'pause'
-    r.save!
-    s.reload.save!
-    assert_equal 'In Progress', r.reload.report_design_field_value('status_label')
-    assert_not_equal 'In Progress', r.reload.report_design_field_value('previous_published_status_label')
-    r = Dynamic.find(r.id)
-    r.set_fields = { state: 'published' }.to_json
-    r.action = 'republish_and_resend'
-    r.save!
-    pa3 = r.reload.get_field_value('last_published')
-    assert_not_equal pa2.to_s, pa3.to_s
-  end
+  # TODO: fix by Sawy
+  # test "should send report to user" do
+  #   text = random_string
+  #   uid = random_string
+  #   child1 = create_project_media project: @project
+  #   u = create_user
+  #   messages = [
+  #     {
+  #       '_id': random_string,
+  #       authorId: uid,
+  #       type: 'text',
+  #       text: text
+  #     }
+  #   ]
+  #   payload = {
+  #     trigger: 'message:appUser',
+  #     app: {
+  #       '_id': @app_id
+  #     },
+  #     version: 'v1.1',
+  #     messages: messages,
+  #     appUser: {
+  #       '_id': random_string,
+  #       'conversationStarted': true
+  #     }
+  #   }.to_json
+  #   Bot::Smooch.run(payload)
+  #   sleep 1
+  #   pm = ProjectMedia.last
+  #   pm.archived = CheckArchivedFlags::FlagCodes::NONE
+  #   pm.save!
+  #   create_relationship source_id: pm.id, target_id: child1.id, user: u
+  #   r = create_report(pm)
+  #   pa1 = r.reload.get_field_value('last_published')
+  #   assert !r.reload.report_design_field_value('visual_card_url')
+  #   r = Dynamic.find(r.id)
+  #   r.save!
+  #   assert !r.reload.report_design_field_value('visual_card_url')
+  #   publish_report(pm, {}, r)
+  #   assert r.reload.report_design_field_value('visual_card_url')
+  #   pa2 = r.reload.get_field_value('last_published')
+  #   assert_not_equal pa1.to_s, pa2.to_s
+  #   s = pm.annotations.where(annotation_type: 'verification_status').last.load
+  #   s.status = 'in_progress'
+  #   assert_raises RuntimeError do
+  #     s.save!
+  #   end
+  #   r = Dynamic.find(r.id)
+  #   r.set_fields = { state: 'paused' }.to_json
+  #   r.action = 'pause'
+  #   r.save!
+  #   s.reload.save!
+  #   assert_equal 'In Progress', r.reload.report_design_field_value('status_label')
+  #   assert_not_equal 'In Progress', r.reload.report_design_field_value('previous_published_status_label')
+  #   r = Dynamic.find(r.id)
+  #   r.set_fields = { state: 'published' }.to_json
+  #   r.action = 'republish_and_resend'
+  #   r.save!
+  #   pa3 = r.reload.get_field_value('last_published')
+  #   assert_not_equal pa2.to_s, pa3.to_s
+  # end
 
   test "should get language" do
     stub_request(:post, "http://alegre/text/langid/").


### PR DESCRIPTION
## Description

Save tipline message inside `ApplicationRecord.transaction` to make sure that item and tipline request were created.

References: CV2-4593

## How has this been tested?

Implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

