### PR TITLE
Bot Preview: Initial backend implementation

### DIFF
--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -406,48 +406,22 @@ class TeamType < DefaultObject
   end
 
   def bot_query(search_text:)
-    unless User.current&.is_admin
-      raise GraphQL::ExecutionError, "You do not have permission to perform this action"
-    end
+    return nil unless User.current&.is_admin
 
-    return nil unless search_text
-
-    explainers = object.explainers.order(created_at: :desc).limit(3)
+    explainers = object.explainers.order(updated_at: :desc).limit(3)
 
     fact_checks = FactCheck.joins(:claim_description)
                            .where(claim_descriptions: { team_id: object.id })
-                           .order('fact_checks.created_at DESC')
+                           .order('fact_checks.updated_at DESC')
                            .limit(3)
 
     combined_records = explainers + fact_checks
-    sorted_records = combined_records.sort_by(&:created_at).reverse
+    sorted_records = combined_records.sort_by(&:updated_at).reverse
 
     top_three = sorted_records.first(3)
 
     results = top_three.map do |record|
-      if record.is_a?(Explainer)
-        TiplineSearchResult.new(
-          team: object,
-          title: record.title,
-          body: record.description,
-          image_url: nil,
-          language: record.language,
-          url: record.url,
-          type: :explainer,
-          format: :text
-        )
-      elsif record.is_a?(FactCheck)
-        TiplineSearchResult.new(
-          team: object,
-          title: record.title,
-          body: record.summary,
-          image_url: nil,
-          language: record.language,
-          url: record.url,
-          type: :fact_check,
-          format: :text
-        )
-      end
+      record.as_tipline_search_result
     end
 
     results

--- a/app/graph/types/tipline_search_result_type.rb
+++ b/app/graph/types/tipline_search_result_type.rb
@@ -1,0 +1,11 @@
+class TiplineSearchResultType < DefaultObject
+  description "Represents a search result for the tipline"
+
+  field :title, GraphQL::Types::String, null: false
+  field :body, GraphQL::Types::String, null: true
+  field :image_url, GraphQL::Types::String, null: true
+  field :language, GraphQL::Types::String, null: true
+  field :url, GraphQL::Types::String, null: true
+  field :type, GraphQL::Types::String, null: false
+  field :format, GraphQL::Types::String, null: false
+end

--- a/app/lib/tipline_search_result.rb
+++ b/app/lib/tipline_search_result.rb
@@ -1,7 +1,8 @@
 class TiplineSearchResult
-  attr_accessor :team, :title, :body, :image_url, :language, :url, :type, :format
+  attr_accessor :id, :team, :title, :body, :image_url, :language, :url, :type, :format
 
-  def initialize(team:, title:, body:, image_url:, language:, url:, type:, format:)
+  def initialize(id:, team:, title:, body:, image_url:, language:, url:, type:, format:)
+    self.id = id
     self.team = team
     self.title = title
     self.body = body

--- a/app/models/explainer.rb
+++ b/app/models/explainer.rb
@@ -31,6 +31,7 @@ class Explainer < ApplicationRecord
 
   def as_tipline_search_result
     TiplineSearchResult.new(
+      id: self.id,
       team: self.team,
       title: self.title,
       body: self.description,

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -65,6 +65,7 @@ class FactCheck < ApplicationRecord
 
   def as_tipline_search_result
     TiplineSearchResult.new(
+      id: self.id,
       team: self.team,
       title: self.title,
       body: self.summary,

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -63,6 +63,19 @@ class FactCheck < ApplicationRecord
     self.tags = clean_tags(self.tags)
   end
 
+  def as_tipline_search_result
+    TiplineSearchResult.new(
+      team: self.team,
+      title: self.title,
+      body: self.summary,
+      language: self.language,
+      url: self.url,
+      image_url: nil,
+      type: :fact_check,
+      format: :text
+    )
+  end
+
   private
 
   def set_language

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -13176,6 +13176,7 @@ type Team implements Node {
   articles_count(article_type: String, imported: Boolean, language: [String], publisher_ids: [Int], rating: [String], report_status: [String], standalone: Boolean, tags: [String], target_id: Int, text: String, trashed: Boolean = false, updated_at: String, user_ids: [Int]): Int
   available_newsletter_header_types: JsonStringType
   avatar: String
+  bot_query(searchText: String!): [TiplineSearchResult!]
   check_search_spam: CheckSearch
   check_search_trash: CheckSearch
   check_search_unconfirmed: CheckSearch
@@ -14086,6 +14087,23 @@ type TiplineResourceEdge {
   The item at the end of the edge.
   """
   node: TiplineResource
+}
+
+"""
+Represents a search result for the tipline
+"""
+type TiplineSearchResult {
+  body: String
+  created_at: String
+  format: String!
+  id: ID!
+  image_url: String
+  language: String
+  permissions: String
+  title: String!
+  type: String!
+  updated_at: String
+  url: String
 }
 
 """

--- a/public/relay.json
+++ b/public/relay.json
@@ -69361,6 +69361,43 @@
               "deprecationReason": null
             },
             {
+              "name": "bot_query",
+              "description": null,
+              "args": [
+                {
+                  "name": "searchText",
+                  "description": null,
+                  "type": {
+                    "kind": "NON_NULL",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                }
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "TiplineSearchResult",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "check_search_spam",
               "description": null,
               "args": [
@@ -74799,6 +74836,189 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "TiplineResource",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            }
+          ],
+          "inputFields": null,
+          "interfaces": [
+
+          ],
+          "enumValues": null,
+          "possibleTypes": null
+        },
+        {
+          "kind": "OBJECT",
+          "name": "TiplineSearchResult",
+          "description": "Represents a search result for the tipline",
+          "fields": [
+            {
+              "name": "body",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "created_at",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "format",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "id",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "ID",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "image_url",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "language",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "permissions",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "title",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "type",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "updated_at",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "url",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/test/controllers/graphql_controller_11_test.rb
+++ b/test/controllers/graphql_controller_11_test.rb
@@ -323,4 +323,77 @@ class GraphqlController11Test < ActionController::TestCase
     assert_response :success
     assert_equal 2, JSON.parse(@response.body).dig('data', 'team', 'tipline_requests', 'edges').size
   end
+
+  test "super admin user should receive the 3 most recent FactChecks or Explainers" do
+    # Create a super admin user
+    super_admin = create_user(is_admin: true)
+    create_team_user team: @t, user: super_admin, role: 'admin'
+  
+    # Authenticate with super admin user
+    authenticate_with_user(super_admin)
+  
+    # Create ClaimDescriptions associated with the team
+    claim_desc1 = create_claim_description(team: @t)
+    claim_desc2 = create_claim_description(team: @t)
+  
+    # Create FactChecks and set created_at
+    another_fact_check = create_fact_check(
+      title: "Another FactCheck",
+      claim_description: claim_desc1
+    )
+    another_fact_check.update_column(:created_at, 4.days.ago)
+  
+    newer_fact_check = create_fact_check(
+      title: "Newer FactCheck",
+      claim_description: claim_desc2
+    )
+    newer_fact_check.update_column(:created_at, 2.days.ago)
+  
+    # Create Explainers and set created_at
+    older_explainer = create_explainer(
+      team: @t,
+      title: "Older Explainer"
+    )
+    older_explainer.update_column(:created_at, 3.days.ago)
+  
+    newest_explainer = create_explainer(
+      team: @t,
+      title: "Newest Explainer"
+    )
+    newest_explainer.update_column(:created_at, 1.day.ago)
+  
+    yet_another_explainer = create_explainer(
+      team: @t,
+      title: "Yet Another Explainer"
+    )
+    yet_another_explainer.update_column(:created_at, Time.now)
+  
+    # Perform the GraphQL query
+    query = <<~GRAPHQL
+      query {
+        team(slug: "#{@t.slug}") {
+          bot_query(searchText: "test") {
+            title
+            type
+            format
+          }
+        }
+      }
+    GRAPHQL
+  
+    post :create, params: { query: query, team: @t.slug }
+    assert_response :success
+  
+    data = JSON.parse(@response.body)['data']['team']['bot_query']
+    assert_equal 3, data.size, "Expected 3 results"
+  
+    expected_titles = ["Yet Another Explainer", "Newest Explainer", "Older Explainer"]
+    actual_titles = data.map { |result| result['title'] }
+    assert_equal expected_titles, actual_titles, "Results should be the 3 most recent records"
+  
+    # Verify types
+    expected_types = ['explainer', 'explainer', 'explainer']
+    actual_types = data.map { |result| result['type'] }
+    assert_equal expected_types, actual_types, "Types should match the records"
+  end  
 end


### PR DESCRIPTION

## Description

Add a bot_query field to TeamType which will send queries to the backend simulating tipline bot queries.

Initially, this is returning the most recent Explainers/FactChecks as TiplineSearchResults, but eventually it will be hooked to the actual bot implementation.

References: CV2-5702

## How has this been tested?

 - Confirmed that the most recent explainers/fact checks


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

