### PR TITLE
CV2-5717: update es parent_id after pin another item

### DIFF
--- a/lib/tasks/migrate/20220224213611_fix_parent_id_for_suggested_items.rake
+++ b/lib/tasks/migrate/20220224213611_fix_parent_id_for_suggested_items.rake
@@ -82,7 +82,7 @@ namespace :check do
         last_team_id = Rails.cache.read('check:migrate:fix_parent_id_for_suggested_list:team_id') || 0
       else
         last_team_id = 0
-        team_condition = { slug: data_args['slug'] } unless data_args['slug'].blank?
+        team_condition = { slug: data_args['slug'] }
       end
       index_alias = CheckElasticSearchModel.get_index_alias
       Team.where('id > ?', last_team_id).where(team_condition).find_each do |team|

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -51,7 +51,7 @@ class RelationshipTest < ActiveSupport::TestCase
     r.save!
     r2 = create_relationship source_id: pm_s.id, target_id: pm_t2.id, relationship_type: Relationship.confirmed_type
     r3 = create_relationship source_id: pm_s.id, target_id: pm_t3.id, relationship_type: Relationship.suggested_type
-    sleep 2
+    sleep 1
     es_s = $repository.find(get_es_id(pm_s))
     assert_equal pm_s.id, es_s['parent_id']
     assert_equal pm_s.reload.sources_count, es_s['sources_count']
@@ -67,22 +67,21 @@ class RelationshipTest < ActiveSupport::TestCase
     r2.target_id = pm_s.id
     r2.disable_es_callbacks = false
     r2.save!
-    # TODO: fix tests
-    # sleep 2
-    # es_t2 = $repository.find(get_es_id(pm_t2))
-    # assert_equal pm_t2.id, es_t2['parent_id']
-    # assert_equal pm_t2.reload.sources_count, es_t2['sources_count']
-    # assert_equal 0, pm_t2.reload.sources_count
-    # [pm_s, pm_t].each do |pm|
-    #   es = $repository.find(get_es_id(pm))
-    #   assert_equal pm_t2.id, es['parent_id']
-    #   assert_equal pm.reload.sources_count, es['sources_count']
-    #   assert_equal 1, pm.reload.sources_count
-    # end
+    sleep 1
+    es_t2 = $repository.find(get_es_id(pm_t2))
+    assert_equal pm_t2.id, es_t2['parent_id']
+    assert_equal pm_t2.reload.sources_count, es_t2['sources_count']
+    assert_equal 0, pm_t2.reload.sources_count
+    [pm_s, pm_t].each do |pm|
+      es = $repository.find(get_es_id(pm))
+      assert_equal pm_t2.id, es['parent_id']
+      assert_equal pm.reload.sources_count, es['sources_count']
+      assert_equal 1, pm.reload.sources_count
+    end
     # Verify destory
-    # r.destroy!
-    # es_t = $repository.find(get_es_id(pm_t))
-    # assert_equal pm_t.id, es_t['parent_id']
+    r.destroy!
+    es_t = $repository.find(get_es_id(pm_t))
+    assert_equal pm_t.id, es_t['parent_id']
   end
 
   test "should remove suggested relation when same items added as similar" do


### PR DESCRIPTION
## Description

Update `parent_id` field in ES for source and target items after user pin a project media item .

References: CV2-5717

## How has this been tested?

Implemented automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

