### PR TITLE
CV2-5558: Downgrade based on last_seen, not created_at; add better logging

### DIFF
--- a/test/models/bot/alegre_test.rb
+++ b/test/models/bot/alegre_test.rb
@@ -190,13 +190,13 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     end
     r = Relationship.last
     assert_equal Relationship.confirmed_type, r.relationship_type
-    pm1.created_at = Time.now - 2.months
+    r.destroy
+    pm1.last_seen = Time.now - 2.months
     pm1.save!
     tbi = Bot::Alegre.get_alegre_tbi(@team.id)
     tbi.set_date_similarity_threshold_enabled = true
     tbi.set_similarity_date_threshold("1")
     tbi.save!
-    r.destroy
     assert_difference 'Relationship.count' do
       result = Bot::Alegre.relate_project_media_to_similar_items(pm2)
     end

--- a/test/models/bot/alegre_test.rb
+++ b/test/models/bot/alegre_test.rb
@@ -185,13 +185,16 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     })
+    ProjectMedia.stubs(:recalculate_last_seen).returns({
+      Time.now - 2.months
+    })
     assert_difference 'Relationship.count' do
       result = Bot::Alegre.relate_project_media_to_similar_items(pm2)
     end
     r = Relationship.last
     assert_equal Relationship.confirmed_type, r.relationship_type
     r.destroy
-    pm1.last_seen = Time.now - 2.months
+    pm1.created_at = Time.now - 2.months
     pm1.save!
     tbi = Bot::Alegre.get_alegre_tbi(@team.id)
     tbi.set_date_similarity_threshold_enabled = true
@@ -203,6 +206,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     r = Relationship.last
     assert_equal Relationship.suggested_type, r.relationship_type
     Bot::Alegre.unstub(:request)
+    ProjectMedia.unstub(:recalculate_last_seen)
   end
 
   test "should index report data" do

--- a/test/models/bot/alegre_test.rb
+++ b/test/models/bot/alegre_test.rb
@@ -185,26 +185,32 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     })
-    ProjectMedia.stubs(:recalculate_last_seen).returns(Time.now - 2.months)
+    # Set the TeamBotInstallation (tbi) for Alegre so that a query
+    # matched to an item seen more than 1 month ago is downgraded to suggestion
+    tbi = Bot::Alegre.get_alegre_tbi(@team.id)
+    tbi.set_date_similarity_threshold_enabled = true
+    tbi.set_similarity_date_threshold("1")
+    tbi.save!
+
+    # First verify a confirmed_type relationship is not downgraded.
+    # because last_seen will be now and not more than one month ago.
     assert_difference 'Relationship.count' do
       result = Bot::Alegre.relate_project_media_to_similar_items(pm2)
     end
     r = Relationship.last
     assert_equal Relationship.confirmed_type, r.relationship_type
-    r.destroy
-    pm1.created_at = Time.now - 2.months
-    pm1.save!
-    tbi = Bot::Alegre.get_alegre_tbi(@team.id)
-    tbi.set_date_similarity_threshold_enabled = true
-    tbi.set_similarity_date_threshold("1")
-    tbi.save!
+    r.destroy!
+
+    # Now stub last_seen so that confirmed_type is downgraded to suggest_type
+    # because it is more than tbi.similarity_date_threshold months old
+    ProjectMedia.any_instance.stubs(:last_seen).returns(Time.now - 2.months)
     assert_difference 'Relationship.count' do
       result = Bot::Alegre.relate_project_media_to_similar_items(pm2)
     end
     r = Relationship.last
     assert_equal Relationship.suggested_type, r.relationship_type
     Bot::Alegre.unstub(:request)
-    ProjectMedia.unstub(:recalculate_last_seen)
+    ProjectMedia.any_instance.unstub(:last_seen)
   end
 
   test "should index report data" do

--- a/test/models/bot/alegre_test.rb
+++ b/test/models/bot/alegre_test.rb
@@ -185,9 +185,7 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         }
       ]
     })
-    ProjectMedia.stubs(:recalculate_last_seen).returns({
-      Time.now - 2.months
-    })
+    ProjectMedia.stubs(:recalculate_last_seen).returns(Time.now - 2.months)
     assert_difference 'Relationship.count' do
       result = Bot::Alegre.relate_project_media_to_similar_items(pm2)
     end


### PR DESCRIPTION
## Description

Better log when and why a relationship is downgraded from a confirmed match to a suggestion. When downgrading for an "old" match, use `last_seen`, not `created_at`

References: CV2-5558

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can verify the changes. Please describe whether or not you implemented automated tests.

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [x] I have made needed changes to the README
- [x] My changes generate no new warnings
- [x] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

