### PR TITLE
CV2-5601 use object id for update cached field

### DIFF
--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -272,8 +272,8 @@ module ProjectMediaCachedFields
           model: Tag,
           affected_ids: proc { |t| [t.annotated_id.to_i] },
           events: {
-            save: :cached_field_project_media_tags_as_sentence_save,
-            destroy: :cached_field_project_media_tags_as_sentence_destroy,
+            save: :recalculate,
+            destroy: :recalculate,
           }
         }
       ]
@@ -720,11 +720,11 @@ module ProjectMediaCachedFields
       self.user && self.user == BotUser.alegre_user ? 'Check' : self.user&.name
     end
 
-    def cached_field_project_media_added_as_similar_by_name_destroy(_target)
+    def self.cached_field_project_media_added_as_similar_by_name_destroy(_target)
       nil
     end
 
-    def cached_field_project_media_confirmed_as_similar_by_name_destroy(_target)
+    def self.cached_field_project_media_confirmed_as_similar_by_name_destroy(_target)
       nil
     end
   end
@@ -742,16 +742,6 @@ module ProjectMediaCachedFields
   Project.class_eval do
     def cached_field_project_media_folder_save(_target)
       self.title
-    end
-  end
-
-  Tag.class_eval do
-    def cached_field_project_media_tags_as_sentence_save(target)
-      target.tags_as_sentence.split(', ').concat([self.tag_text]).uniq.join(', ')
-    end
-
-    def cached_field_project_media_tags_as_sentence_destroy(target)
-      target.tags_as_sentence.split(', ').reject{ |tt| tt == self.tag_text }.uniq.join(', ')
     end
   end
 end


### PR DESCRIPTION
## Description

For the updated cached field use object ID instead of sending the whole object.

References: CV2-5601

## How has this been tested?

Re-run automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

