### PR TITLE
Include the body in a report when the URL is blank

### DIFF
--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -256,7 +256,7 @@ module SmoochSearch
       end
       reports.reject{ |r| r.blank? }.each do |report|
         response = nil
-        no_body = (platform == 'Facebook Messenger')
+        no_body = (platform == 'Facebook Messenger' && !report_design_field_value('published_article_url').blank?)
         response = self.send_message_to_user(uid, report.report_design_text(nil, no_body), {}, false, true, 'search_result') if report.report_design_field_value('use_text_message')
         response = self.send_message_to_user(uid, '', { 'type' => 'image', 'mediaUrl' => report.report_design_image_url }, false, true, 'search_result') if !report.report_design_field_value('use_text_message') && report.report_design_field_value('use_visual_card')
         id = self.get_id_from_send_response(response)


### PR DESCRIPTION
## Description

After CV2-4287 we only send titles and URLs on Facebook Messenger. When the URL is empty, however, this results in a poor user experience. In the case of reports that have a description but do not have a URL we should send the title and description.

References: CV2-4846

## How has this been tested?

Tested logic separate from application, but have not tested in the code base as I am not running a Messenger Tipline locally.

## Things to pay attention to during code review



## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [x] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

