### PR TITLE
Delete `ExplainerItem` when `ProjectMedia` is destroyed.

### DIFF
--- a/app/models/concerns/project_media_associations.rb
+++ b/app/models/concerns/project_media_associations.rb
@@ -21,7 +21,7 @@ module ProjectMediaAssociations
     has_one :claim_description, dependent: :destroy
     belongs_to :source, optional: true
     has_many :tipline_requests, as: :associated
-    has_many :explainer_items
+    has_many :explainer_items, dependent: :destroy
     has_many :explainers, through: :explainer_items
     has_annotations
   end

--- a/test/models/explainer_test.rb
+++ b/test/models/explainer_test.rb
@@ -110,4 +110,14 @@ class ExplainerTest < ActiveSupport::TestCase
     ex.description = 'Now this is the only paragraph'
     ex.save!
   end
+
+  test "should destroy explainer items when project media is destroyed" do
+    t = create_team
+    ex = create_explainer team: t
+    pm = create_project_media team: t
+    pm.explainers << ex
+    assert_difference 'ExplainerItem.count', -1 do
+      pm.destroy!
+    end
+  end
 end


### PR DESCRIPTION
## Description

Fixes an issue reported by Sentry.

Fixes: CV2-5099.

## How has this been tested?

TDD.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

