### PR TITLE
Filter out empty platforms when calculating statistics

### DIFF
--- a/lib/tasks/data/statistics.rake
+++ b/lib/tasks/data/statistics.rake
@@ -66,13 +66,18 @@ namespace :check do
                     end
                   end
 
-                  partial_month = MonthlyTeamStatistic.find_by(team_id: team_id, platform: platform, language: language, start_date: month_start)
-                  if partial_month.present?
-                    partial_month.update!(row_attributes.merge!(team_id: team_id))
-                    team_stats[:updated] += 1
+                  # Check if any statistics are non-zero
+                  if row_attributes.values.any? { |value| value != 0 }
+                    partial_month = MonthlyTeamStatistic.find_by(team_id: team_id, platform: platform, language: language, start_date: month_start)
+                    if partial_month.present?
+                      partial_month.update!(row_attributes.merge!(team_id: team_id))
+                      team_stats[:updated] += 1
+                    else
+                      MonthlyTeamStatistic.create!(row_attributes.merge!(team_id: team_id))
+                      team_stats[:created] += 1
+                    end
                   else
-                    MonthlyTeamStatistic.create!(row_attributes.merge!(team_id: team_id))
-                    team_stats[:created] += 1
+                    team_stats[:skipped_zero] += 1
                   end
 
                 rescue StandardError => e


### PR DESCRIPTION
## Description

We don't need to save statistics when the value is 0, since this is resulting in unnecessary platforms showing up in the data dashboard.

References: CV2-4613

## How has this been tested?

Tested by running `bundle exec rake check:data:statistics` and confirming that the data dashboard does not
get populated with unexpected platforms


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

