### PR TITLE
CV2-5051: disable version for FactCheck when update report

### DIFF
--- a/config/initializers/report_designer.rb
+++ b/config/initializers/report_designer.rb
@@ -50,9 +50,11 @@ Dynamic.class_eval do
       if fc.nil?
         FactCheck.create({ claim_description: pm.claim_description }.merge(fields))
       else
-        fields.each { |field, value| fc.send("#{field}=", value) }
-        fc.skip_check_ability = true
-        fc.save!
+        PaperTrail.request(enabled: false) do
+          fields.each { |field, value| fc.send("#{field}=", value) }
+          fc.skip_check_ability = true
+          fc.save!
+        end
       end
     end
 
@@ -66,16 +68,18 @@ Dynamic.class_eval do
       # Update report fields
       fc = pm&.claim_description&.fact_check
       unless fc.nil?
-        state = self.data['state']
-        fields = {
-          skip_report_update: true,
-          publisher_id: nil,
-          report_status: state,
-          rating: pm.status
-        }
-        fields.each { |field, value| fc.send("#{field}=", value) }
-        fc.skip_check_ability = true
-        fc.save!
+        PaperTrail.request(enabled: false) do
+          state = self.data['state']
+          fields = {
+            skip_report_update: true,
+            publisher_id: nil,
+            report_status: state,
+            rating: pm.status
+          }
+          fields.each { |field, value| fc.send("#{field}=", value) }
+          fc.skip_check_ability = true
+          fc.save!
+        end
       end
     end
   end


### PR DESCRIPTION
## Description

Update report should reflect on FactCheck so I disabled the version for FactCheck to keep history for report change only.

References: CV2-5051

## How has this been tested?

Re-run implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

