### PR TITLE
CV2-4918: migrate claims without fact-checks

### DIFF
--- a/lib/tasks/migrate/20240725173311_migrate_claims_without_fact_checks.rake
+++ b/lib/tasks/migrate/20240725173311_migrate_claims_without_fact_checks.rake
@@ -3,12 +3,25 @@ namespace :check do
     task migrate_claims_without_fact_checks: :environment do
       started = Time.now.to_i
       last_cd_id = Rails.cache.read('check:migrate:migrate_claims_without_fact_checks:claim_description_id') || 0
-      ClaimDescription.where('claim_descriptions.id > ?', last_cd_id).joins("LEFT JOIN fact_checks fc ON claim_descriptions.id = fc.claim_description_id")
+      ClaimDescription.where('claim_descriptions.id > ?', last_cd_id)
+      .joins("LEFT JOIN fact_checks fc ON claim_descriptions.id = fc.claim_description_id")
       .where('fc.id IS NULL').find_in_batches(batch_size: 2500) do |cds|
         print '.'
         fc_items = []
+        # Get default language for claim description team
+        team_ids = cds.map(&:team_id).uniq
+        team_language = {}
+        Team.where(id: team_ids).find_each{|t| team_language[t.id] = t.default_language }
         cds.each do |cd|
-          fc_items << { claim_description_id: cd.id, user_id: cd.user_id, created_at: cd.created_at, updated_at: cd.updated_at }
+          fc_items << {
+            claim_description_id: cd.id,
+            user_id: cd.user_id,
+            summary: '-',
+            title: '-',
+            language: team_language[cd.team_id],
+            created_at: cd.created_at,
+            updated_at: cd.updated_at
+          }
         end
         FactCheck.insert_all(fc_items)
         max_id = cds.map(&:id).max

--- a/lib/tasks/migrate/20240725173311_migrate_claims_without_fact_checks.rake
+++ b/lib/tasks/migrate/20240725173311_migrate_claims_without_fact_checks.rake
@@ -1,0 +1,21 @@
+namespace :check do
+  namespace :migrate do
+    task migrate_claims_without_fact_checks: :environment do
+      started = Time.now.to_i
+      last_cd_id = Rails.cache.read('check:migrate:migrate_claims_without_fact_checks:claim_description_id') || 0
+      ClaimDescription.where('claim_descriptions.id > ?', last_cd_id).joins("LEFT JOIN fact_checks fc ON claim_descriptions.id = fc.claim_description_id")
+      .where('fc.id IS NULL').find_in_batches(batch_size: 2500) do |cds|
+        print '.'
+        fc_items = []
+        cds.each do |cd|
+          fc_items << { claim_description_id: cd.id, user_id: cd.user_id, created_at: cd.created_at, updated_at: cd.updated_at }
+        end
+        FactCheck.insert_all(fc_items)
+        max_id = cds.map(&:id).max
+        Rails.cache.write('check:migrate:migrate_claims_without_fact_checks:claim_description_id', max_id)
+      end
+      minutes = ((Time.now.to_i - started) / 60).to_i
+      puts "[#{Time.now}] Done in #{minutes} minutes."
+    end
+  end
+end


### PR DESCRIPTION
## Description

Migrate claims without fact-checks.

References: CV2-4918

## How has this been tested?

Run rake task against live DB dump locally.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

