### PR TITLE
CV2-5301: fallback to update_at date in case last_published not exist

### DIFF
--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -360,7 +360,7 @@ class CheckSearch
       pm_report = {}
       Dynamic.where(annotation_type: 'report_design', annotated_type: 'ProjectMedia', annotated_id: ids)
       .find_each do |raw|
-        pm_report[raw.annotated_id] = raw.data['last_published'].to_i if raw.data['state'] == 'published'
+        pm_report[raw.annotated_id] = (raw.data['last_published'] || raw.updated_at).to_i if raw.data['state'] == 'published'
       end
 
       # Iterate through each result and generate an output row for the CSV


### PR DESCRIPTION
## Description

For some report_design annotations the `last_published` date not exits so fallback to `updated_at` for the annotation

References: CV2-5301

## How has this been tested?

Re-run automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

