### PR TITLE
CV2-4879: add rake task to set team_id for ClaimDescription

### DIFF
--- a/lib/tasks/migrate/20240715013839_add_team_id_to_claim_description.rake
+++ b/lib/tasks/migrate/20240715013839_add_team_id_to_claim_description.rake
@@ -1,0 +1,26 @@
+namespace :check do
+  namespace :migrate do
+    task add_team_id_to_claim_description: :environment do |_t, args|
+      started = Time.now.to_i
+      slugs = args.extras
+      condition = {}
+      if slugs.blank?
+        last_team_id = Rails.cache.read('check:migrate:add_team_id_to_claim_description:team_id') || 0
+      else
+        last_team_id = 0
+        condition = { slug: slugs }
+      end
+      Team.where(condition).where('id > ?', last_team_id).find_each do |team|
+        puts "Processing team [#{team.slug}]"
+        team.project_medias.joins(:claim_description).find_in_batches(batch_size: 2500) do |pms|
+          print '.'
+          ids = pms.map(&:id)
+          ClaimDescription.where(project_media_id: ids).update_all(team_id: team.id)
+        end
+        Rails.cache.write('check:migrate:add_team_id_to_claim_description:team_id', team.id) if slugs.blank?
+      end
+      minutes = ((Time.now.to_i - started) / 60).to_i
+      puts "[#{Time.now}] Done in #{minutes} minutes."
+    end
+  end
+end


### PR DESCRIPTION
## Description

Set ClaimDescription.team_id based on ClaimDescription.project_media_id .

References: CV2-4879

## How has this been tested?

Run rake task locally against live DB backup.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

