### PR TITLE
CV2-5050 readd target_field value from broken case for text

### DIFF
--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -358,7 +358,7 @@ module AlegreV2
             context: result["context"],
             model: result["model"],
             source_field: get_target_field(project_media, field),
-            target_field: get_target_field(project_media, result["field"]),
+            target_field: get_target_field(project_media, result["field"] || result["context"]["field"]),
             relationship_type: relationship_type
           }
         ]


### PR DESCRIPTION
## Description

Right now we have a lingering issue where relationships are being persisted without target_field - the root of the error is that for text, the field is wrapped inside the `context` parameter (and in fact... may always be there?). Quick fix to address that.

References: CV2-5050

## How has this been tested?

Tested locally against cached data persisted on `Bot::Alegre.process_alegre_callback(params)` and confirmed to work.

## Things to pay attention to during code review

None in particular!

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

