### PR TITLE
CV2-5050 add another doc id lookup for indexed-but-not-searched items via presto

### DIFF
--- a/app/models/concerns/alegre_webhooks.rb
+++ b/app/models/concerns/alegre_webhooks.rb
@@ -25,6 +25,8 @@ module AlegreWebhooks
       doc_id = body.dig('data', 'requested', 'id')
       # search for doc_id on completed full-circuit callbacks
       doc_id = body.dig('data', 'item', 'id') if doc_id.nil?
+      # search for doc_id on indexed-but-not-searched callbacks
+      doc_id = body.dig('data', 'item', 'doc_id') if doc_id.nil?
       # search for doc_id on completed short-circuit callbacks (i.e. items already known to Alegre but added context TODO make these the same structure)
       doc_id = body.dig('data', 'item', 'raw', 'doc_id') if doc_id.nil?
       if doc_id.blank?


### PR DESCRIPTION
## Description

We have a small condition where, when an item is requested to be indexed, but _not_ searched on, we fail on our webhook, when in reality the action should just be to acknowledge and do nothing (and perhaps later figure out how to actually suppress the callback). In the meantime, a simple fix here acknowledges and passes by the item, which I believe would be the intended outcome.

References: CV2-5050

## How has this been tested?

Tested and confirmed to work / resolve error locally in conjunction with CV2-5050-fix-item PR on alegre.

## Things to pay attention to during code review

None in particular.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

