### PR TITLE
5426 – Should be able to ignore tag already added to item

### DIFF
--- a/app/models/annotations/tag.rb
+++ b/app/models/annotations/tag.rb
@@ -97,7 +97,7 @@ class Tag < ApplicationRecord
 
     if !project_media.nil?
       tags = JSON.parse(tags_json)
-      clean_tags(tags).each { |tag| Tag.create! annotated: project_media, tag: tag.strip, skip_check_ability: true }
+      clean_tags(tags).each { |tag| Tag.create annotated: project_media, tag: tag.strip, skip_check_ability: true }
     else
       error = StandardError.new("[ProjectMedia] Exception creating project media's tags in background. Project media is nil.")
       CheckSentry.notify(error, project_media_id: project_media_id)

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -338,4 +338,16 @@ class TagTest < ActiveSupport::TestCase
 
     assert_equal 1, pm2.reload.annotations('tag').count
   end
+
+  test ":create_project_media_tags should be able to ignore tag already added to item" do
+    Sidekiq::Testing.fake!
+
+    team = create_team
+    pm = create_project_media team: team
+    create_tag tag: 'two', annotated: pm
+    assert_equal 1, pm.reload.annotations('tag').count
+
+    Tag.create_project_media_tags(pm.id, ['one', 'two', 'three'].to_json)
+    assert_equal 3, pm.reload.annotations('tag').count
+  end
 end


### PR DESCRIPTION
## Description

:create_project_media_tags should be able to ignore tag already added to item.

References: 5426, 5120

## How has this been tested?

Added a test: `rails test test/models/tag_test.rb:342`

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

