### PR TITLE
Add missing scripts and configuration to GHA image builds for batch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,11 @@ ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 ENV LANGUAGE C.UTF-8
 
+# Setup a user account
+ENV DEPLOYUSER=checkdeploy
+RUN useradd ${DEPLOYUSER} -s /bin/bash -m
+
+
 RUN apt-get update -qq && apt-get install -y --no-install-recommends curl
 
 RUN apt-get update && apt-get install --no-install-recommends -y \
@@ -25,6 +30,9 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libpq-dev \
     libtag1-dev \
     lsof
+
+# CMD and helper scripts
+COPY --chown=root:root production/bin /opt/bin
 
 # tx client
 RUN curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash


### PR DESCRIPTION

## Description

This changes fixes some discrepancies between the legacy GitLab CI deploys using the old `production/Dockerfile` and the new unified Dockerfile setup. Required for batch jobs in Terraform.

References: CV2-4399

## How has this been tested?

Syntax was verified, however, confirmation of fix will require building in GHA to verify.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [X] I have commented my code in hard-to-understand areas, if any
- [X] My changes generate no new warnings

