### PR TITLE
5010 – Fix tag with trailing space error

### DIFF
--- a/app/models/annotations/tag.rb
+++ b/app/models/annotations/tag.rb
@@ -89,7 +89,7 @@ class Tag < ApplicationRecord
   def get_tag_text_reference
     if self.tag.is_a?(String)
       team_id = self.team&.id
-      tag_text = TagText.where(text: (self.tag).strip, team_id: team_id).last
+      tag_text = TagText.where(text: self.tag.strip, team_id: team_id).last
       if tag_text.nil? && team_id.present?
         tag_text = TagText.new
         tag_text.text = self.tag

--- a/app/models/annotations/tag.rb
+++ b/app/models/annotations/tag.rb
@@ -89,7 +89,7 @@ class Tag < ApplicationRecord
   def get_tag_text_reference
     if self.tag.is_a?(String)
       team_id = self.team&.id
-      tag_text = TagText.where(text: self.tag, team_id: team_id).last
+      tag_text = TagText.where(text: (self.tag).strip, team_id: team_id).last
       if tag_text.nil? && team_id.present?
         tag_text = TagText.new
         tag_text.text = self.tag

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -271,4 +271,17 @@ class TagTest < ActiveSupport::TestCase
     tt2.delete
     TagText.update_tags(tt1.id, t.id, tt2.id)
   end
+
+  test "should treat ' tag' and 'tag' as the same tag, and not try to create a new tag" do
+    t = create_team
+    p = create_project team: t
+    pm1 = create_project_media project: p
+    pm2 = create_project_media project: p
+
+    create_tag tag: 'foo', annotated: pm1
+
+    assert_nothing_raised do
+      create_tag tag: ' foo', annotated: pm2
+    end
+  end
 end


### PR DESCRIPTION
## Description

When trying to create an imported fact-check that had a tag with a trailing space it would fail (`text has already been taken`).

We have a normalization step but that runs `before_validation` on `TagText`.
So when we are checking if the tag exists in line 92 from `tag.rb`, the tag has not been normalized. This means:

- We look for 'tag', it is not there. We create it.
- We look for ' tag', it is not there. We try to create it, it gets normalized, so it becomes 'tag'. Then we fail to create it,
because it already exists.

Adding the strip when comparing tags fixes this, but I'm not sure if it is the best solution.

References: 5010

## How has this been tested?

- I added one big test that replicated the issue we saw: `rails test test/controllers/graphql_controller_12_test.rb:613`
- And added one model test: `rails test test/models/tag_test.rb:275`

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

