### PR TITLE
CV2-5391: use save instead of save! to avoid raising error

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -852,7 +852,7 @@ class Bot::Smooch < BotUser
   end
 
   def self.create_project_media(message, type, extra)
-    extra.merge!({ archived: message['archived'] })
+    extra.merge!({ archived: message['archived'] }) unless message['archived'].blank?
     channel_value = self.get_smooch_channel(message)
     extra.merge!({ channel: {main: channel_value }}) unless channel_value.nil?
     pm = ProjectMedia.create!({ media_type: type, smooch_message: message }.merge(extra))

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -164,7 +164,7 @@ class Relationship < ApplicationRecord
       options.each do |key, value|
         r.send("#{key}=", value) if r.respond_to?("#{key}=")
       end
-      r.save!
+      r.save ? r : nil
     end
     r
   end


### PR DESCRIPTION
## Description

Based on CV2-5324 there is a method to check Relationship exists before creating a new one but may the failure related to other validation so I use a `save` instead of `save!` to avoid raising error

References: CV2-5391

## How has this been tested?

Re-run automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

