### PR TITLE
Update item cached fields when detaching fact-check.

### DIFF
--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -70,14 +70,23 @@ module ProjectMediaCachedFields
       }
     }
 
-    FACT_CHECK_EVENT = {
-      model: FactCheck,
-      affected_ids: proc { |fc| [fc.claim_description.project_media_id] },
-      events: {
-        save: :recalculate,
-        destroy: :recalculate
+    FACT_CHECK_EVENTS = [
+      {
+        model: FactCheck,
+        affected_ids: proc { |fc| [fc.claim_description.project_media_id] },
+        events: {
+          save: :recalculate,
+          destroy: :recalculate
+        }
+      },
+      {
+        model: ClaimDescription,
+        affected_ids: proc { |cd| [cd.project_media_id, cd.project_media_id_before_last_save] },
+        events: {
+          save: :recalculate
+        }
       }
-    }
+    ]
 
     { is_suggested: Relationship.suggested_type, is_confirmed: Relationship.confirmed_type }.each do |field_name, _type|
       cached_field field_name,
@@ -181,28 +190,28 @@ module ProjectMediaCachedFields
     cached_field :fact_check_id,
       start_as: nil,
       recalculate: :recalculate_fact_check_id,
-      update_on: [FACT_CHECK_EVENT]
+      update_on: FACT_CHECK_EVENTS
 
     cached_field :fact_check_title,
       start_as: nil,
       recalculate: :recalculate_fact_check_title,
-      update_on: [FACT_CHECK_EVENT]
+      update_on: FACT_CHECK_EVENTS
 
     cached_field :fact_check_summary,
       start_as: nil,
       recalculate: :recalculate_fact_check_summary,
-      update_on: [FACT_CHECK_EVENT]
+      update_on: FACT_CHECK_EVENTS
 
     cached_field :fact_check_url,
       start_as: nil,
       recalculate: :recalculate_fact_check_url,
-      update_on: [FACT_CHECK_EVENT]
+      update_on: FACT_CHECK_EVENTS
 
     cached_field :fact_check_published_on,
       start_as: 0,
       update_es: true,
       recalculate: :recalculate_fact_check_published_on,
-      update_on: [FACT_CHECK_EVENT]
+      update_on: FACT_CHECK_EVENTS
 
     cached_field :description,
       recalculate: :recalculate_description,

--- a/test/models/fact_check_test.rb
+++ b/test/models/fact_check_test.rb
@@ -714,4 +714,18 @@ class FactCheckTest < ActiveSupport::TestCase
       assert_equal 'Foo', pm.reload.report_text_title
     end
   end
+
+  test "should reset cached fields when fact-check is detached" do
+    RequestStore.store[:skip_cached_field_update] = false
+    Sidekiq::Testing.inline! do
+      pm = create_project_media
+      cd = create_claim_description project_media: pm
+      fc = create_fact_check claim_description: cd, title: 'Foo'
+      assert_equal fc.id, pm.reload.fact_check_id
+
+      cd.project_media = nil # Remove the claim/fact-check from the item
+      cd.save!
+      assert_nil pm.reload.fact_check_id
+    end
+  end
 end


### PR DESCRIPTION
## Description

Make sure that the `fact_check_*` cached fields for a `ProjectMedia` are refreshed when a fact-check is detached from that item.

Fixes: CV2-5600.

## How has this been tested?

TDD. I was able to reproduce the issue in a unit test that passed after the fix.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)