### PR TITLE
CV2-5081 switch text to presto-based querying

### DIFF
--- a/app/lib/smooch_nlu.rb
+++ b/app/lib/smooch_nlu.rb
@@ -33,8 +33,6 @@ class SmoochNlu
   end
 
   def update_keywords(language, keywords, keyword, operation, doc_id, context)
-    alegre_operation = nil
-    alegre_params = nil
     common_alegre_params = {
       doc_id: doc_id,
       context: {

--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -155,10 +155,8 @@ class Bot::Alegre < BotUser
         if ['audio', 'image', 'video'].include?(self.get_pm_type(pm))
           self.relate_project_media_async(pm)
         else
-          Bot::Alegre.send_to_media_similarity_index(pm)
-          Bot::Alegre.send_field_to_similarity_index(pm, 'original_title')
-          Bot::Alegre.send_field_to_similarity_index(pm, 'original_description')
-          Bot::Alegre.relate_project_media_to_similar_items(pm)
+          self.relate_project_media_async(pm, 'original_title')
+          self.relate_project_media_async(pm, 'original_description')
         end
         self.get_extracted_text(pm)
         self.get_flags(pm)
@@ -206,7 +204,7 @@ class Bot::Alegre < BotUser
     threshold ||= self.get_threshold_for_query('text', nil, true)
     models ||= [self.matching_model_to_use(team_ids)].flatten
     Hash[self.get_similar_items_from_api(
-      '/similarity/sync/text',
+      'text',
       self.similar_texts_from_api_conditions(text, models, fuzzy, team_ids, fields, threshold),
       threshold
     ).collect{|k,v| [k, v.merge(model: v[:model]||Bot::Alegre.default_matching_model)]}]

--- a/app/models/concerns/alegre_similarity.rb
+++ b/app/models/concerns/alegre_similarity.rb
@@ -133,10 +133,9 @@ module AlegreSimilarity
 
     def send_to_text_similarity_index(pm, field, text, doc_id)
       if !text.blank? && Bot::Alegre::BAD_TITLE_REGEX !~ text
-        self.request(
-          'post',
-          '/text/similarity/',
-          self.send_to_text_similarity_index_package(pm, field, text, doc_id)
+        self.query_sync_with_params(
+          self.send_to_text_similarity_index_package(pm, field, text, doc_id),
+          "text"
         )
       end
     end
@@ -207,10 +206,10 @@ module AlegreSimilarity
       es_matches
     end
 
-    def get_similar_items_from_api(path, conditions, _threshold = {})
+    def get_similar_items_from_api(type, conditions, _threshold = {})
       Rails.logger.error("[Alegre Bot] Sending request to alegre : #{path} , #{conditions.to_json}")
       response = {}
-      result = self.request('post', path, conditions)&.dig('result')
+      result = self.query_sync_with_params(conditions, type)&.dig('result')
       project_medias = result.collect{ |r| self.extract_project_medias_from_context(r) } if !result.nil? && result.is_a?(Array)
       project_medias.each do |request_response|
         request_response.each do |pmid, score_with_context|

--- a/app/models/concerns/alegre_similarity.rb
+++ b/app/models/concerns/alegre_similarity.rb
@@ -207,7 +207,7 @@ module AlegreSimilarity
     end
 
     def get_similar_items_from_api(type, conditions, _threshold = {})
-      Rails.logger.error("[Alegre Bot] Sending request to alegre : #{path} , #{conditions.to_json}")
+      Rails.logger.error("[Alegre Bot] Sending request to alegre : #{type} , #{conditions.to_json}")
       response = {}
       result = self.query_sync_with_params(conditions, type)&.dig('result')
       project_medias = result.collect{ |r| self.extract_project_medias_from_context(r) } if !result.nil? && result.is_a?(Array)

--- a/app/workers/reindex_alegre_workspace.rb
+++ b/app/workers/reindex_alegre_workspace.rb
@@ -67,7 +67,7 @@ class ReindexAlegreWorkspace
     end
   end
 
-  def check_for_write(running_bucket, event_id, team_id, write_remains=false, in_processes=3)
+  def check_for_write(running_bucket, event_id, team_id, write_remains=false, _in_processes=3)
     # manage dispatch of documents to bulk similarity api call in parallel
     if running_bucket.length > 500 || write_remains
       log(event_id, 'Writing to Alegre...')

--- a/test/models/bot/alegre_test.rb
+++ b/test/models/bot/alegre_test.rb
@@ -103,6 +103,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
 
   test "should unarchive item after running" do
     WebMock.stub_request(:delete, 'http://alegre/text/similarity/').to_return(body: {success: true}.to_json)
+    WebMock.stub_request(:post, 'http://alegre/similarity/async/text').to_return(body: {results: []}.to_json)
     stub_configs({ 'alegre_host' => 'http://alegre', 'alegre_token' => 'test' }) do
       WebMock.stub_request(:delete, 'http://alegre/text/similarity/').to_return(status: 200, body: '{}')
       pm = create_project_media
@@ -205,8 +206,8 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   end
 
   test "should index report data" do
-    WebMock.stub_request(:delete, 'http://alegre:3100/similarity/sync/text').to_return(body: {success: true}.to_json)
-    WebMock.stub_request(:post, 'http://alegre:3100/text/similarity/').to_return(body: {}.to_json)
+    WebMock.stub_request(:delete, 'http://alegre:3100/text/similarity/').to_return(body: {success: true}.to_json)
+    WebMock.stub_request(:post, 'http://alegre:3100/similarity/sync/text').to_return(body: {}.to_json)
     pm = create_project_media team: @team
     assert_nothing_raised do
       publish_report(pm)

--- a/test/models/bot/alegre_test.rb
+++ b/test/models/bot/alegre_test.rb
@@ -45,6 +45,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
        WebMock.stub_request(:post, 'http://alegre/text/langid/').to_return(body: 'bad JSON response')
        WebMock.stub_request(:post, 'http://alegre/text/similarity/').to_return(body: 'success')
        WebMock.stub_request(:post, 'http://alegre/similarity/sync/text').to_return(body: 'success')
+       WebMock.stub_request(:post, 'http://alegre/similarity/async/text').to_return(body: 'success')
        WebMock.disable_net_connect! allow: /#{CheckConfig.get('elasticsearch_host')}|#{CheckConfig.get('storage_endpoint')}/
        Bot::Alegre.any_instance.stubs(:get_language).raises(RuntimeError)
        assert_nothing_raised do
@@ -204,7 +205,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   end
 
   test "should index report data" do
-    WebMock.stub_request(:delete, 'http://alegre:3100/text/similarity/').to_return(body: {success: true}.to_json)
+    WebMock.stub_request(:delete, 'http://alegre:3100/similarity/sync/text').to_return(body: {success: true}.to_json)
     WebMock.stub_request(:post, 'http://alegre:3100/text/similarity/').to_return(body: {}.to_json)
     pm = create_project_media team: @team
     assert_nothing_raised do
@@ -214,7 +215,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
 
   test "should use OCR data for similarity matching" do
     WebMock.stub_request(:post, 'http://alegre:3100/text/langid/').with(body: { text: 'Foo bar' }.to_json).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, 'http://alegre:3100/text/similarity/').to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, 'http://alegre:3100/similarity/sync/text').to_return(status: 200, body: '{}')
     pm = create_project_media team: @team
     pm2 = create_project_media team: @team
     Bot::Alegre.stubs(:get_items_with_similar_description).returns({ pm2.id => {:score=>0.9, :context=>{"team_id"=>@team.id, "field"=>"original_description", "project_media_id"=>pm2.id, "has_custom_id"=>true}, :model=>"elasticsearch"} })
@@ -262,7 +263,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   # This test to reproduce errbit error CHECK-1218
   test "should match to existing parent" do
     WebMock.stub_request(:post, 'http://alegre:3100/text/langid/').with(body: { text: 'Foo bar' }.to_json).to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, 'http://alegre:3100/text/similarity/').to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, 'http://alegre:3100/similarity/sync/text').to_return(status: 200, body: '{}')
     pm_s = create_project_media team: @team
     pm = create_project_media team: @team
     pm2 = create_project_media team: @team
@@ -280,7 +281,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   test "should use transcription data for similarity matching" do
     WebMock.stub_request(:post, 'http://alegre:3100/text/langid/').with(body: { text: 'Foo bar' }.to_json).to_return(status: 200, body: '{}')
     WebMock.stub_request(:delete, 'http://alegre:3100/text/similarity/').to_return(status: 200, body: '{}')
-    WebMock.stub_request(:post, 'http://alegre:3100/text/similarity/').to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, 'http://alegre:3100/similarity/sync/text').to_return(status: 200, body: '{}')
     json_schema = {
       type: 'object',
       required: ['job_name'],
@@ -305,7 +306,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
   end
 
   test "should check existing relationship before create a new one" do
-    WebMock.stub_request(:post, 'http://alegre:3100/text/similarity/').to_return(status: 200, body: '{}')
+    WebMock.stub_request(:post, 'http://alegre:3100/similarity/sync/text').to_return(status: 200, body: '{}')
     WebMock.stub_request(:post, 'http://alegre:3100/text/langid/').with(body: { text: 'Foo bar' }.to_json).to_return(status: 200, body: '{}')
     pm = create_project_media team: @team
     pm2 = create_project_media team: @team

--- a/test/models/bot/fetch_2_test.rb
+++ b/test/models/bot/fetch_2_test.rb
@@ -39,7 +39,7 @@ class Bot::FetchTest < ActiveSupport::TestCase
     WebMock.stub_request(:get, 'http://fetch:8000/claim_reviews?end_time=2017-08-11&include_raw=false&offset=0&per_page=100&service=test&start_time=2017-08-06').to_return(body: [@claim_review].to_json)
     WebMock.stub_request(:post, 'http://fetch:8000/subscribe').with(body: { service: 'foo', url: 'http://check:3100/api/webhooks/fetch?team=fetch&token=test', language: nil }.to_json).to_return(body: '{}')
     WebMock.stub_request(:delete, 'http://fetch:8000/subscribe').with(body: { service: 'test', url: 'http://check:3100/api/webhooks/fetch?team=fetch&token=test'}.to_json).to_return(body: '{}')
-    WebMock.stub_request(:post, 'http://alegre:3100/text/similarity/').to_return(body: {}.to_json)
+    WebMock.stub_request(:post, 'http://alegre:3100/similarity/sync/test').to_return(body: {}.to_json)
     WebMock.stub_request(:delete, 'http://alegre:3100/text/similarity/').to_return(body: {}.to_json)
     
     create_verification_status_stuff

--- a/test/models/bot/fetch_2_test.rb
+++ b/test/models/bot/fetch_2_test.rb
@@ -39,7 +39,7 @@ class Bot::FetchTest < ActiveSupport::TestCase
     WebMock.stub_request(:get, 'http://fetch:8000/claim_reviews?end_time=2017-08-11&include_raw=false&offset=0&per_page=100&service=test&start_time=2017-08-06').to_return(body: [@claim_review].to_json)
     WebMock.stub_request(:post, 'http://fetch:8000/subscribe').with(body: { service: 'foo', url: 'http://check:3100/api/webhooks/fetch?team=fetch&token=test', language: nil }.to_json).to_return(body: '{}')
     WebMock.stub_request(:delete, 'http://fetch:8000/subscribe').with(body: { service: 'test', url: 'http://check:3100/api/webhooks/fetch?team=fetch&token=test'}.to_json).to_return(body: '{}')
-    WebMock.stub_request(:post, 'http://alegre:3100/similarity/sync/test').to_return(body: {}.to_json)
+    WebMock.stub_request(:post, 'http://alegre:3100/similarity/sync/text').to_return(body: {}.to_json)
     WebMock.stub_request(:delete, 'http://alegre:3100/text/similarity/').to_return(body: {}.to_json)
     
     create_verification_status_stuff

--- a/test/models/bot/fetch_test.rb
+++ b/test/models/bot/fetch_test.rb
@@ -44,7 +44,7 @@ class Bot::FetchTest < ActiveSupport::TestCase
     WebMock.stub_request(:get, 'http://fetch:8000/claim_reviews?end_time=2017-08-11&include_raw=false&offset=0&per_page=100&service=test&start_time=2017-08-06').to_return(body: [@claim_review].to_json)
     WebMock.stub_request(:post, 'http://fetch:8000/subscribe').with(body: { service: 'foo', url: 'http://check:3100/api/webhooks/fetch?team=fetch&token=test', language: nil }.to_json).to_return(body: '{}')
     WebMock.stub_request(:delete, 'http://fetch:8000/subscribe').with(body: { service: 'test', url: 'http://check:3100/api/webhooks/fetch?team=fetch&token=test'}.to_json).to_return(body: '{}')
-    WebMock.stub_request(:post, 'http://alegre:3100/text/similarity/').to_return(body: {}.to_json)
+    WebMock.stub_request(:post, 'http://alegre:3100/similarity/sync/text').to_return(body: {}.to_json)
     WebMock.stub_request(:delete, 'http://alegre:3100/text/similarity/').to_return(body: {}.to_json)
 
     create_verification_status_stuff

--- a/test/models/bot/smooch_7_test.rb
+++ b/test/models/bot/smooch_7_test.rb
@@ -601,7 +601,7 @@ class Bot::Smooch7Test < ActiveSupport::TestCase
 
   test "should include claim_description_content in smooch search" do
     WebMock.stub_request(:post, 'http://alegre:3100/similarity/async/image').to_return(body: {}.to_json)
-    WebMock.stub_request(:post, 'http://alegre:3100/text/similarity/').to_return(body: {}.to_json)
+    WebMock.stub_request(:post, 'http://alegre:3100/similarity/sync/text').to_return(body: {}.to_json)
     RequestStore.store[:skip_cached_field_update] = false
     t = create_team
     m = create_uploaded_image


### PR DESCRIPTION
## Description

Switches check-api to use presto-based indexing and querying for main branch of alegre work. 

References: CV2-5081

## How has this been tested?

Full QA to come after epic branch piecewise work is completed - this ticket needs unit test satisfaction for the time being

## Things to pay attention to during code review

`app/models/bot/alegre.rb:158` - @caiosba is this looking correct to you? Do we just index title and description in the main branch of logic or is this missing something?

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

