### PR TITLE
Do not pause a report that was never published.

### DIFF
--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -70,7 +70,8 @@ class FactCheck < ApplicationRecord
     })
     report.merge!({ use_introduction: default_use_introduction, introduction: default_introduction }) if language != report_language
     data[:options] = report
-    data[:state] = (self.publish_report ? 'published' : 'paused') if data[:state].blank? || !self.publish_report.nil?
+    unpublished_state = data[:state].blank? ? 'unpublished' : 'paused'
+    data[:state] = (self.publish_report ? 'published' : unpublished_state) if data[:state].blank? || !self.publish_report.nil?
     reports.annotator = self.user || User.current
     reports.set_fields = data.to_json
     reports.skip_check_ability = true

--- a/test/models/fact_check_test.rb
+++ b/test/models/fact_check_test.rb
@@ -316,6 +316,32 @@ class FactCheckTest < ActiveSupport::TestCase
       cd = create_claim_description project_media: pm
       assert_equal 'unpublished', pm.reload.report_status
 
+      fc = create_fact_check claim_description: cd
+      assert_equal 'unpublished', pm.reload.report_status
+
+      fc = FactCheck.find(fc.id)
+      fc.title = random_string
+      fc.save!
+      assert_equal 'unpublished', pm.reload.report_status
+
+      fc = FactCheck.find(fc.id)
+      fc.publish_report = true
+      fc.save!
+      assert_equal 'published', pm.reload.report_status
+
+      fc = FactCheck.find(fc.id)
+      fc.title = random_string
+      fc.save!
+      assert_equal 'published', pm.reload.report_status
+
+      fc = FactCheck.find(fc.id)
+      fc.title = random_string
+      fc.publish_report = false
+      fc.save!
+      assert_equal 'paused', pm.reload.report_status
+
+      pm = create_project_media
+      cd = create_claim_description project_media: pm
       fc = create_fact_check claim_description: cd, publish_report: true
       assert_equal 'published', pm.reload.report_status
 


### PR DESCRIPTION
## Description

When an unpublished fact-check is updated, it should not change the report status to "paused" if it was never published before. It should keep the report status as "unpublished".

Fixes CV2-4382.

## How has this been tested?

I added unit tests for this change.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

