### PR TITLE
Add skip_cache parameter to bypass similarity search cache in Feed API

### DIFF
--- a/app/models/concerns/smooch_search.rb
+++ b/app/models/concerns/smooch_search.rb
@@ -134,7 +134,7 @@ module SmoochSearch
         after = self.date_filter(team_id)
         query = message['text']
         query = CheckS3.rewrite_url(message['mediaUrl']) unless type == 'text'
-        results = self.search_for_similar_published_fact_checks(type, query, [team_id], after, nil, language, false).select{ |pm| is_a_valid_search_result(pm) }
+        results = self.search_for_similar_published_fact_checks(type, query, [team_id], after, nil, language).select{ |pm| is_a_valid_search_result(pm) }
       rescue StandardError => e
         self.handle_search_error(uid, e, language)
       end
@@ -148,7 +148,7 @@ module SmoochSearch
 
     # "type" is text, video, audio or image
     # "query" is either a piece of text of a media URL
-    def search_for_similar_published_fact_checks(type, query, team_ids, after = nil, feed_id = nil, language = nil, skip_cache: false)
+    def search_for_similar_published_fact_checks(type, query, team_ids, after = nil, feed_id = nil, language = nil, skip_cache = false)
       if skip_cache
         self.search_for_similar_published_fact_checks_no_cache(type, query, team_ids, after, feed_id, language)
       else

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -26,7 +26,7 @@ class FeedsControllerTest < ActionController::TestCase
     @f = create_feed published: true
     @f.teams = [@t1, @t2]
     FeedTeam.update_all(shared: true)
-    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], nil, @f.id, skip_cache: false).returns([@pm1, @pm2])
+    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], nil, @f.id, false).returns([@pm1, @pm2])
   end
 
   def teardown


### PR DESCRIPTION

## Description

- Introduced `skip_cache` parameter to Feed API, allowing requests to bypass the similarity search cache when set to `true`.
- Updated `search_for_similar_published_fact_checks` in `SmoochSearch` to support cached and non-cached search logic.
- Added `search_for_similar_published_fact_checks_no_cache` method to perform non-cached similarity searches.
- Modified `FeedResource` to handle and pass the `skip_cache` parameter.

References: CV2-2400

## How has this been tested?

Ensured all existing tests are still passing

## Things to pay attention to during code review

Check if anything was missed


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

