### PR TITLE
Include blank media when iterating through items for clusterization.

### DIFF
--- a/lib/tasks/check_khousheh.rake
+++ b/lib/tasks/check_khousheh.rake
@@ -20,12 +20,13 @@ namespace :check do
       FileUtils.mkdir_p(File.join(Rails.root, 'tmp', 'feed-clusters-input'))
       started = Time.now.to_i
       sort = [{ annotated_id: { order: :asc } }]
+      all_types = CheckSearch::MEDIA_TYPES + ['blank']
       Feed.find_each do |feed|
         # Only feeds that are sharing media
         if feed.data_points.to_a.include?(2)
           output = { call_id: "#{TIMESTAMP}-#{feed.uuid}", nodes: [], edges: [] }
           Team.current = feed.team
-          query = { feed_id: feed.id, feed_view: 'media', show_similar: true }
+          query = { feed_id: feed.id, feed_view: 'media', show_similar: true, show: all_types }
           es_query = CheckSearch.new(query.to_json).medias_query
           total = CheckSearch.new(query.to_json, nil, feed.team.id).number_of_results
           pages = (total / PER_PAGE.to_f).ceil
@@ -211,7 +212,8 @@ namespace :check do
               end
               # Add items to clusters
               Team.current = feed.team
-              query = { feed_id: feed.id, feed_view: 'media', show_similar: true }
+              all_types = CheckSearch::MEDIA_TYPES + ['blank']
+              query = { feed_id: feed.id, feed_view: 'media', show_similar: true, show: all_types }
               es_query = CheckSearch.new(query.to_json).medias_query
               total = CheckSearch.new(query.to_json, nil, feed.team.id).number_of_results
               pages = (total / PER_PAGE.to_f).ceil


### PR DESCRIPTION
## Description

This is to restore the behavior of before we pushed the changes for not including blank items by default.

Fixes CV2-5158.

## How has this been tested?

I executed the `CheckSearch` query on live and it returned more items for clusterization.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

