### PR TITLE
set the annotator to be the “Smooch Bot”

### DIFF
--- a/app/models/concerns/smooch_blocking.rb
+++ b/app/models/concerns/smooch_blocking.rb
@@ -55,6 +55,7 @@ module SmoochBlocking
               flag = Dynamic.new
               flag.annotation_type = 'flag'
               flag.annotated = pm
+              flag.annotator = BotUser.smooch_user
               flag.skip_check_ability = true
               flag.set_fields = { show_cover: true, flags: flags }.to_json
               flag.save!


### PR DESCRIPTION
## Description

Set the annotator to "Smooch Bot" so that the bot user is displayed in the content warning cover when a user is blocked.

Reference: CV2-5142

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

