### PR TITLE
Moving `accessible_teams` from `UserType` to `MeType`.

### DIFF
--- a/app/graph/types/me_type.rb
+++ b/app/graph/types/me_type.rb
@@ -133,6 +133,20 @@ class MeType < DefaultObject
     team_users(status: status).count
   end
 
+  field :accessible_teams, TeamType.connection_type, null: true
+
+  def accessible_teams
+    return Team.none unless object == User.current
+    teams = User.current.is_admin? ? Team.all : User.current.teams.where('team_users.status' => 'member')
+    teams.order('name ASC')
+  end
+
+  field :accessible_teams_count, GraphQL::Types::Int, null: true
+
+  def accessible_teams_count
+    accessible_teams.count
+  end
+
   field :annotations, AnnotationType.connection_type, null: true do
     argument :type, GraphQL::Types::String, required: false
   end

--- a/app/graph/types/user_type.rb
+++ b/app/graph/types/user_type.rb
@@ -26,11 +26,6 @@ class UserType < DefaultObject
     super_admin? ? "#{CheckConfig.get('checkdesk_base_url')}/images/user.png" : object.profile_image
   end
 
-  field :accessible_teams, PublicTeamType.connection_type, null: true
-  def accessible_teams
-    User.current.is_admin? ? Team.all : User.current.teams
-  end
-
   private
 
   def super_admin?

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -255,7 +255,7 @@ module ProjectMediaCreators
         claim_description: cd,
         report_status: (fact_check['publish_report'] ? 'published' : 'unpublished'),
         rating: self.set_status,
-        tags: self.set_tags,
+        tags: self.set_tags.to_a.map(&:strip),
         skip_check_ability: true
       })
     end
@@ -263,6 +263,6 @@ module ProjectMediaCreators
   end
 
   def create_tags
-    self.set_tags.each { |tag| Tag.create!(annotated: self, tag: tag, skip_check_ability: true) } if self.set_tags.is_a?(Array)
+    self.set_tags.each { |tag| Tag.create!(annotated: self, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
   end
 end

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -8899,6 +8899,28 @@ Me type
 """
 type Me implements Node {
   accepted_terms: Boolean
+  accessible_teams(
+    """
+    Returns the elements in the list that come after the specified cursor.
+    """
+    after: String
+
+    """
+    Returns the elements in the list that come before the specified cursor.
+    """
+    before: String
+
+    """
+    Returns the first _n_ elements from the list.
+    """
+    first: Int
+
+    """
+    Returns the last _n_ elements from the list.
+    """
+    last: Int
+  ): TeamConnection
+  accessible_teams_count: Int
   annotations(
     """
     Returns the elements in the list that come after the specified cursor.
@@ -16258,27 +16280,6 @@ type UpdateUserPayload {
 User type
 """
 type User implements Node {
-  accessible_teams(
-    """
-    Returns the elements in the list that come after the specified cursor.
-    """
-    after: String
-
-    """
-    Returns the elements in the list that come before the specified cursor.
-    """
-    before: String
-
-    """
-    Returns the first _n_ elements from the list.
-    """
-    first: Int
-
-    """
-    Returns the last _n_ elements from the list.
-    """
-    last: Int
-  ): PublicTeamConnection
   created_at: String
   dbid: Int
   email: String

--- a/public/relay.json
+++ b/public/relay.json
@@ -48440,6 +48440,81 @@
               "deprecationReason": null
             },
             {
+              "name": "accessible_teams",
+              "description": null,
+              "args": [
+                {
+                  "name": "after",
+                  "description": "Returns the elements in the list that come after the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "before",
+                  "description": "Returns the elements in the list that come before the specified cursor.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "first",
+                  "description": "Returns the first _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "last",
+                  "description": "Returns the last _n_ elements from the list.",
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "OBJECT",
+                "name": "TeamConnection",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "accessible_teams_count",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "annotations",
               "description": null,
               "args": [
@@ -89789,67 +89864,6 @@
           "name": "User",
           "description": "User type",
           "fields": [
-            {
-              "name": "accessible_teams",
-              "description": null,
-              "args": [
-                {
-                  "name": "after",
-                  "description": "Returns the elements in the list that come after the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "before",
-                  "description": "Returns the elements in the list that come before the specified cursor.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "first",
-                  "description": "Returns the first _n_ elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                },
-                {
-                  "name": "last",
-                  "description": "Returns the last _n_ elements from the list.",
-                  "type": {
-                    "kind": "SCALAR",
-                    "name": "Int",
-                    "ofType": null
-                  },
-                  "defaultValue": null,
-                  "isDeprecated": false,
-                  "deprecationReason": null
-                }
-              ],
-              "type": {
-                "kind": "OBJECT",
-                "name": "PublicTeamConnection",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
             {
               "name": "created_at",
               "description": null,

--- a/test/controllers/graphql_controller_12_test.rb
+++ b/test/controllers/graphql_controller_12_test.rb
@@ -611,6 +611,7 @@ class GraphqlController12Test < ActionController::TestCase
   end
 
   test "should treat ' tag' and 'tag' as the same tag, and not try to create a new tag" do
+    Sidekiq::Testing.inline!
     t = create_team
     a = ApiKey.create!
     b = create_bot_user api_key_id: a.id
@@ -622,7 +623,7 @@ class GraphqlController12Test < ActionController::TestCase
               createProjectMedia(input: {
                 project_id: ' + p.id.to_s + ',
                 media_type: "Blank",
-                channel: {main: 1},
+                channel: { main: 1 },
                 set_tags: ["science"],
                 set_status: "verified",
                 set_claim_description: "Claim #1.",
@@ -647,13 +648,14 @@ class GraphqlController12Test < ActionController::TestCase
     post :create, params: { query: query1, team: t.slug }
     assert_response :success
     assert_equal 'science', JSON.parse(@response.body)['data']['createProjectMedia']['project_media']['tags']['edges'][0]['node']['tag_text']
+    sleep 1
 
     query2 = ' mutation create {
       createProjectMedia(input: {
         project_id: ' + p.id.to_s + ',
         media_type: "Blank",
-        channel: {main: 1},
-        set_tags: [" science"],
+        channel: { main: 1 },
+        set_tags: ["science "],
         set_status: "verified",
         set_claim_description: "Claim #2.",
         set_fact_check: {


### PR DESCRIPTION
## Description

This information is only needed for the current user, so, it should be under `MeType`, not `UserType`.

References: CV2-4938 and CV2-4704.

## How has this been tested?

Automated tests were updated to reflect this change.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

