### PR TITLE
Capture user's actual IP when rate limiting in QA and Live where we u…

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,27 +1,36 @@
 class Rack::Attack
   redis = Redis.new(REDIS_CONFIG)
+
+  # Extract real IP address from Cloudflare header if present
+  def self.real_ip(req)
+    req.get_header('HTTP_CF_CONNECTING_IP') || req.ip
+  end
+
   # Throttle all graphql requests by IP address
-  
   throttle('api/graphql', limit: proc { CheckConfig.get('api_rate_limit', 100, :integer) }, period: 60.seconds) do |req|
-    req.ip if req.path == '/api/graphql'
+    real_ip(req) if req.path == '/api/graphql'
   end
 
   # Blocklist IP addresses that are permanently blocked
   blocklist('block aggressive IPs') do |req|
-    redis.get("block:#{req.ip}") == "true"
+    redis.get("block:#{real_ip(req)}") == "true"
   end
 
   # Track excessive login attempts for permanent blocking
   track('track excessive logins/ip') do |req|
     if req.path == '/api/users/sign_in' && req.post?
-      ip = req.ip
-      # Increment the counter for the IP and check if it should be blocked
-      count = redis.incr("track:#{ip}")
-      redis.expire("track:#{ip}", 3600) # Set the expiration time to 1 hour
+      ip = real_ip(req)
+      begin
+        # Increment the counter for the IP and check if it should be blocked
+        count = redis.incr("track:#{ip}")
+        redis.expire("track:#{ip}", 3600) # Set the expiration time to 1 hour
 
-      # Add IP to blocklist if count exceeds the threshold
-      if count.to_i >= CheckConfig.get('login_block_limit', 100, :integer)
-        redis.set("block:#{ip}", true)  # No expiration
+        # Add IP to blocklist if count exceeds the threshold
+        if count.to_i >= CheckConfig.get('login_block_limit', 100, :integer)
+          redis.set("block:#{ip}", true)  # No expiration
+        end
+      rescue => e
+        Rails.logger.error("Rack::Attack Error: #{e.message}")
       end
 
       ip


### PR DESCRIPTION
## Description

When behind cloudflare, Rack::Attack receive's cloudflare's IPs instead of the user's actual IP address. Here, we are changing the configuration to consume HTTP_CF_CONNECTING_IP if it is available.

References: CV2-4476

## How has this been tested?

Confirmed that repeated user login requests result in a blocked IP.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

