### PR TITLE
Explainers data model and API updates

### DIFF
--- a/app/graph/mutations/explainer_mutations.rb
+++ b/app/graph/mutations/explainer_mutations.rb
@@ -6,10 +6,11 @@ module ExplainerMutations
     extend ActiveSupport::Concern
 
     included do
-      argument :title, GraphQL::Types::String, required: true
+      argument :title, GraphQL::Types::String, required: false
       argument :description, GraphQL::Types::String, required: false
       argument :url, GraphQL::Types::String, required: false
       argument :language, GraphQL::Types::String, required: false
+      argument :tags, [GraphQL::Types::String, null: true], required: false
     end
   end
 

--- a/app/graph/types/explainer_type.rb
+++ b/app/graph/types/explainer_type.rb
@@ -12,10 +12,5 @@ class ExplainerType < DefaultObject
   field :team_id, GraphQL::Types::Int, null: true
   field :user, UserType, null: true
   field :team, PublicTeamType, null: true
-
-  field :tags, TagType.connection_type, null: true
-
-  def tags
-    Tag.where(annotation_type: 'tag', annotated_type: object.class.name, annotated_id: object.id)
-  end
+  field :tags, [GraphQL::Types::String, null: true], null: true
 end

--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -306,11 +306,11 @@ class TeamType < DefaultObject
     sort = args[:sort].to_s
     order = [:title, :language, :updated_at].include?(sort.downcase.to_sym) ? sort.downcase.to_sym : :title
     order_type = args[:sort_type].to_s.downcase.to_sym == :desc ? :desc : :asc
+    articles = []
     if args[:article_type] == 'explainer'
-      object.filtered_explainers(args).offset(args[:offset].to_i).order(order => order_type)
-    else
-      []
+      articles = object.filtered_explainers(args).offset(args[:offset].to_i).order(order => order_type)
     end
+    articles
   end
 
   field :articles_count, GraphQL::Types::Int, null: true do
@@ -318,11 +318,11 @@ class TeamType < DefaultObject
   end
 
   def articles_count(**args)
+    count = nil
     if args[:article_type] == 'explainer'
-      object.filtered_explainers(args).count
-    else
-      nil
+      count = object.filtered_explainers(args).count
     end
+    count
   end
 
   field :api_key, ApiKeyType, null: true do

--- a/app/models/explainer.rb
+++ b/app/models/explainer.rb
@@ -10,6 +10,8 @@ class Explainer < ApplicationRecord
   validates_presence_of :team, :title, :description
   validate :language_in_allowed_values, unless: proc { |e| e.language.blank? }
 
+  after_save :create_tag_texts_if_needed
+
   def notify_bots
     # Nothing to do for Explainer
   end
@@ -28,5 +30,24 @@ class Explainer < ApplicationRecord
     allowed_languages = self.team.get_languages || ['en']
     allowed_languages << 'und'
     errors.add(:language, I18n.t(:"errors.messages.invalid_article_language_value")) unless allowed_languages.include?(self.language)
+  end
+
+  # Class methods
+
+  def self.create_tag_texts_if_needed(team_id, tags)
+    tags.each do |tag|
+      next if TagText.where(text: tag, team_id: team_id).exists?
+      tag_text = TagText.new
+      tag_text.text = tag
+      tag_text.team_id = team_id
+      tag_text.skip_check_ability = true
+      tag_text.save!
+    end
+  end
+
+  private
+
+  def create_tag_texts_if_needed
+    Explainer.delay.create_tag_texts_if_needed(self.team_id, self.tags) unless self.tags.blank?
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -133,6 +133,7 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
 
   create_table "accounts", id: :serial, force: :cascade do |t|
     t.integer "user_id"
+    t.integer "team_id"
     t.string "url"
     t.text "omniauth_info"
     t.string "uid"
@@ -141,7 +142,6 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.string "email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "team_id"
     t.index ["uid", "provider", "token", "email"], name: "index_accounts_on_uid_and_provider_and_token_and_email"
     t.index ["url"], name: "index_accounts_on_url", unique: true
     t.index ["user_id"], name: "index_accounts_on_user_id"
@@ -156,43 +156,41 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.integer "annotator_id"
     t.text "entities"
     t.text "data"
-    t.datetime "created_at"
-    t.datetime "updated_at"
     t.string "file"
-    t.text "attribution"
     t.integer "lock_version", default: 0, null: false
     t.boolean "locked", default: false
+    t.text "attribution"
     t.text "fragment"
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.index "task_fieldset((annotation_type)::text, data)", name: "task_fieldset", where: "((annotation_type)::text = 'task'::text)"
     t.index "task_team_task_id((annotation_type)::text, data)", name: "task_team_task_id", where: "((annotation_type)::text = 'task'::text)"
     t.index ["annotated_type", "annotated_id"], name: "index_annotations_on_annotated_type_and_annotated_id"
-    t.index ["annotation_type"], name: "index_annotation_type_order"
+    t.index ["annotation_type"], name: "index_annotation_type_order", opclass: :varchar_pattern_ops
     t.index ["annotation_type"], name: "index_annotations_on_annotation_type"
   end
 
   create_table "api_keys", id: :serial, force: :cascade do |t|
     t.string "access_token", default: "", null: false
+    t.string "title"
+    t.integer "user_id"
+    t.integer "team_id"
     t.datetime "expire_at"
+    t.jsonb "rate_limits", default: {}
+    t.string "application"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "application"
-    t.jsonb "rate_limits", default: {}
-    t.string "title"
     t.string "description"
-    t.bigint "team_id"
-    t.bigint "user_id"
-    t.index ["team_id"], name: "index_api_keys_on_team_id"
-    t.index ["user_id"], name: "index_api_keys_on_user_id"
   end
 
   create_table "assignments", id: :serial, force: :cascade do |t|
     t.integer "assigned_id", null: false
     t.integer "user_id", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.string "assigned_type"
     t.integer "assigner_id"
     t.text "message"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["assigned_id", "assigned_type", "user_id"], name: "index_assignments_on_assigned_id_and_assigned_type_and_user_id", unique: true
     t.index ["assigned_id", "assigned_type"], name: "index_assignments_on_assigned_id_and_assigned_type"
     t.index ["assigned_id"], name: "index_assignments_on_assigned_id"
@@ -219,9 +217,9 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.text "description"
     t.bigint "user_id", null: false
     t.bigint "project_media_id", null: false
+    t.text "context"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "context"
     t.index ["project_media_id"], name: "index_claim_descriptions_on_project_media_id", unique: true
     t.index ["user_id"], name: "index_claim_descriptions_on_user_id"
   end
@@ -235,10 +233,11 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
   end
 
   create_table "clusters", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.integer "project_media_id"
     t.datetime "first_item_at"
     t.datetime "last_item_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.bigint "feed_id"
     t.integer "team_ids", default: [], null: false, array: true
     t.integer "channels", default: [], null: false, array: true
@@ -247,7 +246,6 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.integer "fact_checks_count", default: 0, null: false
     t.datetime "last_request_date"
     t.datetime "last_fact_check_date"
-    t.bigint "project_media_id"
     t.string "title"
     t.index ["feed_id"], name: "index_clusters_on_feed_id"
     t.index ["project_media_id"], name: "index_clusters_on_project_media_id"
@@ -256,10 +254,10 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
   create_table "dynamic_annotation_annotation_types", primary_key: "annotation_type", id: :string, force: :cascade do |t|
     t.string "label", null: false
     t.text "description"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.boolean "singleton", default: true
     t.jsonb "json_schema"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["json_schema"], name: "index_dynamic_annotation_annotation_types_on_json_schema", using: :gin
   end
 
@@ -282,7 +280,7 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "dynamic_annotation_fields", id: :integer, default: -> { "nextval('new_dynamic_annotation_fields_id_seq'::regclass)" }, force: :cascade do |t|
+  create_table "dynamic_annotation_fields", id: :serial, force: :cascade do |t|
     t.integer "annotation_id", null: false
     t.string "field_name", null: false
     t.string "annotation_type", null: false
@@ -293,12 +291,14 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.datetime "updated_at", null: false
     t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
+    t.index ["annotation_id"], name: "index_dynamic_annotation_fields_on_annotation_id"
+    t.index ["annotation_type"], name: "index_dynamic_annotation_fields_on_annotation_type"
     t.index ["field_name"], name: "index_dynamic_annotation_fields_on_field_name"
     t.index ["field_type"], name: "index_dynamic_annotation_fields_on_field_type"
     t.index ["value"], name: "fetch_unique_id", unique: true, where: "(((field_name)::text = 'external_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
     t.index ["value"], name: "index_status", where: "((field_name)::text = 'verification_status_status'::text)"
-    t.index ["value"], name: "smooch_request_message_id_unique_id", unique: true, where: "(((field_name)::text = 'smooch_message_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
     t.index ["value"], name: "smooch_user_unique_id", unique: true, where: "(((field_name)::text = 'smooch_user_id'::text) AND (value <> ''::text) AND (value <> '\"\"'::text))"
+    t.index ["value"], name: "translation_request_id", unique: true, where: "((field_name)::text = 'translation_request_id'::text)"
     t.index ["value_json"], name: "index_dynamic_annotation_fields_on_value_json", using: :gin
   end
 
@@ -323,9 +323,9 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.string "title"
     t.bigint "user_id", null: false
     t.bigint "claim_description_id", null: false
+    t.string "language", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "language", default: "", null: false
     t.string "signature"
     t.index ["claim_description_id"], name: "index_fact_checks_on_claim_description_id", unique: true
     t.index ["language"], name: "index_fact_checks_on_language"
@@ -349,9 +349,9 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.bigint "team_id", null: false
     t.bigint "feed_id", null: false
     t.jsonb "settings", default: {}
+    t.boolean "shared", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "shared", default: false
     t.bigint "saved_search_id"
     t.index ["feed_id"], name: "index_feed_teams_on_feed_id"
     t.index ["saved_search_id"], name: "index_feed_teams_on_saved_search_id"
@@ -362,9 +362,9 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
   create_table "feeds", force: :cascade do |t|
     t.string "name", null: false
     t.jsonb "settings", default: {}
+    t.boolean "published", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "published", default: false
     t.bigint "saved_search_id"
     t.bigint "user_id"
     t.bigint "team_id"
@@ -402,11 +402,11 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.integer "user_id"
     t.integer "account_id"
     t.string "url"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "file"
     t.string "quote"
     t.string "type"
-    t.string "file"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "uuid", default: 0, null: false
     t.index ["url"], name: "index_medias_on_url", unique: true
   end
@@ -489,19 +489,19 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
   end
 
   create_table "project_medias", id: :serial, force: :cascade do |t|
+    t.integer "project_id"
     t.integer "media_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.integer "source_id"
+    t.integer "team_id"
+    t.jsonb "channel", default: {"main"=>0}
+    t.boolean "read", default: false, null: false
+    t.integer "sources_count", default: 0, null: false
     t.integer "archived", default: 0
     t.integer "targets_count", default: 0, null: false
-    t.integer "sources_count", default: 0, null: false
-    t.integer "team_id"
-    t.boolean "read", default: false, null: false
-    t.integer "source_id"
-    t.integer "project_id"
     t.integer "last_seen"
-    t.jsonb "channel", default: {"main"=>0}
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.integer "unmatched", default: 0
     t.string "custom_title"
     t.string "title_field"
@@ -520,18 +520,18 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
   create_table "projects", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "team_id"
+    t.integer "project_group_id"
     t.string "title"
     t.boolean "is_default", default: false
     t.text "description"
     t.string "lead_image"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.integer "archived", default: 0
-    t.text "settings"
     t.string "token"
     t.integer "assignments_count", default: 0
-    t.integer "project_group_id"
     t.integer "privacy", default: 0, null: false
+    t.integer "archived", default: 0
+    t.text "settings"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["id"], name: "index_projects_on_id"
     t.index ["is_default"], name: "index_projects_on_is_default"
     t.index ["privacy"], name: "index_projects_on_privacy"
@@ -543,23 +543,24 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
   create_table "relationships", id: :serial, force: :cascade do |t|
     t.integer "source_id", null: false
     t.integer "target_id", null: false
-    t.string "relationship_type", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.integer "user_id"
-    t.float "weight", default: 0.0
-    t.integer "confirmed_by"
-    t.datetime "confirmed_at"
-    t.string "source_field"
-    t.string "target_field"
-    t.string "model"
-    t.jsonb "details", default: "{}"
+    t.string "relationship_type", null: false
     t.float "original_weight", default: 0.0
+    t.float "float", default: 0.0
     t.jsonb "original_details", default: "{}"
     t.string "original_relationship_type"
     t.string "original_model"
     t.integer "original_source_id"
     t.string "original_source_field"
+    t.integer "confirmed_by"
+    t.datetime "confirmed_at"
+    t.float "weight", default: 0.0
+    t.string "source_field"
+    t.string "target_field"
+    t.string "model"
+    t.jsonb "details", default: "{}"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index "LEAST(source_id, target_id), GREATEST(source_id, target_id)", name: "relationships_least_greatest_idx", unique: true
     t.index ["relationship_type"], name: "index_relationships_on_relationship_type"
     t.index ["source_id", "relationship_type"], name: "index_relationships_on_source_id_and_relationship_type"
@@ -573,18 +574,18 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.bigint "feed_id", null: false
     t.string "request_type", null: false
     t.text "content", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
     t.integer "request_id"
     t.integer "media_id"
+    t.integer "fact_checked_by_count", default: 0, null: false
+    t.integer "project_medias_count", default: 0, null: false
     t.integer "medias_count", default: 0, null: false
     t.integer "requests_count", default: 0, null: false
     t.datetime "last_submitted_at"
     t.string "webhook_url"
     t.datetime "last_called_webhook_at"
     t.integer "subscriptions_count", default: 0, null: false
-    t.integer "fact_checked_by_count", default: 0, null: false
-    t.integer "project_medias_count", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["feed_id"], name: "index_requests_on_feed_id"
     t.index ["media_id"], name: "index_requests_on_media_id"
     t.index ["request_id"], name: "index_requests_on_request_id"
@@ -617,15 +618,15 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
 
   create_table "sources", id: :serial, force: :cascade do |t|
     t.integer "user_id"
+    t.integer "team_id"
     t.string "name"
     t.string "slogan"
     t.string "avatar"
+    t.integer "archived", default: 0
+    t.string "file"
+    t.integer "lock_version", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "team_id"
-    t.string "file"
-    t.integer "archived", default: 0
-    t.integer "lock_version", default: 0, null: false
   end
 
   create_table "tag_texts", id: :serial, force: :cascade do |t|
@@ -648,12 +649,12 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.integer "team_id", null: false
     t.integer "order", default: 0
     t.string "associated_type", default: "ProjectMedia", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "json_schema"
     t.string "fieldset", default: "", null: false
     t.boolean "show_in_browser_extension", default: true, null: false
+    t.string "json_schema"
     t.text "conditional_info"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["team_id", "fieldset", "associated_type"], name: "index_team_tasks_on_team_id_and_fieldset_and_associated_type"
   end
 
@@ -665,35 +666,33 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.string "invitation_token"
     t.string "raw_invitation_token"
     t.datetime "invitation_accepted_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "file"
+    t.text "settings"
     t.string "role"
     t.string "status", default: "member"
-    t.text "settings"
     t.string "invitation_email"
-    t.string "file"
     t.integer "lock_version", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["team_id", "user_id"], name: "index_team_users_on_team_id_and_user_id", unique: true
     t.index ["type"], name: "index_team_users_on_type"
     t.index ["user_id", "team_id", "status"], name: "index_team_users_on_user_id_and_team_id_and_status"
-    t.index ["user_id", "team_id"], name: "index_team_users_on_user_id_and_team_id"
   end
 
   create_table "teams", id: :serial, force: :cascade do |t|
     t.string "name"
     t.string "logo"
-    t.boolean "private", default: true
+    t.boolean "private", default: true, null: false
     t.integer "archived", default: 0
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "country"
     t.text "description"
     t.string "slug"
-    t.text "settings"
     t.boolean "inactive", default: false
-    t.string "country"
+    t.text "settings"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["country"], name: "index_teams_on_country"
     t.index ["inactive"], name: "index_teams_on_inactive"
-    t.index ["slug"], name: "index_teams_on_slug"
     t.index ["slug"], name: "unique_team_slugs", unique: true
   end
 
@@ -711,7 +710,6 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.datetime "updated_at", null: false
     t.string "state"
     t.index ["external_id", "state"], name: "index_tipline_messages_on_external_id_and_state", unique: true
-    t.index ["external_id"], name: "index_tipline_messages_on_external_id"
     t.index ["team_id"], name: "index_tipline_messages_on_team_id"
     t.index ["uid"], name: "index_tipline_messages_on_uid"
   end
@@ -797,7 +795,7 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.datetime "updated_at"
     t.string "language"
     t.string "content_type"
-    t.string "header_type", default: "none", null: false
+    t.string "header_type", default: "link_preview", null: false
     t.string "header_file"
     t.string "header_overlay_text"
     t.string "header_media_url"
@@ -844,35 +842,36 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.integer "invitation_limit"
     t.integer "invited_by_id"
     t.string "invited_by_type"
+    t.datetime "last_accepted_terms_at"
+    t.string "image"
+    t.string "type"
+    t.integer "source_id"
+    t.boolean "is_active", default: true
+    t.boolean "is_admin", default: false
+    t.integer "current_project_id"
+    t.integer "integer"
+    t.text "settings"
+    t.datetime "last_active_at"
+    t.text "cached_teams"
+    t.integer "current_team_id"
+    t.boolean "completed_signup", default: true
+    t.integer "api_key_id"
+    t.string "unconfirmed_email"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "image"
-    t.integer "current_team_id"
-    t.text "settings"
     t.string "confirmation_token"
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
-    t.boolean "is_admin", default: false
-    t.text "cached_teams"
-    t.string "type"
-    t.integer "api_key_id"
-    t.integer "source_id"
-    t.string "unconfirmed_email"
-    t.integer "current_project_id"
-    t.boolean "is_active", default: true
-    t.datetime "last_accepted_terms_at"
     t.string "encrypted_otp_secret"
     t.string "encrypted_otp_secret_iv"
     t.string "encrypted_otp_secret_salt"
     t.integer "consumed_timestep"
     t.boolean "otp_required_for_login"
     t.string "otp_backup_codes", array: true
-    t.boolean "completed_signup", default: true
-    t.datetime "last_active_at"
     t.integer "failed_attempts", default: 0, null: false
     t.string "unlock_token"
     t.datetime "locked_at"
-    t.datetime "last_received_terms_email_at", default: -> { "CURRENT_TIMESTAMP" }
+    t.datetime "last_received_terms_email_at"
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true, where: "((email IS NOT NULL) AND ((email)::text <> ''::text))"
     t.index ["invitation_token"], name: "index_users_on_invitation_token", unique: true
@@ -884,7 +883,8 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
   end
 
   create_table "versions", id: :serial, force: :cascade do |t|
-    t.string "item_type", null: false
+    t.string "item_type"
+    t.string "{:null=>false}"
     t.string "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
@@ -892,19 +892,17 @@ ActiveRecord::Schema.define(version: 2024_05_27_011635) do
     t.text "object_changes"
     t.datetime "created_at"
     t.text "meta"
-    t.string "event_type"
-    t.text "object_after"
     t.integer "associated_id"
     t.string "associated_type"
+    t.string "event_type"
     t.integer "team_id"
+    t.text "object_after"
     t.index ["associated_id"], name: "index_versions_on_associated_id"
     t.index ["event_type"], name: "index_versions_on_event_type"
     t.index ["item_type", "item_id", "whodunnit"], name: "index_versions_on_item_type_and_item_id_and_whodunnit"
     t.index ["team_id"], name: "index_versions_on_team_id"
   end
 
-  add_foreign_key "api_keys", "teams"
-  add_foreign_key "api_keys", "users"
   add_foreign_key "claim_descriptions", "project_medias"
   add_foreign_key "claim_descriptions", "users"
   add_foreign_key "explainers", "teams"

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -2535,7 +2535,8 @@ input CreateExplainerInput {
   clientMutationId: String
   description: String
   language: String
-  title: String!
+  tags: [String]
+  title: String
   url: String
 }
 
@@ -8204,27 +8205,7 @@ type Explainer implements Node {
   id: ID!
   language: String
   permissions: String
-  tags(
-    """
-    Returns the elements in the list that come after the specified cursor.
-    """
-    after: String
-
-    """
-    Returns the elements in the list that come before the specified cursor.
-    """
-    before: String
-
-    """
-    Returns the first _n_ elements from the list.
-    """
-    first: Int
-
-    """
-    Returns the last _n_ elements from the list.
-    """
-    last: Int
-  ): TagConnection
+  tags: [String]
   team: PublicTeam
   team_id: Int
   title: String
@@ -15349,7 +15330,8 @@ input UpdateExplainerInput {
   description: String
   id: ID
   language: String
-  title: String!
+  tags: [String]
+  title: String
   url: String
 }
 

--- a/public/relay.json
+++ b/public/relay.json
@@ -15206,13 +15206,9 @@
               "name": "title",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -15249,6 +15245,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tags",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -44402,59 +44414,16 @@
               "name": "tags",
               "description": null,
               "args": [
-                {
-                  "name": "after",
-                  "description": "Returns the elements in the list that come after the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "before",
-                  "description": "Returns the elements in the list that come before the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "first",
-                  "description": "Returns the first _n_ elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "last",
-                  "description": "Returns the last _n_ elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                }
+
               ],
               "type": {
-                "kind": "OBJECT",
-                "name": "TagConnection",
-                "ofType": null
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
               "isDeprecated": false,
               "deprecationReason": null
@@ -83862,13 +83831,9 @@
               "name": "title",
               "description": null,
               "type": {
-                "kind": "NON_NULL",
-                "name": null,
-                "ofType": {
-                  "kind": "SCALAR",
-                  "name": "String",
-                  "ofType": null
-                }
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
               },
               "defaultValue": null,
               "isDeprecated": false,
@@ -83905,6 +83870,22 @@
                 "kind": "SCALAR",
                 "name": "String",
                 "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "tags",
+              "description": null,
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
               },
               "defaultValue": null,
               "isDeprecated": false,

--- a/test/controllers/graphql_controller_12_test.rb
+++ b/test/controllers/graphql_controller_12_test.rb
@@ -383,15 +383,14 @@ class GraphqlController12Test < ActionController::TestCase
     ex = create_explainer team: @t
     tag = create_tag annotated: ex
     authenticate_with_user(@u)
-    query = "query { team(slug: \"#{@t.slug}\") { get_explainers_enabled, articles(article_type: \"explainer\") { edges { node { ... on Explainer { dbid, tags { edges { node { dbid } } } } } } } } }"
+    query = "query { team(slug: \"#{@t.slug}\") { get_explainers_enabled, articles_count(article_type: \"explainer\"), articles(article_type: \"explainer\") { edges { node { ... on Explainer { dbid, tags } } } } } }"
     post :create, params: { query: query, team: @t.slug }
+    assert_response :success
     team = JSON.parse(@response.body)['data']['team']
+    assert_equal 1, team['articles_count']
     assert team['get_explainers_enabled']
     data = team['articles']['edges']
     assert_equal [ex.id], data.collect{ |edge| edge['node']['dbid'] }
-    tags = data[0]['node']['tags']['edges']
-    assert_equal [tag.id.to_s], tags.collect{ |edge| edge['node']['dbid'] }
-    assert_response :success
   end
 
   test "should create api key" do

--- a/test/models/explainer_test.rb
+++ b/test/models/explainer_test.rb
@@ -91,9 +91,17 @@ class ExplainerTest < ActiveSupport::TestCase
     end
   end
 
-  test "should tag explainer" do
+  test "should tag explainer using annotation" do
     ex = create_explainer
     tag = create_tag annotated: ex
     assert_equal [tag], ex.annotations('tag')
+  end
+
+  test "should create tag texts when setting tags" do
+    Sidekiq::Testing.inline! do
+      assert_difference 'TagText.count' do
+        create_explainer tags: ['foo']
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

In order to list explainers on the frontend side, some changes were needed on the backend.

- Title should not be mandatory at the API level but at the model level (and description as well)
- Store tags in the `Explainer` model and keep them in sync with `TagText` instances
- Adding filters, counter, sorting and pagination to the `TeamType.articles` connection

Reference: CV2-4500.

## How has this been tested?

Automated tests updated and added for 100% coverage.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)