### PR TITLE
Improve IP blocking after unsuccessful logins

### DIFF
--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -273,7 +273,7 @@ development: &default
   nlu_user_rate_limit: 30
   devise_maximum_attempts: 5
   devise_unlock_accounts_after: 1
-  login_rate_limit: 10
+  login_block_limit: 100
   api_rate_limit: 100
   export_csv_maximum_number_of_results: 10000
   export_csv_expire: 604800 # Seconds: Default is 7 days


### PR DESCRIPTION
## Description

Improve IP blocking after unsuccessful logins

- Only add IPs to the track list on unsuccessful login
- On successful login, remove IP completely from tracklist

We have also moved code related to authentication blocking to devise.rb

References: CV2-4866

## How has this been tested?

Tested using the script below. When the credentials are correct, you should be able to log in repeatedly more than 100 times.

When using incorrect credentials, your IP should get blocked after 100 attempts.

```bash
#!/bin/bash

for i in {1..110}
do
  curl -X POST 127.0.0.1:3000/api/users/sign_in \
       -H "Content-Type: application/json" \
       -d '{"api_user": {"email": "email@example.com", "password": "PASSWORD", "otp_attempt": ""}}'
  echo "Attempt $i"
done
```

If your IP gets blocked, access the rails console and run the script below. This will unblock all blocked IPs.

```ruby
redis = Redis.new(REDIS_CONFIG)

tracked_keys = redis.keys('track:*')
blocked_keys = redis.keys('block:*')

tracked_keys.each do |key|
  redis.del(key)
end

blocked_keys.each do |key|
  redis.del(key)
  puts "Unblocked #{key}"
end
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

