### PR TITLE
Parse RSS feeds that return objects instead of strings.

### DIFF
--- a/lib/rss_feed.rb
+++ b/lib/rss_feed.rb
@@ -18,7 +18,9 @@ class RssFeed
         feed = RSS::Parser.parse(rss, false)
         unless feed.nil?
           feed.items.first(count).each do |item|
-            output << item.title.strip + "\n" + item.link.strip
+            title = item.title.kind_of?(String) ? item.title : item.title.content
+            link = item.link.kind_of?(String) ? item.link : item.link.href
+            output << title.to_s.strip + "\n" + link.to_s.strip
           end
         end
       end


### PR DESCRIPTION
## Description

Parse RSS feeds that return objects instead of strings.

Fixes CV2-4906.

## How has this been tested?

Existing tests should cover this.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

