### PR TITLE
Report bad relationship structure only if relationship is not nil.

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -621,8 +621,8 @@ class Bot::Alegre < BotUser
         target.save!
       end
       r = self.fill_in_new_relationship(source, target, pm_id_scores, relationship_type, original_source, original_relationship_type)
-      self.report_exception_if_bad_relationship(r, pm_id_scores, relationship_type)
-      Rails.logger.info "[Alegre Bot] [ProjectMedia ##{target.id}] [Relationships 5/6] Created new relationship for relationship ID Of #{r.id}"
+      self.report_exception_if_bad_relationship(r, pm_id_scores, relationship_type) unless r.nil?
+      Rails.logger.info "[Alegre Bot] [ProjectMedia ##{target.id}] [Relationships 5/6] Created new relationship for relationship ID Of #{r&.id}"
     elsif self.is_relationship_upgrade?(r, relationship_type)
       Rails.logger.info "[Alegre Bot] [ProjectMedia ##{target.id}] [Relationships 5/6] Upgrading relationship from suggested to confirmed for relationship ID of #{r.id}"
       # confirm existing relation if a new one is confirmed


### PR DESCRIPTION
## Description

Report bad relationship structure only if relationship is not nil.

Fixes: CV2-5454 and an issue reported by Sentry.

## How has this been tested?

Existing tests should cover this.

## Things to pay attention to during code review

Maybe the relationship should not even be nil in the first place. But that's a different issue - `Relationship.create_unless_exists` _can_ return nil.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

