### PR TITLE
CV2-5190: use remove instead of chomp

### DIFF
--- a/app/lib/check_cached_fields.rb
+++ b/app/lib/check_cached_fields.rb
@@ -137,11 +137,12 @@ module CheckCachedFields
           pg_field_name: options[:pg_field_name],
           recalculate: options[:recalculate],
         }
-        self.delay_for(1.second).update_cached_field_bg(name, obj, ids, callback, index_options)
+        self.delay_for(1.second).update_cached_field_bg(name, ids, callback, index_options, obj.class.name, obj.id)
       end
     end
 
-    def update_cached_field_bg(name, obj, ids, callback, options)
+    def update_cached_field_bg(name, ids, callback, options, klass, id)
+      obj = klass.constantize.find_by_id id
       recalculate = options[:recalculate]
       self.where(id: ids).each do |target|
         value = callback == :recalculate ? target.send(recalculate) : obj.send(callback, target)

--- a/app/lib/check_cached_fields.rb
+++ b/app/lib/check_cached_fields.rb
@@ -137,12 +137,11 @@ module CheckCachedFields
           pg_field_name: options[:pg_field_name],
           recalculate: options[:recalculate],
         }
-        self.delay_for(1.second).update_cached_field_bg(name, ids, callback, index_options, obj.class.name, obj.id)
+        self.delay_for(1.second).update_cached_field_bg(name, obj, ids, callback, index_options)
       end
     end
 
-    def update_cached_field_bg(name, ids, callback, options, klass, id)
-      obj = klass.constantize.find_by_id id
+    def update_cached_field_bg(name, obj, ids, callback, options)
       recalculate = options[:recalculate]
       self.where(id: ids).each do |target|
         value = callback == :recalculate ? target.send(recalculate) : obj.send(callback, target)

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -426,7 +426,7 @@ module SmoochMessages
         if text_words > CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer)
           # Remove link from text
           link = self.extract_url(message['text'])
-          message['text'] = message['text'].chomp(link.url)
+          message['text'] = message['text'].remove(link.url)
           self.relate_item_and_text(message, associated, app_id, author, request_type, associated_obj, Relationship.confirmed_type)
         end
       end

--- a/test/models/bot/smooch_3_test.rb
+++ b/test/models/bot/smooch_3_test.rb
@@ -212,7 +212,7 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
         authorId: uid,
         type: 'text',
         source: { type: "whatsapp" },
-        text: "short text #{@link_url}",
+        text: "#{@link_url} short text",
       }
       payload[:messages] = [message]
       Bot::Smooch.run(payload.to_json)
@@ -230,8 +230,7 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
       # 2) Send link with long text
       long_text = []
       15.times{ long_text << random_string }
-      # 1) Link + long text
-      link_long_text = long_text.join(' ').concat(' ').concat(@link_url)
+      link_long_text = @link_url.concat(' ').concat(long_text.join(' '))
       message = {
         '_id': random_string,
         authorId: uid,
@@ -263,7 +262,6 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
       payload[:messages] = [message]
       Bot::Smooch.run(payload.to_json)
       sleep 1
-      # TODO: fix Tipline requests count
       assert_no_difference 'ProjectMedia.count' do
         assert_no_difference 'Relationship.count' do
           assert_difference 'TiplineRequest.count', 2 do
@@ -300,7 +298,7 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
       r = Relationship.last
       assert_equal [pm_l1.id, pm.id].sort, [r.source_id, r.target_id].sort
       # 5) Send two messages with the same text but different links
-      link_long_text3 = long_text.join(' ').concat(' ').concat(@link_url_2)
+      link_long_text3 = @link_url_2.concat(' ').concat(long_text.join(' '))
       message = {
         '_id': random_string,
         authorId: uid,


### PR DESCRIPTION
## Description

- Use `.remove` method to delete the link for message text.

References: CV2-5190

## How has this been tested?

Re-run automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

