### PR TITLE
Request/5424 add tagalog translations

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GIT
 
 GIT
   remote: https://github.com/meedan/rails-i18n.git
-  revision: fc05735019c664226240a49e8a7d16685fff3323
+  revision: e3004b7793e5fd759c5b2134e021a29c6d0a6488
   branch: rails-6-x
   specs:
     rails-i18n (6.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GIT
 
 GIT
   remote: https://github.com/meedan/rails-i18n.git
-  revision: f8dd347402d9de9125af4db05f94f6933147b18f
+  revision: fc05735019c664226240a49e8a7d16685fff3323
   branch: rails-6-x
   specs:
     rails-i18n (6.0.0)

--- a/config/tipline_strings.yml
+++ b/config/tipline_strings.yml
@@ -981,29 +981,44 @@ es:
   unsubscribe_button_label: Cancelar suscripción
   unsubscribed: Actualmente no estás suscrita(o) a nuestro boletín.
 tl:
-  add_more_details_state_button_label: ''
-  ask_if_ready_state_button_label: ''
-  cancelled: ''
-  confirm_preferred_language: ''
-  invalid_format: ''
-  keep_subscription_button_label: ''
-  languages: ''
-  languages_and_privacy_title: ''
-  main_menu: ''
-  main_state_button_label: ''
-  navigation_button: ''
-  no_results_in_language: ''
-  privacy_and_purpose: ''
-  privacy_statement: ''
-  privacy_title: ''
-  report_updated: ''
-  search_result_is_not_relevant_button_label: ''
-  search_result_is_relevant_button_label: ''
-  search_state_button_label: ''
-  subscribe_button_label: ''
-  subscribed: ''
-  unsubscribe_button_label: ''
-  unsubscribed: ''
+  add_more_details_state_button_label: Magdagdag
+  ask_if_ready_state_button_label: I-cancel
+  cancelled: Ok!
+  confirm_preferred_language: Pumili ng wika
+  invalid_format: "Hindi suportado ang format ng ipinadala mo."
+  keep_subscription_button_label: Manatiling konektado
+  languages: Mga wika
+  languages_and_privacy_title: Wika at Privacy
+  main_menu: Main menu
+  main_state_button_label: I-cancel
+  navigation_button: Gamitin ang mga button para mag-navigate
+  no_results_in_language: "Walang resulta na nahanap sa %{language}. Narito ang ilang resulta sa ibang wika na maaaring konektado sa hinahanap mo."
+  privacy_and_purpose: |-
+    PRIVACY AT LAYUNIN
+
+    Welcome sa %{team} %{channel} tipline.
+
+    Puwede mong gamitin ang tip line na ito para magpadala ng mga bagay na gusto mong ipa-fact check.
+
+    Ligtas ang data mo rito. Seryoso kami sa aming responsibilidad na alagaan ang iyong personal na impormasyon at panatilihing ang %{channel} ay pribado at ligtas; hindi kailanman ipamamahagi, ibebenta o gagamitin sa ibang layunin ang impormasyon na nakapagtutukoy sa iyo (personally identifiable information o PII) maliban para maibigay at mapabuti ang serbisyong ito.
+
+    Para ma-detect sa lalong mabilis na paraan ang kumakalat na misinformation, posibleng ibahagi namin ang content na hindi PII mula sa tip line na ito sa mga mananaliksik at fact-checking partner na pumasa sa aming pagsusuri.
+
+    Paalala na ang mga website na aming ili-link ay may kanya-kanyang privacy policy.
+
+    Kung hindi mo nais na magamit ang mga isinumite mong impormasyon sa gawaing ito, mangyaring huwag mag-ambag sa aming system.
+  privacy_statement: Privacy statement
+  privacy_title: Privacy
+  report_updated: "*In-update* ang fact check na ito dahil sa bagong impormasyon:"
+  search_result_is_not_relevant_button_label: "Hindi"
+  search_result_is_relevant_button_label: "Oo"
+  search_state_button_label: I-submit
+  subscribe_button_label: Mag-subscribe
+  subscribed: Kasalukuyan kang naka-subscribe sa aming newsletter.
+  unsubscribe_button_label: Mag-unsubscribe
+  unsubscribed: Hindi ka kasalukuyang naka-subscribe sa aming newsletter.
+  nlu_disambiguation: "Pumili ng isa sa mga option na ito:"
+  nlu_cancel: "Bumalik sa menu"
 ta:
   add_more_details_state_button_label: கூடுதல் தகவல்ககள்
   ask_if_ready_state_button_label: ரத்து செய்


### PR DESCRIPTION
## Description

Bump rails-i18n again. Changed long date format instead of the default one.

References: CV2-5424

## How has this been tested?

Manually on the rails console:

`irb(main):002:0> I18n.l(Time.now, locale: 'tl', format: :long)`
`=> "Oktubre 14, 2024 19:05"`

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

