### PR TITLE
Improve search matching by stripping special characters from input

### DIFF
--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -60,7 +60,7 @@ class CheckSearch
     unless @options['keyword'].blank?
       # This regex removes all characters except letters, numbers, hashtag, search operators, emojis and whitespace
       # in any language - stripping out special characters can improve match results
-      @options['keyword'].gsub!(/[^[:word:]\s#~+-|()"\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F700}-\u{1F77F}\u{1F780}-\u{1F7FF}\u{1F800}-\u{1F8FF}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1F1E6}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/, ' ')
+      @options['keyword'].gsub!(/[^[:word:]\s#~+\-|()"\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F700}-\u{1F77F}\u{1F780}-\u{1F7FF}\u{1F800}-\u{1F8FF}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1F1E6}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/, ' ')
 
       # Set fuzzy matching for keyword search, right now with automatic Levenshtein Edit Distance
       # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -58,13 +58,14 @@ class CheckSearch
 
   def adjust_keyword_filter
     unless @options['keyword'].blank?
-      # This regex removes all characters except letters, numbers, hashtag and whitespace in any language - stripping out special characters can improve match results
-      @options['keyword'].gsub!(/[^[:word:]\s#]/, ' ')
+      # This regex removes all characters except letters, numbers, hashtag, search operators, emojis and whitespace
+      # in any language - stripping out special characters can improve match results
+      @options['keyword'].gsub!(/[^[:word:]\s#~+-|()"\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F700}-\u{1F77F}\u{1F780}-\u{1F7FF}\u{1F800}-\u{1F8FF}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1F1E6}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/, ' ')
 
       # Set fuzzy matching for keyword search, right now with automatic Levenshtein Edit Distance
       # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html
       # https://github.com/elastic/elasticsearch/issues/23366
-      @options['keyword'] = "#{@options['keyword']}~" if !@options['keyword'].blank? && @options['fuzzy']
+      @options['keyword'] = "#{@options['keyword']}~" if @options['fuzzy']
     end
   end
 

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -58,7 +58,7 @@ class CheckSearch
 
   def adjust_keyword_filter
     unless @options['keyword'].blank?
-      # This regex removes all characters except letters, numbers, and whitespace in any language - stripping out special characters can improve match results
+      # This regex removes all characters except letters, numbers, hashtag and whitespace in any language - stripping out special characters can improve match results
       @options['keyword'].gsub!(/[^[:word:]\s#]/, ' ')
 
       # Set fuzzy matching for keyword search, right now with automatic Levenshtein Edit Distance

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -59,7 +59,7 @@ class CheckSearch
   def adjust_keyword_filter
     unless @options['keyword'].blank?
       # This regex removes all characters except letters, numbers, and whitespace in any language - stripping out special characters can improve match results
-      @options['keyword'].gsub!(/[^[:word:]\s]/, ' ')
+      @options['keyword'].gsub!(/[^[:word:]\s#]/, ' ')
 
       # Set fuzzy matching for keyword search, right now with automatic Levenshtein Edit Distance
       # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html

--- a/test/lib/check_search_test.rb
+++ b/test/lib/check_search_test.rb
@@ -1,0 +1,20 @@
+require_relative '../test_helper'
+
+class TeamStatisticsTest < ActiveSupport::TestCase
+  def setup
+    @team = create_team
+  end
+
+  def teardown
+  end
+
+  test "should strip special characters from keyword parameter" do
+    query = 'Something has increased 1000% last year'
+    search = CheckSearch.new({ keyword: query }.to_json, nil, @team.id)
+    assert_equal 'Something has increased 1000  last year', search.instance_variable_get('@options')['keyword']
+
+    query = 'Something is going to happen on 04/11, reportedly'
+    search = CheckSearch.new({ keyword: query }.to_json, nil, @team.id)
+    assert_equal 'Something is going to happen on 04 11  reportedly', search.instance_variable_get('@options')['keyword']
+  end
+end

--- a/test/lib/check_search_test.rb
+++ b/test/lib/check_search_test.rb
@@ -1,6 +1,6 @@
 require_relative '../test_helper'
 
-class TeamStatisticsTest < ActiveSupport::TestCase
+class CheckSearchTest < ActiveSupport::TestCase
   def setup
     @team = create_team
   end

--- a/test/lib/tasks/statistics_test.rb
+++ b/test/lib/tasks/statistics_test.rb
@@ -37,9 +37,9 @@ class StatisticsTest < ActiveSupport::TestCase
 
   test "check:data:statistics generates statistics data for teams with no tipline" do
     TeamBotInstallation.delete_all
+    Team.current = nil
 
-    api_key = create_api_key
-    bot_user = create_bot_user api_key_id: api_key.id
+    bot_user = create_bot_user
     bot_user.approve!
 
     non_tipline_team = create_team(slug: 'other-team')

--- a/test/lib/team_statistics_test.rb
+++ b/test/lib/team_statistics_test.rb
@@ -85,18 +85,18 @@ class TeamStatisticsTest < ActiveSupport::TestCase
     RequestStore.store[:skip_cached_field_update] = false
 
     pm1 = create_project_media team: @team, disable_es_callbacks: false
-    create_fact_check title: 'Bar', report_status: 'published', rating: 'verified', language: 'en', claim_description: create_claim_description(project_media: pm1), disable_es_callbacks: false
+    fc1 = create_fact_check title: 'Bar', report_status: 'published', rating: 'verified', language: 'en', claim_description: create_claim_description(project_media: pm1), disable_es_callbacks: false
     create_tipline_request team_id: @team.id, associated: pm1
 
     pm2 = create_project_media team: @team, disable_es_callbacks: false
-    create_fact_check title: 'Foo', report_status: 'published', rating: 'verified', language: 'en', claim_description: create_claim_description(project_media: pm2), disable_es_callbacks: false
+    fc2 = create_fact_check title: 'Foo', report_status: 'published', rating: 'verified', language: 'en', claim_description: create_claim_description(project_media: pm2), disable_es_callbacks: false
     create_tipline_request team_id: @team.id, associated: pm2
     create_tipline_request team_id: @team.id, associated: pm2
 
     sleep 2
 
     object = TeamStatistics.new(@team, 'past_week', 'en')
-    expected = [{ id: pm2.id, label: 'Foo', value: 2 }, { id: pm1.id, label: 'Bar', value: 1 }]
+    expected = [{ id: fc2.id, label: 'Foo', value: 2 }, { id: fc1.id, label: 'Bar', value: 1 }]
     assert_equal expected, object.top_articles_sent
   end
 


### PR DESCRIPTION
## Description

Issue: Search input containing special characters (e.g., %, &, /) was causing inconsistent matches.

Fix: Added preprocessing step to remove special characters from the input query using Ruby’s `gsub`. This keeps letters, numbers, and spaces intact, enhancing match accuracy across multiple languages.

Reference: CV2-5672.

## How has this been tested?

I added a couple of unit tests for this case.

## Things to pay attention to during code review

It should work for non-Latin languages like Japanese and Arabic as well.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

