### PR TITLE
Fix setuptools version pin for check-api builds

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - bugfix/setuptools-pin
 
 deploy_qa:
   image: python:3.7.7
@@ -55,6 +56,7 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
+    - bugfix/setuptools-pin
 
 build_batch:
   image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,7 +35,7 @@ deploy_qa:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
     GITHUB_TOKEN: $GITHUB_TOKEN
   script:
-    - pip install setuptools==75.1.0
+    - pip install setuptools==68.0.0
     - pip install urllib3==2.0.6
     - pip install botocore==1.31.62
     - pip install boto3==1.28.62
@@ -107,7 +107,7 @@ deploy_live:
     AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION
     GITHUB_TOKEN: $GITHUB_TOKEN
   script:
-    - pip install setuptools==75.1.0
+    - pip install setuptools==68.0.0
     - pip install urllib3==2.0.6
     - pip install botocore==1.31.62
     - pip install boto3==1.28.62

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,6 @@ build_qa:
     - docker push "$ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
-    - bugfix/setuptools-pin
 
 deploy_qa:
   image: python:3.7.7
@@ -56,7 +55,6 @@ deploy_qa:
     - echo "new Image was deployed $ECR_API_BASE_URL/qa/check/api:$CI_COMMIT_SHA"
   only:
     - develop
-    - bugfix/setuptools-pin
 
 build_batch:
   image: registry.gitlab.com/gitlab-org/cloud-deploy/aws-base:latest


### PR DESCRIPTION
## Description

This fixes a prior attempt to update setuptools for deployments. Since check-api is using a different container, the version pin must also adjust.

## How has this been tested?

Tested with a branch deployment into QA.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [X] My changes generate no new warnings

