### PR TITLE
Adjust Smooch Bot provider when tipline is running both CAPI and Smooch.

### DIFF
--- a/app/models/concerns/smooch_resend.rb
+++ b/app/models/concerns/smooch_resend.rb
@@ -159,6 +159,7 @@ module SmoochResend
     def resend_facebook_messenger_message_after_window(message, original)
       original = JSON.parse(original) unless original.blank?
       uid = message['appUser']['_id']
+      RequestStore.store[:smooch_bot_provider] = 'ZENDESK'
 
       return self.resend_facebook_messenger_report_after_window(message, original) if original&.dig('fallback_template') =~ /report/
 
@@ -184,6 +185,7 @@ module SmoochResend
     end
 
     def resend_facebook_messenger_report_after_window(message, original)
+      RequestStore.store[:smooch_bot_provider] = 'ZENDESK'
       pm = ProjectMedia.where(id: original['project_media_id']).last
       report = self.get_report_data_to_be_resent(message, original)
       unless report.nil?

--- a/app/workers/tipline_newsletter_worker.rb
+++ b/app/workers/tipline_newsletter_worker.rb
@@ -39,6 +39,7 @@ class TiplineNewsletterWorker
       begin
         RequestStore.store[:smooch_bot_platform] = ts.platform
         Bot::Smooch.get_installation('team_bot_installation_id', tbi.id) { |i| i.id == tbi.id }
+        RequestStore.store[:smooch_bot_provider] = 'ZENDESK' if ts.platform != 'WhatsApp' # Adjustment for tiplines running CAPI and Smooch at the same time
 
         response = (ts.platform == 'WhatsApp' ? Bot::Smooch.send_message_to_user(ts.uid, newsletter.format_as_template_message, {}, false, true, 'newsletter') : Bot::Smooch.send_message_to_user(ts.uid, *newsletter.format_as_tipline_message))
 


### PR DESCRIPTION
Fixes CV2-5127.

## Description

When a tipline is running both CAPI and Smooch, the `get_installation` method will set the provider to `CAPI`. When sending a newsletter, it's necessary to adjust the provider to `ZENDESK` for people who subscribed to the Smooch newsletter, not the CAPI newsletter.

## How has this been tested?

Existing tests should cover this.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)