### PR TITLE
CV2-5348: Fix N+1 query

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -42,13 +42,12 @@ class Bot::Smooch < BotUser
     def get_deduplicated_tipline_requests
       uids = []
       tipline_requests = []
-      ProjectMedia.where(id: self.related_items_ids).each do |pm|
-        pm.tipline_requests.find_each do |tr|
-          uid = tr.tipline_user_uid
-          next if uids.include?(uid)
-          uids << uid
-          tipline_requests << tr
-        end
+      pm_ids = ProjectMedia.where(id: self.related_items_ids).map(&:id)
+      TiplineRequest.where(associated_type: 'ProjectMedia', associated_id: pmids).find_each do |tr|
+        uid = tr.tipline_user_uid
+        next if uids.include?(uid)
+        uids << uid
+        tipline_requests << tr
       end
       tipline_requests
     end

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -43,7 +43,7 @@ class Bot::Smooch < BotUser
       uids = []
       tipline_requests = []
       pm_ids = ProjectMedia.where(id: self.related_items_ids).map(&:id)
-      TiplineRequest.where(associated_type: 'ProjectMedia', associated_id: pmids).find_each do |tr|
+      TiplineRequest.where(associated_type: 'ProjectMedia', associated_id: pm_ids).find_each do |tr|
         uid = tr.tipline_user_uid
         next if uids.include?(uid)
         uids << uid


### PR DESCRIPTION
## Description

Sentry reported a N+1 query issue so I added a unit test to reproduce N+1 query then apply the fix and re-run same unit test

References: CV2-5348

## How has this been tested?

Implemented automated tests.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

