### PR TITLE
Adding a `team_users_count` field to GraphQL `MeType`.

### DIFF
--- a/app/graph/types/me_type.rb
+++ b/app/graph/types/me_type.rb
@@ -125,6 +125,14 @@ class MeType < DefaultObject
     team_users
   end
 
+  field :team_users_count, GraphQL::Types::Int, null: true do
+    argument :status, GraphQL::Types::String, required: false
+  end
+
+  def team_users_count(status: nil)
+    team_users(status: status).count
+  end
+
   field :annotations, AnnotationType.connection_type, null: true do
     argument :type, GraphQL::Types::String, required: false
   end

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -9017,6 +9017,7 @@ type Me implements Node {
     last: Int
     status: String
   ): TeamUserConnection
+  team_users_count(status: String): Int
   teams(
     """
     Returns the elements in the list that come after the specified cursor.

--- a/public/relay.json
+++ b/public/relay.json
@@ -49181,6 +49181,31 @@
               "deprecationReason": null
             },
             {
+              "name": "team_users_count",
+              "description": null,
+              "args": [
+                {
+                  "name": "status",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "teams",
               "description": null,
               "args": [

--- a/test/controllers/graphql_controller_10_test.rb
+++ b/test/controllers/graphql_controller_10_test.rb
@@ -87,7 +87,7 @@ class GraphqlController10Test < ActionController::TestCase
     assert_equal 3, data.size
     assert_equal [u.id, u2.id, u3.id], ids.sort
     # Quey bot
-    query = "query { me { dbid, get_send_email_notifications, get_send_successful_login_notifications, get_send_failed_login_notifications, source { medias(first: 1) { edges { node { id } } } }, annotations(first: 1) { edges { node { id } } }, team_users(first: 1) { edges { node { id } } }, bot { get_description, get_role, get_version, get_source_code_url } } }"
+    query = "query { me { dbid, get_send_email_notifications, get_send_successful_login_notifications, get_send_failed_login_notifications, source { medias(first: 1) { edges { node { id } } } }, annotations(first: 1) { edges { node { id } } }, team_users_count, team_users(first: 1) { edges { node { id } } }, bot { get_description, get_role, get_version, get_source_code_url } } }"
     post :create, params: { query: query }
     assert_response :success
   end


### PR DESCRIPTION
## Description

This new field is not cached, like `number_of_teams`, and can take a `status` argument, this way, it's consistent to be used along with the field `team_users`.

Fixes CV2-4938.

## How has this been tested?

Updated a unit test to cover this case.

## Things to pay attention to during code review

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)