### PR TITLE
CV2-5621: Add missing tests

### DIFF
--- a/test/lib/check_config_test.rb
+++ b/test/lib/check_config_test.rb
@@ -57,4 +57,10 @@ class CheckConfigTest < ActiveSupport::TestCase
     ENV.delete('test_other_env_key')
   end
 
+  test "should handle json value " do
+    stub_configs({ 'test_json_key' => '{"lang":{"en":"default.html"}}', 'test_invalid_json_key' => 'invalid_json_value' }) do
+      assert_equal 'default.html', CheckConfig.get('test_json_key', nil, :json)
+      assert_equal 'invalid_json_value', CheckConfig.get('test_invalid_json_key', nil, :json)
+    end
+  end
 end

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -970,12 +970,14 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
 
   test "should get dynamic resource on tipline bot v2" do
     WebMock.stub_request(:get, /googleapis\.com\/civicinfo/).to_return(body: { pollingLocations: [{ address: {} }], earlyVoteSites: [{ address: {} }] }.to_json)
-    @resource.content_type = 'dynamic'
-    @resource.save!
-    send_message 'hello', '1', '4'
-    assert_state 'resource_waiting_for_user_input'
-    send_message '972 Mission St San Francisco CA'
-    assert_state 'waiting_for_message'
+    stub_configs({ 'google_api_key' => random_string }) do
+      @resource.content_type = 'dynamic'
+      @resource.save!
+      send_message 'hello', '1', '4'
+      assert_state 'resource_waiting_for_user_input'
+      send_message '972 Mission St San Francisco CA'
+      assert_state 'waiting_for_message'
+    end
   end
 
   test "should not get dynamic resource on tipline bot v2 if resource is not available anymore" do
@@ -990,11 +992,13 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
 
   test "should not get dynamic resource on tipline bot v2 if external API returns an error" do
     WebMock.stub_request(:get, /googleapis\.com\/civicinfo/).to_return(body: { pollingLocations: 'Some error' }.to_json)
-    @resource.content_type = 'dynamic'
-    @resource.save!
-    send_message 'hello', '1', '4'
-    assert_state 'resource_waiting_for_user_input'
-    send_message '972 Mission St San Francisco CA'
-    assert_state 'waiting_for_message'
+    stub_configs({ 'google_api_key' => random_string }) do
+      @resource.content_type = 'dynamic'
+      @resource.save!
+      send_message 'hello', '1', '4'
+      assert_state 'resource_waiting_for_user_input'
+      send_message '972 Mission St San Francisco CA'
+      assert_state 'waiting_for_message'
+    end
   end
 end

--- a/test/models/bot/smooch_7_test.rb
+++ b/test/models/bot/smooch_7_test.rb
@@ -413,6 +413,8 @@ class Bot::Smooch7Test < ActiveSupport::TestCase
     sleep 2 # Wait for ElasticSearch to index content
 
     assert_equal [pm1.id, pm2.id, pm3.id], Bot::Smooch.search_for_similar_published_fact_checks('text', 'Foo Bar', [t.id]).to_a.map(&:id)
+    # Calling wiht skip_cache true
+    assert_equal [pm1.id, pm2.id, pm3.id], Bot::Smooch.search_for_similar_published_fact_checks('text', 'Foo Bar', [t.id], nil, nil, nil, true).to_a.map(&:id)
   end
 
   test "should store media" do


### PR DESCRIPTION
## Description

Add missing tests to back test coverage to 100%.
- [x] app/models/concerns/smooch_search.rb: line 153
- [x] app/models/tipline_resource.rb: lines 54, 70, 71, 73, 74, 75, 76, 78
- [x] app/lib/check_config.rb: lines 20, 21

References: CV2-5621

## How has this been tested?

Implemented automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

