### PR TITLE
Try to make sure that clusters center is never null.

### DIFF
--- a/app/graph/types/cluster_type.rb
+++ b/app/graph/types/cluster_type.rb
@@ -18,12 +18,6 @@ class ClusterType < DefaultObject
 
   field :center, ProjectMediaType, null: true
 
-  def center
-    RecordLoader
-      .for(ProjectMedia)
-      .load(object.project_media_id)
-  end
-
   field :first_item_at, GraphQL::Types::Int, null: true
 
   def first_item_at

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -140,7 +140,7 @@ class Feed < ApplicationRecord
   def filtered_clusters(args = {})
     team_ids = args[:team_ids]
     channels = args[:channels]
-    query = self.clusters
+    query = self.clusters.joins(:project_media)
 
     # Filter by workspace
     query = query.where.not("ARRAY[?] && team_ids", self.team_ids - team_ids.to_a.map(&:to_i)) if !team_ids.blank? && team_ids != self.team_ids


### PR DESCRIPTION
## Description

And/or that at least clusters without a center are never returned.

We don't know exactly in which cases this crash happens. So this commit approaches it in two different ways:

* For a given feed, only return clusters that have a center, by adding a `INNER JOIN project_medias` clause to the feed clusters query.
* For the `ClusterType` GraphQL endpoint, fallback to the cluster model `center` method, which already falls back to the first item of the cluster if the center is not present anymore.

Fixes CV2-4850.

## How has this been tested?

Existing tests should cover this.

## Things to pay attention to during code review

I'm wondering if for some reason empty clusters are being created. If this is the case, we should fix the rake task as well.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

