### PR TITLE
Add API documentation for `set_original_claim`

### DIFF
--- a/doc/api-user.md
+++ b/doc/api-user.md
@@ -269,7 +269,7 @@ As we can see above, the `geolocation` task response should be a valid [GeoJSON]
 
 The `url` and `quote` can't be both defined at the same time. It's one or the other. If the `quote` field is set, it means you're creating a claim. If the `url` field is set, it means you're creating a report of type "link".
 
-### Create original claim when creating media
+## Create original claim when creating media
 
 When using `createProjectMedia` to create new project media, you can use the `set_original_claim` field to import a URL as the original claim. This URL can be in the following formats:
 


### PR DESCRIPTION

## Description

Add API documentation for `set_original_claim` in the `createProjectMedia` mutation.


References: CV2-4676

## How has this been tested?

Confirmed that the changes are well formatted and the query example works.


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

