### PR TITLE
Fixing the ID returned by statistics field "top articles sent".

### DIFF
--- a/lib/team_statistics.rb
+++ b/lib/team_statistics.rb
@@ -72,7 +72,7 @@ class TeamStatistics
     clusters.each do |pm_id, demand|
       item = ProjectMedia.find(pm_id)
       title = item.fact_check_title || item.title
-      data << { id: item.id, label: title, value: demand }
+      data << { id: item.fact_check_id, label: title, value: demand }
     end
     data.sort_by{ |object| object[:value] }.reverse
   end


### PR DESCRIPTION
## Description

It should be the article ID, not the media cluster ID.

Fixes: CV2-4111.

## How has this been tested?

Existing tests should cover this.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

