### PR TITLE
Feature flag for data dashboard

### DIFF
--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -397,6 +397,7 @@ class TeamType < DefaultObject
   end
 
   def statistics(period:, language: nil, platform: nil)
+    raise CheckPermissions::AccessDenied.new("You don't have access to this field.") unless User.current&.is_admin
     TeamStatistics.new(object, period, language, platform)
   end
 end

--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -397,7 +397,7 @@ class TeamType < DefaultObject
   end
 
   def statistics(period:, language: nil, platform: nil)
-    raise CheckPermissions::AccessDenied.new("You don't have access to this field.") unless User.current&.is_admin
+    return nil unless User.current&.is_admin
     TeamStatistics.new(object, period, language, platform)
   end
 end


### PR DESCRIPTION
## Description

Make sure that only super-admins can access the `TeamType.statistics` field.

Reference: CV2-5401.

## How has this been tested?

I implemented an automated test for this.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)