### PR TITLE
CV2-5348: refactor ES cached field calling and remove retry_on_conflict

### DIFF
--- a/app/lib/check_cached_fields.rb
+++ b/app/lib/check_cached_fields.rb
@@ -97,17 +97,13 @@ module CheckCachedFields
           update_pg: options[:update_pg],
           pg_field_name: options[:pg_field_name],
         }
-        obj_data = { klass: obj.class.name, id: obj.id }
-        self.delay_for(1.second).index_cached_field_bg(index_options, value, name, YAML::dump(obj_data))
+        self.delay_for(1.second).index_cached_field_bg(index_options, value, name, obj.class.name, obj.id)
       end
     end
 
-    def index_cached_field_bg(index_options, value, name, obj_data)
-      obj_data = begin YAML::load(obj_data) rescue {} end
-      unless obj.blank?
-        obj = obj_data[:klass].constantize.find_by_id obj_data[:id]
-        self.index_and_pg_cached_field(index_options, value, name, obj) unless obj.nil?
-      end
+    def index_cached_field_bg(index_options, value, name, klass, id)
+      obj = klass.constantize.find_by_id id
+      self.index_and_pg_cached_field(index_options, value, name, obj) unless obj.nil?
     end
 
     def update_pg_cache_field(options, value, name, target)

--- a/app/lib/check_cached_fields.rb
+++ b/app/lib/check_cached_fields.rb
@@ -103,9 +103,11 @@ module CheckCachedFields
     end
 
     def index_cached_field_bg(index_options, value, name, obj_data)
-      obj_data = begin YAML::load(obj_data) rescue nil end
-      obj = obj_data[:klass].constantize.find_by_id obj_data[:id]
-      self.index_and_pg_cached_field(index_options, value, name, obj) unless obj.nil?
+      obj_data = begin YAML::load(obj_data) rescue {} end
+      unless obj.blank?
+        obj = obj_data[:klass].constantize.find_by_id obj_data[:id]
+        self.index_and_pg_cached_field(index_options, value, name, obj) unless obj.nil?
+      end
     end
 
     def update_pg_cache_field(options, value, name, target)

--- a/app/lib/check_cached_fields.rb
+++ b/app/lib/check_cached_fields.rb
@@ -97,12 +97,15 @@ module CheckCachedFields
           update_pg: options[:update_pg],
           pg_field_name: options[:pg_field_name],
         }
-        self.delay_for(1.second).index_cached_field_bg(index_options, value, name, obj)
+        obj_data = { klass: obj.class.name, id: obj.id }
+        self.delay_for(1.second).index_cached_field_bg(index_options, value, name, YAML::dump(obj_data))
       end
     end
 
-    def index_cached_field_bg(index_options, value, name, obj)
-      self.index_and_pg_cached_field(index_options, value, name, obj)
+    def index_cached_field_bg(index_options, value, name, obj_data)
+      obj_data = begin YAML::load(obj_data) rescue nil end
+      obj = obj_data[:klass].constantize.find_by_id obj_data[:id]
+      self.index_and_pg_cached_field(index_options, value, name, obj) unless obj.nil?
     end
 
     def update_pg_cache_field(options, value, name, target)

--- a/app/lib/check_elastic_search.rb
+++ b/app/lib/check_elastic_search.rb
@@ -63,7 +63,7 @@ module CheckElasticSearch
       create_doc_if_not_exists(options)
       sleep 1
       client = $repository.client
-      client.update index: CheckElasticSearchModel.get_index_alias, id: options[:doc_id], retry_on_conflict: 3, body: { doc: fields }
+      client.update index: CheckElasticSearchModel.get_index_alias, id: options[:doc_id], body: { doc: fields }
     end
   end
 
@@ -98,7 +98,7 @@ module CheckElasticSearch
     end
     values = store_elasticsearch_data(options[:keys], options[:data])
     client = $repository.client
-    client.update index: CheckElasticSearchModel.get_index_alias, id: options[:doc_id], retry_on_conflict: 3,
+    client.update index: CheckElasticSearchModel.get_index_alias, id: options[:doc_id],
             body: { script: { source: source, params: { value: values, id: values['id'] } } }
   end
 
@@ -178,7 +178,7 @@ module CheckElasticSearch
       begin
         client = $repository.client
         source = "for (int i = 0; i < ctx._source.#{nested_type}.size(); i++) { if(ctx._source.#{nested_type}[i].id == params.id){ctx._source.#{nested_type}.remove(i);}}"
-        client.update index: CheckElasticSearchModel.get_index_alias, id: options[:doc_id], retry_on_conflict: 3,
+        client.update index: CheckElasticSearchModel.get_index_alias, id: options[:doc_id],
                  body: { script: { source: source, params: { id: options[:model_id] } } }
       rescue
         Rails.logger.info "[ES destroy] doc with id #{options[:doc_id]} not exists"


### PR DESCRIPTION
## Description

- Set ElasticSearch’s retry_on_conflict: 0 (so we can rely only on the Sidekiq retry, which retrieves latest value)
- Pass class and ID instead of the full object


References: CV2-5348

## How has this been tested?

Re-run automated tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

