### PR TITLE
CV2-5511 Define number of words to extract media from tipline request

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -547,7 +547,7 @@ class Bot::Smooch < BotUser
   def self.is_a_shortcut_for_submission?(state, message)
     self.is_v2? && (state == 'main' || state == 'waiting_for_message') && (
       !message['mediaUrl'].blank? ||
-      ::Bot::Alegre.get_number_of_words(message['text'].to_s) > CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer) ||
+      ::Bot::Alegre.get_number_of_words(message['text'].to_s) > self.min_number_of_words_for_tipline_long_text ||
       !Twitter::TwitterText::Extractor.extract_urls(message['text'].to_s).blank? # URL in message?
       )
   end
@@ -833,7 +833,7 @@ class Bot::Smooch < BotUser
         extra = { quote: claim }
         pm = ProjectMedia.joins(:media).where('trim(lower(quote)) = ?', claim.downcase).where('project_medias.team_id' => team.id).last
         # Don't create a new text media if it's an unconfirmed request with just a few words
-        if pm.nil? && message['archived'] == CheckArchivedFlags::FlagCodes::UNCONFIRMED && ::Bot::Alegre.get_number_of_words(claim) < CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer)
+        if pm.nil? && message['archived'] == CheckArchivedFlags::FlagCodes::UNCONFIRMED && ::Bot::Alegre.get_number_of_words(claim) < self.min_number_of_words_for_tipline_long_text
           return team
         end
       else

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -281,8 +281,8 @@ module SmoochMessages
     def bundle_list_of_messages_to_items(list, last)
       # Collect messages from list based on media files, long text and short text
       # so we have three types of messages
-      # Long text (text with number of words > min_number_of_words_for_tipline_submit_shortcut)
-      # Short text (text with number of words <= min_number_of_words_for_tipline_submit_shortcut)
+      # Long text (text with number of words > min_number_of_words_for_tipline_long_text)
+      # Short text (text with number of words <= min_number_of_words_for_tipline_long_text)
       # Media (image, audio, video, etc)
       messages = []
       # Define a text variable to hold short text
@@ -292,12 +292,12 @@ module SmoochMessages
           # Get an item for long text (message that match number of words condition)
           if message['payload'].nil?
             contains_link = Twitter::TwitterText::Extractor.extract_urls(message['text'])
-            messages << message if !contains_link.blank? || ::Bot::Alegre.get_number_of_words(message['text'].to_s) > CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer)
+            messages << message if !contains_link.blank? || ::Bot::Alegre.get_number_of_words(message['text'].to_s) > self.min_number_of_words_for_tipline_long_text
             text << message['text']
           end
         elsif !message['mediaUrl'].blank?
           # Get an item for each media file
-          if !message['text'].blank? && ::Bot::Alegre.get_number_of_words(message['text'].to_s) > CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer)
+          if !message['text'].blank? && ::Bot::Alegre.get_number_of_words(message['text'].to_s) > self.min_number_of_words_for_tipline_long_text
             message['caption'] = message['text']
           end
           message['text'] = [message['text'], message['mediaUrl'].to_s].compact.join("\n#{Bot::Smooch::MESSAGE_BOUNDARY}")
@@ -423,7 +423,7 @@ module SmoochMessages
         # Check if message of type text contain a link and long text
         # Text words equal the number of words - 1(which is the link size)
         text_words = ::Bot::Alegre.get_number_of_words(message['text']) - 1
-        if text_words > CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer)
+        if text_words > self.min_number_of_words_for_tipline_long_text
           # Remove link from text
           link = self.extract_url(message['text'])
           message['text'] = message['text'].remove(link.url)
@@ -543,6 +543,11 @@ module SmoochMessages
       response = self.send_message_to_user(uid, message, {}, false, true, 'custom_message')
       success = (response && response.code.to_i < 400)
       success
+    end
+
+    def min_number_of_words_for_tipline_long_text
+      # Define a min number of words to create a media
+      CheckConfig.get('min_number_of_words_for_tipline_long_text') || CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer)
     end
   end
 end

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -280,6 +280,7 @@ development: &default
   header_file_video_max_size_whatsapp: 16 # Megabytes
   header_file_video_max_size_check: 10 # Megabytes, should be less than WhatsApp limit
   url_max_size: 2000
+  min_number_of_words_for_tipline_long_text: 10
 
   # Session
   #

--- a/test/models/bot/smooch_3_test.rb
+++ b/test/models/bot/smooch_3_test.rb
@@ -74,8 +74,8 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
     long_text = []
     15.times{ long_text << random_string }
     # messages contain the following:
-    # 1). long text( > min_number_of_words_for_tipline_submit_shortcut)
-    # 2). short text (< min_number_of_words_for_tipline_submit_shortcut)
+    # 1). long text( > min_number_of_words_for_tipline_long_text)
+    # 2). short text (< min_number_of_words_for_tipline_long_text)
     # 3). link
     # 4). 2 medias
     # Result: created four items (one claim, one link and two items of type image)
@@ -329,8 +329,8 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
     15.times{ long_text << random_string }
     caption = long_text.join(' ')
     # messages contain the following:
-    # 1). media with long text( > min_number_of_words_for_tipline_submit_shortcut)
-    # 2). media with short text (< min_number_of_words_for_tipline_submit_shortcut)
+    # 1). media with long text( > min_number_of_words_for_tipline_long_text)
+    # 2). media with short text (< min_number_of_words_for_tipline_long_text)
     # Result: created three items and one relationship (one claim for caption and two items of type image)
     last_id = ProjectMedia.last.id
     Sidekiq::Testing.fake! do

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -664,7 +664,7 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
   test "should not duplicate messages when saving" do
     @team.set_languages ['en']
     @team.save!
-    message_text = 'not_a_url' #Not a URL, not media, and not longer than 'min_number_of_words_for_tipline_submit_shortcut'
+    message_text = 'not_a_url' #Not a URL, not media, and not longer than 'min_number_of_words_for_tipline_long_text'
     send_message message_text, '1', message_text, '1'
     assert_state 'search'
     Sidekiq::Worker.drain_all


### PR DESCRIPTION
## Description

Define a new parameter to for a min  numbers of words to extract media from tipline request.

References: CV2-5511

## How has this been tested?

Re-run automated tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

