### PR TITLE
CV2-5190: Create a Link and Claim from tipline message that contain both link and long text

### DIFF
--- a/test/models/bot/smooch_3_test.rb
+++ b/test/models/bot/smooch_3_test.rb
@@ -191,6 +191,117 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
     end
   end
 
+  test "should bundle message with link and text" do
+    uid = random_string
+    payload = {
+      trigger: 'message:appUser',
+      app: {
+        '_id': @app_id
+      },
+      version: 'v1.1',
+      messages: [message],
+      appUser: {
+        '_id': random_string,
+        'conversationStarted': true
+      }
+    }
+    Sidekiq::Testing.fake! do
+      long_text = []
+      15.times{ long_text << random_string }
+      # 1) Link + long text
+      link_long_text = long_text.join(' ').concat(' ').concat(@link_url)
+      message = {
+        '_id': random_string,
+        authorId: uid,
+        type: 'text',
+        source: { type: "whatsapp" },
+        text: link_long_text,
+      }
+      payload[:messages] = [message]
+      Bot::Smooch.run(payload.to_json)
+      sleep 1
+      pm_id = ProjectMedia.last.id
+      assert_difference 'ProjectMedia.count', 2 do
+        assert_difference 'Claim.count' do
+          assert_difference 'Link.count' do
+            assert_difference 'Relationship.count' do
+              Sidekiq::Worker.drain_all
+            end
+          end
+        end
+      end
+      l1 = Link.last
+      c1 = Claim.last
+      pm_l1 = l1.project_medias.last
+      pm_c1 = c1.project_medias.last
+      r = Relationship.last
+      assert_equal [pm_l1.id, pm_c1.id].sort, [r.source_id, r.target_id].sort
+      # 2) Same message multiple times (re-send message in step 1)
+      Bot::Smooch.run(payload.to_json)
+      sleep 1
+      # TODO: fix Tipline requests count
+      assert_no_difference 'ProjectMedia.count' do
+        assert_no_difference 'Relationship.count' do
+          # assert_difference 'TiplineRequest.count' do
+            Sidekiq::Worker.drain_all
+          # end
+        end
+      end
+      # assert_equal 2, pm_l1.tipline_requests.count
+      # assert_equal 2, pm_c1.tipline_requests.count
+      # 3) Send different messages with the same link
+      long_text2 = []
+      15.times{ long_text2 << random_string }
+      link_long_text2 = long_text2.join(' ').concat(' ').concat(@link_url)
+      message = {
+        '_id': random_string,
+        authorId: uid,
+        type: 'text',
+        source: { type: "whatsapp" },
+        text: link_long_text2,
+      }
+      payload[:messages] = [message]
+      Bot::Smooch.run(payload.to_json)
+      sleep 1
+      assert_difference 'ProjectMedia.count' do
+        assert_difference 'Relationship.count' do
+          assert_difference 'Claim.count' do
+            assert_no_difference 'Link.count' do
+              Sidekiq::Worker.drain_all
+            end
+          end
+        end
+      end
+      pm = ProjectMedia.last
+      r = Relationship.last
+      assert_equal [pm_l1.id, pm.id].sort, [r.source_id, r.target_id].sort
+      # 4) Send two messages with the same text but different links
+      link_long_text3 = long_text.join(' ').concat(' ').concat(@link_url_2)
+      message = {
+        '_id': random_string,
+        authorId: uid,
+        type: 'text',
+        source: { type: "whatsapp" },
+        text: link_long_text3,
+      }
+      payload[:messages] = [message]
+      Bot::Smooch.run(payload.to_json)
+      sleep 1
+      assert_difference 'ProjectMedia.count' do
+        assert_difference 'Relationship.count' do
+          assert_difference 'Link.count' do
+            assert_no_difference 'Claim.count' do
+              Sidekiq::Worker.drain_all
+            end
+          end
+        end
+      end
+      pm = ProjectMedia.last
+      r = Relationship.last
+      assert_equal [pm_c1.id, pm.id].sort, [r.source_id, r.target_id].sort
+    end
+  end
+
   test "should force relationship between media and caption text" do
     long_text = []
     15.times{ long_text << random_string }


### PR DESCRIPTION
## Description

For the tipline messages that contain both Link and Text we should handle the following cases.

- [x] Send message with a link and only short text
- [x] Send message with a link and long text
- [x] Send the same message with the same link multiple times
- [x] Send different messages with the same link
- [x] Send two messages with the same text but different links

References: CV2-5190

## How has this been tested?

Implemented automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

