### PR TITLE
Reset report text fields when fact-check is removed from item.

### DIFF
--- a/app/models/claim_description.rb
+++ b/app/models/claim_description.rb
@@ -69,7 +69,7 @@ class ClaimDescription < ApplicationRecord
     end
   end
 
-  # Pause and update eport when claim/fact-check is removed
+  # Pause and update report when claim/fact-check is removed
   def update_report
     if self.project_media_id.nil? && !self.project_media_id_before_last_save.nil?
       # Update report status

--- a/app/models/claim_description.rb
+++ b/app/models/claim_description.rb
@@ -72,7 +72,7 @@ class ClaimDescription < ApplicationRecord
   # Pause and update report when claim/fact-check is removed
   def update_report
     if self.project_media_id.nil? && !self.project_media_id_before_last_save.nil?
-      # Update report status
+      # Update report status and text fields
       pm = ProjectMedia.find(self.project_media_id_before_last_save)
       report = Annotation.where(annotation_type: 'report_design', annotated_type: 'ProjectMedia', annotated_id: pm.id).last
       unless report.nil?


### PR DESCRIPTION
## Description

Previously, we were already changing the report status to "paused" when a fact-check was removed from item. This PR does one more thing: also resets all text fields related to the report, in order to avoid similarity matches that shouldn't happen.

Reference: CV2-5630.

## How has this been tested?

TDD. I implemented a new unit test for this case. The test failed before the fix.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)