### PR TITLE
Articles "trash" feature

### DIFF
--- a/app/graph/mutations/explainer_mutations.rb
+++ b/app/graph/mutations/explainer_mutations.rb
@@ -20,6 +20,8 @@ module ExplainerMutations
 
   class Update < Mutations::UpdateMutation
     include SharedCreateAndUpdateFields
+
+    argument :trashed, GraphQL::Types::Boolean, required: false
   end
 
   class Destroy < Mutations::DestroyMutation; end

--- a/app/graph/mutations/fact_check_mutations.rb
+++ b/app/graph/mutations/fact_check_mutations.rb
@@ -26,6 +26,7 @@ module FactCheckMutations
 
     argument :title, GraphQL::Types::String, required: false
     argument :summary, GraphQL::Types::String, required: false
+    argument :trashed, GraphQL::Types::Boolean, required: false
   end
 
   class Destroy < Mutations::DestroyMutation; end

--- a/app/graph/types/explainer_type.rb
+++ b/app/graph/types/explainer_type.rb
@@ -13,4 +13,5 @@ class ExplainerType < DefaultObject
   field :user, UserType, null: true
   field :team, PublicTeamType, null: true
   field :tags, [GraphQL::Types::String, null: true], null: true
+  field :trashed, GraphQL::Types::Boolean, null: true
 end

--- a/app/graph/types/fact_check_type.rb
+++ b/app/graph/types/fact_check_type.rb
@@ -14,4 +14,5 @@ class FactCheckType < DefaultObject
   field :rating, GraphQL::Types::String, null: true
   field :imported, GraphQL::Types::Boolean, null: true
   field :report_status, GraphQL::Types::String, null: true
+  field :trashed, GraphQL::Types::Boolean, null: true
 end

--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -306,6 +306,7 @@ class TeamType < DefaultObject
     argument :rating, [GraphQL::Types::String, null: true], required: false, camelize: false
     argument :imported, GraphQL::Types::Boolean, required: false, camelize: false # Only for fact-checks
     argument :target_id, GraphQL::Types::Int, required: false, camelize: false # Exclude articles already applied to the `ProjectMedia` with this ID
+    argument :trashed, GraphQL::Types::Boolean, required: false, camelize: false, default_value: false
   end
 
   def articles(**args)
@@ -336,6 +337,7 @@ class TeamType < DefaultObject
     argument :rating, [GraphQL::Types::String, null: true], required: false, camelize: false
     argument :imported, GraphQL::Types::Boolean, required: false, camelize: false # Only for fact-checks
     argument :target_id, GraphQL::Types::Int, required: false, camelize: false # Exclude articles already applied to the `ProjectMedia` with this ID
+    argument :trashed, GraphQL::Types::Boolean, required: false, camelize: false, default_value: false
   end
 
   def articles_count(**args)

--- a/app/models/claim_description.rb
+++ b/app/models/claim_description.rb
@@ -14,6 +14,7 @@ class ClaimDescription < ApplicationRecord
 
   validates_presence_of :team
   validates_uniqueness_of :project_media_id, allow_nil: true
+  validate :cant_apply_article_to_item_if_article_is_in_the_trash
   after_commit :update_fact_check, on: [:update]
   after_update :update_report_status
   after_update :replace_media, unless: proc { |cd| cd.disable_replace_media }
@@ -114,5 +115,9 @@ class ClaimDescription < ApplicationRecord
       Version.from_partition(self.team_id).where(item_type: 'FactCheck', item_id: fc_id)
       .where.not(event: 'create').update_all(associated_id: self.project_media_id)
     end
+  end
+
+  def cant_apply_article_to_item_if_article_is_in_the_trash
+    errors.add(:base, I18n.t(:cant_apply_article_to_item_if_article_is_in_the_trash)) if self.project_media && self.fact_check&.trashed
   end
 end

--- a/app/models/explainer.rb
+++ b/app/models/explainer.rb
@@ -19,6 +19,7 @@ class Explainer < ApplicationRecord
   validate :language_in_allowed_values, unless: proc { |e| e.language.blank? }
 
   after_save :update_paragraphs_in_alegre
+  after_update :detach_explainer_if_trashed
 
   def notify_bots
     # Nothing to do for Explainer
@@ -130,5 +131,11 @@ class Explainer < ApplicationRecord
     allowed_languages = self.team.get_languages || ['en']
     allowed_languages << 'und'
     errors.add(:language, I18n.t(:"errors.messages.invalid_article_language_value")) unless allowed_languages.include?(self.language)
+  end
+
+  def detach_explainer_if_trashed
+    if self.trashed && !self.trashed_before_last_save
+      self.project_medias = []
+    end
   end
 end

--- a/app/models/explainer.rb
+++ b/app/models/explainer.rb
@@ -58,7 +58,8 @@ class Explainer < ApplicationRecord
   end
 
   def self.update_paragraphs_in_alegre(id, previous_paragraphs_count, timestamp)
-    explainer = Explainer.find(id)
+    explainer = Explainer.find_by_id(id)
+    return if explainer.nil?
 
     # Skip if the explainer was saved since this job was created (it means that there is a more recent job)
     return if explainer.updated_at.to_f > timestamp

--- a/app/models/explainer_item.rb
+++ b/app/models/explainer_item.rb
@@ -7,6 +7,7 @@ class ExplainerItem < ApplicationRecord
 
   validates_presence_of :explainer, :project_media
   validate :same_team
+  validate :cant_apply_article_to_item_if_article_is_in_the_trash
 
   def version_metadata(_changes)
     { explainer_title: self.explainer.title }.to_json
@@ -16,5 +17,9 @@ class ExplainerItem < ApplicationRecord
 
   def same_team
     errors.add(:base, I18n.t(:explainer_and_item_must_be_from_the_same_team)) unless self.explainer&.team_id == self.project_media&.team_id
+  end
+
+  def cant_apply_article_to_item_if_article_is_in_the_trash
+    errors.add(:base, I18n.t(:cant_apply_article_to_item_if_article_is_in_the_trash)) if self.explainer&.trashed
   end
 end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -494,6 +494,9 @@ class Team < ApplicationRecord
     # Filter by date
     query = query.where(updated_at: Range.new(*format_times_search_range_filter(JSON.parse(filters[:updated_at]), nil))) unless filters[:updated_at].blank?
 
+    # Filter by trashed
+    query = query.where(trashed: !!filters[:trashed])
+
     # Filter by text
     query = self.filter_by_keywords(query, filters, 'Explainer') if filters[:text].to_s.size > 2
 
@@ -533,6 +536,9 @@ class Team < ApplicationRecord
 
     # Filter by report status
     query = query.where('fact_checks.report_status' => [filters[:report_status]].flatten.map(&:to_s)) unless filters[:report_status].blank?
+
+    # Filter by trashed
+    query = query.where('fact_checks.trashed' => !!filters[:trashed])
 
     # Filter by text
     query = self.filter_by_keywords(query, filters) if filters[:text].to_s.size > 2

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -829,6 +829,7 @@ en:
   send_on_must_be_in_the_future: can't be in the past.
   cant_delete_default_folder: The default folder can't be deleted
   explainer_and_item_must_be_from_the_same_team: Explainer and item must be from the same workspace.
+  cant_apply_article_to_item_if_article_is_in_the_trash: This article is in the trash so it can't be added to this media cluster. Please first restore it from the trash.
   shared_feed_imported_media_already_exist: |-
     No media eligible to be imported into your workspace.
     The media selected to import already exist in your workspace in the following items:

--- a/db/migrate/20240913210101_add_trashed_to_articles.rb
+++ b/db/migrate/20240913210101_add_trashed_to_articles.rb
@@ -1,0 +1,6 @@
+class AddTrashedToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :fact_checks, :trashed, :boolean, default: false, index: true
+    add_column :explainers, :trashed, :boolean, default: false, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_08_13_155311) do
+ActiveRecord::Schema.define(version: 2024_09_13_210101) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -324,6 +324,7 @@ ActiveRecord::Schema.define(version: 2024_08_13_155311) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "tags", default: [], array: true
+    t.boolean "trashed", default: false
     t.index ["tags"], name: "index_explainers_on_tags", using: :gin
     t.index ["team_id"], name: "index_explainers_on_team_id"
     t.index ["user_id"], name: "index_explainers_on_user_id"
@@ -344,6 +345,7 @@ ActiveRecord::Schema.define(version: 2024_08_13_155311) do
     t.integer "report_status", default: 0
     t.string "rating"
     t.boolean "imported", default: false
+    t.boolean "trashed", default: false
     t.index ["claim_description_id"], name: "index_fact_checks_on_claim_description_id", unique: true
     t.index ["imported"], name: "index_fact_checks_on_imported"
     t.index ["language"], name: "index_fact_checks_on_language"

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -8265,6 +8265,7 @@ type Explainer implements Node {
   team: PublicTeam
   team_id: Int
   title: String
+  trashed: Boolean
   updated_at: String
   url: String
   user: User
@@ -8418,6 +8419,7 @@ type FactCheck implements Node {
   summary: String
   tags: [String]
   title: String
+  trashed: Boolean
   updated_at: String
   url: String
   user: User
@@ -15590,6 +15592,7 @@ input UpdateExplainerInput {
   language: String
   tags: [String]
   title: String
+  trashed: Boolean
   url: String
 }
 
@@ -15620,6 +15623,7 @@ input UpdateFactCheckInput {
   summary: String
   tags: [String]
   title: String
+  trashed: Boolean
   url: String
 }
 

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -13169,10 +13169,11 @@ type Team implements Node {
     tags: [String]
     target_id: Int
     text: String
+    trashed: Boolean = false
     updated_at: String
     user_ids: [Int]
   ): ArticleUnionConnection
-  articles_count(article_type: String, imported: Boolean, language: [String], publisher_ids: [Int], rating: [String], report_status: [String], standalone: Boolean, tags: [String], target_id: Int, text: String, updated_at: String, user_ids: [Int]): Int
+  articles_count(article_type: String, imported: Boolean, language: [String], publisher_ids: [Int], rating: [String], report_status: [String], standalone: Boolean, tags: [String], target_id: Int, text: String, trashed: Boolean = false, updated_at: String, user_ids: [Int]): Int
   available_newsletter_header_types: JsonStringType
   avatar: String
   check_search_spam: CheckSearch

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -899,7 +899,7 @@ module SampleData
       description: random_string,
       context: random_string,
       user: options[:user] || create_user,
-      project_media: options[:project_media] || create_project_media
+      project_media: options.has_key?(:project_media) ? options[:project_media] : create_project_media
     }.merge(options))
   end
 

--- a/public/relay.json
+++ b/public/relay.json
@@ -69112,6 +69112,18 @@
                   "defaultValue": null,
                   "isDeprecated": false,
                   "deprecationReason": null
+                },
+                {
+                  "name": "trashed",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
+                  "isDeprecated": false,
+                  "deprecationReason": null
                 }
               ],
               "type": {
@@ -69291,6 +69303,18 @@
                     "ofType": null
                   },
                   "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "trashed",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Boolean",
+                    "ofType": null
+                  },
+                  "defaultValue": "false",
                   "isDeprecated": false,
                   "deprecationReason": null
                 }

--- a/public/relay.json
+++ b/public/relay.json
@@ -44796,6 +44796,20 @@
               "deprecationReason": null
             },
             {
+              "name": "trashed",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "updated_at",
               "description": null,
               "args": [
@@ -45616,6 +45630,20 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "trashed",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "isDeprecated": false,
@@ -85405,6 +85433,18 @@
               "deprecationReason": null
             },
             {
+              "name": "trashed",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
               "type": {
@@ -85578,6 +85618,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "trashed",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,

--- a/test/models/claim_description_test.rb
+++ b/test/models/claim_description_test.rb
@@ -197,4 +197,16 @@ class ClaimDescriptionTest < ActiveSupport::TestCase
     cd.save!
     assert_equal pm, cd.project_media_was
   end
+
+  test "should not attach to item if fact-check is in the trash" do
+    t = create_team
+    cd = create_claim_description team: t, project_media: nil
+    fc = create_fact_check claim_description: cd, trashed: true
+    pm = create_project_media team: t
+    assert_raises ActiveRecord::RecordInvalid do
+      cd = ClaimDescription.find(cd.id)
+      cd.project_media = pm
+      cd.save!
+    end
+  end
 end

--- a/test/models/explainer_item_test.rb
+++ b/test/models/explainer_item_test.rb
@@ -109,4 +109,13 @@ class ExplainerItemTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should not attach to item if explainer is in the trash" do
+    t = create_team
+    pm = create_project_media team: t
+    ex = create_explainer team: t, trashed: true
+    assert_raises ActiveRecord::RecordInvalid do
+      ex.project_medias << pm
+    end
+  end
 end

--- a/test/models/explainer_test.rb
+++ b/test/models/explainer_test.rb
@@ -136,4 +136,19 @@ class ExplainerTest < ActiveSupport::TestCase
     assert_equal [], pm.reload.explainers
     assert_equal [], ex.reload.project_medias
   end
+
+  test "should delete after days in the trash" do
+    t = create_team
+    pm = create_project_media team: t
+    ex = create_explainer team: t
+    Sidekiq::Testing.inline! do
+      assert_no_difference 'ProjectMedia.count' do
+        assert_difference 'Explainer.count', -1 do
+          ex = Explainer.find(ex.id)
+          ex.trashed = true
+          ex.save!
+        end
+      end
+    end
+  end
 end

--- a/test/models/explainer_test.rb
+++ b/test/models/explainer_test.rb
@@ -120,4 +120,20 @@ class ExplainerTest < ActiveSupport::TestCase
       pm.destroy!
     end
   end
+
+  test "should detach from items when explainer is sent to the trash" do
+    t = create_team
+    ex = create_explainer team: t
+    pm = create_project_media team: t
+    pm.explainers << ex
+    assert_equal [ex], pm.reload.explainers
+    assert_equal [pm], ex.reload.project_medias
+    assert_difference 'ExplainerItem.count', -1 do
+      ex = Explainer.find(ex.id)
+      ex.trashed = true
+      ex.save!
+    end
+    assert_equal [], pm.reload.explainers
+    assert_equal [], ex.reload.project_medias
+  end
 end

--- a/test/models/explainer_test.rb
+++ b/test/models/explainer_test.rb
@@ -122,6 +122,7 @@ class ExplainerTest < ActiveSupport::TestCase
   end
 
   test "should detach from items when explainer is sent to the trash" do
+    Sidekiq::Testing.fake!
     t = create_team
     ex = create_explainer team: t
     pm = create_project_media team: t

--- a/test/models/fact_check_test.rb
+++ b/test/models/fact_check_test.rb
@@ -181,7 +181,7 @@ class FactCheckTest < ActiveSupport::TestCase
       assert_nil pm.reload.published_url
 
       d = create_dynamic_annotation annotation_type: 'report_design', annotator: u, annotated: pm, set_fields: { options: { language: 'en', use_text_message: true, title: 'Text report created title', text: 'Text report created summary', published_article_url: 'http://text.report/created' } }.to_json, action: 'save'
-      fc = cd.fact_check
+      fc = cd.reload.fact_check
       assert_equal 'Text report created title', pm.reload.fact_check_title
       assert_equal 'Text report created summary', pm.reload.fact_check_summary
       assert_equal 'http://text.report/created', pm.reload.published_url
@@ -423,7 +423,7 @@ class FactCheckTest < ActiveSupport::TestCase
         s.status = 'verified'
         s.save!
         r = publish_report(pm)
-        fc = cd.fact_check
+        fc = cd.reload.fact_check
         fc.title = 'Foo Bar'
         fc.save!
         fc = fc.reload
@@ -550,6 +550,7 @@ class FactCheckTest < ActiveSupport::TestCase
   end
 
   test "should unpublish report when fact-check is sent to the trash" do
+    Sidekiq::Testing.fake!
     RequestStore.store[:skip_cached_field_update] = false
     pm = create_project_media
     cd = create_claim_description(project_media: pm)


### PR DESCRIPTION
## Description

Allow articles (explainers and fact-checks) to be sent to / restored from the trash.

Steps:

- [x] Add a `trashed` attribute to database, GraphQL type and GraphQL update mutation for explainers and fact-checks
- [x] Add a `trashed` filter to articles queries, which is `false` by default
- [x] When a fact-check is trashed, make sure it's detached and unpublished
- [x] When an explainer is trashed, make sure that it's detached from all items
- [x] Validate: Can't apply trashed article to item
- [x] Delete article permanently automatically after 30 days in the trash (Sidekiq scheduled job) (for fact-checks, both the claim and the fact-check must be deleted)
- [x] Add automated tests

Reference: CV2-5068.

## How has this been tested?

Automated tests in order to keep 100% code coverage.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)