### PR TITLE
5120 – Create Tags in the background

### DIFF
--- a/app/lib/generic_worker_helpers.rb
+++ b/app/lib/generic_worker_helpers.rb
@@ -1,0 +1,9 @@
+module GenericWorkerHelpers
+  def run_later(klass_method, *method_args)
+    GenericWorker.perform_async(self.to_s, klass_method, *method_args)
+  end
+
+  def run_later_in(time, klass_method, *method_args)
+    GenericWorker.perform_in(time, self.to_s, klass_method, *method_args)
+  end
+end

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -264,7 +264,9 @@ module ProjectMediaCreators
 
   def create_tags_in_background
     if self.set_tags.is_a?(Array)
-      ProjectMedia.run_later_in(1.second, 'create_tags', project_media_id: self.id, tags_json: self.set_tags.to_json, user_id: self.user_id)
+      project_media_id = self.id
+      tags_json = self.set_tags.to_json
+      ProjectMedia.run_later_in(1.second, 'create_tags', project_media_id, tags_json, user_id: self.user_id)
     end
   end
 end

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -264,7 +264,7 @@ module ProjectMediaCreators
 
   def create_tags_in_background
     if self.set_tags.is_a?(Array)
-        GenericWorker.perform_in(1.second, 'ProjectMedia', 'create_tags', project_media_id: self.id, tags_json: self.set_tags.to_json, user_id: self.user_id)
+      ProjectMedia.run_later_in(1.second, 'create_tags', project_media_id: self.id, tags_json: self.set_tags.to_json, user_id: self.user_id)
     end
   end
 end

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -263,6 +263,7 @@ module ProjectMediaCreators
   end
 
   def create_tags
-    self.set_tags.each { |tag| Tag.create!(annotated: self, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
+    # self.set_tags.each { |tag| Tag.create!(annotated: self, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
+    self.set_tags.each { |tag| GenericWorker.perform_in(1.second, 'tag', 'create!', annotated: self, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
   end
 end

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -263,9 +263,6 @@ module ProjectMediaCreators
   end
 
   def create_tags
-    # self.set_tags.each { |tag| Tag.create!(annotated: self, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
-    # require 'byebug'
-    # byebug
-    self.set_tags.each { |tag| GenericWorker.perform_in(1.second, 'Tag', 'create!', annotated: self, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
+    self.set_tags.each { |tag| GenericWorker.perform_in(1.second, 'Tag', 'create!', annotated_type: 'ProjectMedia' , annotated_id: self.id, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
   end
 end

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -262,9 +262,9 @@ module ProjectMediaCreators
     fc
   end
 
-  def create_tags
+  def create_tags_in_background
     if self.set_tags.is_a?(Array)
-        GenericWorker.perform_in(1.second, 'ProjectMedia', 'create_tags_in_background', project_media_id: self.id, tags_json: self.set_tags.to_json, user_id: self.user_id)
+        GenericWorker.perform_in(1.second, 'ProjectMedia', 'create_tags', project_media_id: self.id, tags_json: self.set_tags.to_json, user_id: self.user_id)
     end
   end
 end

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -263,7 +263,9 @@ module ProjectMediaCreators
   end
 
   def create_tags
-    # self.set_tags.each { |tag| Tag.create!(annotated: self, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
-    self.set_tags.each { |tag| GenericWorker.perform_in(1.second, 'tag', 'create!', annotated: self, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
+    self.set_tags.each { |tag| Tag.create!(annotated: self, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
+    # require 'byebug'
+    # byebug
+    # self.set_tags.each { |tag| GenericWorker.perform_in(1.second, 'Tag', 'create!', annotated: self, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
   end
 end

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -264,7 +264,7 @@ module ProjectMediaCreators
 
   def create_tags
     if self.set_tags.is_a?(Array)
-        GenericWorker.perform_in(1.second, 'ProjectMedia', 'create_tags_in_background', project_media_id: self.id, tags_json: self.set_tags.to_json)
+        GenericWorker.perform_in(1.second, 'ProjectMedia', 'create_tags_in_background', project_media_id: self.id, tags_json: self.set_tags.to_json, user_id: self.user_id)
     end
   end
 end

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -263,9 +263,9 @@ module ProjectMediaCreators
   end
 
   def create_tags
-    self.set_tags.each { |tag| Tag.create!(annotated: self, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
+    # self.set_tags.each { |tag| Tag.create!(annotated: self, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
     # require 'byebug'
     # byebug
-    # self.set_tags.each { |tag| GenericWorker.perform_in(1.second, 'Tag', 'create!', annotated: self, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
+    self.set_tags.each { |tag| GenericWorker.perform_in(1.second, 'Tag', 'create!', annotated: self, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
   end
 end

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -263,6 +263,8 @@ module ProjectMediaCreators
   end
 
   def create_tags
-    self.set_tags.each { |tag| GenericWorker.perform_in(1.second, 'Tag', 'create!', annotated_type: 'ProjectMedia' , annotated_id: self.id, tag: tag.strip, skip_check_ability: true) } if self.set_tags.is_a?(Array)
+    if self.set_tags.is_a?(Array)
+        GenericWorker.perform_in(1.second, 'ProjectMedia', 'create_tags_in_background', project_media_id: self.id, tags_json: self.set_tags.to_json)
+    end
   end
 end

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -531,6 +531,7 @@ class ProjectMedia < ApplicationRecord
   def self.create_tags_in_background(**params)
     params = params.with_indifferent_access
     project_media = ProjectMedia.find_by_id(params['project_media_id'])
+
     unless project_media.nil?
       tags = JSON.parse(params['tags_json'])
       tags.each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -530,9 +530,11 @@ class ProjectMedia < ApplicationRecord
 
 
   def self.create_tags_in_background(**params)
-    project_media = ProjectMedia.find(params['project_media_id'])
-    tags = JSON.parse(params['tags_json'])
-    tags.each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
+    project_media = ProjectMedia.find_by_id(params['project_media_id'])
+    unless project_media.nil?
+      tags = JSON.parse(params['tags_json'])
+      tags.each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
+    end
   end
 
   # private

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -528,6 +528,13 @@ class ProjectMedia < ApplicationRecord
     ms.attributes[:requests] = requests
   end
 
+
+  def self.create_tags_in_background(**params)
+    project_media = ProjectMedia.find(params['project_media_id'])
+    tags = JSON.parse(params['tags_json'])
+    tags.each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
+  end
+
   # private
   #
   # Please add private methods to app/models/concerns/project_media_private.rb

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -33,7 +33,7 @@ class ProjectMedia < ApplicationRecord
 
   before_validation :set_team_id, :set_channel, :set_project_id, on: :create
   before_validation :create_original_claim, if: proc { |pm| pm.set_original_claim.present? }, on: :create
-  after_create :create_annotation, :create_metrics_annotation, :send_slack_notification, :create_relationship, :create_team_tasks, :create_claim_description_and_fact_check, :create_tags
+  after_create :create_annotation, :create_metrics_annotation, :send_slack_notification, :create_relationship, :create_team_tasks, :create_claim_description_and_fact_check, :create_tags_in_background
   after_create :add_source_creation_log, unless: proc { |pm| pm.source_id.blank? }
   after_commit :apply_rules_and_actions_on_create, :set_quote_metadata, :notify_team_bots_create, on: [:create]
   after_commit :create_relationship, on: [:update]
@@ -528,7 +528,7 @@ class ProjectMedia < ApplicationRecord
     ms.attributes[:requests] = requests
   end
 
-  def self.create_tags_in_background(**params)
+  def self.create_tags(**params)
     params = params.with_indifferent_access
     project_media = ProjectMedia.find_by_id(params['project_media_id'])
 

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -528,16 +528,15 @@ class ProjectMedia < ApplicationRecord
     ms.attributes[:requests] = requests
   end
 
-  def self.create_tags(**params)
-    params = params.with_indifferent_access
-    project_media = ProjectMedia.find_by_id(params['project_media_id'])
+  def self.create_tags(project_media_id, tags_json)
+    project_media = ProjectMedia.find_by_id(project_media_id)
 
     if !project_media.nil?
-      tags = JSON.parse(params['tags_json'])
+      tags = JSON.parse(tags_json)
       tags.each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
     else
       error = StandardError.new("[ProjectMedia] Exception creating project media's tags in background. Project media is nil.")
-      CheckSentry.notify(error, project_media_id: params['project_media_id'])
+      CheckSentry.notify(error, project_media_id: project_media_id)
     end
   end
 

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -528,13 +528,15 @@ class ProjectMedia < ApplicationRecord
     ms.attributes[:requests] = requests
   end
 
-
   def self.create_tags_in_background(**params)
+    params = params.with_indifferent_access
     project_media = ProjectMedia.find_by_id(params['project_media_id'])
     unless project_media.nil?
       tags = JSON.parse(params['tags_json'])
       tags.each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
     end
+    error = StandardError.new("[ProjectMedia] Exception creating project media's tags in background. Project media is nil.")
+    CheckSentry.notify(error)
   end
 
   # private

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -532,12 +532,13 @@ class ProjectMedia < ApplicationRecord
     params = params.with_indifferent_access
     project_media = ProjectMedia.find_by_id(params['project_media_id'])
 
-    unless project_media.nil?
+    if !project_media.nil?
       tags = JSON.parse(params['tags_json'])
       tags.each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
+    else
+      error = StandardError.new("[ProjectMedia] Exception creating project media's tags in background. Project media is nil.")
+      CheckSentry.notify(error, project_media_id: params['project_media_id'])
     end
-    error = StandardError.new("[ProjectMedia] Exception creating project media's tags in background. Project media is nil.")
-    CheckSentry.notify(error)
   end
 
   # private

--- a/app/workers/generic_worker.rb
+++ b/app/workers/generic_worker.rb
@@ -5,7 +5,7 @@ class GenericWorker
   def perform(klass_name, klass_method, *method_args)
     klass = klass_name.constantize
     options = method_args.extract_options!.with_indifferent_access
-    if options
+    unless options.blank?
       user_id = options.delete(:user_id) if options.key?(:user_id)
       current_user = User.current
       User.current = User.find_by_id(user_id)

--- a/app/workers/generic_worker.rb
+++ b/app/workers/generic_worker.rb
@@ -4,9 +4,14 @@ class GenericWorker
 
   def perform(klass_name, klass_method, *method_args)
     klass = klass_name.constantize
-    options = method_args.extract_options!
+    options = method_args.extract_options!.with_indifferent_access
     if options
+      if options.key?(:user_id)
+        user_id = options.delete(:user_id)
+        User.current = User.find_by_id(user_id)
+      end
       klass.public_send(klass_method, **options)
+      User.current = nil
     else
       klass.public_send(klass_method)
     end

--- a/app/workers/generic_worker.rb
+++ b/app/workers/generic_worker.rb
@@ -2,13 +2,13 @@ class GenericWorker
 
   include Sidekiq::Worker
 
-  def perform(klass_name, *args)
+  def perform(klass_name, klass_method, *method_args)
     klass = klass_name.constantize
-    options = args.extract_options!
+    options = method_args.extract_options!
     if options
-      klass.public_send(*args, **options)
+      klass.public_send(klass_method, **options)
     else
-      klass.public_send(*args)
+      klass.public_send(klass_method)
     end
   end
 end

--- a/app/workers/generic_worker.rb
+++ b/app/workers/generic_worker.rb
@@ -9,7 +9,7 @@ class GenericWorker
       user_id = options.delete(:user_id) if options.key?(:user_id)
       current_user = User.current
       User.current = User.find_by_id(user_id)
-      klass.public_send(klass_method, **options)
+      klass.public_send(klass_method, *method_args, **options)
       User.current = current_user
     else
       klass.public_send(klass_method)

--- a/app/workers/generic_worker.rb
+++ b/app/workers/generic_worker.rb
@@ -1,0 +1,16 @@
+class GenericWorker
+
+  include Sidekiq::Worker
+
+  def perform(klass_name, *args)
+    # require 'byebug'
+    # byebug
+    klass = klass_name.constantize
+    options = args.extract_options!(args)
+    if options
+      klass.public_send(*args, **options)
+    else
+      klass.public_send(*args)
+    end
+  end
+end

--- a/app/workers/generic_worker.rb
+++ b/app/workers/generic_worker.rb
@@ -6,12 +6,11 @@ class GenericWorker
     klass = klass_name.constantize
     options = method_args.extract_options!.with_indifferent_access
     if options
-      if options.key?(:user_id)
-        user_id = options.delete(:user_id)
-        User.current = User.find_by_id(user_id)
-      end
+      user_id = options.delete(:user_id) if options.key?(:user_id)
+      current_user = User.current
+      User.current = User.find_by_id(user_id)
       klass.public_send(klass_method, **options)
-      User.current = nil
+      User.current = current_user
     else
       klass.public_send(klass_method)
     end

--- a/app/workers/generic_worker.rb
+++ b/app/workers/generic_worker.rb
@@ -3,10 +3,8 @@ class GenericWorker
   include Sidekiq::Worker
 
   def perform(klass_name, *args)
-    # require 'byebug'
-    # byebug
     klass = klass_name.constantize
-    options = args.extract_options!(args)
+    options = args.extract_options!
     if options
       klass.public_send(*args, **options)
     else

--- a/config/initializers/class_extensions.rb
+++ b/config/initializers/class_extensions.rb
@@ -1,0 +1,5 @@
+class Class
+  def run_later_in(time, klass_method, *method_args)
+    GenericWorker.perform_in(time, self.to_s, klass_method, *method_args)
+  end
+end

--- a/config/initializers/class_extensions.rb
+++ b/config/initializers/class_extensions.rb
@@ -1,5 +1,3 @@
 class Class
-  def run_later_in(time, klass_method, *method_args)
-    GenericWorker.perform_in(time, self.to_s, klass_method, *method_args)
-  end
+include GenericWorkerHelpers
 end

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -517,6 +517,7 @@ module SampleData
     end
     options[:skip_autocreate_source] = true unless options.has_key?(:skip_autocreate_source)
     pm.source = create_source({ team: options[:team], skip_check_ability: true }) if options[:skip_autocreate_source]
+    pm.set_tags = options[:tags] if options[:tags]
     pm.save!
     create_cluster_project_media({ cluster: options[:cluster], project_media: pm}) if options[:cluster]
     pm.reload

--- a/test/lib/generic_worker_helpers_test.rb
+++ b/test/lib/generic_worker_helpers_test.rb
@@ -1,0 +1,34 @@
+require_relative '../test_helper'
+
+class GenericWorkerHelpersTest < ActionView::TestCase
+  def setup
+    require 'sidekiq/testing'
+    Sidekiq::Worker.clear_all
+  end
+
+  def teardown
+  end
+
+  test "should run a job, without raising an error, for a method that takes a hash as a parameter" do
+    Sidekiq::Testing.inline!
+
+    assert_difference "Team.where(name: 'BackgroundTeam', slug: 'background-team').count" do
+      Team.run_later('create!', name: 'BackgroundTeam', slug: 'background-team')
+    end
+  end
+
+  test "should run a job, without raising an error, for a method that takes standalone parameters" do
+    Sidekiq::Testing.inline!
+
+    team = create_team
+    project = create_project team: team
+    pm = create_project_media project: project
+
+    project_media_id = pm.id
+    tags_json = ['one', 'two', 'three'].to_json
+
+    ProjectMedia.run_later_in(0.second, 'create_tags', project_media_id, tags_json, user_id: pm.user_id)
+
+    assert_equal 3, pm.annotations('tag').count
+  end
+end

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -2,8 +2,11 @@ require_relative '../test_helper'
 
 class ProjectMedia8Test < ActiveSupport::TestCase
   def setup
-    super
     require 'sidekiq/testing'
+    Sidekiq::Worker.clear_all
+  end
+
+  def teardown
   end
 
   test ":create_tags should create tags when project media id and tags are present" do

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -6,6 +6,18 @@ class ProjectMedia8Test < ActiveSupport::TestCase
     require 'sidekiq/testing'
   end
 
+  test "create tags when project media id and tags are present" do
+    t = create_team
+    p = create_project team: t
+    pm = create_project_media project: p
+
+    ProjectMedia.create_tags_in_background(project_media_id: pm.id, tags_json: ['one', 'two'].to_json)
+  end
+
+  test "does not raise an error when no project media is sent" do
+    ProjectMedia.create_tags_in_background(project_media_id: nil, tags_json: ['one', 'two'].to_json)
+  end
+
   test "when creating an item with tag/tags, tags should be created in the background" do
     Sidekiq::Testing.inline!
 

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -11,11 +11,18 @@ class ProjectMedia8Test < ActiveSupport::TestCase
     p = create_project team: t
     pm = create_project_media project: p
 
-    ProjectMedia.create_tags_in_background(project_media_id: pm.id, tags_json: ['one', 'two'].to_json)
+    assert_nothing_raised do
+      ProjectMedia.create_tags_in_background(project_media_id: pm.id, tags_json: ['one', 'two'].to_json)
+    end
+    assert_equal pm.id, Tag.last.annotated_id
+    assert_equal 'two', Tag.last.tag_text
   end
 
   test "does not raise an error when no project media is sent" do
-    ProjectMedia.create_tags_in_background(project_media_id: nil, tags_json: ['one', 'two'].to_json)
+    assert_nothing_raised do
+      CheckSentry.expects(:notify).once
+      ProjectMedia.create_tags_in_background(project_media_id: nil, tags_json: ['one', 'two'].to_json)
+    end
   end
 
   test "when creating an item with tag/tags, tags should be created in the background" do

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -14,8 +14,7 @@ class ProjectMedia8Test < ActiveSupport::TestCase
     assert_nothing_raised do
       ProjectMedia.create_tags_in_background(project_media_id: pm.id, tags_json: ['one', 'two'].to_json)
     end
-    assert_equal pm.id, Tag.last.annotated_id
-    assert_equal 'two', Tag.last.tag_text
+    assert_equal 2, pm.annotations('tag').count
   end
 
   test "does not raise an error when no project media is sent" do
@@ -30,10 +29,9 @@ class ProjectMedia8Test < ActiveSupport::TestCase
 
     t = create_team
     p = create_project team: t
+    pm = create_project_media project: p, tags: ['one']
 
-    assert_nothing_raised do
-      create_project_media project: p, tags: ['one']
-    end
+    assert_equal 1, pm.annotations('tag').count
   end
 
   test "when creating an item with multiple tags, only one job should be scheduled" do

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -11,16 +11,22 @@ class ProjectMedia8Test < ActiveSupport::TestCase
     project = create_project team: team
     pm = create_project_media project: project
 
+    project_media_id = pm.id
+    tags_json = ['one', 'two'].to_json
+
     assert_nothing_raised do
-      ProjectMedia.create_tags(project_media_id: pm.id, tags_json: ['one', 'two'].to_json)
+      ProjectMedia.create_tags(project_media_id, tags_json)
     end
     assert_equal 2, pm.annotations('tag').count
   end
 
   test ":create_tags should not raise an error when no project media is sent" do
+    project_media_id = nil
+    tags_json = ['one', 'two'].to_json
+
     assert_nothing_raised do
       CheckSentry.expects(:notify).once
-      ProjectMedia.create_tags(project_media_id: nil, tags_json: ['one', 'two'].to_json)
+      ProjectMedia.create_tags(project_media_id, tags_json)
     end
   end
 
@@ -53,7 +59,10 @@ class ProjectMedia8Test < ActiveSupport::TestCase
     project = create_project team: team
     pm = create_project_media project: project
 
-    ProjectMedia.run_later_in(0.second, 'create_tags', project_media_id: pm.id, tags_json: ['one', 'two', 'three'].to_json, user_id: pm.user_id)
+    project_media_id = pm.id
+    tags_json = ['one', 'two', 'three'].to_json
+
+    ProjectMedia.run_later_in(0.second, 'create_tags', project_media_id, tags_json, user_id: pm.user_id)
 
     assert_equal 1, GenericWorker.jobs.size
   end
@@ -65,7 +74,10 @@ class ProjectMedia8Test < ActiveSupport::TestCase
     project = create_project team: team
     pm = create_project_media project: project
 
-    ProjectMedia.run_later_in(0.second, 'create_tags', project_media_id: pm.id, tags_json: ['one', 'two', 'three'].to_json, user_id: pm.user_id)
+    project_media_id = pm.id
+    tags_json = ['one', 'two', 'three'].to_json
+
+    ProjectMedia.run_later_in(0.second, 'create_tags', project_media_id, tags_json, user_id: pm.user_id)
 
     assert_equal 3, pm.annotations('tag').count
   end

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -69,19 +69,4 @@ class ProjectMedia8Test < ActiveSupport::TestCase
 
     assert_equal 1, GenericWorker.jobs.size
   end
-
-  test "when using :run_later_in to schedule multiple tags creation, tags should be created" do
-    Sidekiq::Testing.inline!
-
-    team = create_team
-    project = create_project team: team
-    pm = create_project_media project: project
-
-    project_media_id = pm.id
-    tags_json = ['one', 'two', 'three'].to_json
-
-    ProjectMedia.run_later_in(0.second, 'create_tags', project_media_id, tags_json, user_id: pm.user_id)
-
-    assert_equal 3, pm.annotations('tag').count
-  end
 end

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -1,0 +1,29 @@
+require_relative '../test_helper'
+
+class ProjectMedia8Test < ActiveSupport::TestCase
+  def setup
+    super
+    require 'sidekiq/testing'
+  end
+
+  test "when creating an item with tag/tags, tags should be created in the background" do
+    Sidekiq::Testing.inline!
+
+    t = create_team
+    p = create_project team: t
+    assert_nothing_raised do
+      create_project_media project: p, tags: ['one']
+    end
+  end
+
+  test "when creating an item with multiple tags, only one job should be scheduled" do
+    Sidekiq::Testing.fake!
+
+    t = create_team
+    p = create_project team: t
+    assert_nothing_raised do
+      create_project_media project: p, tags: ['one', 'two', 'three']
+    end
+    assert_equal 1, GenericWorker.jobs.size
+  end
+end

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -12,7 +12,7 @@ class ProjectMedia8Test < ActiveSupport::TestCase
     pm = create_project_media project: p
 
     assert_nothing_raised do
-      ProjectMedia.create_tags_in_background(project_media_id: pm.id, tags_json: ['one', 'two'].to_json)
+      ProjectMedia.create_tags(project_media_id: pm.id, tags_json: ['one', 'two'].to_json)
     end
     assert_equal 2, pm.annotations('tag').count
   end
@@ -20,7 +20,7 @@ class ProjectMedia8Test < ActiveSupport::TestCase
   test "does not raise an error when no project media is sent" do
     assert_nothing_raised do
       CheckSentry.expects(:notify).once
-      ProjectMedia.create_tags_in_background(project_media_id: nil, tags_json: ['one', 'two'].to_json)
+      ProjectMedia.create_tags(project_media_id: nil, tags_json: ['one', 'two'].to_json)
     end
   end
 

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -30,6 +30,7 @@ class ProjectMedia8Test < ActiveSupport::TestCase
 
     t = create_team
     p = create_project team: t
+
     assert_nothing_raised do
       create_project_media project: p, tags: ['one']
     end
@@ -40,6 +41,7 @@ class ProjectMedia8Test < ActiveSupport::TestCase
 
     t = create_team
     p = create_project team: t
+
     assert_nothing_raised do
       create_project_media project: p, tags: ['one', 'two', 'three']
     end

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -6,10 +6,10 @@ class ProjectMedia8Test < ActiveSupport::TestCase
     require 'sidekiq/testing'
   end
 
-  test "create tags when project media id and tags are present" do
-    t = create_team
-    p = create_project team: t
-    pm = create_project_media project: p
+  test ":create_tags should create tags when project media id and tags are present" do
+    team = create_team
+    project = create_project team: team
+    pm = create_project_media project: project
 
     assert_nothing_raised do
       ProjectMedia.create_tags(project_media_id: pm.id, tags_json: ['one', 'two'].to_json)
@@ -17,32 +17,56 @@ class ProjectMedia8Test < ActiveSupport::TestCase
     assert_equal 2, pm.annotations('tag').count
   end
 
-  test "does not raise an error when no project media is sent" do
+  test ":create_tags should not raise an error when no project media is sent" do
     assert_nothing_raised do
       CheckSentry.expects(:notify).once
       ProjectMedia.create_tags(project_media_id: nil, tags_json: ['one', 'two'].to_json)
     end
   end
 
-  test "when creating an item with tag/tags, tags should be created in the background" do
+  test "when creating an item with tag/tags, after_create :create_tags_in_background callback should create tags in the background" do
     Sidekiq::Testing.inline!
 
-    t = create_team
-    p = create_project team: t
-    pm = create_project_media project: p, tags: ['one']
+    team = create_team
+    project = create_project team: team
+    pm = create_project_media project: project, tags: ['one']
 
     assert_equal 1, pm.annotations('tag').count
   end
 
-  test "when creating an item with multiple tags, only one job should be scheduled" do
+  test "when creating an item with multiple tags, after_create :create_tags_in_background callback should only schedule one job" do
     Sidekiq::Testing.fake!
 
-    t = create_team
-    p = create_project team: t
+    team = create_team
+    project = create_project team: team
 
     assert_nothing_raised do
-      create_project_media project: p, tags: ['one', 'two', 'three']
+      create_project_media project: project, tags: ['one', 'two', 'three']
     end
     assert_equal 1, GenericWorker.jobs.size
+  end
+
+  test "when using :run_later_in to schedule multiple tags creation, it should only schedule one job" do
+    Sidekiq::Testing.fake!
+
+    team = create_team
+    project = create_project team: team
+    pm = create_project_media project: project
+
+    ProjectMedia.run_later_in(0.second, 'create_tags', project_media_id: pm.id, tags_json: ['one', 'two', 'three'].to_json, user_id: pm.user_id)
+
+    assert_equal 1, GenericWorker.jobs.size
+  end
+
+  test "when using :run_later_in to schedule multiple tags creation, tags should be created" do
+    Sidekiq::Testing.inline!
+
+    team = create_team
+    project = create_project team: team
+    pm = create_project_media project: project
+
+    ProjectMedia.run_later_in(0.second, 'create_tags', project_media_id: pm.id, tags_json: ['one', 'two', 'three'].to_json, user_id: pm.user_id)
+
+    assert_equal 3, pm.annotations('tag').count
   end
 end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -290,9 +290,9 @@ class TagTest < ActiveSupport::TestCase
     p = create_project team: t
     pm = create_project_media project: p, tags: ['one']
 
-    # assert_equal 1, GenericWorker.jobs.size
+    assert_equal 1, GenericWorker.jobs.size
 
-    assert_equal 'one', Tag.last.tag_text
-    assert_equal pm.id, Tag.last.annotated_id
+    # assert_equal 'one', Tag.last.tag_text
+    # assert_equal pm.id, Tag.last.annotated_id
   end
 end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -284,25 +284,4 @@ class TagTest < ActiveSupport::TestCase
       create_tag tag: ' foo', annotated: pm2
     end
   end
-
-  test "tags should be created in the background" do
-    Sidekiq::Testing.inline!
-
-    t = create_team
-    p = create_project team: t
-    assert_nothing_raised do
-      create_project_media project: p, tags: ['one']
-    end
-  end
-
-  test "when creating multiple tags for the same item only one job should be scheduled" do
-    Sidekiq::Testing.fake!
-
-    t = create_team
-    p = create_project team: t
-    assert_nothing_raised do
-      create_project_media project: p, tags: ['one', 'two', 'three']
-    end
-    assert_equal 1, GenericWorker.jobs.size
-  end
 end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -284,4 +284,15 @@ class TagTest < ActiveSupport::TestCase
       create_tag tag: ' foo', annotated: pm2
     end
   end
+
+  test "tags should be created in the background" do
+    t = create_team
+    p = create_project team: t
+    pm = create_project_media project: p
+
+    pm.set_tags = ['foo']
+    pm.create_tags
+
+    assert_equal 1, GenericWorker.jobs.size
+  end
 end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -286,13 +286,12 @@ class TagTest < ActiveSupport::TestCase
   end
 
   test "tags should be created in the background" do
+    Sidekiq::Testing.inline!
+
     t = create_team
     p = create_project team: t
-    pm = create_project_media project: p, tags: ['one']
-
-    assert_equal 1, GenericWorker.jobs.size
-
-    # assert_equal 'one', Tag.last.tag_text
-    # assert_equal pm.id, Tag.last.annotated_id
+    assert_nothing_raised do
+      create_project_media project: p, tags: ['one']
+    end
   end
 end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -294,4 +294,15 @@ class TagTest < ActiveSupport::TestCase
       create_project_media project: p, tags: ['one']
     end
   end
+
+  test "when creating multiple tags for the same item only one job should be scheduled" do
+    Sidekiq::Testing.fake!
+
+    t = create_team
+    p = create_project team: t
+    assert_nothing_raised do
+      create_project_media project: p, tags: ['one', 'two', 'three']
+    end
+    assert_equal 1, GenericWorker.jobs.size
+  end
 end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -288,11 +288,11 @@ class TagTest < ActiveSupport::TestCase
   test "tags should be created in the background" do
     t = create_team
     p = create_project team: t
-    pm = create_project_media project: p
+    pm = create_project_media project: p, tags: ['one']
 
-    pm.set_tags = ['foo']
-    pm.create_tags
+    # assert_equal 1, GenericWorker.jobs.size
 
-    assert_equal 1, GenericWorker.jobs.size
+    assert_equal 'one', Tag.last.tag_text
+    assert_equal pm.id, Tag.last.annotated_id
   end
 end

--- a/test/workers/generic_worker_test.rb
+++ b/test/workers/generic_worker_test.rb
@@ -14,7 +14,7 @@ class GenericWorkerTest < ActiveSupport::TestCase
     pm = create_project_media project: p
 
     assert_nothing_raised do
-      GenericWorker.perform_async('Tag', 'create!', annotated_type: 'ProjectMedia' , annotated_id: pm.id, tag: 'test_tag', skip_check_ability: true)
+      GenericWorker.perform_async('Tag', 'create!', annotated_type: 'ProjectMedia' , annotated_id: pm.id, tag: 'test_tag', skip_check_ability: true, user_id: pm.user_id)
     end
   end
 

--- a/test/workers/generic_worker_test.rb
+++ b/test/workers/generic_worker_test.rb
@@ -12,8 +12,8 @@ class GenericWorkerTest < ActiveSupport::TestCase
   test "should run a job, without raising an error, for a method that takes no parameters" do
     Sidekiq::Testing.inline!
 
-    assert_nothing_raised do
-      GenericWorker.perform_async('Media', 'types')
+    assert_difference 'Blank.count' do
+      GenericWorker.perform_async('Blank', 'create!')
     end
   end
 
@@ -35,7 +35,7 @@ class GenericWorkerTest < ActiveSupport::TestCase
     project_media_id = pm.id
     tags_json = ['one', 'two'].to_json
 
-    assert_nothing_raised do
+    assert_difference "Tag.where(annotation_type: 'tag').count", difference = 2 do
       GenericWorker.perform_async('ProjectMedia', 'create_tags', project_media_id, tags_json, user_id: pm.user_id)
     end
   end

--- a/test/workers/generic_worker_test.rb
+++ b/test/workers/generic_worker_test.rb
@@ -9,6 +9,14 @@ class GenericWorkerTest < ActiveSupport::TestCase
   def teardown
   end
 
+  test "should run a job, without raising an error, for a method that takes no parameters" do
+    Sidekiq::Testing.inline!
+
+    assert_nothing_raised do
+      GenericWorker.perform_async('Media', 'types')
+    end
+  end
+
   test "should run a job, without raising an error, for a method that takes a hash as a parameter" do
     Sidekiq::Testing.inline!
 
@@ -30,6 +38,16 @@ class GenericWorkerTest < ActiveSupport::TestCase
     assert_nothing_raised do
       GenericWorker.perform_async('ProjectMedia', 'create_tags', project_media_id, tags_json, user_id: pm.user_id)
     end
+  end
+
+  test "should schedule a job, without raising an error, for a method that takes no parameters" do
+    Sidekiq::Testing.fake!
+
+    assert_nothing_raised do
+      GenericWorker.perform_async('Media', 'types')
+    end
+
+    assert_equal 1, GenericWorker.jobs.size
   end
 
   test "should schedule a job, without raising an error, for a method that takes a hash as a parameter" do

--- a/test/workers/generic_worker_test.rb
+++ b/test/workers/generic_worker_test.rb
@@ -9,19 +9,7 @@ class GenericWorkerTest < ActiveSupport::TestCase
   def teardown
   end
 
-  test "should schedule a job for a method that takes a hash: Tag creation" do
-    Sidekiq::Testing.inline!
-
-    t = create_team
-    p = create_project team: t
-    pm = create_project_media project: p
-
-    assert_nothing_raised do
-      GenericWorker.perform_async('Tag', 'create!', annotated_type: 'ProjectMedia' , annotated_id: pm.id, tag: 'test_tag', skip_check_ability: true, user_id: pm.user_id)
-    end
-  end
-
-  test "should schedule a job for a method that takes a hash: Team creation" do
+  test "should run a job, without raising an error, for a method that takes a hash as a parameter" do
     Sidekiq::Testing.inline!
 
     assert_nothing_raised do
@@ -29,7 +17,7 @@ class GenericWorkerTest < ActiveSupport::TestCase
     end
   end
 
-  test "should schedule a job for a method that takes standalone parameters" do
+  test "should run a job, without raising an error, for a method that takes standalone parameters" do
     Sidekiq::Testing.inline!
 
     t = create_team
@@ -42,5 +30,32 @@ class GenericWorkerTest < ActiveSupport::TestCase
     assert_nothing_raised do
       GenericWorker.perform_async('ProjectMedia', 'create_tags', project_media_id, tags_json, user_id: pm.user_id)
     end
+  end
+
+  test "should schedule a job, without raising an error, for a method that takes a hash as a parameter" do
+    Sidekiq::Testing.fake!
+
+    assert_nothing_raised do
+      GenericWorker.perform_async('Team', 'create!', name: 'BackgroundTeam', slug: 'background-team')
+    end
+
+    assert_equal 1, GenericWorker.jobs.size
+  end
+
+  test "should schedule a job, without raising an error, for a method that takes standalone parameters" do
+    Sidekiq::Testing.fake!
+
+    t = create_team
+    p = create_project team: t
+    pm = create_project_media project: p
+
+    project_media_id = pm.id
+    tags_json = ['one', 'two'].to_json
+
+    assert_nothing_raised do
+      GenericWorker.perform_async('ProjectMedia', 'create_tags', project_media_id, tags_json, user_id: pm.user_id)
+    end
+
+    assert_equal 1, GenericWorker.jobs.size
   end
 end

--- a/test/workers/generic_worker_test.rb
+++ b/test/workers/generic_worker_test.rb
@@ -6,7 +6,7 @@ class GenericWorkerTest < ActiveSupport::TestCase
     require 'sidekiq/testing'
   end
 
-  test "should schedule a job for Tag creation" do
+  test "should schedule a job for a method that takes a hash: Tag creation" do
     Sidekiq::Testing.inline!
 
     t = create_team
@@ -18,11 +18,26 @@ class GenericWorkerTest < ActiveSupport::TestCase
     end
   end
 
-  test "should schedule a job for Team creation" do
+  test "should schedule a job for a method that takes a hash: Team creation" do
     Sidekiq::Testing.inline!
 
     assert_nothing_raised do
       GenericWorker.perform_async('Team', 'create!', name: 'BackgroundTeam', slug: 'background-team')
+    end
+  end
+
+  test "should schedule a job for a method that takes standalone parameters" do
+    Sidekiq::Testing.inline!
+
+    t = create_team
+    p = create_project team: t
+    pm = create_project_media project: p
+
+    project_media_id = pm.id
+    tags_json = ['one', 'two'].to_json
+
+    assert_nothing_raised do
+      GenericWorker.perform_async('ProjectMedia', 'create_tags', project_media_id, tags_json, user_id: pm.user_id)
     end
   end
 end

--- a/test/workers/generic_worker_test.rb
+++ b/test/workers/generic_worker_test.rb
@@ -14,7 +14,7 @@ class GenericWorkerTest < ActiveSupport::TestCase
     pm = create_project_media project: p
 
     assert_nothing_raised do
-      GenericWorker.perform_async('Tag', 'create!', annotated: pm, tag: 'test_tag', skip_check_ability: true)
+      GenericWorker.perform_async('Tag', 'create!', annotated_type: 'ProjectMedia' , annotated_id: pm.id, tag: 'test_tag', skip_check_ability: true)
     end
   end
 

--- a/test/workers/generic_worker_test.rb
+++ b/test/workers/generic_worker_test.rb
@@ -2,8 +2,11 @@ require 'test_helper'
 
 class GenericWorkerTest < ActiveSupport::TestCase
   def setup
-    super
     require 'sidekiq/testing'
+    Sidekiq::Worker.clear_all
+  end
+
+  def teardown
   end
 
   test "should schedule a job for a method that takes a hash: Tag creation" do

--- a/test/workers/generic_worker_test.rb
+++ b/test/workers/generic_worker_test.rb
@@ -6,7 +6,9 @@ class GenericWorkerTest < ActiveSupport::TestCase
     require 'sidekiq/testing'
   end
 
-  test "should schedule a job for any class" do
+  test "should schedule a job for Tag creation" do
+    Sidekiq::Testing.inline!
+
     t = create_team
     p = create_project team: t
     pm = create_project_media project: p
@@ -14,6 +16,13 @@ class GenericWorkerTest < ActiveSupport::TestCase
     assert_nothing_raised do
       GenericWorker.perform_async('Tag', 'create!', annotated: pm, tag: 'test_tag', skip_check_ability: true)
     end
-    assert_equal 1, GenericWorker.jobs.size
+  end
+
+  test "should schedule a job for Team creation" do
+    Sidekiq::Testing.inline!
+
+    assert_nothing_raised do
+      GenericWorker.perform_async('Team', 'create!', name: 'BackgroundTeam', slug: 'background-team')
+    end
   end
 end

--- a/test/workers/generic_worker_test.rb
+++ b/test/workers/generic_worker_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class GenericWorkerTest < ActiveSupport::TestCase
+  def setup
+    super
+    require 'sidekiq/testing'
+  end
+
+  test "should schedule a job for any class" do
+    t = create_team
+    p = create_project team: t
+    pm = create_project_media project: p
+
+    assert_nothing_raised do
+      GenericWorker.perform_async('Tag', 'create!', annotated: pm, tag: 'test_tag', skip_check_ability: true)
+    end
+    assert_equal 1, GenericWorker.jobs.size
+  end
+end

--- a/test/workers/generic_worker_test.rb
+++ b/test/workers/generic_worker_test.rb
@@ -12,7 +12,7 @@ class GenericWorkerTest < ActiveSupport::TestCase
   test "should run a job, without raising an error, for a method that takes a hash as a parameter" do
     Sidekiq::Testing.inline!
 
-    assert_nothing_raised do
+    assert_difference "Team.where(name: 'BackgroundTeam', slug: 'background-team').count" do
       GenericWorker.perform_async('Team', 'create!', name: 'BackgroundTeam', slug: 'background-team')
     end
   end


### PR DESCRIPTION
## Description

### Context
While working on  `API/Zapier Error: The app did not respond in-time. It may or may not have completed successfully` we thought tags creation could be causing the slow response.

We couldn’t pinpoint it as the cause, but it’s still a good performance improvement and should help improve the response time. So we are moving forward with it.

### Implementation Notes

Sidekiq’s `delayed extensions` were deprecated in version 5 and removed in 7. So we are taking this opportunity to create a `GenericJob`, and eventually substitute the instances of `.delay`/`.delay_for` we have.

References: 5120, 4959

## How has this been tested?

`rails test test/models/tag_test.rb:288`
`rails test test/workers/generic_worker_test.rb`

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

