### PR TITLE
5514 – Import fact-check as published report

### DIFF
--- a/app/models/bot/fetch.rb
+++ b/app/models/bot/fetch.rb
@@ -262,7 +262,7 @@ class Bot::Fetch < BotUser
       fc.tags = claim_review['keywords'].to_s.split(',').map(&:strip).reject{ |r| r.blank? }
       fc.user = user
       fc.language = fc_language
-      fc.publish_report = true
+      fc.report_status = "published"
       fc.save!
       User.current = current_user
     end

--- a/app/models/bot/fetch.rb
+++ b/app/models/bot/fetch.rb
@@ -262,6 +262,7 @@ class Bot::Fetch < BotUser
       fc.tags = claim_review['keywords'].to_s.split(',').map(&:strip).reject{ |r| r.blank? }
       fc.user = user
       fc.language = fc_language
+      fc.publish_report = true
       fc.report_status = "published"
       fc.save!
       User.current = current_user

--- a/test/models/bot/fetch_test.rb
+++ b/test/models/bot/fetch_test.rb
@@ -253,4 +253,18 @@ class Bot::FetchTest < ActiveSupport::TestCase
       Bot::Fetch::Import.import_claim_review(cr, @team.id, @bot.id, 'undetermined', {}, false)
     end
   end
+
+  test "should import claim review as published report" do
+    cr = @claim_review.deep_dup
+    cr['identifier'] = random_string
+    assert_difference 'FactCheck.count' do
+      Bot::Fetch::Import.import_claim_review(cr, @team.id, @bot.id, 'undetermined', {}, false)
+    end
+
+    r = Dynamic.where(annotation_type: 'report_design').last
+    assert_equal "published", r.state
+
+    fc = FactCheck.last
+    assert_equal "published", fc.report_status
+  end
 end


### PR DESCRIPTION
## Description

### Context
While trying to run a fact check import Jessie noted that the fact checks weren't imported as published.
I looked at some older imports and seems to have been the case for a while even though we set `fc.publish_report = true` in the FetchBot.

### What
We were updating the published value for `Dynamic` but weren't for `FactCheck`. We hadn't  implemented that as part of the big articles work.

So we just need to make sure both are updated as published when importing through the FetchBot.

References: 5390, 5514

## How has this been tested?

`rails test test/models/bot/fetch_test.rb:257`

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

