### PR TITLE
5120 – Dont create duplicate tags and clean up `#`

### DIFF
--- a/app/models/annotations/tag.rb
+++ b/app/models/annotations/tag.rb
@@ -96,7 +96,7 @@ class Tag < ApplicationRecord
 
     if !project_media.nil?
       tags = JSON.parse(tags_json)
-      clean_tags = tags.map { |tag| tag.strip.gsub(/^#/, '') }.uniq!
+      clean_tags = tags.map { |tag| tag.strip.gsub(/^#/, '') }.uniq
       clean_tags.each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
     else
       error = StandardError.new("[ProjectMedia] Exception creating project media's tags in background. Project media is nil.")

--- a/app/models/annotations/tag.rb
+++ b/app/models/annotations/tag.rb
@@ -1,5 +1,6 @@
 class Tag < ApplicationRecord
   include AnnotationBase
+  extend TagHelpers
 
   # "tag" is a reference to a TagText object
   field :tag, GraphQL::Types::Int, presence: true
@@ -96,8 +97,7 @@ class Tag < ApplicationRecord
 
     if !project_media.nil?
       tags = JSON.parse(tags_json)
-      clean_tags = tags.map { |tag| tag.strip.gsub(/^#/, '') }.uniq
-      clean_tags.each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
+      clean_tags(tags).each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
     else
       error = StandardError.new("[ProjectMedia] Exception creating project media's tags in background. Project media is nil.")
       CheckSentry.notify(error, project_media_id: project_media_id)

--- a/app/models/annotations/tag.rb
+++ b/app/models/annotations/tag.rb
@@ -96,7 +96,7 @@ class Tag < ApplicationRecord
 
     if !project_media.nil?
       tags = JSON.parse(tags_json)
-      tags.each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
+      tags.uniq.each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
     else
       error = StandardError.new("[ProjectMedia] Exception creating project media's tags in background. Project media is nil.")
       CheckSentry.notify(error, project_media_id: project_media_id)

--- a/app/models/annotations/tag.rb
+++ b/app/models/annotations/tag.rb
@@ -96,7 +96,8 @@ class Tag < ApplicationRecord
 
     if !project_media.nil?
       tags = JSON.parse(tags_json)
-      tags.uniq.each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
+      clean_tags = tags.map { |tag| tag.strip.gsub(/^#/, '') }.uniq!
+      clean_tags.each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
     else
       error = StandardError.new("[ProjectMedia] Exception creating project media's tags in background. Project media is nil.")
       CheckSentry.notify(error, project_media_id: project_media_id)

--- a/app/models/annotations/tag.rb
+++ b/app/models/annotations/tag.rb
@@ -91,6 +91,18 @@ class Tag < ApplicationRecord
     ret
   end
 
+  def self.create_project_media_tags(project_media_id, tags_json)
+    project_media = ProjectMedia.find_by_id(project_media_id)
+
+    if !project_media.nil?
+      tags = JSON.parse(tags_json)
+      tags.each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
+    else
+      error = StandardError.new("[ProjectMedia] Exception creating project media's tags in background. Project media is nil.")
+      CheckSentry.notify(error, project_media_id: project_media_id)
+    end
+  end
+
   private
 
   def get_tag_text_reference

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -267,7 +267,7 @@ module ProjectMediaCreators
     if self.set_tags.is_a?(Array)
       project_media_id = self.id
       tags_json = self.set_tags.to_json
-      ProjectMedia.run_later_in(1.second, 'create_tags', project_media_id, tags_json, user_id: self.user_id)
+      Tag.run_later_in(1.second, 'create_project_media_tags', project_media_id, tags_json, user_id: self.user_id)
     end
   end
 end

--- a/app/models/concerns/tag_helpers.rb
+++ b/app/models/concerns/tag_helpers.rb
@@ -1,0 +1,9 @@
+require 'active_support/concern'
+
+module TagHelpers
+  extend ActiveSupport::Concern
+
+  def clean_tags(tags)
+    tags.map { |tag| tag.strip.gsub(/^#/, '') }.uniq
+  end
+end

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -18,7 +18,7 @@ class FactCheck < ApplicationRecord
   validates_format_of :url, with: URI.regexp, allow_blank: true, allow_nil: true
   validate :language_in_allowed_values, :title_or_summary_exists, :rating_in_allowed_values
 
-  before_save :uniq_tags
+  before_save :clean_tags
   after_save :update_report, unless: proc { |fc| fc.skip_report_update || !DynamicAnnotation::AnnotationType.where(annotation_type: 'report_design').exists? || fc.project_media.blank? }
   after_save :update_item_status, if: proc { |fc| fc.saved_change_to_rating? }
   after_update :detach_claim_if_trashed
@@ -57,8 +57,9 @@ class FactCheck < ApplicationRecord
     data
   end
 
-  def uniq_tags
-    self.tags.uniq! if !self.tags.blank?
+  def clean_tags
+    return if self.tags.blank?
+    self.tags.map! { |tag| tag.strip.gsub(/^#/, '') }.uniq!
   end
 
   private

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -59,7 +59,7 @@ class FactCheck < ApplicationRecord
 
   def clean_tags
     return if self.tags.blank?
-    self.tags.map! { |tag| tag.strip.gsub(/^#/, '') }.uniq!
+    self.tags = self.tags.map! { |tag| tag.strip.gsub(/^#/, '') }.uniq
   end
 
   private

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -59,7 +59,7 @@ class FactCheck < ApplicationRecord
 
   def clean_tags
     return if self.tags.blank?
-    self.tags = self.tags.map! { |tag| tag.strip.gsub(/^#/, '') }.uniq
+    self.tags = self.tags.map { |tag| tag.strip.gsub(/^#/, '') }.uniq
   end
 
   private

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -18,6 +18,7 @@ class FactCheck < ApplicationRecord
   validates_format_of :url, with: URI.regexp, allow_blank: true, allow_nil: true
   validate :language_in_allowed_values, :title_or_summary_exists, :rating_in_allowed_values
 
+  before_save :uniq_tags
   after_save :update_report, unless: proc { |fc| fc.skip_report_update || !DynamicAnnotation::AnnotationType.where(annotation_type: 'report_design').exists? || fc.project_media.blank? }
   after_save :update_item_status, if: proc { |fc| fc.saved_change_to_rating? }
   after_update :detach_claim_if_trashed
@@ -54,6 +55,10 @@ class FactCheck < ApplicationRecord
       data << [fc.id, fc.title, fc.summary, fc.url, fc.language, fc.report_status, fc.imported.to_s]
     end
     data
+  end
+
+  def uniq_tags
+    self.tags.uniq! if !self.tags.blank?
   end
 
   private

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -528,18 +528,6 @@ class ProjectMedia < ApplicationRecord
     ms.attributes[:requests] = requests
   end
 
-  def self.create_tags(project_media_id, tags_json)
-    project_media = ProjectMedia.find_by_id(project_media_id)
-
-    if !project_media.nil?
-      tags = JSON.parse(tags_json)
-      tags.each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
-    else
-      error = StandardError.new("[ProjectMedia] Exception creating project media's tags in background. Project media is nil.")
-      CheckSentry.notify(error, project_media_id: project_media_id)
-    end
-  end
-
   # private
   #
   # Please add private methods to app/models/concerns/project_media_private.rb

--- a/test/controllers/graphql_controller_12_test.rb
+++ b/test/controllers/graphql_controller_12_test.rb
@@ -695,7 +695,7 @@ class GraphqlController12Test < ActionController::TestCase
                 project_id: ' + p.id.to_s + ',
                 media_type: "Blank",
                 channel: { main: 1 },
-                set_tags: ["science", "science"],
+                set_tags: ["science", "science", "#science"],
                 set_status: "verified",
                 set_claim_description: "Claim #1.",
                 set_fact_check: {

--- a/test/controllers/graphql_controller_12_test.rb
+++ b/test/controllers/graphql_controller_12_test.rb
@@ -680,4 +680,55 @@ class GraphqlController12Test < ActionController::TestCase
   assert_response :success
   assert_equal 'science', JSON.parse(@response.body)['data']['createProjectMedia']['project_media']['tags']['edges'][0]['node']['tag_text']
   end
+
+  test "should not create duplicate tags for the ProjectMedia and FactCheck" do
+    Sidekiq::Testing.inline!
+    t = create_team
+    a = ApiKey.create!
+    b = create_bot_user api_key_id: a.id
+    create_team_user team: t, user: b
+    p = create_project team: t
+    authenticate_with_token(a)
+
+    query1 = ' mutation create {
+              createProjectMedia(input: {
+                project_id: ' + p.id.to_s + ',
+                media_type: "Blank",
+                channel: { main: 1 },
+                set_tags: ["science", "science"],
+                set_status: "verified",
+                set_claim_description: "Claim #1.",
+                set_fact_check: {
+                  title: "Title #1",
+                  language: "en",
+                }
+              }) {
+                project_media {
+                full_url
+                  claim_description {
+                    fact_check {
+                      tags
+                    }
+                  }
+                  tags {
+                    edges {
+                      node {
+                        tag_text
+                      }
+                    }
+                  }
+                }
+              }
+            } '
+
+    post :create, params: { query: query1, team: t.slug }
+    assert_response :success
+
+    pm = JSON.parse(@response.body)['data']['createProjectMedia']['project_media']
+    pm_tags = pm['tags']['edges']
+    fc_tags = pm['claim_description']['fact_check']['tags']
+
+    assert_equal 1, pm_tags.count
+    assert_equal 1, fc_tags.count
+  end
 end

--- a/test/lib/generic_worker_helpers_test.rb
+++ b/test/lib/generic_worker_helpers_test.rb
@@ -9,7 +9,7 @@ class GenericWorkerHelpersTest < ActionView::TestCase
   def teardown
   end
 
-  test "should run a job, without raising an error, for a method that takes a hash as a parameter" do
+  test "should run a job async, without raising an error, for a method that takes a hash as a parameter" do
     Sidekiq::Testing.inline!
 
     assert_difference "Team.where(name: 'BackgroundTeam', slug: 'background-team').count" do
@@ -17,7 +17,7 @@ class GenericWorkerHelpersTest < ActionView::TestCase
     end
   end
 
-  test "should run a job, without raising an error, for a method that takes standalone parameters" do
+  test "should run a job in a specified time, without raising an error, for a method that takes standalone parameters" do
     Sidekiq::Testing.inline!
 
     team = create_team

--- a/test/lib/generic_worker_helpers_test.rb
+++ b/test/lib/generic_worker_helpers_test.rb
@@ -27,7 +27,7 @@ class GenericWorkerHelpersTest < ActionView::TestCase
     project_media_id = pm.id
     tags_json = ['one', 'two', 'three'].to_json
 
-    ProjectMedia.run_later_in(0.second, 'create_tags', project_media_id, tags_json, user_id: pm.user_id)
+    Tag.run_later_in(0.second, 'create_project_media_tags', project_media_id, tags_json, user_id: pm.user_id)
 
     assert_equal 3, pm.annotations('tag').count
   end

--- a/test/models/fact_check_test.rb
+++ b/test/models/fact_check_test.rb
@@ -600,7 +600,7 @@ class FactCheckTest < ActiveSupport::TestCase
   test "should not have duplicate tags" do
     pm = create_project_media
     cd = create_claim_description(project_media: pm)
-    fc = create_fact_check claim_description: cd, tags: ['one', 'one']
+    fc = create_fact_check claim_description: cd, tags: ['one', 'one', '#one']
 
     assert_equal 1, fc.tags.count
   end

--- a/test/models/fact_check_test.rb
+++ b/test/models/fact_check_test.rb
@@ -603,5 +603,19 @@ class FactCheckTest < ActiveSupport::TestCase
     fc = create_fact_check claim_description: cd, tags: ['one', 'one', '#one']
 
     assert_equal 1, fc.tags.count
+    assert_equal 'one', fc.tags.first
+  end
+
+  test "should add existing tag to a new fact check" do
+    pm = create_project_media
+    cd = create_claim_description(project_media: pm)
+    create_fact_check claim_description: cd, tags: ['one']
+
+    pm2 = create_project_media
+    cd2 = create_claim_description(project_media: pm2)
+    fc2 = create_fact_check claim_description: cd2, tags: ['#one']
+
+    assert_equal 1, fc2.tags.count
+    assert_equal 'one', fc2.tags.first
   end
 end

--- a/test/models/fact_check_test.rb
+++ b/test/models/fact_check_test.rb
@@ -596,4 +596,12 @@ class FactCheckTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should not have duplicate tags" do
+    pm = create_project_media
+    cd = create_claim_description(project_media: pm)
+    fc = create_fact_check claim_description: cd, tags: ['one', 'one']
+
+    assert_equal 1, fc.tags.count
+  end
 end

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -30,4 +30,14 @@ class ProjectMedia8Test < ActiveSupport::TestCase
     end
     assert_equal 1, GenericWorker.jobs.size
   end
+
+  test "when creating an item with multiple tags, after_create :create_tags_in_background callback should not create duplicate tags" do
+    Sidekiq::Testing.inline!
+
+    team = create_team
+    project = create_project team: team
+    pm = create_project_media project: project, tags: ['one', 'one']
+
+    assert_equal 1, pm.annotations('tag').count
+  end
 end

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -54,19 +54,4 @@ class ProjectMedia8Test < ActiveSupport::TestCase
     end
     assert_equal 1, GenericWorker.jobs.size
   end
-
-  test "when using :run_later_in to schedule multiple tags creation, it should only schedule one job" do
-    Sidekiq::Testing.fake!
-
-    team = create_team
-    project = create_project team: team
-    pm = create_project_media project: project
-
-    project_media_id = pm.id
-    tags_json = ['one', 'two', 'three'].to_json
-
-    ProjectMedia.run_later_in(0.second, 'create_tags', project_media_id, tags_json, user_id: pm.user_id)
-
-    assert_equal 1, GenericWorker.jobs.size
-  end
 end

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -36,7 +36,7 @@ class ProjectMedia8Test < ActiveSupport::TestCase
 
     team = create_team
     project = create_project team: team
-    pm = create_project_media project: project, tags: ['one', 'one']
+    pm = create_project_media project: project, tags: ['one', 'one', '#one']
 
     assert_equal 1, pm.annotations('tag').count
   end

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -9,30 +9,6 @@ class ProjectMedia8Test < ActiveSupport::TestCase
   def teardown
   end
 
-  test ":create_tags should create tags when project media id and tags are present" do
-    team = create_team
-    project = create_project team: team
-    pm = create_project_media project: project
-
-    project_media_id = pm.id
-    tags_json = ['one', 'two'].to_json
-
-    assert_nothing_raised do
-      ProjectMedia.create_tags(project_media_id, tags_json)
-    end
-    assert_equal 2, pm.annotations('tag').count
-  end
-
-  test ":create_tags should not raise an error when no project media is sent" do
-    project_media_id = nil
-    tags_json = ['one', 'two'].to_json
-
-    assert_nothing_raised do
-      CheckSentry.expects(:notify).once
-      ProjectMedia.create_tags(project_media_id, tags_json)
-    end
-  end
-
   test "when creating an item with tag/tags, after_create :create_tags_in_background callback should create tags in the background" do
     Sidekiq::Testing.inline!
 

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -284,4 +284,30 @@ class TagTest < ActiveSupport::TestCase
       create_tag tag: ' foo', annotated: pm2
     end
   end
+
+  test ":create_project_media_tags should create tags when project media id and tags are present" do
+    team = create_team
+    project = create_project team: team
+    pm = create_project_media project: project
+
+    project_media_id = pm.id
+    tags_json = ['one', 'two'].to_json
+
+    assert_nothing_raised do
+      Tag.create_project_media_tags(project_media_id, tags_json)
+    end
+    assert_equal 2, pm.annotations('tag').count
+  end
+
+  test ":create_project_media_tags should not raise an error when no project media is sent" do
+    project_media_id = nil
+    tags_json = ['one', 'two'].to_json
+
+    assert_nothing_raised do
+      CheckSentry.expects(:notify).once
+      Tag.create_project_media_tags(project_media_id, tags_json)
+    end
+  end
+
+
 end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -309,5 +309,14 @@ class TagTest < ActiveSupport::TestCase
     end
   end
 
+  test ":create_project_media_tags should not try to create duplicate tags" do
+    Sidekiq::Testing.fake!
 
+    team = create_team
+    project = create_project team: team
+    pm = create_project_media project: project
+    Tag.create_project_media_tags(pm.id, ['one', 'one'].to_json)
+
+    assert_equal 1, pm.reload.annotations('tag').count
+  end
 end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -315,7 +315,7 @@ class TagTest < ActiveSupport::TestCase
     team = create_team
     project = create_project team: team
     pm = create_project_media project: project
-    Tag.create_project_media_tags(pm.id, ['one', 'one'].to_json)
+    Tag.create_project_media_tags(pm.id, ['one', 'one', '#one'].to_json)
 
     assert_equal 1, pm.reload.annotations('tag').count
   end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -319,4 +319,18 @@ class TagTest < ActiveSupport::TestCase
 
     assert_equal 1, pm.reload.annotations('tag').count
   end
+
+  test ":create_project_media_tags should be able to add an existing tag to a new project media" do
+    Sidekiq::Testing.fake!
+
+    team = create_team
+    project = create_project team: team
+    pm = create_project_media project: project
+    Tag.create_project_media_tags(pm.id, ['one'].to_json)
+
+    pm2 = create_project_media project: project
+    Tag.create_project_media_tags(pm2.id, ['#one'].to_json)
+
+    assert_equal 1, pm2.reload.annotations('tag').count
+  end
 end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -317,7 +317,12 @@ class TagTest < ActiveSupport::TestCase
     pm = create_project_media project: project
     Tag.create_project_media_tags(pm.id, ['one', 'one', '#one'].to_json)
 
-    assert_equal 1, pm.reload.annotations('tag').count
+    tags = pm.reload.annotations('tag')
+    tag_text_id = tags.last.data['tag']
+    tag_text = TagText.find(tag_text_id).text
+
+    assert_equal 1, tags.count
+    assert_equal 'one', tag_text
   end
 
   test ":create_project_media_tags should be able to add an existing tag to a new project media" do

--- a/test/workers/generic_worker_test.rb
+++ b/test/workers/generic_worker_test.rb
@@ -36,7 +36,7 @@ class GenericWorkerTest < ActiveSupport::TestCase
     tags_json = ['one', 'two'].to_json
 
     assert_difference "Tag.where(annotation_type: 'tag').count", difference = 2 do
-      GenericWorker.perform_async('ProjectMedia', 'create_tags', project_media_id, tags_json, user_id: pm.user_id)
+      GenericWorker.perform_async('Tag', 'create_project_media_tags', project_media_id, tags_json, user_id: pm.user_id)
     end
   end
 
@@ -71,7 +71,7 @@ class GenericWorkerTest < ActiveSupport::TestCase
     tags_json = ['one', 'two'].to_json
 
     assert_nothing_raised do
-      GenericWorker.perform_async('ProjectMedia', 'create_tags', project_media_id, tags_json, user_id: pm.user_id)
+      GenericWorker.perform_async('Tag', 'create_project_media_tags', project_media_id, tags_json, user_id: pm.user_id)
     end
 
     assert_equal 1, GenericWorker.jobs.size


### PR DESCRIPTION
## Description

### Context
While looking into a tags issue I noticed a few things:
- when we made a request with duplicate tags:
    - we got an error, so the job was retried 
    - the tag was added twice to the FactCheck
    - the tag is added once to the ProjectMedia
- when we made a request with a tag with a `#`
   - we got an error, so the job was retried
       - there seem to have been two errors related to this:
           - ActiveRecord::RecordInvalid: Tag already exists
           - ActiveRecord::RecordInvalid: Text has already been taken 
   - the tag with the `#` is added to the FactCheck 
   - the tag is not added to the ProjectMedia

### What was happening
- There are a few things happening at the same time:
    - Creation of a `ProjectMedia` with tags 
    - Creation of a `FactCheck` with tags
    - Tags are an `Object` from the `Tag` Class for `ProjectMedia`, but are a simple array for `FactCheck`
- For the ProjectMedia:
    - It would create the tag, then it would try to create the same tag again, and then it would fail and retry again, and so on
    - This happen because we have validations in place for the `Tag` class
- For `FactCheck`:
   - It would just create the tags twice
   - Because we have no validations for the tags array

### How it was fixed
To make sure we don't have duplicate tags:
- I added a method to do a clean up step, to make sure the `FactCheck` tags are unique, and
- added uniq to project media tag creation in `Tag` 

To make sure we deal `#tags`
- I updated the clean up step in `FactCheck`, and
- added a clean up step to project media tag creation in `Tag`

### Notes
While running tests there were some cases where the creation of the `ProjectMedia`/`FactCheck` completely failed due to failed Tag's validations. Maybe if we fail to create the tags, we still want the `ProjectMedia`/`FactCheck` to be created (just without the tags). If that is the case, maybe we should look into it in a separate ticket.

References: 5120

## How has this been tested?

rails test test/workers/generic_worker_test.rb
rails test test/models/project_media_8_test.rb
rails test test/lib/generic_worker_helpers_test.rb
rails test test/models/tag_test.rb
rails test test/controllers/graphql_controller_12_test.rb:684

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

