### PR TITLE
Update imported fact-check tag creation

### DIFF
--- a/app/models/bot/fetch.rb
+++ b/app/models/bot/fetch.rb
@@ -259,6 +259,7 @@ class Bot::Fetch < BotUser
       fc.title = self.get_title(claim_review).to_s
       fc.url = claim_review['url'].to_s
       fc.summary = self.get_summary(claim_review).to_s
+      fc.tags = claim_review['keywords'].to_s.split(',').map(&:strip).reject{ |r| r.blank? }
       fc.user = user
       fc.language = fc_language
       fc.publish_report = true


### PR DESCRIPTION
## Description

While I was testing backlog imports locally, I noticed that the tags were being created, but not added to the fact check.

This happened because we associate them with the project media (here:check-api/app/models/bot/fetch.rb ) and not the fact-check itself, and those are now separate things. Meaning, we need to add them to the fact-check itself.

References: 5227

## How has this been tested?

By importing fact-checks using our script and FetchBot.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

