### PR TITLE
CV2-5148: Use more inclusive detection of URLs in message text

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -1,5 +1,4 @@
 require 'digest'
-require 'uri'
 
 class Bot::Smooch < BotUser
   class MessageDeliveryError < StandardError; end
@@ -546,7 +545,7 @@ class Bot::Smooch < BotUser
     self.is_v2? && (state == 'main' || state == 'waiting_for_message') && (
       !message['mediaUrl'].blank? ||
       ::Bot::Alegre.get_number_of_words(message['text'].to_s) > CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer) ||
-      !URI.regexp.match(message['text'].to_s).nil? # URL in message?
+      !Twitter::TwitterText::Extractor.extract_urls(message['text'].to_s).blank? # URL in message?
       )
   end
 

--- a/test/models/bot/smooch_test.rb
+++ b/test/models/bot/smooch_test.rb
@@ -806,6 +806,10 @@ class Bot::SmoochTest < ActiveSupport::TestCase
     message = {"text"=>"abc", "mediaUrl"=>"not blank"}
     assert_equal(true, Bot::Smooch.is_a_shortcut_for_submission?(state,message), "Missed media shortcut")
 
+    # Should be a submission shortcut
+    message = {"text"=>"abc example.com"}
+    assert_equal(true, Bot::Smooch.is_a_shortcut_for_submission?(state,message), "Missed non-qualified URL shortcut")
+
     Bot::Smooch.unstub(:is_v2?)
   end
 end


### PR DESCRIPTION
## Description

URI.regexp.match... only matched fully-qualified urls (i.e., urls need to include http://, https://, or another protocol) . I knew this at the time I did #2011 , but I didn't realize until testing that this was inconsistent with how WhatsApp handles URLs.

The changes in this PR use Twitter::TwitterText::Extractor.extract_urls, which recognizes urls without the protocol. This is consistent with how WhatsApp and more in line with user expectations.

References: CV2-5148

## How has this been tested?

Added a unit test for this specific case

## Things to pay attention to during code review

N/A

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [x] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

