### PR TITLE
Reverting migration until empty clusterization center issue is actually resolved

### DIFF
--- a/db/migrate/20240813155311_allow_empty_project_media_id_for_clusters.rb
+++ b/db/migrate/20240813155311_allow_empty_project_media_id_for_clusters.rb
@@ -1,0 +1,5 @@
+class AllowEmptyProjectMediaIdForClusters < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null(:clusters, :project_media_id, true)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_07_19_183518) do
+ActiveRecord::Schema.define(version: 2024_08_13_155311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -235,7 +235,7 @@ ActiveRecord::Schema.define(version: 2024_07_19_183518) do
   end
 
   create_table "clusters", force: :cascade do |t|
-    t.integer "project_media_id", null: false
+    t.integer "project_media_id"
     t.datetime "first_item_at"
     t.datetime "last_item_at"
     t.datetime "created_at", null: false


### PR DESCRIPTION
## Description

Reverting migration until empty clusterization center issue is actually resolved.

Reference: CV2-4869.

## How has this been tested?

This should be tested by running the clusterization rake task successfully on QA.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

