### PR TITLE
CV2-4666: Sentry issue

### DIFF
--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -334,9 +334,9 @@ module SmoochMessages
 
     def save_message(message_json, app_id, author = nil, request_type = 'default_requests', associated_id = nil, associated_class = nil)
       message = JSON.parse(message_json)
-      return if TiplineRequest.where(smooch_message_id: message['_id']).last.present?
+      return if TiplineRequest.where(smooch_message_id: message['_id']).exists?
       associated_obj = nil
-      associated_obj = begin associated_class.constantize.where(id: associated_id).last rescue nil end unless associated_id.nil?
+      associated_obj = associated_class.constantize.where(id: associated_id).last unless associated_id.nil?
       self.get_installation(self.installation_setting_id_keys, app_id)
       Team.current = Team.find self.config['team_id'].to_i
       ApplicationRecord.transaction do

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -322,7 +322,9 @@ module SmoochMessages
       queue = RequestStore.store[:smooch_bot_queue].to_s
       queue = queue.blank? ? 'smooch_priority' : (mapping[queue] || 'smooch_priority')
       type = (message['type'] == 'text' && !message['text'][/https?:\/\/[^\s]+/, 0].blank?) ? 'link' : message['type']
-      SmoochWorker.set(queue: queue).perform_in(1.second + interval.seconds, message.to_json, type, app_id, request_type, YAML.dump(annotated))
+      associated_id = annotated&.id
+      associated_class = annotated.class.name
+      SmoochWorker.set(queue: queue).perform_in(1.second + interval.seconds, message.to_json, type, app_id, request_type, associated_id, associated_class)
     end
 
     def default_archived_flag
@@ -330,8 +332,11 @@ module SmoochMessages
       Bot::Alegre.team_has_alegre_bot_installed?(team_id) ? CheckArchivedFlags::FlagCodes::PENDING_SIMILARITY_ANALYSIS : CheckArchivedFlags::FlagCodes::NONE
     end
 
-    def save_message(message_json, app_id, author = nil, request_type = 'default_requests', associated_obj = nil)
+    def save_message(message_json, app_id, author = nil, request_type = 'default_requests', associated_id = nil, associated_class = nil)
       message = JSON.parse(message_json)
+      return if TiplineRequest.where(smooch_message_id: message['_id']).last.present?
+      associated_obj = nil
+      associated_obj = begin associated_class.constantize.where(id: associated_id).last rescue nil end unless associated_id.nil?
       self.get_installation(self.installation_setting_id_keys, app_id)
       Team.current = Team.find self.config['team_id'].to_i
       ApplicationRecord.transaction do

--- a/app/workers/smooch_worker.rb
+++ b/app/workers/smooch_worker.rb
@@ -6,11 +6,10 @@ class SmoochWorker
 
   sidekiq_retry_in { |_count, _exception| 20 }
 
-  def perform(json_message, type, app_id, request_type, annotated)
-    annotated = YAML.load(annotated)
+  def perform(message_json, type, app_id, request_type, associated_id = nil, associated_class = nil)
     User.current = BotUser.smooch_user
     benchmark.send("smooch_save_#{type}_message") do
-      Bot::Smooch.save_message(json_message, app_id, User.current, request_type, annotated)
+      Bot::Smooch.save_message(message_json, app_id, User.current, request_type, associated_id, associated_class)
     end
     benchmark.finish
     User.current = nil

--- a/app/workers/smooch_worker.rb
+++ b/app/workers/smooch_worker.rb
@@ -8,6 +8,12 @@ class SmoochWorker
 
   def perform(message_json, type, app_id, request_type, associated_id = nil, associated_class = nil)
     User.current = BotUser.smooch_user
+    # This is a temp code for existing jobs and should remove it in next deployment
+    annotated = begin YAML.load(associated_id) rescue nil end
+    unless annotated.nil?
+      associated_id = annotated.id
+      associated_class = annotated.class.name
+    end
     benchmark.send("smooch_save_#{type}_message") do
       Bot::Smooch.save_message(message_json, app_id, User.current, request_type, associated_id, associated_class)
     end

--- a/test/models/bot/smooch_3_test.rb
+++ b/test/models/bot/smooch_3_test.rb
@@ -35,7 +35,7 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
         language: 'en'
       }.to_json
       assert_difference 'ProjectMedia.count' do
-        SmoochWorker.perform_async(json_message, 'image', @app_id, 'default_requests', YAML.dump({}))
+        SmoochWorker.perform_async(json_message, 'image', @app_id, 'default_requests')
       end
     end
   end

--- a/test/models/bot/smooch_3_test.rb
+++ b/test/models/bot/smooch_3_test.rb
@@ -203,9 +203,7 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
         Bot::Smooch.save_message(message.to_json, @app_id)
       end
       message['mediaUrl'] = @video_url_2
-      assert_raises 'ActiveRecord::RecordInvalid' do
-        Bot::Smooch.save_message(message.to_json, @app_id)
-      end
+      Bot::Smooch.save_message(message.to_json, @app_id)
       # audio
       message = {
         type: 'file',
@@ -224,9 +222,7 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
         Bot::Smooch.save_message(message.to_json, @app_id)
       end
       message['mediaUrl'] = @audio_url_2
-      assert_raises 'ActiveRecord::RecordInvalid' do
-        Bot::Smooch.save_message(message.to_json, @app_id)
-      end
+      Bot::Smooch.save_message(message.to_json, @app_id)
     end
   end
 

--- a/test/models/bot/smooch_4_test.rb
+++ b/test/models/bot/smooch_4_test.rb
@@ -596,9 +596,7 @@ class Bot::Smooch4Test < ActiveSupport::TestCase
       medias_count = Media.count
 
       assert_no_difference 'ProjectMedia.count' do
-        assert_raises ActiveRecord::StatementInvalid do
-          Bot::Smooch.save_message(message.to_json, @app_id)
-        end
+        Bot::Smooch.save_message(message.to_json, @app_id)
       end
       assert_equal medias_count, Media.count
     end

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -396,7 +396,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
         },
         language: 'en',
       }
-      Bot::Smooch.save_message(message.to_json, @app_id, nil, 'menu_options_requests', pm)
+      Bot::Smooch.save_message(message.to_json, @app_id, nil, 'menu_options_requests', pm.id, pm.class.name)
       message = {
         type: 'text',
         text: random_string,
@@ -413,7 +413,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
         },
         language: 'en',
       }
-      Bot::Smooch.save_message(message.to_json, @app_id, nil, 'menu_options_requests', pm)
+      Bot::Smooch.save_message(message.to_json, @app_id, nil, 'menu_options_requests', pm.id, pm.class.name)
       # verifiy new channel value
       data = {"main" => CheckChannels::ChannelCodes::MANUAL, "others" => [CheckChannels::ChannelCodes::WHATSAPP, CheckChannels::ChannelCodes::MESSENGER]}
       assert_equal data, pm.reload.channel
@@ -433,7 +433,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
         },
         language: 'en',
       }
-      Bot::Smooch.save_message(message.to_json, @app_id, nil, 'menu_options_requests', pm2)
+      Bot::Smooch.save_message(message.to_json, @app_id, nil, 'menu_options_requests', pm2.id, pm2.class.name)
       # verifiy new channel value
       data = {"main" => CheckChannels::ChannelCodes::WHATSAPP, "others" => [CheckChannels::ChannelCodes::MESSENGER]}
       assert_equal data, pm2.reload.channel
@@ -466,7 +466,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
           assert_raises ActiveRecord::StatementInvalid do
             3.times do |i|
               threads << Thread.new {
-                Bot::Smooch.save_message(message.to_json, @app_id, author, 'timeout_requests', nil)
+                Bot::Smooch.save_message(message.to_json, @app_id, author, 'timeout_requests', nil, nil)
               }
             end
             threads.map(&:join)

--- a/test/models/bot/smooch_7_test.rb
+++ b/test/models/bot/smooch_7_test.rb
@@ -502,12 +502,12 @@ class Bot::Smooch7Test < ActiveSupport::TestCase
           language: 'en',
         }
       end
-      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'relevant_search_result_requests', pm)
-      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'relevant_search_result_requests', pm)
-      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'timeout_search_requests', pm)
-      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests', pm)
-      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests', pm)
-      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests', pm)
+      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'relevant_search_result_requests', pm.id, pm.class.name)
+      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'relevant_search_result_requests', pm.id, pm.class.name)
+      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'timeout_search_requests', pm.id, pm.class.name)
+      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests', pm.id, pm.class.name)
+      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests', pm.id, pm.class.name)
+      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests', pm.id, pm.class.name)
       message = lambda do
         {
           type: 'text',
@@ -526,9 +526,9 @@ class Bot::Smooch7Test < ActiveSupport::TestCase
           language: 'en',
         }
       end
-      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'relevant_search_result_requests', pm2)
-      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests', pm2)
-      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests', pm2)
+      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'relevant_search_result_requests', pm2.id, pm2.class.name)
+      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests', pm2.id, pm2.class.name)
+      Bot::Smooch.save_message(message.call.to_json, @app_id, nil, 'irrelevant_search_result_requests', pm2.id, pm2.class.name)
       # Verify cached field
       assert_equal 6, pm.tipline_search_results_count
       assert_equal 2, pm.positive_tipline_search_results_count


### PR DESCRIPTION

## Description

- Simplify SmoochWorker job to accept id instead of object.
- Check existing TiplineRequest with `smooch_message_id` before creating new one.

References: CV2-4666

## How has this been tested?

Verified locally and waiting existing tests to pass via Travis.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

