### PR TITLE
Setting initial value for `last_request_date` for feed clusters.

### DIFF
--- a/lib/tasks/check_khousheh.rake
+++ b/lib/tasks/check_khousheh.rake
@@ -278,7 +278,7 @@ namespace :check do
                     updated_cluster_attributes[:channels] = (cluster.channels.to_a + pm.channel.to_h['others'].to_a + [pm.channel.to_h['main']]).uniq.compact_blank
                     updated_cluster_attributes[:media_count] = cluster.media_count + 1
                     updated_cluster_attributes[:requests_count] = cluster.requests_count + pm.requests_count
-                    updated_cluster_attributes[:last_request_date] = (pm.tipline_requests.last&.created_at.to_i > cluster.last_request_date.to_i) ? pm.tipline_requests.last.created_at : cluster.last_request_date
+                    updated_cluster_attributes[:last_request_date] = (pm.tipline_requests.last&.created_at.to_i > cluster.last_request_date.to_i) ? pm.tipline_requests.last.created_at : (cluster.last_request_date || Time.at(pm.last_seen))
                     updated_cluster_attributes[:fact_checks_count] = cluster.fact_checks_count
                     updated_cluster_attributes[:last_fact_check_date] = cluster.last_fact_check_date
                     unless pm_fc_mapping[pm.id].blank?


### PR DESCRIPTION
## Description

There was a change introduced in CV2-5331 that normalized how the `last_request_date` field for a shared feed cluster is calculated. But there is an issue: if the cluster doesn't have any request, no value is set. The fix needed here is to be sure that there is an initial value, which can be the same date as the last item that joined the cluster, when this item has no requests.

Fixes: CV2-5446.

## How has this been tested?

Tested by executing the Khousheh rake task.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

