### PR TITLE
Move claim/fact-check/report from child to parent when creating relationship if child has a published report but the parent doesn't

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -12,6 +12,7 @@ class Relationship < ApplicationRecord
 
   before_validation :set_user, on: :create
   before_validation :set_confirmed, if: :is_being_confirmed?, on: :update
+  before_validation :move_fact_check_and_report_to_main, on: :create
   validate :relationship_type_is_valid, :items_are_from_the_same_team
   validate :target_not_published_report, on: :create
   validate :similar_item_exists, on: :create, if: proc { |r| r.is_suggested? }
@@ -365,5 +366,33 @@ class Relationship < ApplicationRecord
 
   def cant_be_related_to_itself
     errors.add(:base, I18n.t(:item_cant_be_related_to_itself)) if self.source_id == self.target_id
+  end
+
+  def move_fact_check_and_report_to_main
+    Relationship.transaction do
+      source = self.source
+      target = self.target
+      if source && target && source.team_id == target.team_id # Must verify since this method runs before the validation
+        target_report = target.get_annotations('report_design').to_a.map(&:load).last
+
+        # If the child item has a claim/fact-check and published report but the parent item doesn't, then move the claim/fact-check/report from the child to the parent
+        if !source.claim_description && target.claim_description && target_report && target_report.get_field_value('state') == 'published'
+          # Move report
+          target_report.annotated_id = source.id
+          target_report.save!
+
+          # Move claim/fact-check
+          claim_description = target.claim_description
+          claim_description.project_media = source
+          claim_description.save!
+
+          # Clear caches
+          source.clear_cached_fields
+          target.clear_cached_fields
+          source.reload
+          target.reload
+        end
+      end
+    end
   end
 end

--- a/test/models/relationship_2_test.rb
+++ b/test/models/relationship_2_test.rb
@@ -250,6 +250,7 @@ class Relationship2Test < ActiveSupport::TestCase
   end
 
   test "should propagate change if source and target are swapped" do
+    Sidekiq::Testing.inline!
     u = create_user is_admin: true
     t = create_team
     with_current_user_and_team(u, t) do


### PR DESCRIPTION
## Description

* Previously: We have items A and B. B has a published report. If we try to add B as similar to A it's going to fail because B has a published report.
* Now: Move the fact-check from B to A if A doesn't have a fact-check. Remain failing if A already has a fact-check.

Reference: CV2-5652.

## How has this been tested?

An extensive automated test was implemented for this.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

