### PR TITLE
Cv2 5080 request model to presto

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -53,7 +53,7 @@ class Request < ApplicationRecord
         models_thresholds = self.text_similarity_settings.reject{ |_k, v| v['min_words'] > words }
         if models_thresholds.count > 0
           params = { text: media.quote, models: models_thresholds.keys, per_model_threshold: models_thresholds.transform_values{ |v| v['threshold'] }, limit: alegre_limit, context: context }
-          similar_request_id = ::Bot::Alegre.request('post', '/text/similarity/search/', params)&.dig('result').to_a.collect{ |result| result&.dig('_source', 'context', 'request_id').to_i }.find{ |id| id != 0 && id < self.id }
+          similar_request_id = ::Bot::Alegre.get_async_with_params(params, "text")&.dig('result').to_a.collect{ |result| result&.dig('_source', 'context', 'request_id').to_i }.find{ |id| id != 0 && id < self.id }
         end
       # elsif ['UploadedImage', 'UploadedAudio', 'UploadedVideo'].include?(media.type)
       #   threshold = 0.85 #FIXME: Should be feed setting
@@ -194,7 +194,7 @@ class Request < ApplicationRecord
         models: request.text_similarity_settings.keys(),
         context: context
       }
-      ::Bot::Alegre.request('post', '/text/similarity/', params)
+      ::Bot::Alegre.get_async_with_params(params, "text")
     # elsif ['UploadedImage', 'UploadedAudio', 'UploadedVideo'].include?(media.type)
     #   type = media.type.gsub(/^Uploaded/, '').downcase
     #   url = media.file&.file&.public_url

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -53,7 +53,7 @@ class Request < ApplicationRecord
         models_thresholds = self.text_similarity_settings.reject{ |_k, v| v['min_words'] > words }
         if models_thresholds.count > 0
           params = { text: media.quote, models: models_thresholds.keys, per_model_threshold: models_thresholds.transform_values{ |v| v['threshold'] }, limit: alegre_limit, context: context }
-          similar_request_id = ::Bot::Alegre.get_async_with_params(params, "text")&.dig('result').to_a.collect{ |result| result&.dig('_source', 'context', 'request_id').to_i }.find{ |id| id != 0 && id < self.id }
+          similar_request_id = ::Bot::Alegre.get_sync_with_params(params, "text")&.dig('result').to_a.collect{ |result| result&.dig('_source', 'context', 'request_id').to_i }.find{ |id| id != 0 && id < self.id }
         end
       # elsif ['UploadedImage', 'UploadedAudio', 'UploadedVideo'].include?(media.type)
       #   threshold = 0.85 #FIXME: Should be feed setting

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -139,7 +139,7 @@ class RequestTest < ActiveSupport::TestCase
     m2 = Media.create! type: 'Claim', quote: 'Foo bar foo bar 2'
     r2 = create_request media: m2, feed: f
     response = { 'result' => [{ '_source' => { 'context' => { 'request_id' => r1.id } } }] }
-    Bot::Alegre.stubs(:request).with('post', '/text/similarity/search/', { text: 'Foo bar foo bar 2', models: [::Bot::Alegre::ELASTICSEARCH_MODEL, ::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::ELASTICSEARCH_MODEL => 0.85, ::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
+    Bot::Alegre.stubs(:request).with('post', '/similarity/async/text/', { text: 'Foo bar foo bar 2', models: [::Bot::Alegre::ELASTICSEARCH_MODEL, ::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::ELASTICSEARCH_MODEL => 0.85, ::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
     r2.attach_to_similar_request!
     #Alegre should be called with ES and vector model for request with 4 or more words
     assert_equal r1, r2.reload.similar_to_request
@@ -155,7 +155,7 @@ class RequestTest < ActiveSupport::TestCase
     m2 = Media.create! type: 'Claim', quote: 'Foo bar 2'
     r2 = create_request media: m2, feed: f
     response = { 'result' => [{ '_source' => { 'context' => { 'request_id' => r1.id } } }] }
-    Bot::Alegre.stubs(:request).with('post', '/text/similarity/search/', { text: 'Foo bar 2', models: [::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
+    Bot::Alegre.stubs(:request).with('post', '/similarity/async/text/', { text: 'Foo bar 2', models: [::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
     r2.attach_to_similar_request!
     #Alegre should only be called with vector models for 2 or 3 word request
     assert_equal r1, r2.reload.similar_to_request

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -116,7 +116,7 @@ class RequestTest < ActiveSupport::TestCase
   end
 
   test "should send text request to Alegre" do
-    Bot::Alegre.stubs(:request).returns(true)
+    Bot::Alegre.stubs(:request).returns({'result' => []})
     assert_nothing_raised do
       create_request(media: create_claim_media)
     end
@@ -124,7 +124,6 @@ class RequestTest < ActiveSupport::TestCase
   end
 
   test "should send media request to Alegre" do
-    Bot::Alegre.stubs(:request).returns(true)
     assert_nothing_raised do
       create_request(media: create_uploaded_image)
     end
@@ -132,14 +131,14 @@ class RequestTest < ActiveSupport::TestCase
   end
 
   test "should attach to similar text long" do
-    Bot::Alegre.stubs(:request).returns(true)
     f = create_feed
+    Bot::Alegre.stubs(:request).with('post', '/similarity/async/text', anything).returns({})
     m1 = Media.create! type: 'Claim', quote: 'Foo bar foo bar'
     r1 = create_request media: m1, feed: f
     m2 = Media.create! type: 'Claim', quote: 'Foo bar foo bar 2'
     r2 = create_request media: m2, feed: f
     response = { 'result' => [{ '_source' => { 'context' => { 'request_id' => r1.id } } }] }
-    Bot::Alegre.stubs(:request).with('post', '/similarity/sync/text/', { text: 'Foo bar foo bar 2', models: [::Bot::Alegre::ELASTICSEARCH_MODEL, ::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::ELASTICSEARCH_MODEL => 0.85, ::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
+    Bot::Alegre.stubs(:request).with('post', '/similarity/sync/text', { text: 'Foo bar foo bar 2', models: [::Bot::Alegre::ELASTICSEARCH_MODEL, ::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::ELASTICSEARCH_MODEL => 0.85, ::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
     r2.attach_to_similar_request!
     #Alegre should be called with ES and vector model for request with 4 or more words
     assert_equal r1, r2.reload.similar_to_request
@@ -148,14 +147,14 @@ class RequestTest < ActiveSupport::TestCase
   end
   
   test "should attach to similar text short" do
-    Bot::Alegre.stubs(:request).returns(true)
     f = create_feed
+    Bot::Alegre.stubs(:request).with('post', '/similarity/async/text', anything).returns({})
     m1 = Media.create! type: 'Claim', quote: 'Foo bar foo bar'
     r1 = create_request media: m1, feed: f
     m2 = Media.create! type: 'Claim', quote: 'Foo bar 2'
     r2 = create_request media: m2, feed: f
     response = { 'result' => [{ '_source' => { 'context' => { 'request_id' => r1.id } } }] }
-    Bot::Alegre.stubs(:request).with('post', '/similarity/sync/text/', { text: 'Foo bar 2', models: [::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
+    Bot::Alegre.stubs(:request).with('post', '/similarity/sync/text', { text: 'Foo bar 2', models: [::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
     r2.attach_to_similar_request!
     #Alegre should only be called with vector models for 2 or 3 word request
     assert_equal r1, r2.reload.similar_to_request
@@ -164,7 +163,7 @@ class RequestTest < ActiveSupport::TestCase
   end
   
   test "should not attach to similar text short" do
-    Bot::Alegre.stubs(:request).returns(true)
+    Bot::Alegre.stubs(:request).returns({'result' => []})
     f = create_feed
     m1 = Media.create! type: 'Claim', quote: 'Foo bar foo bar'
     r1 = create_request media: m1, feed: f
@@ -193,7 +192,7 @@ class RequestTest < ActiveSupport::TestCase
   # end
 
   test "should attach to similar link" do
-    Bot::Alegre.stubs(:request).returns(true)
+    Bot::Alegre.stubs(:request).returns({'result' => []})
     f = create_feed
     m = create_valid_media
     create_request request_type: 'text', media: m

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -139,7 +139,7 @@ class RequestTest < ActiveSupport::TestCase
     m2 = Media.create! type: 'Claim', quote: 'Foo bar foo bar 2'
     r2 = create_request media: m2, feed: f
     response = { 'result' => [{ '_source' => { 'context' => { 'request_id' => r1.id } } }] }
-    Bot::Alegre.stubs(:request).with('post', '/similarity/async/text/', { text: 'Foo bar foo bar 2', models: [::Bot::Alegre::ELASTICSEARCH_MODEL, ::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::ELASTICSEARCH_MODEL => 0.85, ::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
+    Bot::Alegre.stubs(:request).with('post', '/similarity/sync/text/', { text: 'Foo bar foo bar 2', models: [::Bot::Alegre::ELASTICSEARCH_MODEL, ::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::ELASTICSEARCH_MODEL => 0.85, ::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
     r2.attach_to_similar_request!
     #Alegre should be called with ES and vector model for request with 4 or more words
     assert_equal r1, r2.reload.similar_to_request
@@ -155,7 +155,7 @@ class RequestTest < ActiveSupport::TestCase
     m2 = Media.create! type: 'Claim', quote: 'Foo bar 2'
     r2 = create_request media: m2, feed: f
     response = { 'result' => [{ '_source' => { 'context' => { 'request_id' => r1.id } } }] }
-    Bot::Alegre.stubs(:request).with('post', '/similarity/async/text/', { text: 'Foo bar 2', models: [::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
+    Bot::Alegre.stubs(:request).with('post', '/similarity/sync/text/', { text: 'Foo bar 2', models: [::Bot::Alegre::MEAN_TOKENS_MODEL], per_model_threshold: {::Bot::Alegre::MEAN_TOKENS_MODEL =>  0.9}, limit: 20, context: { feed_id: f.id } }).returns(response)
     r2.attach_to_similar_request!
     #Alegre should only be called with vector models for 2 or 3 word request
     assert_equal r1, r2.reload.similar_to_request


### PR DESCRIPTION
## Description

More work moving low level alegre calls over to presto-based alegre calls

References: CV2-5080

## How has this been tested?

Not tested yet - follows previous patterns we've solved for, so shouldn't be excessively difficult!

## Things to pay attention to during code review

Nothing in particular.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

