### PR TITLE
CV2-5529: Fix requests for caption item(confirmed item for media item)

### DIFF
--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -449,8 +449,8 @@ module SmoochMessages
     def relate_item_and_text(message, associated, app_id, author, request_type, associated_obj, relationship_type)
       message['_id'] = SecureRandom.hex
       message['type'] = 'text'
-      message['request_body'] = message['text']
       message['text'] = message['caption'] unless message['caption'].nil?
+      message['request_body'] = message['text']
       message.delete('caption')
       message.delete('mediaUrl')
       target = self.create_project_media_from_message(message)


### PR DESCRIPTION
## Description

Make the request for the caption item (confirmed item for media type) to be caption text instead of link.

References: CV2-5529

## How has this been tested?

Re-run automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

