### PR TITLE
Change the way RackAttack blocks excessive login requests

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,32 +1,35 @@
 class Rack::Attack
+  redis = Redis.new(REDIS_CONFIG)
   # Throttle all graphql requests by IP address
-  throttle('api/graphql', limit:  proc { CheckConfig.get('api_rate_limit', 100, :integer) }, period: 60.seconds) do |req|
+  
+  throttle('api/graphql', limit: proc { CheckConfig.get('api_rate_limit', 100, :integer) }, period: 60.seconds) do |req|
     req.ip if req.path == '/api/graphql'
   end
 
   # Blocklist IP addresses that are permanently blocked
   blocklist('block aggressive IPs') do |req|
-    Rails.cache.fetch("block:#{req.ip}") { false }
+    redis.get("block:#{req.ip}") == "true"
   end
 
   # Track excessive login attempts for permanent blocking
   track('track excessive logins/ip') do |req|
     if req.path == '/api/users/sign_in' && req.post?
+      ip = req.ip
       # Increment the counter for the IP and check if it should be blocked
-      count = Rails.cache.increment("track:#{req.ip}") || 0
-      Rails.cache.write("track:#{req.ip}", count, expires_in: 1.hour)
+      count = redis.incr("track:#{ip}")
+      redis.expire("track:#{ip}", 3600) # Set the expiration time to 1 hour
 
       # Add IP to blocklist if count exceeds the threshold
-      if count >= CheckConfig.get('login_block_limit', 100, :integer)
-        Rails.cache.write("block:#{req.ip}", true)  # No expiration
+      if count.to_i >= CheckConfig.get('login_block_limit', 100, :integer)
+        redis.set("block:#{ip}", true)  # No expiration
       end
 
-      req.ip
+      ip
     end
   end
 
   # Response to blocked requests
-  self.blocklisted_response = lambda do |env|
-    [ 403, {}, ['Blocked - Your IP has been permanently blocked due to suspicious activity.']]
+  self.blocklisted_responder = lambda do |req|
+    [403, {}, ['Blocked - Your IP has been permanently blocked due to suspicious activity.']]
   end
 end

--- a/test/lib/check_rack_attack_test.rb
+++ b/test/lib/check_rack_attack_test.rb
@@ -2,7 +2,8 @@ require 'test_helper'
 
 class ThrottlingTest < ActionDispatch::IntegrationTest
   setup do
-    Rails.cache.clear
+    redis = Redis.new(REDIS_CONFIG)
+    redis.flushdb
   end
 
   test "should throttle excessive requests to /api/graphql" do
@@ -21,7 +22,7 @@ class ThrottlingTest < ActionDispatch::IntegrationTest
     stub_configs({ 'login_block_limit' => 2 }) do
       user_params = { api_user: { email: 'user@example.com', password: random_complex_password } }
 
-      3.times do
+      2.times do
         post api_user_session_path, params: user_params, as: :json
       end
 


### PR DESCRIPTION
## Description

Here we are changing the way RackAttach blocks excessive login requests
 - Use redis directly instead of Rails.Cache
 - Change deprecated responder method call

References:  CV2-4476

## How has this been tested?

Checkout this branch, start check-api and copy the below script into a new bash file:

```bash
#!/bin/bash

for i in {1..110}
do
  curl -X POST http://localhost:3000/api/users/sign_in \
       -H "Content-Type: application/json" \
       -d '{"api_user": {"email": "user@someemail.com", "incorrect-password": "123456789", "otp_attempt": ""}}'
  echo "Attempt $i"
done

```

When you run the file, you should see output similar to the below after 100 attempts:

```
Blocked - Your IP has been permanently blocked due to suspicious activity.Attempt 101
```


- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

