### PR TITLE
CV2-4713 dont wait for results when checking a disabled modality for a given workspace

### DIFF
--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -1137,6 +1137,33 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     assert_equal({}, Bot::Alegre.get_similar_items_v2(pm, nil))
   end
 
+  test "should return a similarity_disabled_for_project_media? of true for a disabled workspace" do
+    tbi = TeamBotInstallation.where(team: @team, user: @bot).last
+    tbi.set_image_similarity_enabled = false
+    tbi.save!
+    Bot::Alegre.stubs(:merge_suggested_and_confirmed).never
+    pm = create_project_media team: @team, media: create_uploaded_image
+    assert_equal(false, Bot::Alegre.similarity_disabled_for_project_media?(pm))
+  end
+
+  test "should return a similarity_disabled_for_project_media? of true for a disabled workspace" do
+    tbi = TeamBotInstallation.where(team: @team, user: @bot).last
+    tbi.set_image_similarity_enabled = true
+    tbi.save!
+    Bot::Alegre.stubs(:merge_suggested_and_confirmed).never
+    pm = create_project_media team: @team, media: create_uploaded_image
+    assert_equal(true, Bot::Alegre.similarity_disabled_for_project_media?(pm))
+  end
+
+  test "should not wait for a response when disabled" do
+    tbi = TeamBotInstallation.where(team: @team, user: @bot).last
+    tbi.set_image_similarity_enabled = false
+    tbi.save!
+    Bot::Alegre.stubs(:merge_suggested_and_confirmed).never
+    pm = create_project_media team: @team, media: create_uploaded_image
+    assert_equal({}, Bot::Alegre.wait_for_results(pm, args))
+  end
+
   test "should not relate project media for video if disabled on workspace" do
     tbi = TeamBotInstallation.where(team: @team, user: @bot).last
     tbi.set_video_similarity_enabled = false

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -1161,7 +1161,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     tbi.save!
     Bot::Alegre.stubs(:merge_suggested_and_confirmed).never
     pm = create_project_media team: @team, media: create_uploaded_image
-    assert_equal({}, Bot::Alegre.wait_for_results(pm, args))
+    assert_equal({}, Bot::Alegre.wait_for_results(pm, {}))
   end
 
   test "should not relate project media for video if disabled on workspace" do

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -1137,13 +1137,13 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     assert_equal({}, Bot::Alegre.get_similar_items_v2(pm, nil))
   end
 
-  test "should return a similarity_disabled_for_project_media? of false for a disabled workspace" do
+  test "should return a similarity_disabled_for_project_media? of true for a disabled workspace" do
     tbi = TeamBotInstallation.where(team: @team, user: @bot).last
     tbi.set_image_similarity_enabled = false
     tbi.save!
     Bot::Alegre.stubs(:merge_suggested_and_confirmed).never
     pm = create_project_media team: @team, media: create_uploaded_image
-    assert_equal(false, Bot::Alegre.similarity_disabled_for_project_media?(pm))
+    assert_equal(true, Bot::Alegre.similarity_disabled_for_project_media?(pm))
   end
 
   test "should return a similarity_disabled_for_project_media? of true for an enabled workspace" do
@@ -1152,7 +1152,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     tbi.save!
     Bot::Alegre.stubs(:merge_suggested_and_confirmed).never
     pm = create_project_media team: @team, media: create_uploaded_image
-    assert_equal(true, Bot::Alegre.similarity_disabled_for_project_media?(pm))
+    assert_equal(false, Bot::Alegre.similarity_disabled_for_project_media?(pm))
   end
 
   test "should not wait for a response when disabled" do

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -1137,7 +1137,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     assert_equal({}, Bot::Alegre.get_similar_items_v2(pm, nil))
   end
 
-  test "should return a similarity_disabled_for_project_media? of true for a disabled workspace" do
+  test "should return a similarity_disabled_for_project_media? of false for a disabled workspace" do
     tbi = TeamBotInstallation.where(team: @team, user: @bot).last
     tbi.set_image_similarity_enabled = false
     tbi.save!
@@ -1146,7 +1146,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     assert_equal(false, Bot::Alegre.similarity_disabled_for_project_media?(pm))
   end
 
-  test "should return a similarity_disabled_for_project_media? of true for a disabled workspace" do
+  test "should return a similarity_disabled_for_project_media? of true for an enabled workspace" do
     tbi = TeamBotInstallation.where(team: @team, user: @bot).last
     tbi.set_image_similarity_enabled = true
     tbi.save!


### PR DESCRIPTION
## Description

Fairly straightforward explanation as above - workspaces can disable similarity across all modalities or be selective in disabling a modality. When, for a given `project_media`, the similarity functionality is disabled, we don't send a request to Alegre to fingerprint the item, yet we wait for a response, which appears to be the source of 100% of the `AlegreTimeout` errors. This should solve them by doing a bit of DRY'ing and refactoring to have a way of checking that in all the stages of the fingerprinting / searching process.

References: CV2-4713

## How has this been tested?

Tested in REPL against live cases when debugging / identifying the issue, added a few tests for this as well

## Things to pay attention to during code review

Just review refactoring - should be straightforward!

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

