### PR TITLE
Searching for fact-checks should match claim fields too.

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -547,9 +547,9 @@ class Team < ApplicationRecord
   def filter_by_keywords(query, filters, type = 'FactCheck')
     tsquery = Team.sanitize_sql_array(["websearch_to_tsquery(?)", filters[:text]])
     if type == 'FactCheck'
-      tsvector = "to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(summary, '') || coalesce(url, '') || coalesce(claim_descriptions.description, '') || coalesce(claim_descriptions.context, ''))"
+      tsvector = "to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(summary, '') || ' ' || coalesce(url, '') || ' ' || coalesce(claim_descriptions.description, '') || ' ' || coalesce(claim_descriptions.context, ''))"
     else
-      tsvector = "to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(description, '') || coalesce(url, ''))"
+      tsvector = "to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(description, '') || ' ' || coalesce(url, ''))"
     end
     query.where(Arel.sql("#{tsvector} @@ #{tsquery}"))
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -545,9 +545,9 @@ class Team < ApplicationRecord
   end
 
   def filter_by_keywords(query, filters, type = 'FactCheck')
-    tsquery = Team.sanitize_sql_array(["websearch_to_tsquery(?)", filters[:text]]) # FIXME: May not work for all languages
+    tsquery = Team.sanitize_sql_array(["websearch_to_tsquery(?)", filters[:text]])
     if type == 'FactCheck'
-      tsvector = "to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(summary, '') || coalesce(url, ''))"
+      tsvector = "to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(summary, '') || coalesce(url, '') || coalesce(claim_descriptions.description, '') || coalesce(claim_descriptions.context, ''))"
     else
       tsvector = "to_tsvector('simple', coalesce(title, '') || ' ' || coalesce(description, '') || coalesce(url, ''))"
     end

--- a/test/models/team_2_test.rb
+++ b/test/models/team_2_test.rb
@@ -1528,12 +1528,13 @@ class Team2Test < ActiveSupport::TestCase
     Sidekiq::Testing.fake!
     t = create_team
     # Fact-checks
-    create_fact_check title: 'Some Other Test', claim_description: create_claim_description(project_media: create_project_media(team: t))
-    create_fact_check title: 'Bar Bravo Foo Test', claim_description: create_claim_description(project_media: create_project_media(team: t))
+    create_fact_check title: 'Some Other Test', claim_description: create_claim_description(description: 'Claim', project_media: create_project_media(team: t))
+    create_fact_check title: 'Bar Bravo Foo Test', claim_description: create_claim_description(context: 'Claim', project_media: create_project_media(team: t))
     create_fact_check title: 'Foo Alpha Bar Test', claim_description: create_claim_description(project_media: create_project_media(team: t))
     assert_equal 3, t.filtered_fact_checks.count
     assert_equal 3, t.filtered_fact_checks(text: 'Test').count
     assert_equal 2, t.filtered_fact_checks(text: 'Foo Bar').count
+    assert_equal 2, t.filtered_fact_checks(text: 'Claim').count
     assert_equal 1, t.filtered_fact_checks(text: 'Foo Bar Bravo').count
     assert_equal 1, t.filtered_fact_checks(text: 'Foo Bar Alpha').count
     assert_equal 0, t.filtered_fact_checks(text: 'Foo Bar Delta').count


### PR DESCRIPTION
## Description

Now searching for fact-checks can also match the claim fields "description" and "context".

Fixes: CV2-5194.

## How has this been tested?

I added a unit test.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

