### PR TITLE
Make sure that items belong to only one media cluster

### DIFF
--- a/app/models/cluster.rb
+++ b/app/models/cluster.rb
@@ -70,7 +70,7 @@ class Cluster < ApplicationRecord
     cluster.project_medias.where.not(team_id: team.id).limit(max).select(:id, :media_id).find_each do |pm|
       next if ProjectMedia.where(team_id: team.id, media_id: pm.media_id).exists?
       target = cluster.import_media_to_team(team, pm)
-      Relationship.create(source: parent, target: target, relationship_type: Relationship.confirmed_type) # Didn't use "!" so if fails silently if the similarity bot creates a relationship first
+      Relationship.create_unless_exists(parent.id, target.id, Relationship.confirmed_type)
     end
   end
 end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -304,7 +304,7 @@ class Relationship < ApplicationRecord
   def point_targets_to_new_source
     # Get existing targets for the source
     target_ids = Relationship.where(source_id: self.source_id).map(&:target_id)
-    # Delete duplicate relation from target(CHECK-1603)
+    # Delete duplicate relationships from target (CHECK-1603)
     Relationship.where(source_id: self.target_id, target_id: target_ids).delete_all
     Relationship.where(source_id: self.target_id).find_each do |old_relationship|
       old_relationship.delete
@@ -313,6 +313,8 @@ class Relationship < ApplicationRecord
         weight: old_relationship.weight
       }
       Relationship.create_unless_exists(self.source_id, old_relationship.target_id, old_relationship.relationship_type, options)
+      old_relationship.source.clear_cached_fields
+      old_relationship.target.clear_cached_fields
     end
   end
 

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -19,9 +19,10 @@ class Relationship < ApplicationRecord
   validate :cant_be_related_to_itself
   validates :relationship_type, uniqueness: { scope: [:source_id, :target_id], message: :already_exists }, on: :create
 
+  before_create :point_targets_to_new_source
   before_create :destroy_same_suggested_item, if: proc { |r| r.is_confirmed? }
   after_create :move_to_same_project_as_main, prepend: true
-  after_create :point_targets_to_new_source, :update_counters, prepend: true
+  after_create :update_counters, prepend: true
   after_update :reset_counters, prepend: true
   after_update :propagate_inversion
   after_save :turn_off_unmatched_field, if: proc { |r| r.is_confirmed? || r.is_suggested? }

--- a/db/migrate/20241123001206_add_unique_index_to_relationships_table.rb
+++ b/db/migrate/20241123001206_add_unique_index_to_relationships_table.rb
@@ -1,0 +1,33 @@
+class AddUniqueIndexToRelationshipsTable < ActiveRecord::Migration[6.1]
+  def change
+    # The code below is a copy-paste from the rake task lib/tasks/migrate/20230216030351_delete_duplicate_relationships.rake
+    # and it's responsible for deleting any remaining duplicate relationship, but first, before running this migration, be 
+    # sure to run the rake task above, with: rake check:migrate:delete_duplicate_relationships
+    duplicates = Relationship.group(:target_id).having('COUNT(id) > 1').count
+    n = duplicates.size
+    i = 0
+    duplicates.each do |pm_id, count|
+      i += 1
+      puts "[#{Time.now}] #{i}/#{n}"
+      if count > 1
+        relationships = Relationship.where(target_id: pm_id).order('id ASC').to_a
+        # Keep the confirmed relationship, or the one whose model is image, video or audio... if none, keep the first one
+        keep = relationships.find{ |r| r.relationship_type == Relationship.confirmed_type } || relationships.find{ |r| ['image', 'video', 'audio'].include?(r.model) } || relationships.first
+        raise "No relationship to keep for target_id #{pm_id}!" if keep.nil?
+        relationships.each do |relationship|
+          if relationship.id == keep.id
+            puts "  Keeping relationship ##{r.id}"
+          else
+            puts "  Deleting relationship ##{r.id}"
+            relationship.destroy!
+          end
+          relationship.source.clear_cached_fields
+          relationship.target.clear_cached_fields
+        end
+      end
+    end
+
+    remove_index :relationships, name: 'index_relationships_on_target_id'
+    add_index :relationships, :target_id, unique: true
+  end
+end

--- a/db/migrate/20241123001206_add_unique_index_to_relationships_table.rb
+++ b/db/migrate/20241123001206_add_unique_index_to_relationships_table.rb
@@ -16,10 +16,10 @@ class AddUniqueIndexToRelationshipsTable < ActiveRecord::Migration[6.1]
         raise "No relationship to keep for target_id #{pm_id}!" if keep.nil?
         relationships.each do |relationship|
           if relationship.id == keep.id
-            puts "  Keeping relationship ##{r.id}"
+            puts "  Keeping relationship ##{relationship.id}"
           else
-            puts "  Deleting relationship ##{r.id}"
-            relationship.destroy!
+            puts "  Deleting relationship ##{relationship.id}"
+            relationship.delete
           end
           relationship.source.clear_cached_fields
           relationship.target.clear_cached_fields

--- a/db/migrate/20241123135242_add_trigger_to_relationships_table.rb
+++ b/db/migrate/20241123135242_add_trigger_to_relationships_table.rb
@@ -20,10 +20,10 @@ class AddTriggerToRelationshipsTable < ActiveRecord::Migration[6.1]
       $$ LANGUAGE plpgsql;
     SQL
 
-    # Attach the trigger to the table
+    # Attach the trigger to the table (only on INSERT - we shouldn't have it for UPDATE since we need to support reverting a relationship
     execute <<~SQL
       CREATE TRIGGER enforce_relationships
-      BEFORE INSERT OR UPDATE ON relationships
+      BEFORE INSERT ON relationships
       FOR EACH ROW
       EXECUTE FUNCTION validate_relationships();
     SQL

--- a/db/migrate/20241123135242_add_trigger_to_relationships_table.rb
+++ b/db/migrate/20241123135242_add_trigger_to_relationships_table.rb
@@ -1,0 +1,37 @@
+class AddTriggerToRelationshipsTable < ActiveRecord::Migration[6.1]
+  def up
+    # Create the trigger function
+    execute <<~SQL
+      CREATE OR REPLACE FUNCTION validate_relationships()
+      RETURNS TRIGGER AS $$
+      BEGIN
+          -- Check if source_id exists as a target_id
+          IF EXISTS (SELECT 1 FROM relationships WHERE target_id = NEW.source_id) THEN
+              RAISE EXCEPTION 'source_id % already exists as a target_id', NEW.source_id;
+          END IF;
+
+          -- Check if target_id exists as a source_id
+          IF EXISTS (SELECT 1 FROM relationships WHERE source_id = NEW.target_id) THEN
+              RAISE EXCEPTION 'target_id % already exists as a source_id', NEW.target_id;
+          END IF;
+
+          RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql;
+    SQL
+
+    # Attach the trigger to the table
+    execute <<~SQL
+      CREATE TRIGGER enforce_relationships
+      BEFORE INSERT OR UPDATE ON relationships
+      FOR EACH ROW
+      EXECUTE FUNCTION validate_relationships();
+    SQL
+  end
+
+  def down
+    # Remove the trigger and function if rolling back
+    execute "DROP TRIGGER IF EXISTS enforce_relationships ON relationships;"
+    execute "DROP FUNCTION IF EXISTS validate_relationships();"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_11_23_001206) do
+ActiveRecord::Schema.define(version: 2024_11_23_135242) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -120,6 +120,26 @@ ActiveRecord::Schema.define(version: 2024_11_23_001206) do
           RETURN dynamic_field_value;
         END;
         $function$
+  SQL
+  create_function :validate_relationships, sql_definition: <<-'SQL'
+      CREATE OR REPLACE FUNCTION public.validate_relationships()
+       RETURNS trigger
+       LANGUAGE plpgsql
+      AS $function$
+      BEGIN
+          -- Check if source_id exists as a target_id
+          IF EXISTS (SELECT 1 FROM relationships WHERE target_id = NEW.source_id) THEN
+              RAISE EXCEPTION 'source_id % already exists as a target_id', NEW.source_id;
+          END IF;
+
+          -- Check if target_id exists as a source_id
+          IF EXISTS (SELECT 1 FROM relationships WHERE source_id = NEW.target_id) THEN
+              RAISE EXCEPTION 'target_id % already exists as a source_id', NEW.target_id;
+          END IF;
+
+          RETURN NEW;
+      END;
+      $function$
   SQL
 
   create_table "account_sources", id: :serial, force: :cascade do |t|
@@ -292,7 +312,7 @@ ActiveRecord::Schema.define(version: 2024_11_23_001206) do
     t.jsonb "value_json", default: "{}"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
+    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY (ARRAY[('external_id'::character varying)::text, ('smooch_user_id'::character varying)::text, ('verification_status_status'::character varying)::text]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
     t.index ["annotation_id"], name: "index_dynamic_annotation_fields_on_annotation_id"
     t.index ["annotation_type"], name: "index_dynamic_annotation_fields_on_annotation_type"
@@ -962,4 +982,8 @@ ActiveRecord::Schema.define(version: 2024_11_23_001206) do
   add_foreign_key "project_media_requests", "project_medias"
   add_foreign_key "project_media_requests", "requests"
   add_foreign_key "requests", "feeds"
+
+  create_trigger :enforce_relationships, sql_definition: <<-SQL
+      CREATE TRIGGER enforce_relationships BEFORE INSERT OR UPDATE ON public.relationships FOR EACH ROW EXECUTE PROCEDURE validate_relationships()
+  SQL
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_10_15_223059) do
+ActiveRecord::Schema.define(version: 2024_11_23_001206) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -596,7 +596,7 @@ ActiveRecord::Schema.define(version: 2024_10_15_223059) do
     t.index ["source_id", "target_id", "relationship_type"], name: "relationship_index", unique: true
     t.index ["source_id"], name: "index_relationships_on_source_id"
     t.index ["target_id", "relationship_type"], name: "index_relationships_on_target_id_and_relationship_type"
-    t.index ["target_id"], name: "index_relationships_on_target_id"
+    t.index ["target_id"], name: "index_relationships_on_target_id", unique: true
     t.check_constraint "source_id <> target_id", name: "source_target_must_be_different"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -312,7 +312,7 @@ ActiveRecord::Schema.define(version: 2024_11_23_135242) do
     t.jsonb "value_json", default: "{}"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY (ARRAY[('external_id'::character varying)::text, ('smooch_user_id'::character varying)::text, ('verification_status_status'::character varying)::text]))"
+    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
     t.index ["annotation_id"], name: "index_dynamic_annotation_fields_on_annotation_id"
     t.index ["annotation_type"], name: "index_dynamic_annotation_fields_on_annotation_type"
@@ -984,6 +984,6 @@ ActiveRecord::Schema.define(version: 2024_11_23_135242) do
   add_foreign_key "requests", "feeds"
 
   create_trigger :enforce_relationships, sql_definition: <<-SQL
-      CREATE TRIGGER enforce_relationships BEFORE INSERT OR UPDATE ON public.relationships FOR EACH ROW EXECUTE PROCEDURE validate_relationships()
+      CREATE TRIGGER enforce_relationships BEFORE INSERT ON public.relationships FOR EACH ROW EXECUTE PROCEDURE validate_relationships()
   SQL
 end

--- a/lib/tasks/migrate/20230216030351_delete_duplicate_relationships.rake
+++ b/lib/tasks/migrate/20230216030351_delete_duplicate_relationships.rake
@@ -14,10 +14,10 @@ namespace :check do
           raise "No relationship to keep for target_id #{pm_id}!" if keep.nil?
           relationships.each do |relationship|
             if relationship.id == keep.id
-              puts "  Keeping relationship ##{r.id}"
+              puts "  Keeping relationship ##{relationship.id}"
             else
-              puts "  Deleting relationship ##{r.id}"
-              relationship.destroy!
+              puts "  Deleting relationship ##{relationship.id}"
+              relationship.delete
             end
             relationship.source.clear_cached_fields
             relationship.target.clear_cached_fields

--- a/lib/tasks/migrate/20230216030351_delete_duplicate_relationships.rake
+++ b/lib/tasks/migrate/20230216030351_delete_duplicate_relationships.rake
@@ -8,10 +8,10 @@ namespace :check do
         i += 1
         puts "[#{Time.now}] #{i}/#{n}"
         if count > 1
-          relationships = Relationship.where(target_id: pm_id).to_a
-          # Keep the relationship whose model is image, video or audio... if none, keep the first one
-          keep = relationships.find{ |r| ['image', 'video', 'audio'].include?(r.model) } || relationships.first
-          raise "No relationship to keeo for target_id #{pm_id}!" if keep.nil?
+          relationships = Relationship.where(target_id: pm_id).order('id ASC').to_a
+          # Keep the confirmed relationship, or the one whose model is image, video or audio... if none, keep the first one
+          keep = relationships.find{ |r| r.relationship_type == Relationship.confirmed_type } || relationships.find{ |r| ['image', 'video', 'audio'].include?(r.model) } || relationships.first
+          raise "No relationship to keep for target_id #{pm_id}!" if keep.nil?
           relationships.each do |relationship|
             if relationship.id == keep.id
               puts "  Keeping relationship ##{r.id}"
@@ -19,6 +19,8 @@ namespace :check do
               puts "  Deleting relationship ##{r.id}"
               relationship.destroy!
             end
+            relationship.source.clear_cached_fields
+            relationship.target.clear_cached_fields
           end
         end
       end

--- a/test/models/bot/smooch_3_test.rb
+++ b/test/models/bot/smooch_3_test.rb
@@ -298,21 +298,21 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
       r = Relationship.last
       assert_equal [pm_l1.id, pm.id].sort, [r.source_id, r.target_id].sort
       # 5) Send two messages with the same text but different links
-      link_long_text3 = @link_url_2.concat(' ').concat(long_text.join(' '))
+      link_long_text3 = @link_url_2.concat(' ').concat(long_text.join(' ')).concat(' ').concat(random_string)
       message = {
         '_id': random_string,
         authorId: uid,
         type: 'text',
-        source: { type: "whatsapp" },
+        source: { type: 'whatsapp' },
         text: link_long_text3,
       }
       payload[:messages] = [message]
       Bot::Smooch.run(payload.to_json)
       sleep 1
-      assert_difference 'ProjectMedia.count' do
+      assert_difference 'ProjectMedia.count', 2 do
         assert_difference 'Relationship.count' do
           assert_difference 'Link.count' do
-            assert_no_difference 'Claim.count' do
+            assert_difference 'Claim.count' do
               Sidekiq::Worker.drain_all
             end
           end
@@ -320,7 +320,7 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
       end
       pm = ProjectMedia.last
       r = Relationship.last
-      assert_equal [pm_c1.id, pm.id].sort, [r.source_id, r.target_id].sort
+      assert_equal pm.id, r.target_id
     end
   end
 

--- a/test/models/relationship_2_test.rb
+++ b/test/models/relationship_2_test.rb
@@ -420,4 +420,46 @@ class Relationship2Test < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should belong to only one media cluster" do
+    t = create_team
+    pm1 = create_project_media team: t
+    pm2 = create_project_media team: t
+    pm3 = create_project_media team: t
+
+    # Create a relationship between two items
+    assert_difference 'Relationship.count' do
+      assert_nothing_raised do
+        create_relationship source_id: pm1.id, target_id: pm2.id
+      end
+    end
+
+    # If an item is already a parent, it can't be a child in another relationship
+    assert_no_difference 'Relationship.count' do
+      assert_raises ActiveRecord::StatementInvalid do
+        create_relationship source_id: pm3.id, target_id: pm1.id
+      end
+    end
+
+    # If an item is already a child, it can't be a child in another relationship
+    assert_no_difference 'Relationship.count' do
+      assert_raises ActiveRecord::StatementInvalid do
+        create_relationship source_id: pm3.id, target_id: pm2.id
+      end
+    end
+
+    # If an item is already a child, it can't be a parent in another relationship
+    assert_no_difference 'Relationship.count' do
+      assert_raises ActiveRecord::StatementInvalid do
+        create_relationship source_id: pm2.id, target_id: pm3.id
+      end
+    end
+
+    # If an item is already a parent, it can still have another child
+    assert_difference 'Relationship.count' do
+      assert_nothing_raised do
+        create_relationship source_id: pm1.id, target_id: pm3.id
+      end
+    end
+  end
 end

--- a/test/models/relationship_2_test.rb
+++ b/test/models/relationship_2_test.rb
@@ -426,18 +426,12 @@ class Relationship2Test < ActiveSupport::TestCase
     pm1 = create_project_media team: t
     pm2 = create_project_media team: t
     pm3 = create_project_media team: t
+    pm4 = create_project_media team: t
 
     # Create a relationship between two items
     assert_difference 'Relationship.count' do
       assert_nothing_raised do
         create_relationship source_id: pm1.id, target_id: pm2.id
-      end
-    end
-
-    # If an item is already a parent, it can't be a child in another relationship
-    assert_no_difference 'Relationship.count' do
-      assert_raises ActiveRecord::StatementInvalid do
-        create_relationship source_id: pm3.id, target_id: pm1.id
       end
     end
 
@@ -455,10 +449,17 @@ class Relationship2Test < ActiveSupport::TestCase
       end
     end
 
+    # If an item is already a parent, it can't be a child in another relationship - move targets to new relationship
+    assert_equal 1, Relationship.where(source_id: pm1.id).count
+    assert_equal 0, Relationship.where(source_id: pm3.id).count
+    create_relationship source_id: pm3.id, target_id: pm1.id
+    assert_equal 0, Relationship.where(source_id: pm1.id).count
+    assert_equal 2, Relationship.where(source_id: pm3.id).count
+
     # If an item is already a parent, it can still have another child
     assert_difference 'Relationship.count' do
       assert_nothing_raised do
-        create_relationship source_id: pm1.id, target_id: pm3.id
+        create_relationship source_id: pm3.id, target_id: pm4.id
       end
     end
   end

--- a/test/models/relationship_2_test.rb
+++ b/test/models/relationship_2_test.rb
@@ -463,4 +463,29 @@ class Relationship2Test < ActiveSupport::TestCase
       end
     end
   end
+
+  # If we're trying to create a relationship between C (target_id) and B (source_id), but there is already a relationship between A (source_id) and B (target_id),
+  # then, instead, create the relationship between A (source_id) and C (target_id) (so, if A's cluster contains B, then C comes in and our algorithm says C is similar
+  # to B, it is added to A's cluster). Exception: If the relationship between A (source_id) and B (target_id) is a suggestion, we should not create any relationship
+  # at all when trying to create a relationship between C (target_id) and B (source_id) (regardless if it’s a suggestion or a confirmed match) - but we should log that case.
+  test "should add to existing media cluster" do
+    t = create_team
+    a = create_project_media team: t
+    b = create_project_media team: t
+    c = create_project_media team: t
+    Relationship.create_unless_exists(a.id, b.id, Relationship.confirmed_type)
+    Relationship.create_unless_exists(b.id, c.id, Relationship.confirmed_type)
+    assert !Relationship.where(source: b, target: c).exists?
+    assert Relationship.where(source: a, target: b).exists?
+    assert Relationship.where(source: a, target: c).exists?
+
+    a = create_project_media team: t
+    b = create_project_media team: t
+    c = create_project_media team: t
+    Relationship.create_unless_exists(a.id, b.id, Relationship.suggested_type)
+    Relationship.create_unless_exists(b.id, c.id, Relationship.confirmed_type)
+    assert !Relationship.where(source: b, target: c).exists?
+    assert Relationship.where(source: a, target: b).exists?
+    assert !Relationship.where(source: a, target: c).exists?
+  end
 end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -380,21 +380,23 @@ class RelationshipTest < ActiveSupport::TestCase
   end
 
   test "should move similar items when export item" do
+    Sidekiq::Testing.fake!
     t = create_team
-    pm = create_project_media team: t
+    pm1 = create_project_media team: t
     pm2 = create_project_media team: t
-    pm_1 = create_project_media team: t
-    pm_2 = create_project_media team: t
-    pm2_1 = create_project_media team: t
-    # Add pm_1 & pm_2 as a similar item to pm
-    create_relationship source_id: pm.id, target_id: pm_1.id, relationship_type: Relationship.suggested_type
-    create_relationship source_id: pm.id, target_id: pm_2.id, relationship_type: Relationship.suggested_type
-    # Add pm_1 & pm2_1 as a similar item to pm2
-    create_relationship source_id: pm2.id, target_id: pm_1.id, relationship_type: Relationship.suggested_type
-    create_relationship source_id: pm.id, target_id: pm2_1.id, relationship_type: Relationship.suggested_type
-    # Expose pm to pm2
-    create_relationship source_id: pm.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
-    assert_equal 3, Relationship.where(source_id: pm.id, relationship_type: Relationship.suggested_type).count
+    pm1a = create_project_media team: t
+    pm1b = create_project_media team: t
+    pm2a = create_project_media team: t
+    pm2b = create_project_media team: t
+    # Add pm1a & pm1b as a similar items to pm1
+    create_relationship source_id: pm1.id, target_id: pm1a.id, relationship_type: Relationship.suggested_type
+    create_relationship source_id: pm1.id, target_id: pm1b.id, relationship_type: Relationship.suggested_type
+    # Add pm2a & pm2b as a similar items to pm2
+    create_relationship source_id: pm2.id, target_id: pm2a.id, relationship_type: Relationship.suggested_type
+    create_relationship source_id: pm2.id, target_id: pm2b.id, relationship_type: Relationship.suggested_type
+    # Export pm1 to pm2
+    create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.confirmed_type
+    assert_equal 4, Relationship.where(source_id: pm1.id, relationship_type: Relationship.suggested_type).count
     assert_equal 0, Relationship.where(source_id: pm2.id, relationship_type: Relationship.suggested_type).count
   end
 end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -277,15 +277,17 @@ class RelationshipTest < ActiveSupport::TestCase
     t = create_team
     pm1 = create_project_media team: t
     pm2 = create_project_media team: t
-    assert_nothing_raised do
+    assert_difference 'Relationship.count' do
       create_relationship source_id: pm1.id, target_id: pm2.id
     end
-    assert_raises 'ActiveRecord::RecordNotUnique' do
+    assert_no_difference 'Relationship.count' do
       create_relationship source_id: pm2.id, target_id: pm1.id
     end
     pm3 = create_project_media
-    assert_raises 'ActiveRecord::RecordInvalid' do
-      create_relationship source_id: pm3.id, target_id: pm3.id
+    assert_no_difference 'Relationship.count' do
+      assert_raises ActiveRecord::RecordInvalid do
+        create_relationship source_id: pm3.id, target_id: pm3.id
+      end
     end
   end
 


### PR DESCRIPTION
## Description

Make sure that items can belong to maximum one media cluster. Steps:

- [x] Add a database migration that adds a unique index for the `target_id` column of the `relationships` table
- [x] Add a database migration that adds a trigger that guarantees that an item is either parent or child, never both (so, if there is already the value X for a `source_id`, then there can't be a `target_id` with that same value, and vice-versa)
- [x] Implement unit tests to guarantee the two situations above
- [x] Add a migration rake task to delete duplicate relationships (and copy that same logic to the migration above)
- [x] Make sure that we're using `Relationship.create_unless_exists` everywhere, instead of using `Relationship.new` or `Relationship.create`
- [x] Implement this logic for the `Relationship.create_unless_exists` method: If we’re trying to create a relationship between C (target_id) and B (source_id), but there is already a relationship between A (source_id) and B (target_id), then, instead, create the relationship between A (source_id) and C (target_id) (so, if A's cluster contains B, then C comes in and our algorithm says C is similar to B, it is added to A's cluster). Exception: If the relationship between A (source_id) and B (target_id) is a suggestion, we should not create any relationship at all when trying to create a relationship between C (target_id) and B (source_id) (regardless if it’s a suggestion or a confirmed match) - but we should log that case.
- [x] Make sure that this logic also works for the relationships between media and caption (and between link and text message) created by the Smooch Bot

Reference: CV2-5653.

## How has this been tested?

Unit tests implemented.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)