### PR TITLE
CV2-5451: set confirmed fields for relationship

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -18,7 +18,7 @@ class Relationship < ApplicationRecord
   validate :cant_be_related_to_itself
   validates :relationship_type, uniqueness: { scope: [:source_id, :target_id], message: :already_exists }, on: :create
 
-  before_create :destroy_same_suggested_item, if: proc { |r| r.is_confirmed? }
+  before_create :set_confirmed, :destroy_same_suggested_item, if: proc { |r| r.is_confirmed? }
   after_create :move_to_same_project_as_main, prepend: true
   after_create :point_targets_to_new_source, :update_counters, prepend: true
   after_update :reset_counters, prepend: true

--- a/test/models/bot/smooch_2_test.rb
+++ b/test/models/bot/smooch_2_test.rb
@@ -109,6 +109,17 @@ class Bot::Smooch2Test < ActiveSupport::TestCase
     r.destroy
     s = child.annotations.where(annotation_type: 'verification_status').last.load
     assert_equal 'undetermined', s.status
+    u = create_user
+    create_team_user team: @team, user: u, role: 'admin'
+    with_current_user_and_team(u, @team) do
+      child2 = create_project_media project: @project
+      s2 = child2.annotations.where(annotation_type: 'verification_status').last.load
+      assert_equal 'undetermined', s2.status
+      create_tipline_request team_id: @project.team_id, associated: child2, language: 'en', smooch_message_id: random_string, smooch_data: { app_id: @app_id, authorId: random_string, language: 'en' }
+      r = create_relationship source_id: parent.id, target_id: child2.id, relationship_type: Relationship.confirmed_type, user: @bot
+      s2 = child2.annotations.where(annotation_type: 'verification_status').last.load
+      assert_equal 'verified', s2.status
+    end
   end
 
   test "should send message to user when status changes" do


### PR DESCRIPTION
## Description

Set the confirmed fields (confirmed_at & confirmed_by) before creation in case relationship type is confirmed which allow child to inherit parent status

References: CV2-5451

## How has this been tested?

implemented automated tests.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

