### PR TITLE
Adding a log line for outgoing Smooch requests.

### DIFF
--- a/app/models/concerns/smooch_zendesk.rb
+++ b/app/models/concerns/smooch_zendesk.rb
@@ -74,6 +74,7 @@ module SmoochZendesk
       response_body = nil
       response_code = 0
       begin
+        Rails.logger.info("[Smooch Bot] [Zendesk] Sending message to #{uid} for app #{app_id}: #{params.to_json}")
         response_body = api_instance.post_message(app_id, uid, message_post_body) # It will raise an exception if message can't be sent
         response_code = 200
       rescue SmoochApi::ApiError => e


### PR DESCRIPTION
## Description

Adding a log line for the outgoing Smooch requests. This can help debugging some issues.

Reference: CV2-5378.

## How has this been tested?

I confirmed in the logs that the new log line appears for outgoing requests to Smooch API.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

