### PR TITLE
Send report when bulk-accepting suggestion.

### DIFF
--- a/app/models/concerns/relationship_bulk.rb
+++ b/app/models/concerns/relationship_bulk.rb
@@ -26,6 +26,7 @@ module RelationshipBulk
           team_id: team&.id,
           user_id: User.current&.id,
           source_id: source_id,
+          action: updates[:action]
         }
         self.delay.run_update_callbacks(ids.to_json, extra_options.to_json)
         { source_project_media: pm_source }
@@ -110,6 +111,8 @@ module RelationshipBulk
         callbacks.each do |callback|
           r.send(callback)
         end
+        # Send report if needed
+        Relationship.inherit_status_and_send_report(r.id) if extra_options['action'] == 'accept'
       end
       # Update un-matched field
       ProjectMedia.where(id: target_ids).update_all(unmatched: 0)

--- a/test/controllers/graphql_controller_12_test.rb
+++ b/test/controllers/graphql_controller_12_test.rb
@@ -469,6 +469,8 @@ class GraphqlController12Test < ActionController::TestCase
   end
 
   test "should send report when bulk-accepting suggestion" do
+    Sidekiq::Testing.fake!
+    WebMock.stub_request(:get, /#{CheckConfig.get('narcissus_url')}/).to_return(body: '{"url":"http://screenshot/test/test.png"}')
     create_verification_status_stuff
     pm1 = create_project_media team: @t ; s = pm1.last_status_obj ; s.status = 'false' ; s.save!
     publish_report(pm1)


### PR DESCRIPTION
## Description

When bulk-accepting a suggestion, the callback that sends a report is not called. This PR fixes it.

Fixes CV2-4758.

## How has this been tested?

TDD. A functional test was added for this case.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

