### PR TITLE
4880 – Seeds Script: Create standalone claim descriptions and fact-checks

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -83,7 +83,7 @@ class Setup
   def users
     @users ||= begin
       all_users = {}
-      all_users.merge!(invited_users)
+      # all_users.merge!(invited_users)
       all_users[:main_user_a] = main_user_a
       all_users.each_value { |user| user.confirm && user.save! }
       all_users
@@ -93,7 +93,7 @@ class Setup
   def teams
     @teams ||= begin
       all_teams = {}
-      all_teams.merge!(invited_teams)
+      # all_teams.merge!(invited_teams)
       all_teams[:main_team_a] = main_team_a
       all_teams
     end
@@ -424,11 +424,11 @@ class PopulatedWorkspaces
   def medias_params
     [
       *CLAIMS_PARAMS,
-      *UPLOADED_AUDIO_PARAMS,
-      *UPLOADED_IMAGE_PARAMS,
-      *UPLOADED_VIDEO_PARAMS,
-      *BLANK_PARAMS,
-      *LINK_PARAMS.call
+      # *UPLOADED_AUDIO_PARAMS,
+      # *UPLOADED_IMAGE_PARAMS,
+      # *UPLOADED_VIDEO_PARAMS,
+      # *BLANK_PARAMS,
+      # *LINK_PARAMS.call
     ].shuffle!
   end
 
@@ -729,26 +729,26 @@ ActiveRecord::Base.transaction do
     populated_workspaces = PopulatedWorkspaces.new(setup)
     populated_workspaces.fetch_bot_installation
     populated_workspaces.populate_projects
-    puts 'Creating saved searches for all teams...'
-    populated_workspaces.saved_searches
-    puts 'Creating feed...'
-    feed_1 = populated_workspaces.main_user_feed("share_factchecks")
-    feed_2 = populated_workspaces.main_user_feed("share_everything")
-    puts 'Making and inviting to Shared Feed... (won\'t run if you are not creating any invited users)'
-    populated_workspaces.share_feed(feed_1)
-    populated_workspaces.share_feed(feed_2)
-    puts 'Accepting invitation to a Shared Feed...'
-    populated_workspaces.accept_invitation(feed_2, :invited_user_c)
-    puts 'Making Confirmed Relationships between items...'
-    populated_workspaces.confirm_relationships
-    puts 'Making Suggested Relationships between items...'
-    populated_workspaces.suggest_relationships
-    puts 'Making Tipline requests...'
-    populated_workspaces.tipline_requests
-    puts 'Publishing half of each user\'s Fact Checks...'
-    populated_workspaces.publish_fact_checks
-    puts 'Creating Clusters'
-    populated_workspaces.clusters(feed_2)
+    # puts 'Creating saved searches for all teams...'
+    # populated_workspaces.saved_searches
+    # puts 'Creating feed...'
+    # feed_1 = populated_workspaces.main_user_feed("share_factchecks")
+    # feed_2 = populated_workspaces.main_user_feed("share_everything")
+    # puts 'Making and inviting to Shared Feed... (won\'t run if you are not creating any invited users)'
+    # populated_workspaces.share_feed(feed_1)
+    # populated_workspaces.share_feed(feed_2)
+    # puts 'Accepting invitation to a Shared Feed...'
+    # populated_workspaces.accept_invitation(feed_2, :invited_user_c)
+    # puts 'Making Confirmed Relationships between items...'
+    # populated_workspaces.confirm_relationships
+    # puts 'Making Suggested Relationships between items...'
+    # populated_workspaces.suggest_relationships
+    # puts 'Making Tipline requests...'
+    # populated_workspaces.tipline_requests
+    # puts 'Publishing half of each user\'s Fact Checks...'
+    # populated_workspaces.publish_fact_checks
+    # puts 'Creating Clusters'
+    # populated_workspaces.clusters(feed_2)
     puts 'Creating Explainers'
     populated_workspaces.explainers
   rescue RuntimeError => e

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -419,6 +419,24 @@ class PopulatedWorkspaces
     end
   end
 
+  def standalone_fact_check
+    claim_description_attributes = {
+      description: 'testing standalone fc',
+      context: Faker::Lorem.sentence,
+      user: users[:main_user_a],
+      team: teams[:main_team_a],
+      fact_check_attributes: {
+        summary: Faker::Company.catch_phrase,
+        title: Faker::Company.name,
+        user: users[:main_user_a],
+        language: 'en',
+        url: "https://www.thespruceeats.com/step-by-step-basic-cake-recipe-304553?timestamp=#{Time.now.to_f}"
+      },
+    }
+
+    ClaimDescription.create!(claim_description_attributes)
+  end
+
   private
 
   def medias_params
@@ -751,6 +769,8 @@ ActiveRecord::Base.transaction do
     # populated_workspaces.clusters(feed_2)
     puts 'Creating Explainers'
     populated_workspaces.explainers
+    puts 'Creating Standalone FactChecks'
+    populated_workspaces.standalone_fact_check
   rescue RuntimeError => e
     if e.message.include?('We could not parse this link')
       puts "—————"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -442,6 +442,19 @@ class PopulatedWorkspaces
     end
   end
 
+  def verify_standalone_claims_and_fact_checks
+    status = ['undetermined', 'not_applicable', 'in_progress', 'verified', 'false']
+
+    users.each_value do |user|
+      claims = user.claim_descriptions.where(project_media_id: nil)
+      fact_checks = claims.map { |claim| claim.fact_check }.compact! # some claims don't have fact checks, so they return nil
+      fact_checks.each do |fact_check|
+        fact_check.rating = status.sample
+        fact_check.save!
+      end
+    end
+  end
+
   private
 
   def medias_params
@@ -772,10 +785,11 @@ ActiveRecord::Base.transaction do
     # populated_workspaces.publish_fact_checks
     # puts 'Creating Clusters'
     # populated_workspaces.clusters(feed_2)
-    puts 'Creating Explainers'
-    populated_workspaces.explainers
+    # puts 'Creating Explainers'
+    # populated_workspaces.explainers
     puts 'Creating Standalone FactChecks'
     populated_workspaces.standalone_claims_and_fact_checks
+    populated_workspaces.verify_standalone_claims_and_fact_checks
   rescue RuntimeError => e
     if e.message.include?('We could not parse this link')
       puts "—————"


### PR DESCRIPTION
## Description

This creates both standalone claim descriptions and standalone claim descriptions with fact checks. Though only the second is visible in the UI. We also:
- verify the fact checks with a random status ('undetermined', 'not_applicable', 'in_progress', 'verified' or 'false')
- add a link to half of the standalone fact checks

References: 4880

## How has this been tested?

Created new users and added to an existing user.

## Things to pay attention to during code review

I also had to update how we were verifying and publishing the fact-checks that are related to a project media. It was breaking since now we can have `claim_descriptions` with `nil` `project_media_id`.

https://github.com/meedan/check-api/blob/fc59e8166c56827520431f450699d29421be1665/db/seeds.rb#L333

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

