### PR TITLE
CV2-5148: include URLs as shortcuts triggering submission

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -546,7 +546,7 @@ class Bot::Smooch < BotUser
     self.is_v2? && (state == 'main' || state == 'waiting_for_message') && (
       !message['mediaUrl'].blank? ||
       ::Bot::Alegre.get_number_of_words(message['text'].to_s) > CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer) ||
-      URI.regexp.match(message['text'].to_s)!=nil # URL in message?
+      !URI.regexp.match(message['text'].to_s).nil? # URL in message?
       )
   end
 

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -546,7 +546,7 @@ class Bot::Smooch < BotUser
     self.is_v2? && (state == 'main' || state == 'waiting_for_message') && (
       !message['mediaUrl'].blank? ||
       ::Bot::Alegre.get_number_of_words(message['text'].to_s) > CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer) ||
-      URI.regexp =~ message['text'].to_s # URL in message?
+      URI.regexp.match(message['text'].to_s)!=nil # URL in message?
       )
   end
 

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -1,4 +1,5 @@
 require 'digest'
+require 'uri'
 
 class Bot::Smooch < BotUser
   class MessageDeliveryError < StandardError; end
@@ -542,7 +543,11 @@ class Bot::Smooch < BotUser
   end
 
   def self.is_a_shortcut_for_submission?(state, message)
-    self.is_v2? && (state == 'main' || state == 'waiting_for_message') && (!message['mediaUrl'].blank? || ::Bot::Alegre.get_number_of_words(message['text'].to_s) > CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer))
+    self.is_v2? && (state == 'main' || state == 'waiting_for_message') && (
+      !message['mediaUrl'].blank? ||
+      ::Bot::Alegre.get_number_of_words(message['text'].to_s) > CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer) ||
+      URI.regexp =~ message['text'].to_s # URL in message?
+      )
   end
 
   def self.process_menu_option(message, state, app_id)

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -664,12 +664,12 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
   test "should not duplicate messages when saving" do
     @team.set_languages ['en']
     @team.save!
-    url = 'http://localhost'
-    send_message url, '1', url, '1'
+    message_text = 'not_a_url' #Not a URL, not media, and not longer than 'min_number_of_words_for_tipline_submit_shortcut'
+    send_message message_text, '1', message_text, '1'
     assert_state 'search'
     Sidekiq::Worker.drain_all
     tr = TiplineRequest.last
-    assert_equal 2, tr.smooch_data['text'].split("\n#{Bot::Smooch::MESSAGE_BOUNDARY}").select{ |x| x.chomp.strip == url }.size
+    assert_equal 2, tr.smooch_data['text'].split("\n#{Bot::Smooch::MESSAGE_BOUNDARY}").select{ |x| x.chomp.strip == message_text }.size
   end
 
   test "should get search results in different languages" do

--- a/test/models/bot/smooch_test.rb
+++ b/test/models/bot/smooch_test.rb
@@ -789,4 +789,23 @@ class Bot::SmoochTest < ActiveSupport::TestCase
     tr = pm.tipline_requests.last
     assert_equal 'en', tr.smooch_user_request_language
   end
+
+  test "should submit message for factchecking" do
+    Bot::Smooch.stubs(:is_v2?).returns{true}
+    state='main'
+
+    # Should not be a submission shortcut
+    message = {"text": "abc"}
+    assert_equal(false, Bot::Smooch::is_a_shortcut_for_submission(state,message), "Unexpected shortcut"
+
+    # Should be a submission shortcut
+    message = {"text": "abc http://example.com"}
+    assert_equal(true, Bot::Smooch::is_a_shortcut_for_submission(state,message), "Missed URL shortcut"
+
+    # Should be a submission shortcut
+    message = {"text": "abc", "mediaUrl": "not blank"}
+    assert_equal(true, Bot::Smooch::is_a_shortcut_for_submission(state,message), "Missed media shortcut"
+
+    Bot::Smooch.unstubs(:is_v2?)
+  end
 end

--- a/test/models/bot/smooch_test.rb
+++ b/test/models/bot/smooch_test.rb
@@ -796,15 +796,15 @@ class Bot::SmoochTest < ActiveSupport::TestCase
 
     # Should not be a submission shortcut
     message = {"text": "abc"}
-    assert_equal(false, Bot::Smooch::is_a_shortcut_for_submission(state,message), "Unexpected shortcut"
+    assert_equal(false, Bot::Smooch::is_a_shortcut_for_submission(state,message), "Unexpected shortcut")
 
     # Should be a submission shortcut
     message = {"text": "abc http://example.com"}
-    assert_equal(true, Bot::Smooch::is_a_shortcut_for_submission(state,message), "Missed URL shortcut"
+    assert_equal(true, Bot::Smooch::is_a_shortcut_for_submission(state,message), "Missed URL shortcut")
 
     # Should be a submission shortcut
     message = {"text": "abc", "mediaUrl": "not blank"}
-    assert_equal(true, Bot::Smooch::is_a_shortcut_for_submission(state,message), "Missed media shortcut"
+    assert_equal(true, Bot::Smooch::is_a_shortcut_for_submission(state,message), "Missed media shortcut")
 
     Bot::Smooch.unstubs(:is_v2?)
   end

--- a/test/models/bot/smooch_test.rb
+++ b/test/models/bot/smooch_test.rb
@@ -791,21 +791,21 @@ class Bot::SmoochTest < ActiveSupport::TestCase
   end
 
   test "should submit message for factchecking" do
-    Bot::Smooch.stubs(:is_v2?).returns{true}
+    Bot::Smooch.stubs(:is_v2?).returns(true)
     state='main'
 
     # Should not be a submission shortcut
-    message = {"text": "abc"}
-    assert_equal(false, Bot::Smooch::is_a_shortcut_for_submission(state,message), "Unexpected shortcut")
+    message = {"text"=>"abc"}
+    assert_equal(false, Bot::Smooch.is_a_shortcut_for_submission?(state,message), "Unexpected shortcut")
 
     # Should be a submission shortcut
-    message = {"text": "abc http://example.com"}
-    assert_equal(true, Bot::Smooch::is_a_shortcut_for_submission(state,message), "Missed URL shortcut")
+    message = {"text"=>"abc http://example.com"}
+    assert_equal(true, Bot::Smooch.is_a_shortcut_for_submission?(state,message), "Missed URL shortcut")
 
     # Should be a submission shortcut
-    message = {"text": "abc", "mediaUrl": "not blank"}
-    assert_equal(true, Bot::Smooch::is_a_shortcut_for_submission(state,message), "Missed media shortcut")
+    message = {"text"=>"abc", "mediaUrl"=>"not blank"}
+    assert_equal(true, Bot::Smooch.is_a_shortcut_for_submission?(state,message), "Missed media shortcut")
 
-    Bot::Smooch.unstubs(:is_v2?)
+    Bot::Smooch.unstub(:is_v2?)
   end
 end


### PR DESCRIPTION
## Description

Since #1676 , we have treated messages with media or more than `min_number_of_words_for_tipline_submit_shortcut` specially and allowed them to directly enter the submission state to search for fact-checks. 

This PR has any message with a URL exhibit the same behavior. That is, "abc http://example.com" should directly enter the submission state even though it is shorter than `min_number_of_words_for_tipline_submit_shortcut` having only two words.

References: CV2-5148

## How has this been tested?

Wrote unit tests and actually ran them locally now.

## Things to pay attention to during code review

N/A

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [x] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

