### PR TITLE
Ticket CV2-4889: Expose number of articles for an item in GraphQL

### DIFF
--- a/app/graph/types/project_media_type.rb
+++ b/app/graph/types/project_media_type.rb
@@ -374,4 +374,12 @@ class ProjectMediaType < DefaultObject
   field :fact_check, FactCheckType, null: true
 
   field :explainers, ExplainerType.connection_type, null: true
+
+  field :articles_count, GraphQL::Types::Int, null: true
+
+  def articles_count
+    count = object.explainers.count
+    count += 1 if object.fact_check
+    count
+  end
 end

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -10592,6 +10592,7 @@ type ProjectMedia implements Node {
   ): AnnotationUnionConnection
   annotations_count(annotation_type: String!): Int
   archived: Int
+  articles_count: Int
   assignments(
     """
     Returns the elements in the list that come after the specified cursor.
@@ -11525,7 +11526,6 @@ type ProjectMedia implements Node {
   last_status: String
   last_status_obj: Dynamic
   linked_items_count: Int
-  list_columns_values: JsonStringType
   log(
     """
     Returns the elements in the list that come after the specified cursor.
@@ -13154,7 +13154,6 @@ type Team implements Node {
     """
     last: Int
   ): TeamUserConnection
-  list_columns: JsonStringType
   medias_count: Int
   members_count: Int
   name: String!
@@ -15982,7 +15981,6 @@ input UpdateTeamInput {
   language: String
   language_detection: Boolean
   languages: JsonStringType
-  list_columns: JsonStringType
   media_verification_statuses: JsonStringType
   name: String
   outgoing_urls_utm_code: String

--- a/public/relay.json
+++ b/public/relay.json
@@ -57246,6 +57246,20 @@
               "deprecationReason": null
             },
             {
+              "name": "articles_count",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "assignments",
               "description": null,
               "args": [
@@ -60783,20 +60797,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "list_columns_values",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "JsonStringType",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -69371,20 +69371,6 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "TeamUserConnection",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "list_columns",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "JsonStringType",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -88043,18 +88029,6 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Boolean",
-                "ofType": null
-              },
-              "defaultValue": null,
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
-              "name": "list_columns",
-              "description": null,
-              "type": {
-                "kind": "SCALAR",
-                "name": "JsonStringType",
                 "ofType": null
               },
               "defaultValue": null,

--- a/test/controllers/graphql_controller_12_test.rb
+++ b/test/controllers/graphql_controller_12_test.rb
@@ -332,7 +332,7 @@ class GraphqlController12Test < ActionController::TestCase
     create_cluster_project_media cluster: c, project_media: pm
 
     authenticate_with_user(@u)
-    query = 'query { feed(id: "' + f.id.to_s + '") { cluster(project_media_id: ' + pm.id.to_s + ') { dbid, project_media(id: ' + pm.id.to_s + ') { id, imported_from_feed { id } }, project_medias(teamId: ' + @t.id.to_s + ', first: 1) { edges { node { id } } }, cluster_teams(first: 10) { edges { node { id, team { name }, last_request_date, media_count, requests_count, fact_checks(first: 1) { edges { node { id } } } } } } } } }'
+    query = 'query { feed(id: "' + f.id.to_s + '") { cluster(project_media_id: ' + pm.id.to_s + ') { dbid, project_media(id: ' + pm.id.to_s + ') { id, articles_count, imported_from_feed { id } }, project_medias(teamId: ' + @t.id.to_s + ', first: 1) { edges { node { id } } }, cluster_teams(first: 10) { edges { node { id, team { name }, last_request_date, media_count, requests_count, fact_checks(first: 1) { edges { node { id } } } } } } } } }'
     post :create, params: { query: query }
     assert_response :success
     assert_equal c.id, JSON.parse(@response.body)['data']['feed']['cluster']['dbid']


### PR DESCRIPTION
## Description

Adding a new field to `ProjectMediaType` on the GraphQL API: `articles_count`. It returns the total number of articles (explainers plus fact-check) for a given item.

Reference: CV2-4889.

## How has this been tested?

Adapted an existing functional test to request this field.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)