### PR TITLE
Fix flaky test in OmniauthIntegrationTest

### DIFF
--- a/test/integration/omniauth_integration_test.rb
+++ b/test/integration/omniauth_integration_test.rb
@@ -1,6 +1,11 @@
 require_relative '../test_helper'
 
 class OmniauthIntegrationTest < ActionDispatch::IntegrationTest
+  setup do
+    redis = Redis.new(REDIS_CONFIG)
+    redis.flushdb
+  end
+
   test "should close in case of failure" do
     get '/api/users/auth/slack/callback', params: { error: 'access_denied' }
     assert_redirected_to '/close.html'


### PR DESCRIPTION
## Description

Since we added rate limiting for login requests, we need to flush redis before the tests run.


## How has this been tested?

Ran the test repeatedly to confirm it is not flaky


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

