### PR TITLE
Do not rate limit successful login attempts

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,4 +1,5 @@
 require 'error_codes'
+require 'redis'
 
 class CustomFailure < Devise::FailureApp
   def respond
@@ -49,6 +50,12 @@ Devise.setup do |config|
   end
   config.mailer = 'DeviseMailer'
   config.invite_for = 1.month
+
+  Warden::Manager.after_authentication do |user, auth, opts|
+    @redis = Redis.new(REDIS_CONFIG)
+    ip = auth.request.ip
+    @redis.decr("track:#{ip}")
+  end
 end
 
 AuthTrail.geocode = false

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -36,6 +36,8 @@ class Rack::Attack
         count = redis.incr("track:#{ip}")
         redis.expire("track:#{ip}", 3600) # Set the expiration time to 1 hour
 
+        redis.set("track:#{ip}", 0) if count < 0
+
         # Add IP to blocklist if count exceeds the threshold
         if count.to_i >= CheckConfig.get('login_block_limit', 100, :integer)
           redis.set("block:#{ip}", true)  # No expiration


### PR DESCRIPTION
## Description

When a login attempt is successful, we should not increment the counter for rate limiting.

I changed our rate limiting approach to decrease our unsuccessful login rate counter by one after every successful login attempt.

References: CV2-4866

## How has this been tested?

You can test this locally using this bash script:

```bash                                                                         
#!/bin/bash

# Variables
URL="http://localhost:3000/api/users/sign_in/"
DATA='{ "api_user": { "email": "$EMAIL", "password": "$PASSWORD", "otp_attempt": "" } }'

# Loop to execute the curl command repeatedly
for i in {1..120}
do
  HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
    -H "Content-Type: application/json" \
    --data "$DATA" \
    "$URL")

  echo "Attempt $i: HTTP Response Code $HTTP_RESPONSE"
done
```

1. When using the correct username/password, the user should never be rate limited.
2. When using incorrect credentials, the user will be rate limited (by default after 100 attempts).

In case you hit the rate limit, you can unblock your IP by running this script in the rails console:

```ruby
redis = Redis.new(REDIS_CONFIG)

tracked_keys = redis.keys('track:*')
blocked_keys = redis.keys('block:*')

tracked_keys.each do |key|
  redis.del(key)
end

blocked_keys.each do |key|
  redis.del(key)
end
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

