### PR TITLE
Make sure that "test" controller also enqueues and executes bot events in background like the GraphQL controller does

### DIFF
--- a/app/controllers/test_controller.rb
+++ b/app/controllers/test_controller.rb
@@ -1,7 +1,8 @@
 require 'sample_data'
 
 class TestController < ApplicationController
-  before_action :check_environment
+  before_action :check_environment, :init_bot_events
+  after_action :trigger_bot_events
 
   include SampleData
 
@@ -249,5 +250,13 @@ class TestController < ApplicationController
 
   def check_environment
     (render(plain: 'Only available in test mode', status: 400) and return) unless Rails.env === 'test'
+  end
+
+  def init_bot_events
+    BotUser.init_event_queue if Rails.env.test?
+  end
+
+  def trigger_bot_events
+    BotUser.trigger_events if Rails.env.test?
   end
 end


### PR DESCRIPTION
## Description

Almost all integration tests in Check Web call the Check API test controller in order to create test data: https://github.com/meedan/check-web/blob/develop/test/spec/api_helpers.rb .

But the [test controller](https://github.com/meedan/check-api/blob/develop/app/controllers/test_controller.rb) on Check API side is missing [this logic](https://github.com/meedan/check-api/blob/develop/app/controllers/api/v1/graphql_controller.rb#L181-L187) that we have in the GraphQL controller which makes sure that all bot events are enqueued and executed in background.

This means that integration tests may be taking longer than needed, since some actions are happening in foreground, not in background.

This PR implements for the Test controller the same bot events logic we have in GraphQL controller.

Reference: CV2-5364.

## How has this been tested?

Existing Check API test suite should pass and the Check Web integration tests should pass for this branch too.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

