### PR TITLE
CV2-5434: Review TeamTaskWorker performance

### DIFF
--- a/app/workers/team_task_worker.rb
+++ b/app/workers/team_task_worker.rb
@@ -3,7 +3,7 @@ class TeamTaskWorker
 
   sidekiq_options :queue => :tsqueue
 
-  def perform(action, id, author_id, fields = YAML::dump({}), keep_completed_tasks = false, options_diff = {})
+  def perform(action, id, author_id, timestamp, fields = YAML::dump({}), keep_completed_tasks = false, options_diff = {})
     RequestStore.store[:skip_notifications] = true
     user_current = User.current
     team_current = Team.current
@@ -12,7 +12,7 @@ class TeamTaskWorker
     User.current = author
     if action == 'update' || action == 'add'
       team_task = TeamTask.find_by_id(id)
-      return if team_task.nil?
+      return if team_task.nil? || team_task.updated_at.to_f > timestamp
       Team.current = team_task.team
       action == 'update' ?
         team_task.update_teamwide_tasks_bg(fields, options_diff) : team_task.add_teamwide_tasks_bg


### PR DESCRIPTION
## Description

Add a logic to  TeamTaskWorker based on update_at date to skip the background job if there is a more recent one.

References:  CV2-5434

## How has this been tested?

Re-run automated tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

