### PR TITLE
Need to split the maximum size for tipline content video files.

### DIFF
--- a/app/models/concerns/tipline_content_multimedia.rb
+++ b/app/models/concerns/tipline_content_multimedia.rb
@@ -51,7 +51,7 @@ module TiplineContentMultimedia
       output_path = File.join(Rails.root, 'tmp', "#{content_name}-#{type}-output-#{self.id}-#{now}.mp4")
       video = FFMPEG::Movie.new(input.path)
       video.transcode(output_path, options)
-      raise TiplineContentMultimedia::ConvertedFileTooLarge.new('Converted file for tipline content is too large') if (File.size(output_path).to_f / 1024000.0) > self.header_file_video_max_size
+      raise TiplineContentMultimedia::ConvertedFileTooLarge.new('Converted file for tipline content is too large') if (File.size(output_path).to_f / 1024000.0) > self.header_file_video_max_size_whatsapp
       path = "#{content_name}/video/#{content_name}-#{type}-#{self.id}-#{now}"
       CheckS3.write(path, 'video/mp4', File.read(output_path))
       url = CheckS3.public_url(path)

--- a/app/models/concerns/tipline_content_video.rb
+++ b/app/models/concerns/tipline_content_video.rb
@@ -5,12 +5,12 @@ module TiplineContentVideo
 
   # Max size that WhatsApp supports
   def header_file_video_max_size_whatsapp
-    16
+    CheckConfig.get(:header_file_video_max_size_whatsapp, 16, :integer)
   end
 
-  # Max size for Check (we need to convert it to H.264, so let's be safe)
+  # Max size for Check (we need to convert it to H.264, so let's be safe and use a value less than what WhatsApp supports)
   def header_file_video_max_size_check
-    10
+    CheckConfig.get(:header_file_video_max_size_check, 10, :integer)
   end
 
   def validate_header_file_video

--- a/app/models/concerns/tipline_content_video.rb
+++ b/app/models/concerns/tipline_content_video.rb
@@ -3,13 +3,18 @@ require 'active_support/concern'
 module TiplineContentVideo
   extend ActiveSupport::Concern
 
-  # MP4 less than 10 MB (WhatsApp supports 16 MB, let's be safe)
-  def header_file_video_max_size
+  # Max size that WhatsApp supports
+  def header_file_video_max_size_whatsapp
+    16
+  end
+
+  # Max size for Check (we need to convert it to H.264, so let's be safe)
+  def header_file_video_max_size_check
     10
   end
 
   def validate_header_file_video
-    self.validate_header_file(self.header_file_video_max_size, ['mp4'], 'errors.messages.video_too_large')
+    self.validate_header_file(self.header_file_video_max_size_check, ['mp4'], 'errors.messages.video_too_large')
   end
 
   def should_convert_header_video?

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -277,6 +277,8 @@ development: &default
   api_rate_limit: 100
   export_csv_maximum_number_of_results: 10000
   export_csv_expire: 604800 # Seconds: Default is 7 days
+  header_file_video_max_size_whatsapp: 16 # Megabytes
+  header_file_video_max_size_check: 10 # Megabytes, should be less than WhatsApp limit
 
   # Session
   #

--- a/test/models/tipline_newsletter_test.rb
+++ b/test/models/tipline_newsletter_test.rb
@@ -484,7 +484,8 @@ class TiplineNewsletterTest < ActiveSupport::TestCase
     # This test file is 300 KB, but 1.6 MB after converting
     WebMock.stub_request(:get, /:9000/).to_return(body: File.read(File.join(Rails.root, 'test', 'data', 'h265-video.mp4')))
     TiplineNewsletter.any_instance.stubs(:new_file_uploaded?).returns(true)
-    TiplineNewsletter.any_instance.stubs(:header_file_video_max_size).returns(1) # Maximum 1 MB
+    TiplineNewsletter.any_instance.stubs(:header_file_video_max_size_check).returns(2) # Maximum 2 MB
+    TiplineNewsletter.any_instance.stubs(:header_file_video_max_size_whatsapp).returns(1) # Maximum 1 MB
     CheckSentry.stubs(:notify).once
     Sidekiq::Testing.inline! do
       create_tipline_newsletter header_type: 'video', header_file: 'h265-video.mp4'


### PR DESCRIPTION
## Description

We need one maximum size for the Check upload and another one that is actually the maximum size supported by WhatsApp. This separation is needed because we need to convert the uploaded video to H.264, which is the codec support by WhatsApp. So we need a safe margin for that.

Fixes: CV2-5326.

## How has this been tested?

Unit test updated.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

