### PR TITLE
Support WhatsApp newsletter templates with an "unsubscribe" button

### DIFF
--- a/app/models/concerns/smooch_resend.rb
+++ b/app/models/concerns/smooch_resend.rb
@@ -109,13 +109,19 @@ module SmoochResend
     end
 
     def clicked_on_template_button?(message)
-      ['report', 'message'].include?(self.get_information_from_clicked_template_button(message).first.to_s)
+      ['report', 'message', 'newsletter'].include?(self.get_information_from_clicked_template_button(message).first.to_s)
     end
 
     def get_information_from_clicked_template_button(message, delete = false)
       quoted_id = message.dig('quotedMessage', 'content', '_id')
       unless quoted_id.blank?
-        info = Rails.cache.read("smooch:original:#{quoted_id}").to_s.split(':')
+        info = Rails.cache.read("smooch:original:#{quoted_id}").to_s
+        begin
+          original = JSON.parse(info)
+          info = ['newsletter'] if original['fallback_template'] == 'newsletter'
+        rescue
+          info = info.split(':')
+        end
         Rails.cache.delete("smooch:original:#{quoted_id}") if delete
         return info
       end
@@ -130,6 +136,9 @@ module SmoochResend
         self.send_report_on_template_button_click(message, uid, language, info)
       when 'message'
         self.send_message_on_template_button_click(message, uid, language, info)
+      when 'newsletter'
+        team_id = self.config['team_id'].to_i
+        self.toggle_subscription(uid, language, team_id, self.get_platform_from_message(message), self.get_workflow(language)) if self.user_is_subscribed_to_newsletter?(uid, language, team_id)
       end
     end
   end


### PR DESCRIPTION
## Description

To help reduce the number of spam reports and avoid reduction in quality scores we should allow users to unsubscribe from a newsletter when delivered. As far as Check API is concerned, this means supporting WhatsApp newsletter templates that have an "unsubscribe" button.

References: CV2-5252.

Steps:

- [x] Implement the feature: Call the "unsubscribe" action when a newsletter template button is clicked.
- [x] Implement a unit test.

## How has this been tested?

![Captura de tela de 2024-11-28 23-20-40](https://github.com/user-attachments/assets/328eb173-eb79-4e37-aa97-c0770978fb5d)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)