### PR TITLE
CV2-5087 move Articles side effecting saves to to it via presto

### DIFF
--- a/app/models/explainer.rb
+++ b/app/models/explainer.rb
@@ -69,7 +69,7 @@ class Explainer < ApplicationRecord
       text: explainer.title,
       models: ALEGRE_MODELS_AND_THRESHOLDS.keys,
     }
-    Bot::Alegre.get_async_raw_params(params, "text")
+    Bot::Alegre.get_sync_raw_params(params, "text")
 
     # Index paragraphs
     count = 0
@@ -82,7 +82,7 @@ class Explainer < ApplicationRecord
         text: paragraph.strip,
         models: ALEGRE_MODELS_AND_THRESHOLDS.keys,
       }
-      Bot::Alegre.get_async_raw_params(params, "text")
+      Bot::Alegre.get_sync_raw_params(params, "text")
     end
 
     # Remove paragraphs that don't exist anymore (we delete after updating in order to avoid race conditions)

--- a/app/models/explainer.rb
+++ b/app/models/explainer.rb
@@ -108,7 +108,7 @@ class Explainer < ApplicationRecord
         language: language
       }
     }
-    Bot::Alegre.get_async_raw_params(params, "text")
+    response = Bot::Alegre.get_sync_raw_params(params, "text")
     results = response['result'].to_a.sort_by{ |result| result['_score'] }
     explainer_ids = results.collect{ |result| result.dig('_source', 'context', 'explainer_id').to_i }.uniq.first(3)
     explainer_ids.empty? ? Explainer.none : Explainer.where(team_id: team_id, id: explainer_ids)

--- a/app/models/explainer.rb
+++ b/app/models/explainer.rb
@@ -93,7 +93,7 @@ class Explainer < ApplicationRecord
         quiet: true,
         context: base_context.merge({ paragraph: count })
       }
-      Bot::Alegre.request_delete_from_raw(params, type)
+      Bot::Alegre.request_delete_from_raw(params, "text")
     end
   end
 

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -139,6 +139,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
 
   test "should submit query without details on tipline bot v2" do
     WebMock.stub_request(:post, /\/text\/similarity\/search\//).to_return(body: {}.to_json) # For explainers
+    WebMock.stub_request(:post, /\/similarity\/async\/text/).to_return(body: {}.to_json) # For explainers
     claim = 'This is a test claim'
     send_message 'hello', '1', '1', random_string, random_string, claim, random_string, random_string, '1'
     assert_saved_query_type 'default_requests'
@@ -208,6 +209,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
   end
 
   test "should submit query with details on tipline bot v2" do
+    WebMock.stub_request(:post, /\/similarity\/async\/text/).to_return(body: {}.to_json) # For explainers
     WebMock.stub_request(:post, /\/text\/similarity\/search\//).to_return(body: {}.to_json) # For explainers
     claim = 'This is a test claim'
     send_message 'hello', '1', '1', random_string, '2', random_string, claim, '1'
@@ -285,7 +287,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
   end
 
   test "should submit query and handle search error on tipline bot v2" do
-    WebMock.stub_request(:post, /\/text\/similarity\/search\//).to_return(body: {}.to_json) # For explainers
+    WebMock.stub_request(:post, /\/similarity\/async\/text/).to_return(body: {}.to_json) # For explainers
     CheckSearch.any_instance.stubs(:medias).raises(StandardError)
     Sidekiq::Testing.inline! do
       send_message 'hello', '1', '1', 'Foo bar', '1'
@@ -384,7 +386,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     ProjectMedia.any_instance.stubs(:report_status).returns('published')
     ProjectMedia.any_instance.stubs(:analysis_published_article_url).returns(random_url)
     Bot::Alegre.stubs(:get_merged_similar_items).returns({ create_project_media.id => { score: 0.9 } })
-    WebMock.stub_request(:post, /\/text\/similarity\/search\//).to_return(body: {}.to_json) # For explainers
+    WebMock.stub_request(:post, /\/similarity\/async\/text/).to_return(body: {}.to_json) # For explainers
     Sidekiq::Testing.inline! do
       send_message 'hello', '1', '1', "Foo bar foo bar #{url} foo bar", '1'
     end
@@ -693,7 +695,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     pm = create_project_media team: @team
     publish_report(pm, {}, nil, { language: 'pt', use_visual_card: false })
     Bot::Smooch.stubs(:get_search_results).returns([pm])
-    WebMock.stub_request(:post, /\/text\/similarity\/search\//).to_return(body: {}.to_json) # For explainers
+    WebMock.stub_request(:post, /\/similarity\/async\/text/).to_return(body: {}.to_json) # For explainers
     Sidekiq::Testing.inline! do
       send_message 'hello', '1', '1', 'Foo bar', '1'
     end

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -139,7 +139,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
 
   test "should submit query without details on tipline bot v2" do
     WebMock.stub_request(:post, /\/text\/similarity\/search\//).to_return(body: {}.to_json) # For explainers
-    WebMock.stub_request(:post, /\/similarity\/async\/text/).to_return(body: {}.to_json) # For explainers
+    WebMock.stub_request(:post, /\/similarity\/sync\/text/).to_return(body: {}.to_json) # For explainers
     claim = 'This is a test claim'
     send_message 'hello', '1', '1', random_string, random_string, claim, random_string, random_string, '1'
     assert_saved_query_type 'default_requests'
@@ -209,7 +209,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
   end
 
   test "should submit query with details on tipline bot v2" do
-    WebMock.stub_request(:post, /\/similarity\/async\/text/).to_return(body: {}.to_json) # For explainers
+    WebMock.stub_request(:post, /\/similarity\/sync\/text/).to_return(body: {}.to_json) # For explainers
     WebMock.stub_request(:post, /\/text\/similarity\/search\//).to_return(body: {}.to_json) # For explainers
     claim = 'This is a test claim'
     send_message 'hello', '1', '1', random_string, '2', random_string, claim, '1'
@@ -287,7 +287,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
   end
 
   test "should submit query and handle search error on tipline bot v2" do
-    WebMock.stub_request(:post, /\/similarity\/async\/text/).to_return(body: {}.to_json) # For explainers
+    WebMock.stub_request(:post, /\/similarity\/sync\/text/).to_return(body: {}.to_json) # For explainers
     CheckSearch.any_instance.stubs(:medias).raises(StandardError)
     Sidekiq::Testing.inline! do
       send_message 'hello', '1', '1', 'Foo bar', '1'
@@ -386,7 +386,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     ProjectMedia.any_instance.stubs(:report_status).returns('published')
     ProjectMedia.any_instance.stubs(:analysis_published_article_url).returns(random_url)
     Bot::Alegre.stubs(:get_merged_similar_items).returns({ create_project_media.id => { score: 0.9 } })
-    WebMock.stub_request(:post, /\/similarity\/async\/text/).to_return(body: {}.to_json) # For explainers
+    WebMock.stub_request(:post, /\/similarity\/sync\/text/).to_return(body: {}.to_json) # For explainers
     Sidekiq::Testing.inline! do
       send_message 'hello', '1', '1', "Foo bar foo bar #{url} foo bar", '1'
     end
@@ -695,7 +695,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     pm = create_project_media team: @team
     publish_report(pm, {}, nil, { language: 'pt', use_visual_card: false })
     Bot::Smooch.stubs(:get_search_results).returns([pm])
-    WebMock.stub_request(:post, /\/similarity\/async\/text/).to_return(body: {}.to_json) # For explainers
+    WebMock.stub_request(:post, /\/similarity\/sync\/text/).to_return(body: {}.to_json) # For explainers
     Sidekiq::Testing.inline! do
       send_message 'hello', '1', '1', 'Foo bar', '1'
     end

--- a/test/models/explainer_test.rb
+++ b/test/models/explainer_test.rb
@@ -100,12 +100,12 @@ class ExplainerTest < ActiveSupport::TestCase
 
     # Index two paragraphs and title when the explainer is created
     Bot::Alegre.stubs(:request).with('post', '/similarity/async/text', anything).times(3)
-    Bot::Alegre.stubs(:request).with('delete', '/similarity/async/text', anything).never
+    Bot::Alegre.stubs(:request).with('delete', '/text/similarity/', anything).never
     ex = create_explainer description: description
 
     # Update the index when paragraphs change
     Bot::Alegre.stubs(:request).with('post', '/similarity/async/text', anything).times(2)
-    Bot::Alegre.stubs(:request).with('delete', '/similarity/async/text', anything).once
+    Bot::Alegre.stubs(:request).with('delete', '/text/similarity/', anything).once
     ex = Explainer.find(ex.id)
     ex.description = 'Now this is the only paragraph'
     ex.save!

--- a/test/models/explainer_test.rb
+++ b/test/models/explainer_test.rb
@@ -90,7 +90,7 @@ class ExplainerTest < ActiveSupport::TestCase
     end
   end
 
-  test "should index explainer information" do
+  test "should index explainer information zzz" do
     Sidekiq::Testing.inline!
     description = %{
       The is the first paragraph.
@@ -99,12 +99,12 @@ class ExplainerTest < ActiveSupport::TestCase
     }
 
     # Index two paragraphs and title when the explainer is created
-    Bot::Alegre.stubs(:request).with('post', '/similarity/async/text', anything).times(3)
+    Bot::Alegre.stubs(:request).with('post', '/similarity/sync/text', anything).times(3)
     Bot::Alegre.stubs(:request).with('delete', '/text/similarity/', anything).never
     ex = create_explainer description: description
 
     # Update the index when paragraphs change
-    Bot::Alegre.stubs(:request).with('post', '/similarity/async/text', anything).times(2)
+    Bot::Alegre.stubs(:request).with('post', '/similarity/sync/text', anything).times(2)
     Bot::Alegre.stubs(:request).with('delete', '/text/similarity/', anything).once
     ex = Explainer.find(ex.id)
     ex.description = 'Now this is the only paragraph'

--- a/test/models/explainer_test.rb
+++ b/test/models/explainer_test.rb
@@ -90,7 +90,7 @@ class ExplainerTest < ActiveSupport::TestCase
     end
   end
 
-  test "should index explainer information zzz" do
+  test "should index explainer information" do
     Sidekiq::Testing.inline!
     description = %{
       The is the first paragraph.

--- a/test/models/explainer_test.rb
+++ b/test/models/explainer_test.rb
@@ -99,13 +99,13 @@ class ExplainerTest < ActiveSupport::TestCase
     }
 
     # Index two paragraphs and title when the explainer is created
-    Bot::Alegre.stubs(:request).with('post', '/text/similarity/', anything).times(3)
-    Bot::Alegre.stubs(:request).with('delete', '/text/similarity/', anything).never
+    Bot::Alegre.stubs(:request).with('post', '/similarity/async/text', anything).times(3)
+    Bot::Alegre.stubs(:request).with('delete', '/similarity/async/text', anything).never
     ex = create_explainer description: description
 
     # Update the index when paragraphs change
-    Bot::Alegre.stubs(:request).with('post', '/text/similarity/', anything).times(2)
-    Bot::Alegre.stubs(:request).with('delete', '/text/similarity/', anything).once
+    Bot::Alegre.stubs(:request).with('post', '/similarity/async/text', anything).times(2)
+    Bot::Alegre.stubs(:request).with('delete', '/similarity/async/text', anything).once
     ex = Explainer.find(ex.id)
     ex.description = 'Now this is the only paragraph'
     ex.save!


### PR DESCRIPTION
## Description

Moves article processing to presto vectorization instead of entirely in alegre

References: CV2-5087

## How has this been tested?

Not yet tested - changing code first to determine effect of changes then work through necessary changes from there - testing will need to just ensure that articles do in fact get indexed if you send these commands to alegre from check-api

## Things to pay attention to during code review

None in particular!

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

