### PR TITLE
Cv2 5084 Update Reindexing to use async presto endpoint

### DIFF
--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -290,10 +290,6 @@ module AlegreV2
       request("post", async_path_for_type(type), params.merge(suppress_search_response: suppress_search_response))
     end
 
-    def index_async_with_params(params, type)
-      request("post", async_path_for_type(type), params)
-    end
-
     def index_sync_with_params(params, type)
       query_sync_with_params(params, type)
     end

--- a/app/workers/reindex_alegre_workspace.rb
+++ b/app/workers/reindex_alegre_workspace.rb
@@ -72,6 +72,7 @@ class ReindexAlegreWorkspace
     if running_bucket.length > 500 || write_remains
       log(event_id, 'Writing to Alegre...')
       running_bucket.each do |item|
+        # FIXME we need to go back to bulk uploads eventually
         Bot::Alegre.query_async_with_params(item[:doc], item[:type])
       end
       log(event_id, 'Wrote to Alegre.')

--- a/app/workers/reindex_alegre_workspace.rb
+++ b/app/workers/reindex_alegre_workspace.rb
@@ -45,12 +45,15 @@ class ReindexAlegreWorkspace
   end
 
   def get_request_doc(pm, field, field_value)
-    Bot::Alegre.send_to_text_similarity_index_package(
-      pm,
-      field,
-      field_value,
-      Bot::Alegre.item_doc_id(pm, field)
-    )
+    {
+      doc: Bot::Alegre.send_to_text_similarity_index_package(
+        pm,
+        field,
+        field_value,
+        Bot::Alegre.item_doc_id(pm, field)
+      ),
+      type: Bot::Alegre.get_pm_type(pm)
+    }
   end
 
   def get_request_docs_for_project_media(pm)
@@ -68,7 +71,9 @@ class ReindexAlegreWorkspace
     # manage dispatch of documents to bulk similarity api call in parallel
     if running_bucket.length > 500 || write_remains
       log(event_id, 'Writing to Alegre...')
-      Parallel.map(running_bucket.each_slice(30).to_a, in_processes: in_processes) { |bucket_slice| Bot::Alegre.request('post', '/text/bulk_similarity/', { documents: bucket_slice }) }
+      running_bucket.each do |item|
+        Bot::Alegre.get_sync_with_params(item[:doc], item[:type])
+      end
       log(event_id, 'Wrote to Alegre.')
       # track state in case job needs to restart
       write_last_id(event_id, team_id, running_bucket.last[:context][:project_media_id]) if running_bucket.length > 0 && running_bucket.last[:context]

--- a/app/workers/reindex_alegre_workspace.rb
+++ b/app/workers/reindex_alegre_workspace.rb
@@ -72,7 +72,7 @@ class ReindexAlegreWorkspace
     if running_bucket.length > 500 || write_remains
       log(event_id, 'Writing to Alegre...')
       running_bucket.each do |item|
-        Bot::Alegre.get_sync_with_params(item[:doc], item[:type])
+        Bot::Alegre.get_async_with_params(item[:doc], item[:type])
       end
       log(event_id, 'Wrote to Alegre.')
       # track state in case job needs to restart

--- a/app/workers/reindex_alegre_workspace.rb
+++ b/app/workers/reindex_alegre_workspace.rb
@@ -72,7 +72,7 @@ class ReindexAlegreWorkspace
     if running_bucket.length > 500 || write_remains
       log(event_id, 'Writing to Alegre...')
       running_bucket.each do |item|
-        Bot::Alegre.get_async_with_params(item[:doc], item[:type])
+        Bot::Alegre.query_async_with_params(item[:doc], item[:type])
       end
       log(event_id, 'Wrote to Alegre.')
       # track state in case job needs to restart

--- a/test/workers/reindex_alegre_workspace_test.rb
+++ b/test/workers/reindex_alegre_workspace_test.rb
@@ -58,16 +58,19 @@ class ReindexAlegreWorkspaceTest < ActiveSupport::TestCase
 
   test "checks alegre package in get_request_doc" do
     package = {
-      :doc_id=>Bot::Alegre.item_doc_id(@pm, "title"),
-      :text=>"Some text",
-      :context=>{
-        :team_id=>@pm.team_id,
-        :project_media_id=>@pm.id,
-        :has_custom_id=>true,
-        :temporary_media=>false,
-        :field=>"title"
+      :doc=>{
+        :doc_id=>Bot::Alegre.item_doc_id(@pm, "title"),
+        :text=>"Some text",
+        :context=>{
+          :team_id=>@pm.team_id,
+          :project_media_id=>@pm.id,
+          :has_custom_id=>true,
+          :temporary_media=>false,
+          :field=>"title"
+        },
+        :models=>["elasticsearch"]
       },
-      :models=>["elasticsearch"]
+      :type=>"text"
     }
     response = ReindexAlegreWorkspace.new.get_request_doc(@pm, "title", "Some text")
     assert_equal package, response
@@ -93,16 +96,19 @@ class ReindexAlegreWorkspaceTest < ActiveSupport::TestCase
   
   test "tests the parallel request" do
     package = {
-      :doc_id=>Bot::Alegre.item_doc_id(@pm, "title"),
-      :text=>"Some text",
-      :context=>{
-        :team_id=>@pm.team_id,
-        :project_media_id=>@pm.id,
-        :has_custom_id=>true,
-        :temporary_media=>false,
-        :field=>"title"
+      :doc=>{
+        :doc_id=>Bot::Alegre.item_doc_id(@pm, "title"),
+        :text=>"Some text",
+        :context=>{
+          :team_id=>@pm.team_id,
+          :project_media_id=>@pm.id,
+          :has_custom_id=>true,
+          :temporary_media=>false,
+          :field=>"title"
+        },
+        :models=>["elasticsearch"]
       },
-      :models=>["elasticsearch"]
+      :type=>"text"
     }
     response = ReindexAlegreWorkspace.new.check_for_write(1.upto(30).collect{|x| package}, "a", @team.id, true, 1)
     assert_equal Array, response.class

--- a/test/workers/reindex_alegre_workspace_test.rb
+++ b/test/workers/reindex_alegre_workspace_test.rb
@@ -25,7 +25,7 @@ class ReindexAlegreWorkspaceTest < ActiveSupport::TestCase
     @tbi.save
     Bot::Alegre.stubs(:get_alegre_tbi).returns(TeamBotInstallation.new)
     Sidekiq::Testing.inline!
-    Bot::Alegre.stubs(:request).with('post', '/text/bulk_similarity/', anything).returns("done")
+    Bot::Alegre.stubs(:request).with('post', '/similarity/async/text', anything).returns("done")
   end
 
   def teardown


### PR DESCRIPTION
## Description

Moves our reindexer task over to presto - annoyingly we use bulk for this but have to dip down to singular document updates for now, since we don't have a bulk endpoint yet for presto.
References: CV2-5084

## How has this been tested?

Tested the new plumbing with a test workspace on QA server, otherwise should flow with existing setup just fine

## Things to pay attention to during code review

None in particular, low risk change.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

