### PR TITLE
CV2-5419: rescue ActiveRecord::RecordNotUnique for relationship save

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -155,8 +155,12 @@ class Relationship < ApplicationRecord
 
   def self.create_unless_exists(source_id, target_id, relationship_type, options = {})
     r = Relationship.where(source_id: source_id, target_id: target_id).last
-    if r.nil?
+    ret = r
+    if !r.nil? && relationship_type == Relationship.confirmed_type && r.relationship_type != relationship_type
+      r.destroy
       ret = nil
+    end
+    if ret.nil?
       begin
         r = Relationship.new
         r.skip_check_ability = true
@@ -170,13 +174,8 @@ class Relationship < ApplicationRecord
       rescue ActiveRecord::RecordNotUnique
         ret = Relationship.where(source_id: source_id, target_id: target_id).last
       end
-      r = ret
-    elsif relationship_type == Relationship.confirmed_type && r.relationship_type != relationship_type
-      r.relationship_type = relationship_type
-      r.user = User.current unless User.current.nil?
-      r.save
     end
-    r
+    ret
   end
 
   protected

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -171,6 +171,10 @@ class Relationship < ApplicationRecord
         ret = Relationship.where(source_id: source_id, target_id: target_id).last
       end
       r = ret
+    elsif relationship_type == Relationship.confirmed_type && r.relationship_type != relationship_type
+      r.relationship_type = relationship_type
+      r.user = User.current unless User.current.nil?
+      r.save
     end
     r
   end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -156,15 +156,21 @@ class Relationship < ApplicationRecord
   def self.create_unless_exists(source_id, target_id, relationship_type, options = {})
     r = Relationship.where(source_id: source_id, target_id: target_id).last
     if r.nil?
-      r = Relationship.new
-      r.skip_check_ability = true
-      r.relationship_type = relationship_type
-      r.source_id = source_id
-      r.target_id = target_id
-      options.each do |key, value|
-        r.send("#{key}=", value) if r.respond_to?("#{key}=")
+      ret = nil
+      begin
+        r = Relationship.new
+        r.skip_check_ability = true
+        r.relationship_type = relationship_type
+        r.source_id = source_id
+        r.target_id = target_id
+        options.each do |key, value|
+          r.send("#{key}=", value) if r.respond_to?("#{key}=")
+        end
+        ret = r.save ? r : nil
+      rescue ActiveRecord::RecordNotUnique
+        ret = Relationship.where(source_id: source_id, target_id: target_id).last
       end
-      r.save ? r : nil
+      r = ret
     end
     r
   end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -262,8 +262,8 @@ class RelationshipTest < ActiveSupport::TestCase
     assert_no_difference 'Relationship.count' do
       r2 = Relationship.create_unless_exists(source.id, target.id, Relationship.confirmed_type)
     end
-    assert_equal r.id, r2.id
-    assert_equal Relationship.confirmed_type, r.reload.relationship_type
+    assert_nil Relationship.where(id: r.id).last
+    assert_equal Relationship.confirmed_type, r2.relationship_type
     Relationship.any_instance.stubs(:save).raises(ActiveRecord::RecordNotUnique)
     target = create_project_media team: t
     r = nil

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -255,5 +255,13 @@ class RelationshipTest < ActiveSupport::TestCase
       r2 = Relationship.create_unless_exists(source.id, target.id, Relationship.confirmed_type)
     end
     assert_equal r, r2
+    Relationship.any_instance.stubs(:save).raises(ActiveRecord::RecordNotUnique)
+    target = create_project_media team: t
+    r = nil
+    assert_no_difference 'Relationship.count' do
+      r = Relationship.create_unless_exists(source.id, target.id, Relationship.confirmed_type)
+    end
+    assert_nil r
+    Relationship.any_instance.unstub(:save)
   end
 end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -255,6 +255,15 @@ class RelationshipTest < ActiveSupport::TestCase
       r2 = Relationship.create_unless_exists(source.id, target.id, Relationship.confirmed_type)
     end
     assert_equal r, r2
+    # Should update type if the new one is confirmed
+    target = create_project_media team: t
+    r = create_relationship source_id: source.id, target_id: target.id, relationship_type: Relationship.suggested_type
+    r2 = nil
+    assert_no_difference 'Relationship.count' do
+      r2 = Relationship.create_unless_exists(source.id, target.id, Relationship.confirmed_type)
+    end
+    assert_equal r.id, r2.id
+    assert_equal Relationship.confirmed_type, r.reload.relationship_type
     Relationship.any_instance.stubs(:save).raises(ActiveRecord::RecordNotUnique)
     target = create_project_media team: t
     r = nil


### PR DESCRIPTION
## Description

Sentry issue: Handle the database validation `ActiveRecord::RecordNotUnique`.

Added a unit test to cover rescue case but I could not reproduce the race condition using `Thread.new`

References: CV2-5419

## How has this been tested?

Implemented automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

