### PR TITLE
New data point for tipline requests: When they were first responded

### DIFF
--- a/app/graph/types/tipline_request_type.rb
+++ b/app/graph/types/tipline_request_type.rb
@@ -13,6 +13,7 @@ class TiplineRequestType < DefaultObject
   field :smooch_report_correction_sent_at, GraphQL::Types::Int, null: true
   field :smooch_request_type, GraphQL::Types::String, null: true
   field :associated_graphql_id, GraphQL::Types::String, null: true
+  field :responded_at, GraphQL::Types::Int, null: true
 
   field :smooch_user_external_identifier, GraphQL::Types::String, null: true
 

--- a/app/models/tipline_request.rb
+++ b/app/models/tipline_request.rb
@@ -18,6 +18,14 @@ class TiplineRequest < ApplicationRecord
   after_commit :update_elasticsearch_field, on: :update
   after_commit :destroy_elasticsearch_field, on: :destroy
 
+  def returned_search_results?
+    self.smooch_request_type =~ /search/
+  end
+
+  def responded_at
+    self.returned_search_results? ? self.created_at.to_i : self.smooch_report_sent_at.to_i
+  end
+
   def smooch_user_slack_channel_url
     return if self.smooch_data.blank?
     slack_channel_url = ''

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -13919,6 +13919,7 @@ type TiplineRequest implements Node {
   dbid: Int
   id: ID!
   permissions: String
+  responded_at: Int
   smooch_data: JsonStringType
   smooch_report_correction_sent_at: Int
   smooch_report_received_at: Int

--- a/public/relay.json
+++ b/public/relay.json
@@ -73520,6 +73520,20 @@
               "deprecationReason": null
             },
             {
+              "name": "responded_at",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "smooch_data",
               "description": null,
               "args": [

--- a/test/models/tipline_request_test.rb
+++ b/test/models/tipline_request_test.rb
@@ -1,6 +1,13 @@
 require_relative '../test_helper'
 
 class TiplineRequestTest < ActiveSupport::TestCase
+  def setup
+    User.current = Team.current = nil
+  end
+
+  def teardown
+  end
+
   test "should create tipline request" do
     assert_difference 'TiplineRequest.count' do
       create_tipline_request
@@ -52,5 +59,17 @@ class TiplineRequestTest < ActiveSupport::TestCase
   test "should get associated GraphQL ID" do
     tr = create_tipline_request
     assert_kind_of String, tr.associated_graphql_id
+  end
+
+  test "should return the time it was responded" do
+    tr = create_tipline_request smooch_request_type: 'default_requests'
+    assert_equal 0, tr.responded_at
+
+    tr = create_tipline_request smooch_request_type: 'relevant_search_result_requests'
+    assert_equal tr.created_at.to_i, tr.responded_at
+
+    now = Time.now.to_i
+    tr = create_tipline_request smooch_request_type: 'default_requests', smooch_report_sent_at: now
+    assert_equal now, tr.responded_at
   end
 end


### PR DESCRIPTION
## Description

This PR adds a new data point for tipline requests, which is the first time they are responded. "Responded" means: when the tipline request received the first fact-check/report from Check. For search queries that returned results, the time is the same as the request time itself.

Steps:

- [x] Add a `responded_at` attribute to `TiplineRequest`
- [x] Expose it in the respective GraphQL type
- [x] Add unit tests to it

## How has this been tested?

Automated tests added for all new code in order to keep 100% code coverage.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

