### PR TITLE
CV2-5532: Move all Explainers from the target to the source

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -328,17 +328,23 @@ class Relationship < ApplicationRecord
   end
 
   def move_explainers_to_source
-    ExplainerItem.transaction do
-      # Destroy common Explainer from target item (use destroy to log this event)
-      explainer_ids = ExplainerItem.where(project_media_id: [self.source_id, self.target_id])
-      .group('explainer_id').having("count(explainer_id) = ?", 2).pluck(:explainer_id)
-      ExplainerItem.where(explainer_id: explainer_ids, project_media_id: self.target_id).destroy_all
-      # Move the Explainer from target to source by using update_all(as no callbacks) and then update logs
-      ExplainerItem.where(project_media_id: self.target_id).update_all(project_media_id: self.source_id)
-      # Update logs (to make item history consistent with Explainers attached to item)
-      Version.from_partition(self.source.team_id)
-      .where(event_type: 'create_explaineritem', associated_type: 'ProjectMedia', associated_id: self.target_id)
-      .update_all(associated_id: self.source_id)
+    # Three cases to move explainers
+    # 1) Relationship is new and confirmed
+    # 2) Item is being confirmed (move from suggested to confirmed)
+    # 3) Pin item (sawp source_id & target_id)
+    if self.relationship_type_before_last_save.nil? || self.is_being_confirmed? || (self.source_id_before_last_save && self.source_id_before_last_save == self.target_id)
+      ExplainerItem.transaction do
+        # Destroy common Explainer from target item (use destroy to log this event)
+        explainer_ids = ExplainerItem.where(project_media_id: [self.source_id, self.target_id])
+        .group('explainer_id').having("count(explainer_id) = ?", 2).pluck(:explainer_id)
+        ExplainerItem.where(explainer_id: explainer_ids, project_media_id: self.target_id).destroy_all
+        # Move the Explainer from target to source by using update_all(as no callbacks) and then update logs
+        ExplainerItem.where(project_media_id: self.target_id).update_all(project_media_id: self.source_id)
+        # Update logs (to make item history consistent with Explainers attached to item)
+        Version.from_partition(self.source.team_id)
+        .where(event_type: 'create_explaineritem', associated_type: 'ProjectMedia', associated_id: self.target_id)
+        .update_all(associated_id: self.source_id)
+      end
     end
   end
 

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -199,6 +199,56 @@ class RelationshipTest < ActiveSupport::TestCase
     end
   end
 
+  test "should move explainer to source after pin item or match items" do
+    t = create_team
+    e = create_explainer team: t
+    e_s = create_explainer team: t
+    e_t = create_explainer team: t
+    source = create_project_media team: t
+    target = create_project_media team: t
+    u = create_user
+    create_team_user team: t, user: u, role: 'admin'
+    with_versioning do
+      with_current_user_and_team(u, t) do
+        source.explainers << e
+        source.explainers << e_s
+        target.explainers << e
+        target.explainers << e_t
+      end
+    end
+    assert_equal 2, source.explainer_items.count
+    assert_equal 2, target.explainer_items.count
+    pp Version.from_partition(t.id)
+    sv_count = Version.from_partition(t.id).where(event_type: 'create_explaineritem', associated_id: source.id).count
+    tv_count = Version.from_partition(t.id).where(event_type: 'create_explaineritem', associated_id: target.id).count
+    assert_equal 2, sv_count
+    assert_equal 2, tv_count
+    r = create_relationship source_id: source.id, target_id: target.id, relationship_type: Relationship.confirmed_type
+    assert_equal 3, source.explainer_items.count
+    assert_equal 0, target.explainer_items.count
+    sv_count = Version.from_partition(t.id).where(event_type: 'create_explaineritem', associated_id: source.id).count
+    tv_count = Version.from_partition(t.id).where(event_type: 'create_explaineritem', associated_id: target.id).count
+    assert_equal 4, sv_count
+    assert_equal 0, tv_count
+    # Pin target item
+    r.source_id = target.id
+    r.target_id = source.id
+    r.save!
+    assert_equal 0, source.explainer_items.count
+    assert_equal 3, target.explainer_items.count
+    sv_count = Version.from_partition(t.id).where(event_type: 'create_explaineritem', associated_id: source.id).count
+    tv_count = Version.from_partition(t.id).where(event_type: 'create_explaineritem', associated_id: target.id).count
+    assert_equal 0, sv_count
+    assert_equal 4, tv_count
+    # should not move for similar item
+    pm2_s = create_project_media team: t
+    pm2 = create_project_media team: t
+    e2 = create_explainer team: t
+    pm2.explainers << e
+    r2 = create_relationship source_id: pm2_s.id, target_id: pm2.id, relationship_type: Relationship.suggested_type
+    assert_equal 1, pm2.explainer_items.count
+  end
+
   test "should not attempt to update source count if source does not exist" do
     r = create_relationship relationship_type: Relationship.confirmed_type
     r.source.delete

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -218,7 +218,6 @@ class RelationshipTest < ActiveSupport::TestCase
     end
     assert_equal 2, source.explainer_items.count
     assert_equal 2, target.explainer_items.count
-    pp Version.from_partition(t.id)
     sv_count = Version.from_partition(t.id).where(event_type: 'create_explaineritem', associated_id: source.id).count
     tv_count = Version.from_partition(t.id).where(event_type: 'create_explaineritem', associated_id: target.id).count
     assert_equal 2, sv_count


### PR DESCRIPTION
## Description

Move all Explainers from the target to the source  when user match two items or pin another item.

References: CV2-5532

## How has this been tested?

Implemented automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

