### PR TITLE
Return the previous project media for claim description

### DIFF
--- a/app/graph/types/claim_description_type.rb
+++ b/app/graph/types/claim_description_type.rb
@@ -8,6 +8,7 @@ class ClaimDescriptionType < DefaultObject
   field :context, GraphQL::Types::String, null: true, resolver_method: :claim_context
   field :user, UserType, null: true
   field :project_media, ProjectMediaType, null: true
+  field :project_media_was, ProjectMediaType, null: true
   field :fact_check, FactCheckType, null: true do
     argument :report_status, GraphQL::Types::String, required: false, camelize: false
   end

--- a/app/models/claim_description.rb
+++ b/app/models/claim_description.rb
@@ -38,6 +38,10 @@ class ClaimDescription < ApplicationRecord
     self.index_in_elasticsearch(data)
   end
 
+  def project_media_was
+    ProjectMedia.find_by_id(self.project_media_id_before_last_save)
+  end
+
   private
 
   def set_team

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -728,6 +728,7 @@ type ClaimDescription implements Node {
   id: ID!
   permissions: String
   project_media: ProjectMedia
+  project_media_was: ProjectMedia
   updated_at: String
   user: User
 }

--- a/public/relay.json
+++ b/public/relay.json
@@ -3697,6 +3697,20 @@
               "deprecationReason": null
             },
             {
+              "name": "project_media_was",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "ProjectMedia",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "updated_at",
               "description": null,
               "args": [

--- a/test/models/claim_description_test.rb
+++ b/test/models/claim_description_test.rb
@@ -165,4 +165,12 @@ class ClaimDescriptionTest < ActiveSupport::TestCase
     assert_equal 'paused', fc.reload.report_status
     assert_equal 'paused', pm.report_status(true)
   end
+
+  test "should get information from removed item" do
+    pm = create_project_media
+    cd = create_claim_description project_media: pm
+    cd.project_media = nil
+    cd.save!
+    assert_equal pm, cd.project_media_was
+  end
 end


### PR DESCRIPTION
## Description

Use case: we may need to update the project media information in the Relay store when it's removed from a claim.

Reference: CV2-5000.

## How has this been tested?

I added an automated test.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

