### PR TITLE
CV2-4754: force relation between media and long caption

### DIFF
--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -296,6 +296,9 @@ module SmoochMessages
           end
         elsif !message['mediaUrl'].blank?
           # Get an item for each media file
+          if !message['text'].blank? && ::Bot::Alegre.get_number_of_words(message['text'].to_s) > CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer)
+            message['caption'] = message['text']
+          end
           message['text'] = [message['text'], message['mediaUrl'].to_s].compact.join("\n#{Bot::Smooch::MESSAGE_BOUNDARY}")
           text << message['text']
           messages << self.adjust_media_type(message)

--- a/test/models/bot/smooch_3_test.rb
+++ b/test/models/bot/smooch_3_test.rb
@@ -77,7 +77,7 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
     # 1). long text( > min_number_of_words_for_tipline_submit_shortcut)
     # 2). short text (< min_number_of_words_for_tipline_submit_shortcut)
     # 3). 2 medias
-    # Result: created three items (on claim and two items of type image)
+    # Result: created three items (one claim and two items of type image)
     Sidekiq::Testing.fake! do
       uid = random_string
       messages = [
@@ -178,6 +178,68 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
       request = TiplineRequest.last
       text = request.smooch_data['text'].split("\n#{Bot::Smooch::MESSAGE_BOUNDARY}")
       assert_equal ['foo', 'bar'], text
+    end
+  end
+
+  test "should force relationship between media and caption text" do
+    long_text = []
+    15.times{ long_text << random_string }
+    caption = long_text.join(' ')
+    # messages contain the following:
+    # 1). media with long text( > min_number_of_words_for_tipline_submit_shortcut)
+    # 2). media with short text (< min_number_of_words_for_tipline_submit_shortcut)
+    # Result: created three items and one relationship (one claim for caption and two items of type image)
+    last_id = ProjectMedia.last.id
+    Sidekiq::Testing.fake! do
+      uid = random_string
+      messages = [
+        {
+          '_id': random_string,
+          authorId: uid,
+          type: 'image',
+          source: { type: "whatsapp" },
+          text: 'first image',
+          mediaUrl: @media_url
+        },
+        {
+          '_id': random_string,
+          authorId: uid,
+          type: 'image',
+          source: { type: "whatsapp" },
+          text: caption,
+          mediaUrl: @media_url_2
+        }
+      ]
+      messages.each do |message|
+        payload = {
+          trigger: 'message:appUser',
+          app: {
+            '_id': @app_id
+          },
+          version: 'v1.1',
+          messages: [message],
+          appUser: {
+            '_id': random_string,
+            'conversationStarted': true
+          }
+        }.to_json
+        Bot::Smooch.run(payload)
+        sleep 1
+      end
+      assert_difference 'ProjectMedia.count', 3 do
+        assert_difference 'UploadedImage.count', 2 do
+          assert_difference 'Claim.count' do
+            assert_difference 'Relationship.count' do
+              Sidekiq::Worker.drain_all
+            end
+          end
+        end
+      end
+      claim_item = ProjectMedia.joins(:media).where('medias.type' => 'Claim').last
+      assert_equal caption, claim_item.media.quote
+      r = Relationship.last
+      assert_equal Relationship.suggested_type, r.relationship_type
+      assert_equal claim_item.id, r.target_id
     end
   end
 


### PR DESCRIPTION
## Description

Create a relationship between media items and long caption.

References: CV2-4754

## How has this been tested?

Implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

