### PR TITLE
CV2-5596: remove empty tags before create tags in background

### DIFF
--- a/app/models/annotations/tag.rb
+++ b/app/models/annotations/tag.rb
@@ -93,14 +93,15 @@ class Tag < ApplicationRecord
   end
 
   def self.create_project_media_tags(project_media_id, tags_json)
-    project_media = ProjectMedia.find_by_id(project_media_id)
-
-    if !project_media.nil?
-      tags = JSON.parse(tags_json)
-      clean_tags(tags).each { |tag| Tag.create annotated: project_media, tag: tag.strip, skip_check_ability: true }
-    else
-      error = StandardError.new("[ProjectMedia] Exception creating project media's tags in background. Project media is nil.")
-      CheckSentry.notify(error, project_media_id: project_media_id)
+    tags = JSON.parse(tags_json).reject { |t| t.blank? }
+    unless tags.empty?
+      project_media = ProjectMedia.find_by_id(project_media_id)
+      if !project_media.nil?
+        clean_tags(tags).each { |tag| Tag.create annotated: project_media, tag: tag.strip, skip_check_ability: true }
+      else
+        error = StandardError.new("[ProjectMedia] Exception creating project media's tags in background. Project media is nil.")
+        CheckSentry.notify(error, project_media_id: project_media_id)
+      end
     end
   end
 

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -260,9 +260,8 @@ module ProjectMediaCreators
 
   def create_tags_in_background
     if self.set_tags.is_a?(Array)
-      project_media_id = self.id
-      tags_json = self.set_tags.to_json
-      Tag.run_later_in(1.second, 'create_project_media_tags', project_media_id, tags_json, user_id: self.user_id)
+      tags = self.set_tags.reject { |t| t.blank? }
+      Tag.run_later_in(1.second, 'create_project_media_tags', self.id, tags.to_json, user_id: self.user_id) unless tags.empty?
     end
   end
 end

--- a/test/workers/generic_worker_test.rb
+++ b/test/workers/generic_worker_test.rb
@@ -36,8 +36,14 @@ class GenericWorkerTest < ActiveSupport::TestCase
     project_media_id = pm.id
     tags_json = ['one', 'two'].to_json
 
-    assert_difference "Tag.where(annotation_type: 'tag').count", difference = 2 do
+    assert_difference "Tag.where(annotation_type: 'tag').count", 2 do
       GenericWorker.perform_async('Tag', 'create_project_media_tags', project_media_id, tags_json, user_id: pm.user_id)
+    end
+    tags_json = [''].to_json
+    assert_nothing_raised do
+      assert_no_difference "Tag.where(annotation_type: 'tag').count" do
+        GenericWorker.perform_async('Tag', 'create_project_media_tags', project_media_id, tags_json, user_id: pm.user_id)
+      end
     end
   end
 


### PR DESCRIPTION
## Description

- Fix Sentry error related to tags can't be blank by remove blank tags from tags array.
- Create a background job for creating tags if tags not empty.

References: CV2-5596

## How has this been tested?

re-produce the bug using unit test.


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

