### PR TITLE
Setting retry interval for GenericWorker.

### DIFF
--- a/app/workers/generic_worker.rb
+++ b/app/workers/generic_worker.rb
@@ -3,6 +3,7 @@ class GenericWorker
   include Sidekiq::Worker
 
   sidekiq_options retry: 3
+  sidekiq_retry_in { |_count, _exception| 3 }
 
   def perform(klass_name, klass_method, *method_args)
     klass = klass_name.constantize


### PR DESCRIPTION
## Description

This change tries to avoid a single case reported by Sentry: A race condition situation where the related object was still not fully persisted in the database when the job executed. Setting a longer retry interval which should avoid this case.

Fixes: CV2-5459.

## How has this been tested?

This should already be tested by Sidekiq itself.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

