### PR TITLE
4703: Update @meedan people involvement in item history

### DIFF
--- a/app/graph/types/source_type.rb
+++ b/app/graph/types/source_type.rb
@@ -42,6 +42,6 @@ class SourceType < DefaultObject
   private
 
   def super_admin?
-    object.user.is_admin && !object.user.is_member_of?(Team.current)
+    object.user&.is_admin && !object.user&.is_member_of?(Team.current)
   end
 end

--- a/app/graph/types/source_type.rb
+++ b/app/graph/types/source_type.rb
@@ -34,4 +34,14 @@ class SourceType < DefaultObject
 
   field :medias_count, GraphQL::Types::Int, null: true
   field :collaborators, UserType.connection_type, null: true
+
+  def image
+    super_admin? ? "#{CheckConfig.get('checkdesk_base_url')}/images/user.png" : object.image
+  end
+
+  private
+
+  def super_admin?
+    object.user.is_admin && !object.user.is_member_of?(Team.current)
+  end
 end

--- a/app/graph/types/user_type.rb
+++ b/app/graph/types/user_type.rb
@@ -19,7 +19,7 @@ class UserType < DefaultObject
   end
 
   def name
-    object.is_admin ? 'Meedan' : object.name
+    object.is_admin && !object.is_member_of?(Team.current) ? 'Meedan' : object.name
   end
   
   field :accessible_teams, PublicTeamType.connection_type, null: true

--- a/app/graph/types/user_type.rb
+++ b/app/graph/types/user_type.rb
@@ -11,9 +11,9 @@ class UserType < DefaultObject
   field :is_bot, GraphQL::Types::Boolean, null: true
   field :is_active, GraphQL::Types::Boolean, null: true
   field :number_of_teams, GraphQL::Types::Int, null: true
-  
+
   field :source, SourceType, null: true
-  
+
   def source
     Source.find(object.source_id)
   end
@@ -25,7 +25,7 @@ class UserType < DefaultObject
   def profile_image
     super_admin? ? "#{CheckConfig.get('checkdesk_base_url')}/images/user.png" : object.profile_image
   end
-  
+
   field :accessible_teams, PublicTeamType.connection_type, null: true
   def accessible_teams
     User.current.is_admin? ? Team.all : User.current.teams

--- a/app/graph/types/user_type.rb
+++ b/app/graph/types/user_type.rb
@@ -19,7 +19,17 @@ class UserType < DefaultObject
   end
 
   def name
-    object.is_admin && !object.is_member_of?(Team.current) ? 'Meedan' : object.name
+    meedan_user? ? 'Meedan' : object.name
+  end
+
+  def profile_image
+    meedan_user? ? 'http://localhost:3000/images/checklogo.png' : object.profile_image
+  end
+
+  private
+
+  def meedan_user?
+    object.is_admin && !object.is_member_of?(Team.current)
   end
   
   field :accessible_teams, PublicTeamType.connection_type, null: true

--- a/app/graph/types/user_type.rb
+++ b/app/graph/types/user_type.rb
@@ -19,16 +19,16 @@ class UserType < DefaultObject
   end
 
   def name
-    meedan_user? ? 'Meedan' : object.name
+    super_admin? ? CheckConfig.get('super_admin_name') : object.name
   end
 
   def profile_image
-    meedan_user? ? 'http://localhost:3000/images/checklogo.png' : object.profile_image
+    super_admin? ? "#{CheckConfig.get('checkdesk_base_url')}/images/user.png" : object.profile_image
   end
 
   private
 
-  def meedan_user?
+  def super_admin?
     object.is_admin && !object.is_member_of?(Team.current)
   end
   

--- a/app/graph/types/user_type.rb
+++ b/app/graph/types/user_type.rb
@@ -11,13 +11,17 @@ class UserType < DefaultObject
   field :is_bot, GraphQL::Types::Boolean, null: true
   field :is_active, GraphQL::Types::Boolean, null: true
   field :number_of_teams, GraphQL::Types::Int, null: true
-
+  
   field :source, SourceType, null: true
-
+  
   def source
     Source.find(object.source_id)
   end
 
+  def name
+    object.is_admin ? 'Meedan' : object.name
+  end
+  
   field :accessible_teams, PublicTeamType.connection_type, null: true
   def accessible_teams
     User.current.is_admin? ? Team.all : User.current.teams

--- a/app/graph/types/user_type.rb
+++ b/app/graph/types/user_type.rb
@@ -34,6 +34,6 @@ class UserType < DefaultObject
   private
 
   def super_admin?
-    object.is_admin && !object.is_member_of?(Team.current)
+    object&.is_admin && !object&.is_member_of?(Team.current)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -245,7 +245,7 @@ class User < ApplicationRecord
   end
 
   def profile_image
-    self.source.nil? ? nil : self.source.avatar
+    self.source.nil? ? nil : self.source.image
   end
 
   def bot_events

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -11,6 +11,8 @@ development: &default
   elasticsearch_index:
   elasticsearch_log: true
   elasticsearch_sync: false
+  super_admin_name: 'Meedan'
+
   # WARNING For production, don't use a wildcard: set the allowed domains explicitly as a regular expression, e.g.
   # '(https?://.*\.?(meedan.com|meedan.org))'
   allowed_origins: '.*'

--- a/test/controllers/graphql_controller_12_test.rb
+++ b/test/controllers/graphql_controller_12_test.rb
@@ -522,7 +522,7 @@ class GraphqlController12Test < ActionController::TestCase
     assert_equal 'false', pm2.reload.last_status
   end
 
-  test "should return super-admin user name as 'meedan' if user IS NOT a part of the team" do
+  test "should return super-admin user as 'meedan' if user IS NOT a part of the team" do
     u1 = create_user name: 'Mei'
     u2 = create_user name: 'Satsuki', is_admin: true
 
@@ -534,20 +534,22 @@ class GraphqlController12Test < ActionController::TestCase
 
     authenticate_with_user(u1)
 
-    query1 = "query { user (id: #{ u1.id }) { name } }"
+    query1 = "query { user (id: #{ u1.id }) { name, profile_image } }"
     post :create, params: { query: query1 }
     assert_response :success
     assert_equal false, u1.is_admin?
     assert_equal 'Mei', JSON.parse(@response.body)['data']['user']['name']
+    assert_equal 'http://localhost:3000/images/user.png', JSON.parse(@response.body)['data']['user']['profile_image']
 
-    query2 = "query { user (id: #{ u2.id }) { name } }"
+    query2 = "query { user (id: #{ u2.id }) { name, profile_image } }"
     post :create, params: { query: query2 }
     assert_response :success
     assert_equal true, u2.is_admin?
     assert_equal 'Meedan', JSON.parse(@response.body)['data']['user']['name']
+    assert_equal 'http://localhost:3000/images/checklogo.png', JSON.parse(@response.body)['data']['user']['profile_image']
   end
 
-  test "should return super-admin user name as their name if user IS a part of the team" do
+  test "should return super-admin user themself if user IS a part of the team" do
     u1 = create_user name: 'Mei'
     u2 = create_user name: 'Satsuki', is_admin: true
 
@@ -558,16 +560,18 @@ class GraphqlController12Test < ActionController::TestCase
 
     authenticate_with_user(u1)
 
-    query1 = "query { user (id: #{ u1.id }) { name } }"
+    query1 = "query { user (id: #{ u1.id }) { name, profile_image } }"
     post :create, params: { query: query1 }
     assert_response :success
     assert_equal false, u1.is_admin?
     assert_equal 'Mei', JSON.parse(@response.body)['data']['user']['name']
+    assert_equal 'http://localhost:3000/images/user.png', JSON.parse(@response.body)['data']['user']['profile_image']
 
-    query2 = "query { user (id: #{ u2.id }) { name } }"
+    query2 = "query { user (id: #{ u2.id }) { name, profile_image } }"
     post :create, params: { query: query2 }
     assert_response :success
     assert_equal true, u2.is_admin?
     assert_equal 'Satsuki', JSON.parse(@response.body)['data']['user']['name']
+    assert_equal 'http://localhost:3000/images/user.png', JSON.parse(@response.body)['data']['user']['profile_image']
   end
 end

--- a/test/controllers/graphql_controller_12_test.rb
+++ b/test/controllers/graphql_controller_12_test.rb
@@ -521,4 +521,28 @@ class GraphqlController12Test < ActionController::TestCase
     assert_equal 'false', pm1.reload.last_status
     assert_equal 'false', pm2.reload.last_status
   end
+
+  test "should return super-admin user as 'meedan'" do
+    u1 = create_user name: 'Mei'
+    u2 = create_user name: 'Satsuki', is_admin: true
+
+    t = create_team
+
+    tu1 = create_team_user user: u1, team: t
+    tu2 = create_team_user user: u2, team: t
+
+    authenticate_with_user(u1)
+
+    query1 = "query { user (id: #{ u1.id }) { name } }"
+    post :create, params: { query: query1 }
+    assert_response :success
+    assert_equal false, u1.is_admin?
+    assert_equal 'Mei', JSON.parse(@response.body)['data']['user']['name']
+
+    query2 = "query { user (id: #{ u2.id }) { name } }"
+    post :create, params: { query: query2 }
+    assert_response :success
+    assert_equal true, u2.is_admin?
+    assert_equal 'Meedan', JSON.parse(@response.body)['data']['user']['name']
+  end
 end


### PR DESCRIPTION
## Description

##### Context
To provide a better “single voice” CS experience we need to limit the visibility of specific Meedan teammates in Item histories for workspaces. As teammates come and go, and different people need to step in and provide support the individual who performed an action in a workspace from the Meedan side is irrelevant to the partner.

#### What
- If a user is a `super admin` and not a member of the workspace
	- show their `name` and `profile_picture` as Meedan
- If a user is a s`super admin` and a member of the workspace
	- show their `name` and `profile_picture` as their own

#### How
In the graphql layer, in the `user_type`, I added methods  `name` and `profile_picture` that check whether a user is `super_admin` and a member of the workspace and send both accordingly.


References: 4703

## How has this been tested?

I added two tests:
1. `rails test test/controllers/graphql_controller_12_test.rb:525` ("should return super-admin user as 'meedan' if user IS NOT a part of the team")
2. `rails test test/controllers/graphql_controller_12_test.rb:552` ("should return super-admin user themself if user IS a part of the team")

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

