### PR TITLE
CV2-5608: remove show_parent? method

### DIFF
--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -241,6 +241,7 @@ class CheckSearch
       custom_conditions[k] = [@options[v]].flatten if @options.has_key?(v)
     end
     core_conditions.merge!({ archived: @options['archived'] })
+    core_conditions.merge!({ sources_count: 0 }) unless @options['show_similar']
     range_filter(:pg, custom_conditions)
     relation = ProjectMedia
     if @options['operator'].upcase == 'OR'

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -241,6 +241,7 @@ class CheckSearch
       custom_conditions[k] = [@options[v]].flatten if @options.has_key?(v)
     end
     core_conditions.merge!({ archived: @options['archived'] })
+    # Use sources_count condition for PG query to get either parent or child based on show_similar option
     core_conditions.merge!({ sources_count: 0 }) unless @options['show_similar']
     range_filter(:pg, custom_conditions)
     relation = ProjectMedia

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -272,18 +272,11 @@ class CheckSearch
   end
 
   def should_include_related_items?
-    @options['show_similar'] || show_parent?
-  end
-
-  def show_parent?
-    search_keys = ['verification_status', 'tags', 'rules', 'language', 'fc_language', 'request_language', 'report_language', 'team_tasks', 'assigned_to', 'channels', 'report_status']
-    !@options['projects'].blank? && !@options['keyword'].blank? && (search_keys & @options.keys).blank?
+    @options['show_similar']
   end
 
   def get_search_field
-    field = 'annotated_id'
-    field = 'parent_id' if !@options['show_similar'] && show_parent?
-    field
+    @options['show_similar'] ? 'annotated_id' : 'parent_id'
   end
 
   def medias_query(include_related_items = self.should_include_related_items?)

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -241,7 +241,6 @@ class CheckSearch
       custom_conditions[k] = [@options[v]].flatten if @options.has_key?(v)
     end
     core_conditions.merge!({ archived: @options['archived'] })
-    core_conditions.merge!({ sources_count: 0 }) unless should_include_related_items?
     range_filter(:pg, custom_conditions)
     relation = ProjectMedia
     if @options['operator'].upcase == 'OR'
@@ -271,15 +270,11 @@ class CheckSearch
     results.blank? ? [0] : results.keys
   end
 
-  def should_include_related_items?
-    @options['show_similar']
-  end
-
   def get_search_field
     @options['show_similar'] ? 'annotated_id' : 'parent_id'
   end
 
-  def medias_query(include_related_items = self.should_include_related_items?)
+  def medias_query
     core_conditions = []
     custom_conditions = []
     core_conditions << { terms: { get_search_field => @options['project_media_ids'] } } unless @options['project_media_ids'].blank?
@@ -287,7 +282,6 @@ class CheckSearch
     core_conditions << { terms: { archived: @options['archived'] } }
     custom_conditions << { terms: { read: @options['read'].map(&:to_i) } } if @options.has_key?('read')
     custom_conditions << { terms: { cluster_teams: @options['cluster_teams'] } } if @options.has_key?('cluster_teams')
-    core_conditions << { term: { sources_count: 0 } } unless include_related_items
     custom_conditions << { terms: { unmatched: @options['unmatched'] } } if @options.has_key?('unmatched')
     custom_conditions.concat keyword_conditions
     custom_conditions.concat tags_conditions

--- a/test/controllers/elastic_search_5_test.rb
+++ b/test/controllers/elastic_search_5_test.rb
@@ -22,6 +22,8 @@ class ElasticSearch5Test < ActionController::TestCase
     create_relationship source_id: parent.id, target_id: child_2.id, relationship_type: Relationship.confirmed_type
     sleep 2
     result = CheckSearch.new({}.to_json, nil, t.id)
+    assert_equal [parent.id], result.medias.map(&:id).sort
+    result = CheckSearch.new({show_similar: true}.to_json, nil, t.id)
     assert_equal [parent.id, child_1.id, child_2.id], result.medias.map(&:id).sort
     result = CheckSearch.new({ keyword: 'child_media' }.to_json, nil, t.id)
     assert_equal [parent.id], result.medias.map(&:id)

--- a/test/controllers/elastic_search_5_test.rb
+++ b/test/controllers/elastic_search_5_test.rb
@@ -13,25 +13,6 @@ class ElasticSearch5Test < ActionController::TestCase
     end
   end
 
-  test "should search for parent items only" do
-    t = create_team
-    p = create_project team: t
-    p2 = create_project team: t
-    pm1 = create_project_media disable_es_callbacks: false, project: p
-    pm2 = create_project_media disable_es_callbacks: false, project: p
-    sleep 2
-    result = CheckSearch.new({}.to_json, nil, t.id)
-    assert_equal [pm1.id, pm2.id].sort, result.medias.map(&:id).sort
-    r = create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
-    sleep 2
-    result = CheckSearch.new({ projects: [p.id] }.to_json, nil, t.id)
-    assert_equal [pm1.id], result.medias.map(&:id)
-    result = CheckSearch.new({}.to_json, nil, t.id)
-    assert_equal [pm1.id].sort, result.medias.map(&:id)
-    result = CheckSearch.new({ show_similar: true }.to_json, nil, t.id)
-    assert_equal [pm1.id, pm2.id].sort, result.medias.map(&:id).sort
-  end
-
   test "should match secondary items and show items based on show_similar option" do
     t = create_team
     parent = create_project_media team: t, disable_es_callbacks: false

--- a/test/controllers/elastic_search_5_test.rb
+++ b/test/controllers/elastic_search_5_test.rb
@@ -32,21 +32,20 @@ class ElasticSearch5Test < ActionController::TestCase
     assert_equal [pm1.id, pm2.id].sort, result.medias.map(&:id).sort
   end
 
-  test "should match secondary items but surface the main ones" do
-    # This case only happen when browsing a list and seach by keyword
+  test "should match secondary items and show items based on show_similar option" do
     t = create_team
-    p = create_project team: t
-    pm = create_project_media disable_es_callbacks: false, project: p
-    pm1 = create_project_media disable_es_callbacks: false, project: p
-    pm2 = create_project_media quote: 'target_media', disable_es_callbacks: false, project: p
-    r = create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
+    parent = create_project_media team: t, disable_es_callbacks: false
+    child_1 = create_project_media team: t, quote: 'child_media a', disable_es_callbacks: false
+    child_2 = create_project_media team: t, quote: 'child_media b', disable_es_callbacks: false
+    create_relationship source_id: parent.id, target_id: child_1.id, relationship_type: Relationship.confirmed_type
+    create_relationship source_id: parent.id, target_id: child_2.id, relationship_type: Relationship.confirmed_type
     sleep 2
-    result = CheckSearch.new({ projects: [p.id] }.to_json, nil, t.id)
-    assert_equal [pm.id, pm1.id], result.medias.map(&:id).sort
-    result = CheckSearch.new({ projects: [p.id], keyword: 'target_media' }.to_json, nil, t.id)
-    assert_equal [pm1.id], result.medias.map(&:id)
-    result = CheckSearch.new({ projects: [p.id], keyword: 'target_media', tags: ['test'] }.to_json, nil, t.id)
-    assert_empty result.medias.map(&:id)
+    result = CheckSearch.new({}.to_json, nil, t.id)
+    assert_equal [parent.id, child_1.id, child_2.id], result.medias.map(&:id).sort
+    result = CheckSearch.new({ keyword: 'child_media' }.to_json, nil, t.id)
+    assert_equal [parent.id], result.medias.map(&:id)
+    result = CheckSearch.new({ keyword: 'child_media', show_similar: true }.to_json, nil, t.id)
+    assert_equal [child_1.id, child_2.id], result.medias.map(&:id).sort
   end
 
   test "should reindex data" do

--- a/test/controllers/graphql_controller_2_test.rb
+++ b/test/controllers/graphql_controller_2_test.rb
@@ -356,12 +356,11 @@ class GraphqlController2Test < ActionController::TestCase
     authenticate_with_user(u)
     t = create_team slug: 'team'
     create_team_user user: u, team: t
-    p = create_project team: t
-    pm1 = create_project_media project: p, quote: 'Test 1 Bar', disable_es_callbacks: false
-    pm2 = create_project_media project: p, quote: 'Test 2 Foo', disable_es_callbacks: false
+    pm1 = create_project_media team: t, quote: 'Test 1 Bar', disable_es_callbacks: false
+    pm2 = create_project_media team: t, quote: 'Test 2 Foo', disable_es_callbacks: false
     create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type, disable_es_callbacks: false
-    pm3 = create_project_media project: p, quote: 'Test 3 Bar', disable_es_callbacks: false
-    pm4 = create_project_media project: p, quote: 'Test 4 Foo', disable_es_callbacks: false
+    pm3 = create_project_media team: t, quote: 'Test 3 Bar', disable_es_callbacks: false
+    pm4 = create_project_media team: t, quote: 'Test 4 Foo', disable_es_callbacks: false
     create_relationship source_id: pm3.id, target_id: pm4.id, relationship_type: Relationship.confirmed_type, disable_es_callbacks: false
     sleep 1
 


### PR DESCRIPTION
## Description

Simplify and get rid of the show_parent? logic so search all items and either show parent or secondary items based on `show_similar` option
i.e show_similar = false then show parent items only otherwise show secondary items


References: CV2-5608

## How has this been tested?

Implemented automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

