### PR TITLE
CV2-5050 accommodate changes on add callbacks to not search inside item

### DIFF
--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -549,20 +549,20 @@ module AlegreV2
 
     def process_alegre_callback(params)
       redis = Redis.new(REDIS_CONFIG)
-      project_media = ProjectMedia.find(params.dig('data', 'item', 'raw', 'context', 'project_media_id')) rescue nil
+      project_media = ProjectMedia.find(params.dig('data', 'raw', 'context', 'project_media_id')) rescue nil
       should_relate = true
       if project_media.nil?
         project_media = TemporaryProjectMedia.new
-        project_media.text = params.dig('data', 'item', 'raw', 'text')
-        project_media.url = params.dig('data', 'item', 'raw', 'url')
-        project_media.id = params.dig('data', 'item', 'raw', 'context', 'project_media_id')
-        project_media.team_id = params.dig('data', 'item', 'raw', 'context', 'team_id')
-        project_media.field = params.dig('data', 'item', 'raw', 'context', 'field')
+        project_media.text = params.dig('data', 'raw', 'text')
+        project_media.url = params.dig('data', 'raw', 'url')
+        project_media.id = params.dig('data', 'raw', 'context', 'project_media_id')
+        project_media.team_id = params.dig('data', 'raw', 'context', 'team_id')
+        project_media.field = params.dig('data', 'raw', 'context', 'field')
         project_media.type = params['model_type']
         should_relate = false
       end
-      confirmed = params.dig('data', 'item', 'raw', 'confirmed')
-      field = params.dig('data', 'item', 'raw', 'context', 'field')
+      confirmed = params.dig('data', 'raw', 'confirmed')
+      field = params.dig('data', 'raw', 'context', 'field')
       access_key = confirmed ? :confirmed_results : :suggested_or_confirmed_results
       key = get_required_keys(project_media, field)[access_key]
       response = cache_items_via_callback(project_media, field, confirmed, params.dig('data', 'results', 'result').dup) #dup so we can better debug when playing with this in a repl

--- a/app/models/concerns/alegre_webhooks.rb
+++ b/app/models/concerns/alegre_webhooks.rb
@@ -24,9 +24,9 @@ module AlegreWebhooks
       redis = Redis.new(REDIS_CONFIG)
       doc_id = body.dig('data', 'requested', 'id')
       # search for doc_id on completed full-circuit callbacks
-      doc_id = body.dig('data', 'item', 'id') if doc_id.nil?
+      doc_id = body.dig('data', 'id') if doc_id.nil?
       # search for doc_id on completed short-circuit callbacks (i.e. items already known to Alegre but added context TODO make these the same structure)
-      doc_id = body.dig('data', 'item', 'raw', 'doc_id') if doc_id.nil?
+      doc_id = body.dig('data', 'raw', 'doc_id') if doc_id.nil?
       if doc_id.blank?
         CheckSentry.notify(AlegreCallbackError.new('Unexpected params format from Alegre'), params: {alegre_response: request.params, body: body})
       end

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -249,7 +249,7 @@ class WebhooksControllerTest < ActionController::TestCase
 
   test "should process Alegre callback webhook with is_shortcircuited_search_result_callback" do
     id = random_number
-    payload = { 'action' => 'audio', 'data' => {'is_shortcircuited_search_result_callback' => true, 'item' => { 'callback_url' => '/presto/receive/add_item', 'id' => id.to_s }} }
+    payload = { 'action' => 'audio', 'data' => {'is_shortcircuited_search_result_callback' => true, 'callback_url' => '/presto/receive/add_item', 'id' => id.to_s} }
     Bot::Alegre.stubs(:process_alegre_callback).returns({})
     post :index, params: { name: :alegre, token: CheckConfig.get('alegre_token') }, body: payload.to_json
     assert_equal '200', response.code
@@ -258,7 +258,7 @@ class WebhooksControllerTest < ActionController::TestCase
 
   test "should process Alegre callback webhook with is_search_result_callback" do
     id = random_number
-    payload = { 'action' => 'audio', 'data' => {'is_search_result_callback' => true, 'item' => { 'callback_url' => '/presto/receive/add_item', 'id' => id.to_s }} }
+    payload = { 'action' => 'audio', 'data' => {'is_search_result_callback' => true, 'callback_url' => '/presto/receive/add_item', 'id' => id.to_s} }
     Bot::Alegre.stubs(:process_alegre_callback).returns({})
     post :index, params: { name: :alegre, token: CheckConfig.get('alegre_token') }, body: payload.to_json
     assert_equal '200', response.code

--- a/test/models/bot/alegre_v2_test.rb
+++ b/test/models/bot/alegre_v2_test.rb
@@ -870,29 +870,27 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     params = {
         "model_type": "image",
         "data": {
-            "item": {
-                "id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
-                "callback_url": "http://alegre:3100/presto/receive/add_item/image",
-                "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
-                "text": nil,
-                "raw": {
-                    "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
-                    "context": {
-                        "team_id": pm1.team_id,
-                        "project_media_id": pm1.id,
-                        "has_custom_id": true,
-                        "temporary_media": false,
-                    },
-                    "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
-                    "threshold": 0.73,
-                    "confirmed": true,
-                    "created_at": "2024-03-14T22:05:47.588975",
-                    "limit": 200,
-                    "requires_callback": true,
-                    "final_task": "search"
+            "id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
+            "callback_url": "http://alegre:3100/presto/receive/add_item/image",
+            "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+            "text": nil,
+            "raw": {
+                "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
+                "context": {
+                    "team_id": pm1.team_id,
+                    "project_media_id": pm1.id,
+                    "has_custom_id": true,
+                    "temporary_media": false,
                 },
-                "hash_value": "1110101010001011110100000011110010101000000010110101101010100101101111110101101001011010100001011111110101011010010000101010010110101101010110100000001010100101101010111110101000010101011100001110101010101111100001010101001011101010101011010001010101010010"
+                "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+                "threshold": 0.73,
+                "confirmed": true,
+                "created_at": "2024-03-14T22:05:47.588975",
+                "limit": 200,
+                "requires_callback": true,
+                "final_task": "search"
             },
+            "hash_value": "1110101010001011110100000011110010101000000010110101101010100101101111110101101001011010100001011111110101011010010000101010010110101101010110100000001010100101101010111110101000010101011100001110101010101111100001010101001011101010101011010001010101010010",
             "results": {
                 "result": [
                     {
@@ -918,29 +916,27 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     unconfirmed_params = {
         "model_type": "image",
         "data": {
-            "item": {
-                "id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
-                "callback_url": "http://alegre:3100/presto/receive/add_item/image",
-                "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
-                "text": nil,
-                "raw": {
-                    "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
-                    "context": {
-                        "team_id": pm1.team_id,
-                        "project_media_id": pm1.id,
-                        "has_custom_id": true,
-                        "temporary_media": false,
-                    },
-                    "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
-                    "threshold": 0.63,
-                    "confirmed": false,
-                    "created_at": "2024-03-14T22:05:47.588975",
-                    "limit": 200,
-                    "requires_callback": true,
-                    "final_task": "search"
+            "id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
+            "callback_url": "http://alegre:3100/presto/receive/add_item/image",
+            "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+            "text": nil,
+            "raw": {
+                "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
+                "context": {
+                    "team_id": pm1.team_id,
+                    "project_media_id": pm1.id,
+                    "has_custom_id": true,
+                    "temporary_media": false,
                 },
-                "hash_value": "1110101010001011110100000011110010101000000010110101101010100101101111110101101001011010100001011111110101011010010000101010010110101101010110100000001010100101101010111110101000010101011100001110101010101111100001010101001011101010101011010001010101010010"
+                "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+                "threshold": 0.63,
+                "confirmed": false,
+                "created_at": "2024-03-14T22:05:47.588975",
+                "limit": 200,
+                "requires_callback": true,
+                "final_task": "search"
             },
+            "hash_value": "1110101010001011110100000011110010101000000010110101101010100101101111110101101001011010100001011111110101011010010000101010010110101101010110100000001010100101101010111110101000010101011100001110101010101111100001010101001011101010101011010001010101010010",
             "results": {
                 "result": [
                     {
@@ -982,28 +978,26 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         "model_type": "image",
         "data": {
             "is_shortcircuited_search_result_callback": true,
-            "item": {
-                "callback_url": "http://alegre:3100/presto/receive/add_item/image",
-                "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
-                "text": nil,
-                "raw": {
-                    "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
-                    "context": {
-                        "team_id": pm1.team_id,
-                        "project_media_id": pm1.id,
-                        "has_custom_id": true,
-                        "temporary_media": false,
-                    },
-                    "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
-                    "threshold": 0.85,
-                    "confirmed": true,
-                    "created_at": "2024-03-14T22:05:47.588975",
-                    "limit": 200,
-                    "requires_callback": true,
-                    "final_task": "search"
+            "callback_url": "http://alegre:3100/presto/receive/add_item/image",
+            "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+            "text": nil,
+            "raw": {
+                "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
+                "context": {
+                    "team_id": pm1.team_id,
+                    "project_media_id": pm1.id,
+                    "has_custom_id": true,
+                    "temporary_media": false,
                 },
-                "hash_value": "1110101010001011110100000011110010101000000010110101101010100101101111110101101001011010100001011111110101011010010000101010010110101101010110100000001010100101101010111110101000010101011100001110101010101111100001010101001011101010101011010001010101010010"
+                "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+                "threshold": 0.85,
+                "confirmed": true,
+                "created_at": "2024-03-14T22:05:47.588975",
+                "limit": 200,
+                "requires_callback": true,
+                "final_task": "search"
             },
+            "hash_value": "1110101010001011110100000011110010101000000010110101101010100101101111110101101001011010100001011111110101011010010000101010010110101101010110100000001010100101101010111110101000010101011100001110101010101111100001010101001011101010101011010001010101010010",
             "results": {
                 "result": [
                     {
@@ -1030,28 +1024,26 @@ class Bot::AlegreTest < ActiveSupport::TestCase
         "model_type": "image",
         "data": {
             "is_shortcircuited_search_result_callback": true,
-            "item": {
-                "callback_url": "http://alegre:3100/presto/receive/add_item/image",
-                "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
-                "text": nil,
-                "raw": {
-                    "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
-                    "context": {
-                        "team_id": pm1.team_id,
-                        "project_media_id": pm1.id,
-                        "has_custom_id": true,
-                        "temporary_media": false,
-                    },
-                    "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
-                    "threshold": 0.73,
-                    "confirmed": false,
-                    "created_at": "2024-03-14T22:05:47.588975",
-                    "limit": 200,
-                    "requires_callback": true,
-                    "final_task": "search"
+            "callback_url": "http://alegre:3100/presto/receive/add_item/image",
+            "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+            "text": nil,
+            "raw": {
+                "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
+                "context": {
+                    "team_id": pm1.team_id,
+                    "project_media_id": pm1.id,
+                    "has_custom_id": true,
+                    "temporary_media": false,
                 },
-                "hash_value": "1110101010001011110100000011110010101000000010110101101010100101101111110101101001011010100001011111110101011010010000101010010110101101010110100000001010100101101010111110101000010101011100001110101010101111100001010101001011101010101011010001010101010010"
+                "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+                "threshold": 0.73,
+                "confirmed": false,
+                "created_at": "2024-03-14T22:05:47.588975",
+                "limit": 200,
+                "requires_callback": true,
+                "final_task": "search"
             },
+            "hash_value": "1110101010001011110100000011110010101000000010110101101010100101101111110101101001011010100001011111110101011010010000101010010110101101010110100000001010100101101010111110101000010101011100001110101010101111100001010101001011101010101011010001010101010010",
             "results": {
                 "result": [
                     {
@@ -1092,29 +1084,27 @@ class Bot::AlegreTest < ActiveSupport::TestCase
     params = {
         "model_type": "image",
         "data": {
-            "item": {
-                "id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
-                "callback_url": "http://alegre:3100/presto/receive/add_item/image",
-                "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
-                "text": nil,
-                "raw": {
-                    "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
-                    "context": {
-                        "team_id": pm1.team_id,
-                        "project_media_id": 123456789,
-                        "has_custom_id": true,
-                        "temporary_media": true,
-                    },
-                    "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
-                    "threshold": 0.73,
-                    "confirmed": true,
-                    "created_at": "2024-03-14T22:05:47.588975",
-                    "limit": 200,
-                    "requires_callback": true,
-                    "final_task": "search"
+            "id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
+            "callback_url": "http://alegre:3100/presto/receive/add_item/image",
+            "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+            "text": nil,
+            "raw": {
+                "doc_id": "Y2hlY2stcHJvamVjdF9tZWRpYS0yMTQt",
+                "context": {
+                    "team_id": pm1.team_id,
+                    "project_media_id": 123456789,
+                    "has_custom_id": true,
+                    "temporary_media": true,
                 },
-                "hash_value": "1110101010001011110100000011110010101000000010110101101010100101101111110101101001011010100001011111110101011010010000101010010110101101010110100000001010100101101010111110101000010101011100001110101010101111100001010101001011101010101011010001010101010010"
+                "url": "http://minio:9000/check-api-dev/uploads/uploaded_image/55/09572dedf610aad68090214303c14829.png",
+                "threshold": 0.73,
+                "confirmed": true,
+                "created_at": "2024-03-14T22:05:47.588975",
+                "limit": 200,
+                "requires_callback": true,
+                "final_task": "search"
             },
+            "hash_value": "1110101010001011110100000011110010101000000010110101101010100101101111110101101001011010100001011111110101011010010000101010010110101101010110100000001010100101101010111110101000010101011100001110101010101111100001010101001011101010101011010001010101010010",
             "results": {
                 "result": [
                     {


### PR DESCRIPTION
## Description

Somehow we dropped an embedded 'item' layer in our responses to check-api from alegre. I believe this is sourced in changes to the schema layout in presto, and it just cascaded through to check-api. This removes that layer, which puts check-api back in sync with the message packets actually coming through in QA

References: CV2-5050

## How has this been tested?

Testing based on observed sentry responses and cloudwatch logs, 

## Things to pay attention to during code review

None

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

