### PR TITLE
Do not raise exception if child item can't inherit status from parent item

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -71,7 +71,7 @@ class Bot::Smooch < BotUser
           status = parent.last_verification_status
           if !s.nil? && s.status != status
             s.status = status
-            s.save!
+            s.save
           end
           ::Bot::Smooch.send_report_from_parent_to_child(parent.id, target.id)
         end


### PR DESCRIPTION
## Description

Otherwise, an exception can prevent the report from being sent.

Fixes: CV2-4656.

## How has this been tested?

This fix should be covered by existing tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

