### PR TITLE
Be able to export a full list of media clusters.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,7 +10,7 @@ checks:
     enabled: false
   method-complexity:
     config:
-      threshold: 22
+      threshold: 25
   method-count:
     config:
       threshold: 65

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -347,10 +347,9 @@ class CheckSearch
     # Paginate
     search = CheckSearch.new(query, nil, team_id)
     search_after = [0]
-    while true
+    while !search_after.empty?
       result = $repository.search(_source: 'annotated_id', query: search.medias_query, sort: [{ annotated_id: { order: :asc } }], size: 10000, search_after: search_after).results
-      ids = result.collect{ |i| i['annotated_id'] }.uniq.map(&:to_i)
-      break if ids.empty?
+      ids = result.collect{ |i| i['annotated_id'] }.uniq.compact.map(&:to_i)
 
       # Iterate through each result and generate an output row for the CSV
       ProjectMedia.where(id: ids, team_id: search.team_condition(team_id)).find_each do |pm|
@@ -374,7 +373,7 @@ class CheckSearch
         data << row
       end
 
-      search_after = [ids.max]
+      search_after = [ids.max].compact
     end
 
     data

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -89,6 +89,10 @@ class CheckSearch
     Team.find_by_id(team_id)
   end
 
+  def feed
+    @feed
+  end
+
   def teams
     []
   end
@@ -336,16 +340,22 @@ class CheckSearch
   def self.get_exported_data(query, team_id)
     team = Team.find(team_id)
     Team.current = team
+    search = CheckSearch.new(query, nil, team_id)
+    feed_sharing_only_fact_checks = (search.feed && search.feed.data_points == [1])
 
     # Prepare the export
     data = []
-    header = ['Claim', 'Item page URL', 'Status', 'Created by', 'Submitted at', 'Published at', 'Number of media', 'Tags']
-    fields = team.team_tasks.sort
-    fields.each { |tt| header << tt.label }
+    header = nil
+    if feed_sharing_only_fact_checks
+      header = ['Fact-check title', 'Fact-check summary', 'Fact-check URL', 'Tags', 'Workspace', 'Updated at', 'Rating']
+    else
+      header = ['Claim', 'Item page URL', 'Status', 'Created by', 'Submitted at', 'Published at', 'Number of media', 'Tags']
+      fields = team.team_tasks.sort
+      fields.each { |tt| header << tt.label }
+    end
     data << header
 
     # Paginate
-    search = CheckSearch.new(query, nil, team_id)
     search_after = [0]
     while !search_after.empty?
       result = $repository.search(_source: 'annotated_id', query: search.medias_query, sort: [{ annotated_id: { order: :asc } }], size: 10000, search_after: search_after).results
@@ -353,22 +363,35 @@ class CheckSearch
 
       # Iterate through each result and generate an output row for the CSV
       ProjectMedia.where(id: ids, team_id: search.team_condition(team_id)).find_each do |pm|
-        row = [
-          pm.claim_description&.description,
-          pm.full_url,
-          pm.status_i18n,
-          pm.author_name.to_s.gsub(/ \[.*\]$/, ''),
-          pm.created_at.strftime("%Y-%m-%d %H:%M:%S"),
-          pm.published_at&.strftime("%Y-%m-%d %H:%M:%S"),
-          pm.linked_items_count,
-          pm.tags_as_sentence
-        ]
-        annotations = pm.get_annotations('task').map(&:load)
-        fields.each do |field|
-          annotation = annotations.find { |a| a.team_task_id == field.id }
-          answer = (annotation ? (begin annotation.first_response_obj.file_data[:file_urls].join("\n") rescue annotation.first_response.to_s end) : '')
-          answer = begin JSON.parse(answer).collect{ |x| x['url'] }.join(', ') rescue answer end
-          row << answer
+        row = nil
+        if feed_sharing_only_fact_checks
+          row = [
+            pm.fact_check_title,
+            pm.fact_check_summary,
+            pm.fact_check_url,
+            pm.tags_as_sentence,
+            pm.team_name,
+            pm.updated_at_timestamp,
+            pm.status
+          ]
+        else
+          row = [
+            pm.claim_description&.description,
+            pm.full_url,
+            pm.status_i18n,
+            pm.author_name.to_s.gsub(/ \[.*\]$/, ''),
+            pm.created_at.strftime("%Y-%m-%d %H:%M:%S"),
+            pm.published_at&.strftime("%Y-%m-%d %H:%M:%S"),
+            pm.linked_items_count,
+            pm.tags_as_sentence
+          ]
+          annotations = pm.get_annotations('task').map(&:load)
+          fields.each do |field|
+            annotation = annotations.find { |a| a.team_task_id == field.id }
+            answer = (annotation ? (begin annotation.first_response_obj.file_data[:file_urls].join("\n") rescue annotation.first_response.to_s end) : '')
+            answer = begin JSON.parse(answer).collect{ |x| x['url'] }.join(', ') rescue answer end
+            row << answer
+          end
         end
         data << row
       end

--- a/test/lib/list_export_test.rb
+++ b/test/lib/list_export_test.rb
@@ -62,6 +62,10 @@ class ListExportTest < ActiveSupport::TestCase
   test "should export fact-check feed CSV" do
     setup_elasticsearch
     RequestStore.store[:skip_cached_field_update] = false
+
+    pender_url = CheckConfig.get('pender_url_private')
+    WebMock.stub_request(:get, /#{pender_url}/).to_return(body: '{}', status: 200)
+
     t = create_team
     2.times do
       pm = create_project_media team: t, disable_es_callbacks: false

--- a/test/lib/list_export_test.rb
+++ b/test/lib/list_export_test.rb
@@ -45,7 +45,7 @@ class ListExportTest < ActiveSupport::TestCase
     assert_equal 2, csv_content.size
   end
 
-  test "should export feed CSV" do
+  test "should export media feed CSV" do
     t = create_team
     f = create_feed team: t
     2.times { f.clusters << create_cluster }
@@ -57,6 +57,32 @@ class ListExportTest < ActiveSupport::TestCase
     csv_content = CSV.parse(response.body, headers: true)
     assert_equal 2, csv_content.size
     assert_equal 2, export.number_of_rows
+  end
+
+  test "should export fact-check feed CSV" do
+    setup_elasticsearch
+    RequestStore.store[:skip_cached_field_update] = false
+    t = create_team
+    2.times do
+      pm = create_project_media team: t, disable_es_callbacks: false
+      r = publish_report(pm, {}, nil, { language: 'en', use_visual_card: false })
+      r = Dynamic.find(r.id)
+      r.disable_es_callbacks = false
+      r.set_fields = { state: 'published' }.to_json
+      r.save!
+    end
+    ss = create_saved_search team: t
+    f = create_feed team: t, data_points: [1], saved_search: ss, published: true
+
+    sleep 2 # Wait for indexing
+
+    export = ListExport.new(:media, { feed_id: f.id, feed_view: 'fact_check' }.to_json, t.id)
+    csv_url = export.generate_csv_and_send_email(create_user)
+    response = Net::HTTP.get_response(URI(csv_url))
+    assert_equal 200, response.code.to_i
+    csv_content = CSV.parse(response.body, headers: true)
+    assert_equal 2, export.number_of_rows
+    assert_equal 2, csv_content.size
   end
 
   test "should export fact-checks CSV" do

--- a/test/lib/list_export_test.rb
+++ b/test/lib/list_export_test.rb
@@ -26,18 +26,23 @@ class ListExportTest < ActiveSupport::TestCase
     end
   end
 
-  test "should export media CSV" do
+  test "should export media (including child media) CSV" do
+    setup_elasticsearch
     t = create_team
     create_team_task team_id: t.id, fieldset: 'tasks'
-    2.times { create_project_media team: t }
+    parent = create_project_media team: t, disable_es_callbacks: false
+    child = create_project_media team: t, disable_es_callbacks: false
+    create_relationship source_id: parent.id, target_id: child.id, relationship_type: Relationship.confirmed_type
 
-    export = ListExport.new(:media, '{}', t.id)
+    sleep 2 # Wait for indexing
+
+    export = ListExport.new(:media, { show_similar: true }.to_json, t.id)
     csv_url = export.generate_csv_and_send_email(create_user)
     response = Net::HTTP.get_response(URI(csv_url))
     assert_equal 200, response.code.to_i
     csv_content = CSV.parse(response.body, headers: true)
-    assert_equal 2, csv_content.size
     assert_equal 2, export.number_of_rows
+    assert_equal 2, csv_content.size
   end
 
   test "should export feed CSV" do


### PR DESCRIPTION
## Description

The current export limit for media lists is 10.000 because this is the maximum size of a result window in ElasticSearch. The solution is to paginate the results.

Fixes: CV2-5205.

## How has this been tested?

This is just a refactoring, the existing test should cover it.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

