### PR TITLE
CV2-5529: de-duplicate requests for matched items

### DIFF
--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -291,16 +291,20 @@ module SmoochMessages
         if message['type'] == 'text'
           # Get an item for long text (message that match number of words condition)
           if message['payload'].nil?
-            contains_link = Twitter::TwitterText::Extractor.extract_urls(message['text'])
+            contains_link = self.extract_url(message['text'])
             messages << message if !contains_link.blank? || ::Bot::Alegre.get_number_of_words(message['text'].to_s) > self.min_number_of_words_for_tipline_long_text
-            text << message['text']
+            # Text should be a link only in case we have two matched items (link and long text)
+            text << (contains_link.blank? ? message['text'] : contains_link.url)
           end
         elsif !message['mediaUrl'].blank?
           # Get an item for each media file
           if !message['text'].blank? && ::Bot::Alegre.get_number_of_words(message['text'].to_s) > self.min_number_of_words_for_tipline_long_text
             message['caption'] = message['text']
+            # Text should be a media url in case we have two matched items (media and caption)
+            message['text'] = message['mediaUrl'].to_s
+          else
+            message['text'] = [message['text'], message['mediaUrl'].to_s].compact.join("\n#{Bot::Smooch::MESSAGE_BOUNDARY}")
           end
-          message['text'] = [message['text'], message['mediaUrl'].to_s].compact.join("\n#{Bot::Smooch::MESSAGE_BOUNDARY}")
           text << message['text']
           messages << self.adjust_media_type(message)
         end

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -291,10 +291,15 @@ module SmoochMessages
         if message['type'] == 'text'
           # Get an item for long text (message that match number of words condition)
           if message['payload'].nil?
-            contains_link = self.extract_url(message['text'])
-            messages << message if !contains_link.blank? || ::Bot::Alegre.get_number_of_words(message['text'].to_s) > self.min_number_of_words_for_tipline_long_text
+            link_from_message = nil
+            begin
+              link_from_message = self.extract_url(message['text'])
+            rescue SecurityError
+              # rescue to avoid raising error
+            end
+            messages << message if !link_from_message.blank? || ::Bot::Alegre.get_number_of_words(message['text'].to_s) > self.min_number_of_words_for_tipline_long_text
             # Text should be a link only in case we have two matched items (link and long text)
-            text << (contains_link.blank? ? message['text'] : contains_link.url)
+            text << (link_from_message.blank? ? message['text'] : link_from_message.url)
           end
         elsif !message['mediaUrl'].blank?
           # Get an item for each media file

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -314,22 +314,6 @@ module SmoochMessages
           messages << self.adjust_media_type(message)
         end
       end
-      # collect all text in right order and add a boundary so we can easily split messages if needed
-      all_text = text.reject{ |t| t.blank? }.join("\n#{Bot::Smooch::MESSAGE_BOUNDARY}")
-      if messages.blank?
-        # No messages exist (this happens when all messages are short text)
-        # So will create a new message of type text and assign short text to it
-        message = last.clone
-        message['type'] = 'text'
-        message['text'] = all_text
-        messages << message
-      else
-        # Attach all existing text (media text, long text and short text) to each item
-        messages.each do |raw|
-          # Define a new key `request_body` so we can append all text to request body
-          raw['request_body'] = all_text
-        end
-      end
       # Attach text to exising messages and return all messages
       self.attach_text_to_messages(text, messages, last)
     end


### PR DESCRIPTION
## Description

Case 1: Link + Message Text - Instead of concatenating the URL and the text to be the same content of both tipline requests, let’s separate this:

- The request associated with the link media contains only the link
- The request associated with the text media contains only the text

Case 2: Media + Caption - We should apply the same solution for media + caption:

- The request associated with the media contains only the media
- The request associated with the caption contains only the text

References: CV2-5529

## How has this been tested?

Re-run automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

