### PR TITLE
Do not send report if search results were already received.

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -63,7 +63,7 @@ class Bot::Smooch < BotUser
       relationship = Relationship.find_by_id(rid)
       unless relationship.nil?
         # A relationship created by the Smooch Bot or Alegre Bot is related to search results, so the user has already received the report as a search result - unless it's a suggestion
-        return if [BotUser.smooch_user&.id, BotUser.alegre_user&.id].include?(relationship.user_id) && !relationship.confirmed_by
+        return if [BotUser.smooch_user&.id, BotUser.alegre_user&.id].include?(relationship.user_id) && (relationship.confirmed_at.to_i <= relationship.created_at.to_i)
         target = relationship.target
         parent = relationship.source
         if ::Bot::Smooch.team_has_smooch_bot_installed(target) && relationship.is_confirmed?

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -62,10 +62,10 @@ class Bot::Smooch < BotUser
     def self.inherit_status_and_send_report(rid)
       relationship = Relationship.find_by_id(rid)
       unless relationship.nil?
-        # A relationship created by the Smooch Bot or Alegre Bot is related to search results, so the user has already received the report as a search result - unless it's a suggestion
-        return if [BotUser.smooch_user&.id, BotUser.alegre_user&.id].include?(relationship.user_id) && (relationship.confirmed_at.to_i <= relationship.created_at.to_i)
         target = relationship.target
         parent = relationship.source
+
+        # Always inherit status for confirmed matches
         if ::Bot::Smooch.team_has_smooch_bot_installed(target) && relationship.is_confirmed?
           s = target.annotations.where(annotation_type: 'verification_status').last&.load
           status = parent.last_verification_status
@@ -73,17 +73,21 @@ class Bot::Smooch < BotUser
             s.status = status
             s.save
           end
-          ::Bot::Smooch.send_report_from_parent_to_child(parent.id, target.id)
+
+          # A relationship created by the Smooch Bot or Alegre Bot is related to search results (unless it's a suggestion that was confirmed), so the user has already received the report as a search result... no need to send another report
+          # Only send a report for (1) Confirmed matches created manually OR (2) Suggestions accepted
+          created_by_bot = [BotUser.smooch_user&.id, BotUser.alegre_user&.id].include?(relationship.user_id)
+          ::Bot::Smooch.send_report_from_parent_to_child(parent.id, target.id) if !created_by_bot || relationship.confirmed_by
         end
       end
     end
 
     after_create do
-      self.class.delay_for(1.seconds, { queue: 'smooch_priority'}).inherit_status_and_send_report(self.id)
+      self.class.delay_for(2.seconds, { queue: 'smooch_priority'}).inherit_status_and_send_report(self.id)
     end
 
     after_update do
-      self.class.delay_for(1.seconds, { queue: 'smooch_priority'}).inherit_status_and_send_report(self.id) if self.suggestion_accepted?
+      self.class.delay_for(2.seconds, { queue: 'smooch_priority'}).inherit_status_and_send_report(self.id) if self.suggestion_accepted?
     end
 
     after_destroy do

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -18,7 +18,7 @@ class Relationship < ApplicationRecord
   validate :cant_be_related_to_itself
   validates :relationship_type, uniqueness: { scope: [:source_id, :target_id], message: :already_exists }, on: :create
 
-  before_create :set_confirmed, :destroy_same_suggested_item, if: proc { |r| r.is_confirmed? }
+  before_create :destroy_same_suggested_item, if: proc { |r| r.is_confirmed? }
   after_create :move_to_same_project_as_main, prepend: true
   after_create :point_targets_to_new_source, :update_counters, prepend: true
   after_update :reset_counters, prepend: true


### PR DESCRIPTION
## Description

I noticed a regression introduced by CV2-5451 that we overlooked. We shouldn't set `confirmed_by` and `confirmed_at` for all relationships, but really keep setting them only for when a relationship created as a suggestion is confirmed... this is the purpose of these two fields. Instead, the logic for inhering the status from the parent item and sending a report is that should have been fixed. This is what this PR does. So:

- Child item should always inherit status from parent item for confirmed relationships, regardless if they are created as confirmed matches or a suggestion that is confirmed... also, should be the same logic if the relationship is created by a bot or by a human
- But when a child item matches a parent item, we should NOT send a report if the user already received a report as search results... this means that we should not send a report for confirmed relationships created by bots

Reference: CV2-5451.

## How has this been tested?

Existing unit tests should cover this. I tested manually as well:

- Get a tipline search result: You should not also receive a report for the match that is created between the existing item and your media, because you already received search results
- Manually-created similar item: Send report
- Confirmed suggestion: Send report

In all cases above, the child item should inherit the status from the parent.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

