### PR TITLE
Allow deletion of api keys with media

### DIFF
--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -16,7 +16,9 @@ class ApiKey < ApplicationRecord
 
   validate :validate_team_api_keys_limit, on: :create
 
-  has_one :bot_user, dependent: :destroy
+  has_one :bot_user
+
+  after_destroy :delete_bot_user
 
   # Reimplement this method in your application
   def self.applications
@@ -49,6 +51,14 @@ class ApiKey < ApplicationRecord
       new_bot_user.skip_check_ability = true
       new_bot_user.set_role 'editor'
       new_bot_user.save!
+    end
+  end
+
+  def delete_bot_user
+    if bot_user.present? && bot_user.owns_media?
+      bot_user.update(api_key_id: nil)
+    else
+      bot_user.destroy
     end
   end
 

--- a/app/models/concerns/user_private.rb
+++ b/app/models/concerns/user_private.rb
@@ -86,8 +86,7 @@ module UserPrivate
   end
 
   def can_destroy_user
-    count = ProjectMedia.where(user_id: self.id).count
-    throw :abort if count > 0
+    throw :abort if owns_media?
   end
 
   def set_user_notification_settings(type, enabled)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -435,6 +435,11 @@ class User < ApplicationRecord
     user
   end
 
+  def owns_media?
+    ProjectMedia.where(user_id: self.id).count > 0
+  end
+
+
   # private
   #
   # Please add private methods to app/models/concerns/user_private.rb

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -64,4 +64,22 @@ class ApiKeyTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should delete API key even if key's user has been used to create media" do
+    a = create_api_key
+    b = create_bot_user
+    b.api_key = a
+    b.save!
+    pm = create_project_media user: b
+
+    assert_equal b, pm.user
+
+    assert_difference 'ApiKey.count', -1 do
+      a.destroy
+    end
+
+    assert_raises ActiveRecord::RecordNotFound do
+      ApiKey.find(a.id)
+    end
+  end
 end


### PR DESCRIPTION
## Description

Allow deletion of API keys even if the key's user has been used to create media.

References: CV2-5096

## How has this been tested?

Tested in the UI using these steps:

1. Create an Api Key
2. Use the token to create project media
3. Confirm that the Api Key can be deleted

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

