### PR TITLE
Make `ProjectMedia.set_original_claim` work as expected for a video URL with arguments

### DIFF
--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -35,14 +35,15 @@ module ProjectMediaCreators
     if claim.match?(/\A#{URI::DEFAULT_PARSER.make_regexp(['http', 'https'])}\z/)
       uri = URI.parse(claim)
       content_type = fetch_content_type(uri)
+      ext = File.extname(uri.path)
 
       case content_type
       when /^image\//
-        self.media = create_media_from_url('UploadedImage', claim)
+        self.media = create_media_from_url('UploadedImage', claim, ext)
       when /^video\//
-        self.media = create_media_from_url('UploadedVideo', claim)
+        self.media = create_media_from_url('UploadedVideo', claim, ext)
       when /^audio\//
-        self.media = create_media_from_url('UploadedAudio', claim)
+        self.media = create_media_from_url('UploadedAudio', claim, ext)
       else
         self.media = create_link_media(claim)
       end
@@ -56,19 +57,19 @@ module ProjectMediaCreators
     response['content-type']
   end
 
-  def create_media_from_url(type, url)
+  def create_media_from_url(type, url, ext)
     klass = type.constantize
-    file = download_file(url)
+    file = download_file(url, ext)
     m = klass.new
     m.file = file
     m.save!
     m
   end
 
-  def download_file(url)
+  def download_file(url, ext)
     raise "Invalid URL when creating media from original claim attribute" unless url =~ /\A#{URI::DEFAULT_PARSER.make_regexp(['http', 'https'])}\z/
 
-    file = Tempfile.new(['download', File.extname(url)])
+    file = Tempfile.new(['download', ext])
     file.binmode
     file.write(URI(url).open.read)
     file.rewind

--- a/app/resources/api/v2/feed_resource.rb
+++ b/app/resources/api/v2/feed_resource.rb
@@ -18,7 +18,7 @@ module Api
       filter :after, apply: ->(records, _value, _options) { records }
       filter :feed_id, apply: ->(records, _value, _options) { records }
       filter :webhook_url, apply: ->(records, _value, _options) { records }
-      filter :skip_save_request, apply: ->(records, value, _options) { records }
+      filter :skip_save_request, apply: ->(records, _value, _options) { records }
 
       paginator :none
 
@@ -56,7 +56,7 @@ module Api
         RequestStore.store[:pause_database_connection] = true # Release database connection during Bot::Alegre.request_api
         RequestStore.store[:smooch_bot_settings] = feed.get_smooch_bot_settings.to_h
         results = Bot::Smooch.search_for_similar_published_fact_checks(type, query, feed.team_ids, after, feed_id)
-        Feed.delay({ retry: 0, queue: 'feed' }).save_request(feed_id, type, query, webhook_url, results.to_a.map(&:id)) unless skip_save_request 
+        Feed.delay({ retry: 0, queue: 'feed' }).save_request(feed_id, type, query, webhook_url, results.to_a.map(&:id)) unless skip_save_request
         results
       end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,7 @@ en:
         description: 'Conclusion: the source is a sockpuppet'
   errors:
     messages:
+      extension_whitelist_error: extension is not supported
       invalid_password: Invalid password
       invalid_qrcode: Invalid validation code
       # This string is preceded by the name of the file being validated.

--- a/test/models/project_media_test.rb
+++ b/test/models/project_media_test.rb
@@ -465,4 +465,12 @@ class ProjectMediaTest < ActiveSupport::TestCase
     assert_equal 2, ProjectMedia.where(id: [pm_s.id, pm_t.id], archived: CheckArchivedFlags::FlagCodes::NONE).count
     assert_not_nil Relationship.where(id: r.id).last
   end
+
+  test "should create item with original claim video with arguments" do
+    video_url = 'https://test.xyz/video.mp4?foo=bar'
+    WebMock.stub_request(:get, video_url).to_return(body: File.read(File.join(Rails.root, 'test', 'data', 'rails.mp4')), headers: { 'Content-Type' => 'video/mp4' })
+    assert_difference 'ProjectMedia.count' do
+      create_project_media media: nil, set_original_claim: video_url
+    end
+  end
 end


### PR DESCRIPTION
## Description

This PR fixes a bug with `ProjectMedia.set_original_claim` attribute for video URLs that contained arguments, for example: https://test.xyz/video.mp4?foo=bar. The item wouldn't be created, since the extension validation would fail.

The fix is to use `File.extname` over the URL path only, not the full URL, since the former strips the arguments, while the latter contains them.

Fixes: CV2-5232.

## How has this been tested?

TDD. I was able to reproduce the bug in a unit test contained in this PR. The test passed once the fix was implemented.

## Things to pay attention to during code review

At some point, we may get rid of `File.extname` altogether and instead rely on the content-type response header in order to extract the extension.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

