### PR TITLE
CV2-5300: set a max length validation for media URL

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -69,7 +69,7 @@ class Link < Media
   end
 
   def url_max_size
-    # Use 2k as max size to stay within safe limits as max size is 2712 bytes.
+    # Use 2k as max size to stay within safe limits for a unique URL index in PostgreSQL as max size is 2712 bytes.
     errors.add(:base, "Media URL exceeds the maximum size (2000 bytes)") if !self.url.nil? && self.url.bytesize > CheckConfig.get('url_max_size', 2000, :integer)
   end
 

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -3,7 +3,7 @@ class Link < Media
 
   validates :url, presence: true, on: :create
   validate :validate_pender_result_and_retry, on: :create
-  validate :url_is_unique, on: :create
+  validate :url_is_unique, :url_max_size, on: :create
 
   after_create :set_pender_result_as_annotation, :set_account
 
@@ -66,6 +66,10 @@ class Link < Media
       existing = Media.where(url: self.url).first
       errors.add(:base, "Media with this URL exists and has id #{existing.id}") unless existing.nil?
     end
+  end
+
+  def url_max_size
+    errors.add(:base, "Media URL exceeds the maximum size (2000 bytes)") if !self.url.nil? && self.url.bytesize > 2000
   end
 
   def validate_pender_result_and_retry

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -69,7 +69,8 @@ class Link < Media
   end
 
   def url_max_size
-    errors.add(:base, "Media URL exceeds the maximum size (2000 bytes)") if !self.url.nil? && self.url.bytesize > 2000
+    # Use 2k as max size to stay within safe limits as max size is 2712 bytes.
+    errors.add(:base, "Media URL exceeds the maximum size (2000 bytes)") if !self.url.nil? && self.url.bytesize > CheckConfig.get('url_max_size', 2000, :integer)
   end
 
   def validate_pender_result_and_retry

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -279,6 +279,7 @@ development: &default
   export_csv_expire: 604800 # Seconds: Default is 7 days
   header_file_video_max_size_whatsapp: 16 # Megabytes
   header_file_video_max_size_check: 10 # Megabytes, should be less than WhatsApp limit
+  url_max_size: 2000
 
   # Session
   #

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -604,6 +604,18 @@ class MediaTest < ActiveSupport::TestCase
     end
   end
 
+  test 'should validate url length' do
+    pender_url = CheckConfig.get('pender_url_private') + '/api/medias'
+    url = "#{random_url}?params=#{random_string(2000)}"
+    response = { type: 'media', data: { url: url, type: 'item', title: "Foo \u0000 bar" } }
+    WebMock.stub_request(:get, pender_url).with({ query: { url: url } }).to_return(body: response.to_json)
+    assert_no_difference 'Link.count' do
+      assert_raises ActiveRecord::RecordInvalid do
+        create_media url: url
+      end
+    end
+  end
+
   test "should have uuid" do
     m = create_media
     assert_equal m.id, m.uuid


### PR DESCRIPTION
## Description

 Set a max length (2000) validation for media URL.

References: CV2-5300

## How has this been tested?

Implemented automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

