### PR TITLE
Revert rejecting suggestion if relationship creation fails.

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_09_24_130424) do
+ActiveRecord::Schema.define(version: 2024_10_09_192811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -292,7 +292,7 @@ ActiveRecord::Schema.define(version: 2024_09_24_130424) do
     t.jsonb "value_json", default: "{}"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
+    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY (ARRAY[('external_id'::character varying)::text, ('smooch_user_id'::character varying)::text, ('verification_status_status'::character varying)::text]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
     t.index ["annotation_id"], name: "index_dynamic_annotation_fields_on_annotation_id"
     t.index ["annotation_type"], name: "index_dynamic_annotation_fields_on_annotation_type"
@@ -593,6 +593,7 @@ ActiveRecord::Schema.define(version: 2024_09_24_130424) do
     t.index ["source_id"], name: "index_relationships_on_source_id"
     t.index ["target_id", "relationship_type"], name: "index_relationships_on_target_id_and_relationship_type"
     t.index ["target_id"], name: "index_relationships_on_target_id"
+    t.check_constraint "source_id <> target_id", name: "source_target_must_be_different"
   end
 
   create_table "requests", force: :cascade do |t|

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -723,8 +723,8 @@ module SampleData
 
   def create_relationship(options = {})
     t = create_team
-    source_id = options[:source_id] || create_project_media(team: t).id
-    target_id = options[:target_id] || create_project_media(team: t).id
+    source_id = options[:source_id] || options[:source]&.id || create_project_media(team: t).id
+    target_id = options[:target_id] || options[:target]&.id || create_project_media(team: t).id
     options = {
       source_id: source_id,
       target_id: target_id,

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -296,7 +296,7 @@ class RelationshipTest < ActiveSupport::TestCase
     assert_equal suggestion, Relationship.where(source_id: pm1.id, target: pm2.id).last
   end
 
-  test "should revert rejecting suggestion when creation fails (using create_unless_exists) bli" do
+  test "should revert rejecting suggestion when creation fails (using create_unless_exists)" do
     Sidekiq::Testing.fake!
     t = create_team
     pm1 = create_project_media team: t
@@ -317,7 +317,7 @@ class RelationshipTest < ActiveSupport::TestCase
     assert_equal suggestion, Relationship.where(source_id: pm1.id, target: pm2.id).last
   end
 
-  test "should not be related to itself bli" do
+  test "should not be related to itself" do
     t = create_team
     pm1 = create_project_media team: t
     pm2 = create_project_media team: t


### PR DESCRIPTION
## Description

When a confirmed relationship is created, if there is any suggestion between the same two items, the suggestion should be delete. We had logic in two different places for that. This PR keeps this logic in only one place (the relationship model), so I removed the logic from the `create_unless_exists` method, which now also takes the relationship type into account. This way we have the logic in only one place, and having this logic as a `before_create` that contains a transaction means that the `destroy` of the suggestion will be rolled back by PostgreSQL if the `create` fails.

Fixes: CV2-5436.

## How has this been tested?

I added a couple of new unit tests, and made sure that the existing tests for `create_unless_exists` still work.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

