### PR TITLE
Team statistics by rating should return the rating ID, not the label.

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -835,7 +835,6 @@ en:
     No media eligible to be imported into your workspace.
     The media selected to import already exist in your workspace in the following items:
     %{urls}
-  no_rating: No rating
   info:
     messages:
       sent_to_trash_by_rule: '"%{item_title}" has been sent to trash by an automation

--- a/lib/team_statistics.rb
+++ b/lib/team_statistics.rb
@@ -60,8 +60,7 @@ class TeamStatistics
   def number_of_fact_checks_by_rating
     data = {}
     fact_checks_base_query.group(:rating).count.each do |status_id, count|
-      label = status_id.blank? ? I18n.t(:no_rating) : ProjectMedia.new(team: @team).status_i18n(status_id)
-      data[label] = count
+      data[status_id.to_s] = count
     end
     data.sort.to_h
   end

--- a/test/lib/team_statistics_test.rb
+++ b/test/lib/team_statistics_test.rb
@@ -75,7 +75,7 @@ class TeamStatisticsTest < ActiveSupport::TestCase
       assert_equal 2, object.number_of_explainers_created
       assert_equal 2, object.number_of_fact_checks_created
       assert_equal 1, object.number_of_published_fact_checks
-      assert_equal({ 'False' => 1, 'Verified' => 1 }, object.number_of_fact_checks_by_rating)
+      assert_equal({ 'false' => 1, 'verified' => 1 }, object.number_of_fact_checks_by_rating)
       assert_equal({ 'foo' => 3, 'bar' => 2 }, object.top_articles_tags)
     end
   end


### PR DESCRIPTION
## Description

This way, the API client can manipulate it better, for example, translate to another language or get the color associated with it.

Reference: CV2-5389.

## How has this been tested?

Automated test updated to cover these changes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

