### PR TITLE
CV2-5250: Associate a caption as a text media with the media item

### DIFF
--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -418,7 +418,7 @@ module SmoochMessages
     def smooch_relate_items_for_same_message(message, associated, app_id, author, request_type, associated_obj)
       if !message['caption'].blank?
         # Check if message contains caption then create an item and force relationship
-        self.relate_item_and_text(message, associated, app_id, author, request_type, associated_obj, Relationship.suggested_type)
+        self.relate_item_and_text(message, associated, app_id, author, request_type, associated_obj, Relationship.confirmed_type)
       elsif message['type'] == 'text' && associated.class.name == 'ProjectMedia' && associated.media.type == 'Link'
         # Check if message of type text contain a link and long text
         # Text words equal the number of words - 1(which is the link size)

--- a/test/models/bot/smooch_3_test.rb
+++ b/test/models/bot/smooch_3_test.rb
@@ -383,7 +383,7 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
       claim_item = ProjectMedia.joins(:media).where('medias.type' => 'Claim').last
       assert_equal caption, claim_item.media.quote
       r = Relationship.last
-      assert_equal Relationship.suggested_type, r.relationship_type
+      assert_equal Relationship.confirmed_type, r.relationship_type
       assert_equal claim_item.id, r.target_id
       assert_equal 1, claim_item.tipline_requests.count
     end


### PR DESCRIPTION
## Description

Automatically associate a caption as a text media with the image media.

References: CV2-5250

## How has this been tested?

Implemented automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

