### PR TITLE
CV2-4741 increase timeout from one to two minutes

### DIFF
--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -432,7 +432,7 @@ module AlegreV2
     def wait_for_results(project_media, args)
       return {} if similarity_disabled_for_project_media?(project_media)
       cached_data = get_cached_data(get_required_keys(project_media, nil))
-      timeout = args[:timeout] || 120
+      timeout = args[:timeout] || CheckConfig.get('alegre_timeout', 120, :integer).to_f
       start_time = Time.now
       while start_time + timeout > Time.now && is_cached_data_not_good(cached_data) #more robust for any type of null response
         sleep(1)

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -432,7 +432,7 @@ module AlegreV2
     def wait_for_results(project_media, args)
       return {} if similarity_disabled_for_project_media?(project_media)
       cached_data = get_cached_data(get_required_keys(project_media, nil))
-      timeout = args[:timeout] || 60
+      timeout = args[:timeout] || 120
       start_time = Time.now
       while start_time + timeout > Time.now && is_cached_data_not_good(cached_data) #more robust for any type of null response
         sleep(1)

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -45,6 +45,7 @@ development: &default
   similarity_media_file_url_host: ''
   min_number_of_words_for_tipline_submit_shortcut: 10
   nlu_disambiguation_threshold: 0.11
+  alegre_timeout: 120
 
   # Localization
   #


### PR DESCRIPTION
## Description

Simple bump from one minute to two minutes for timeout errors in waiting on alegre responses.

References: CV2-4741

## How has this been tested?

Not tested yet - should be straightforward

## Things to pay attention to during code review

NA

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

