### PR TITLE
Make claim/fact-check standalone when associated item is deleted

### DIFF
--- a/app/models/concerns/project_media_associations.rb
+++ b/app/models/concerns/project_media_associations.rb
@@ -18,7 +18,7 @@ module ProjectMediaAssociations
     has_many :project_media_requests, dependent: :destroy
     has_many :cluster_project_medias, dependent: :destroy
     has_many :clusters, through: :cluster_project_medias
-    has_one :claim_description, dependent: :destroy
+    has_one :claim_description, dependent: :nullify
     belongs_to :source, optional: true
     has_many :tipline_requests, as: :associated
     has_many :explainer_items, dependent: :destroy

--- a/test/models/project_media_test.rb
+++ b/test/models/project_media_test.rb
@@ -312,17 +312,19 @@ class ProjectMediaTest < ActiveSupport::TestCase
     assert_equal 'Shared Database', pm.creator_name
   end
 
-  test "should delete claims and fact-checks when item is deleted" do
+  test "should make claims and fact-checks standalone when item is deleted" do
     pm = create_project_media
     cd = create_claim_description project_media: pm
     fc = create_fact_check claim_description: cd
     assert_difference 'ProjectMedia.count', -1 do
-      assert_difference 'ClaimDescription.count', -1 do
-        assert_difference 'FactCheck.count', -1 do
+      assert_no_difference 'ClaimDescription.count' do
+        assert_no_difference 'FactCheck.count' do
           pm.destroy!
         end
       end
     end
+    assert_nil cd.reload.project_media
+    assert_equal cd, fc.reload.claim_description
   end
 
   test "should delete project_media_requests and requests when item is deleted" do


### PR DESCRIPTION
## Description

Now that it’s possible to have claims/fact-checks not associated with an item, we should not delete them when the associated item is deleted. They should become standalone articles.

Fixes: CV2-5283.

## How has this been tested?

There should be an automated test for this (I'm still going to add, checking first if any existing test will fail).

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

