### PR TITLE
CV2-4713 flip notification logic

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -401,7 +401,6 @@ class Bot::Alegre < BotUser
   def self.media_file_url(pm)
     # FIXME Ugly hack to get a usable URL in docker-compose development environment.
     if pm.is_a?(TemporaryProjectMedia)
-      print("HELLO")
       url = pm.url
     else
       url = (ENV['RAILS_ENV'] != 'development' ? pm.media.file.file.public_url : "#{CheckConfig.get('storage_endpoint')}/#{CheckConfig.get('storage_bucket')}/#{pm.media.file.file.path}")

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -450,7 +450,7 @@ module AlegreV2
           sleep(1)
           cached_data = get_cached_data(get_required_keys(project_media, nil))
         end
-        CheckSentry.notify(AlegreTimeoutError.new('Timeout when waiting for async response from Alegre'), params: args.merge({ cached_data: cached_data })) if start_time + timeout > Time.now
+        CheckSentry.notify(AlegreTimeoutError.new('Timeout when waiting for async response from Alegre'), params: args.merge({ cached_data: cached_data })) if start_time + timeout < Time.now
         response = get_similar_items_v2_callback(project_media, nil)
         delete(project_media, nil) if project_media.is_a?(TemporaryProjectMedia)
         return response

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -435,7 +435,6 @@ module AlegreV2
       type = args[:type]
       if ['audio', 'image', 'video'].include?(type)
         if project_media.nil?
-          print("hello")
           project_media = TemporaryProjectMedia.new
           project_media.url = media_url
           project_media.id = Digest::MD5.hexdigest(project_media.url).to_i(16)
@@ -450,7 +449,7 @@ module AlegreV2
           sleep(1)
           cached_data = get_cached_data(get_required_keys(project_media, nil))
         end
-        CheckSentry.notify(AlegreTimeoutError.new('Timeout when waiting for async response from Alegre'), params: args.merge({ cached_data: cached_data })) if start_time + timeout < Time.now
+        CheckSentry.notify(AlegreTimeoutError.new('Timeout when waiting for async response from Alegre'), params: args.merge({ cached_data: cached_data.merge(time: Time.now, start_time: start_time, timeout: timeout) })) if start_time + timeout < Time.now
         response = get_similar_items_v2_callback(project_media, nil)
         delete(project_media, nil) if project_media.is_a?(TemporaryProjectMedia)
         return response


### PR DESCRIPTION
## Description

Flip logic for notifying of timed out response - currently we are logging all *not* timed-out results, we need the opposite.

References: CV2-4713

## How has this been tested?

Identified and tested in REPL during live triaging of this ticket

## Things to pay attention to during code review

NA

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

