### PR TITLE
Add rack-cloudflare gem to Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -639,6 +639,7 @@ GEM
     rack (2.2.8.1)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
+    rack-cloudflare (1.0.5)
     rack-cors (1.0.6)
       rack (>= 1.6.0)
     rack-protection (2.2.0)
@@ -988,6 +989,7 @@ DEPENDENCIES
   pusher
   rack (= 2.2.8.1)
   rack-attack
+  rack-cloudflare
   rack-cors (= 1.0.6)
   rack-protection (= 2.2.0)
   railroady


### PR DESCRIPTION
## Description

In #1911, we added the rack-cloudflare gem, but Gemfile.lock was not properly updated, leading to a failing build.


References:  CV2-4476

## How has this been tested?

Confirmed that bundler does not fail, and starting the check-api container is successful


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

