### PR TITLE
CV2-5224: Delete duplicate relationships when exporting an item to another one

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -276,9 +276,9 @@ class Relationship < ApplicationRecord
 
   def point_targets_to_new_source
     # Get existing targets for the source
-    target_ids = Relationship.where(source_id: self.source_id, relationship_type: self.relationship_type).map(&:target_id)
+    target_ids = Relationship.where(source_id: self.source_id).map(&:target_id)
     # Delete duplicate relation from target(CHECK-1603)
-    Relationship.where(source_id: self.target_id, relationship_type: self.relationship_type, target_id: target_ids).delete_all
+    Relationship.where(source_id: self.target_id, target_id: target_ids).delete_all
     Relationship.where(source_id: self.target_id).where('relationship_type = ? OR relationship_type = ?', Relationship.confirmed_type.to_yaml, Relationship.suggested_type.to_yaml).each do |old_relationship|
       old_relationship.delete
       new_relationship = Relationship.new(

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -279,17 +279,13 @@ class Relationship < ApplicationRecord
     target_ids = Relationship.where(source_id: self.source_id).map(&:target_id)
     # Delete duplicate relation from target(CHECK-1603)
     Relationship.where(source_id: self.target_id, target_id: target_ids).delete_all
-    Relationship.where(source_id: self.target_id).where('relationship_type = ? OR relationship_type = ?', Relationship.confirmed_type.to_yaml, Relationship.suggested_type.to_yaml).each do |old_relationship|
+    Relationship.where(source_id: self.target_id).find_each do |old_relationship|
       old_relationship.delete
-      new_relationship = Relationship.new(
-        source_id: self.source_id,
-        target_id: old_relationship.target_id,
-        relationship_type: old_relationship.relationship_type,
+      options = {
         user_id: old_relationship.user_id,
         weight: old_relationship.weight
-      )
-      new_relationship.skip_check_ability = true
-      new_relationship.save!
+      }
+      Relationship.create_unless_exists(self.source_id, old_relationship.target_id, old_relationship.relationship_type, options)
     end
   end
 

--- a/test/models/relationship_2_test.rb
+++ b/test/models/relationship_2_test.rb
@@ -54,11 +54,11 @@ class Relationship2Test < ActiveSupport::TestCase
   end
 
   test "should destroy relationships when project media is destroyed" do
-    pm = create_project_media project: @project
-    pm2 = create_project_media project: @project
-    pm3 = create_project_media project: @project
+    pm = create_project_media team: @team
+    pm2 = create_project_media team: @team
+    pm3 = create_project_media team: @team
     create_relationship source_id: pm.id, target_id: pm2.id
-    create_relationship target_id: pm.id, source_id: pm3.id
+    create_relationship source_id: pm.id, target_id: pm3.id
     assert_difference 'Relationship.count', -2 do
       pm.destroy
     end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -378,4 +378,23 @@ class RelationshipTest < ActiveSupport::TestCase
       assert_match /violates check constraint "source_target_must_be_different"/, e.message
     end
   end
+
+  test "should move similar items when export item" do
+    t = create_team
+    pm = create_project_media team: t
+    pm2 = create_project_media team: t
+    pm_1 = create_project_media team: t
+    pm_2 = create_project_media team: t
+    pm2_1 = create_project_media team: t
+    # Add pm_1 & pm_2 as a similar item to pm
+    create_relationship source_id: pm.id, target_id: pm_1.id, relationship_type: Relationship.suggested_type
+    create_relationship source_id: pm.id, target_id: pm_2.id, relationship_type: Relationship.suggested_type
+    # Add pm_1 & pm2_1 as a similar item to pm2
+    create_relationship source_id: pm2.id, target_id: pm_1.id, relationship_type: Relationship.suggested_type
+    create_relationship source_id: pm.id, target_id: pm2_1.id, relationship_type: Relationship.suggested_type
+    # Expose pm to pm2
+    create_relationship source_id: pm.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
+    assert_equal 3, Relationship.where(source_id: pm.id, relationship_type: Relationship.suggested_type).count
+    assert_equal 0, Relationship.where(source_id: pm2.id, relationship_type: Relationship.suggested_type).count
+  end
 end


### PR DESCRIPTION
## Description

When moving an item to be similar to another one, delete the ones that are already related to the new target.

References: CV2-5224

## How has this been tested?

Implemented automated tests.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

