### PR TITLE
Make sure that an item can't be related to itself.

### DIFF
--- a/db/migrate/20241009192811_add_constraint_relationship_source_and_target_must_be_different.rb
+++ b/db/migrate/20241009192811_add_constraint_relationship_source_and_target_must_be_different.rb
@@ -1,0 +1,16 @@
+class AddConstraintRelationshipSourceAndTargetMustBeDifferent < ActiveRecord::Migration[6.1]
+  def up
+    execute <<-SQL
+      ALTER TABLE relationships
+      ADD CONSTRAINT source_target_must_be_different
+      CHECK (source_id <> target_id);
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      ALTER TABLE relationships
+      DROP CONSTRAINT source_target_must_be_different;
+    SQL
+  end  
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_09_24_130424) do
+ActiveRecord::Schema.define(version: 2024_10_09_192811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -292,7 +292,7 @@ ActiveRecord::Schema.define(version: 2024_09_24_130424) do
     t.jsonb "value_json", default: "{}"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
+    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY (ARRAY[('external_id'::character varying)::text, ('smooch_user_id'::character varying)::text, ('verification_status_status'::character varying)::text]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
     t.index ["annotation_id"], name: "index_dynamic_annotation_fields_on_annotation_id"
     t.index ["annotation_type"], name: "index_dynamic_annotation_fields_on_annotation_type"
@@ -593,6 +593,7 @@ ActiveRecord::Schema.define(version: 2024_09_24_130424) do
     t.index ["source_id"], name: "index_relationships_on_source_id"
     t.index ["target_id", "relationship_type"], name: "index_relationships_on_target_id_and_relationship_type"
     t.index ["target_id"], name: "index_relationships_on_target_id"
+    t.check_constraint "source_id <> target_id", name: "source_target_must_be_different"
   end
 
   create_table "requests", force: :cascade do |t|

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -273,4 +273,17 @@ class RelationshipTest < ActiveSupport::TestCase
     assert_nil r
     Relationship.any_instance.unstub(:save)
   end
+
+  test "should not be related to itself" do
+    t = create_team
+    pm1 = create_project_media team: t
+    pm2 = create_project_media team: t
+    r = create_relationship source: pm1, target: pm2
+    begin
+      r.update_column :target_id, pm1.id
+      flunk 'Expected save to fail, but it succeeded'
+    rescue ActiveRecord::StatementInvalid => e
+      assert_match /violates check constraint "source_target_must_be_different"/, e.message
+    end
+  end
 end


### PR DESCRIPTION
## Description

We already had an Active Record validation for that, but it was bypassed for straight updates or race conditions. This PR makes it more robust by adding a database constraint.

Fixes: CV2-5437.

## How has this been tested?

TDD. I added a unit test that reproduces the issue.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

