### PR TITLE
Set sidekiq_options retry to 3 for the GenericWorker

### DIFF
--- a/app/workers/generic_worker.rb
+++ b/app/workers/generic_worker.rb
@@ -2,6 +2,8 @@ class GenericWorker
 
   include Sidekiq::Worker
 
+  sidekiq_options retry: 3
+
   def perform(klass_name, klass_method, *method_args)
     klass = klass_name.constantize
     options = method_args.extract_options!.with_indifferent_access


### PR DESCRIPTION
## Description

Pretty straight forward. Sets the maximum retry count to 3.

#### Note

We want to add custom retry logic, but that works differently between Sidekiq 5 and 6.
So we think it is better to focus later on the Sidekiq upgrade, and until there, worker instances can handle their exceptions instead of relying on the generic worker for that.

References: 5120, https://github.com/meedan/check-api/pull/2005

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

