### PR TITLE
Implementing support to re-sending Facebook Messenger newsletters after 24-hours window

### DIFF
--- a/app/models/concerns/smooch_resend.rb
+++ b/app/models/concerns/smooch_resend.rb
@@ -162,6 +162,14 @@ module SmoochResend
 
       return self.resend_facebook_messenger_report_after_window(message, original) if original&.dig('fallback_template') =~ /report/
 
+      # A newsletter
+      if original&.dig('fallback_template') == 'newsletter'
+        newsletter = TiplineNewsletter.where(language: original['language'], team_id: self.config['team_id'].to_i).last
+        newsletter_content = newsletter.build_content
+        self.send_message_to_user(uid, newsletter_content, self.message_tags_payload(newsletter_content))
+        return true
+      end
+
       # A status message
       if original&.dig('fallback_template') == 'fact_check_status'
         text = original['message']

--- a/test/models/bot/smooch_4_test.rb
+++ b/test/models/bot/smooch_4_test.rb
@@ -695,4 +695,26 @@ class Bot::Smooch4Test < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should resend newsletter after Facebook Messenger 24-hours window" do
+    WebMock.stub_request(:get, 'http://test.com/feed.rss').to_return(body: '<rss></rss>')
+    msgid = random_string
+    response = OpenStruct.new({ body: OpenStruct.new(message: OpenStruct.new({ id: msgid })) })
+    Bot::Smooch.save_smooch_response(response, nil, random_string, 'newsletter', 'en', { message: random_string })
+    message = {
+      app: {
+        '_id': @app_id
+      },
+      appUser: {
+        '_id': random_string,
+      },
+      message: {
+        '_id': msgid
+      },
+      destination: {
+        type: 'messenger'
+      }
+    }.to_json
+    assert Bot::Smooch.resend_message_after_window(message)
+  end
 end


### PR DESCRIPTION
## Description

On a Facebook Messenger tipline, if the newsletter is sent to a user who hasn't interacted with the tipline in the last 24 hours, the message is not sent unless it contains a tag (it's like templates for WhatsApp). This commit adds support to that.

Fixes: CV2-4787.

## How has this been tested?

Tested locally and received the newsletter, but I also added a unit test for this case.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)