### PR TITLE
Search for similar items only if `show_similar` flag is explicitly passed

### DIFF
--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -282,6 +282,7 @@ class CheckSearch
     core_conditions << { terms: { get_search_field => @options['project_media_ids'] } } unless @options['project_media_ids'].blank?
     core_conditions << { terms: { team_id: [@options['team_id']].flatten } } if @options['team_id'].is_a?(Array)
     core_conditions << { terms: { archived: @options['archived'] } }
+    core_conditions << { term: { sources_count: 0 } } unless @options['show_similar']
     custom_conditions << { terms: { read: @options['read'].map(&:to_i) } } if @options.has_key?('read')
     custom_conditions << { terms: { cluster_teams: @options['cluster_teams'] } } if @options.has_key?('cluster_teams')
     custom_conditions << { terms: { unmatched: @options['unmatched'] } } if @options.has_key?('unmatched')

--- a/test/controllers/elastic_search_5_test.rb
+++ b/test/controllers/elastic_search_5_test.rb
@@ -23,10 +23,10 @@ class ElasticSearch5Test < ActionController::TestCase
     sleep 2
     result = CheckSearch.new({}.to_json, nil, t.id)
     assert_equal [parent.id], result.medias.map(&:id).sort
-    result = CheckSearch.new({show_similar: true}.to_json, nil, t.id)
+    result = CheckSearch.new({ show_similar: true }.to_json, nil, t.id)
     assert_equal [parent.id, child_1.id, child_2.id], result.medias.map(&:id).sort
     result = CheckSearch.new({ keyword: 'child_media' }.to_json, nil, t.id)
-    assert_equal [parent.id], result.medias.map(&:id)
+    assert_equal [], result.medias.map(&:id)
     result = CheckSearch.new({ keyword: 'child_media', show_similar: true }.to_json, nil, t.id)
     assert_equal [child_1.id, child_2.id], result.medias.map(&:id).sort
   end

--- a/test/controllers/graphql_controller_2_test.rb
+++ b/test/controllers/graphql_controller_2_test.rb
@@ -379,7 +379,7 @@ class GraphqlController2Test < ActionController::TestCase
     assert_response :success
     assert_equal 4, JSON.parse(@response.body)['data']['search']['number_of_results']
 
-    query = 'query CheckSearch { search(query: "{\"keyword\":\"Foo\",\"show_similar\":false}") { number_of_results } }'
+    query = 'query CheckSearch { search(query: "{\"keyword\":\"Foo\",\"show_similar\":true}") { number_of_results } }'
     post :create, params: { query: query, team: 'team' }
     assert_response :success
     assert_equal 2, JSON.parse(@response.body)['data']['search']['number_of_results']


### PR DESCRIPTION
## Description

Search for similar items only if `show_similar` flag is explicitly passed

Fixes: CV2-5608.

## How has this been tested?

Automated tests updated.

## Things to pay attention to during code review

Please make sure you agree with this approach.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

