### PR TITLE
CV2-5617: use workspace similarity settings for explainers

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -275,7 +275,7 @@ class Bot::Alegre < BotUser
   end
 
   def self.get_matching_key_value(pm, media_type, similarity_method, automatic, model_name)
-    self.get_threshold_given_model_settings(team_id, media_type, similarity_method, automatic, model_name)
+    self.get_threshold_given_model_settings(pm.team_id, media_type, similarity_method, automatic, model_name)
   end
 
   def self.get_similarity_methods_and_models_given_media_type_and_team_id(media_type, team_id, get_vector_settings)

--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -257,7 +257,8 @@ class Bot::Alegre < BotUser
   end
 
   def self.get_threshold_given_model_settings(team_id, media_type, similarity_method, automatic, model_name)
-    tbi = self.get_alegre_tbi(team_id)
+    tbi = nil
+    tbi = self.get_alegre_tbi(team_id) unless team_id.nil?
     similarity_level = automatic ? 'matching' : 'suggestion'
     generic_key = "#{media_type}_#{similarity_method}_#{similarity_level}_threshold"
     specific_key = "#{media_type}_#{similarity_method}_#{model_name}_#{similarity_level}_threshold"
@@ -275,7 +276,7 @@ class Bot::Alegre < BotUser
   end
 
   def self.get_matching_key_value(pm, media_type, similarity_method, automatic, model_name)
-    self.get_threshold_given_model_settings(pm.team_id, media_type, similarity_method, automatic, model_name)
+    self.get_threshold_given_model_settings(pm&.team_id, media_type, similarity_method, automatic, model_name)
   end
 
   def self.get_similarity_methods_and_models_given_media_type_and_team_id(media_type, team_id, get_vector_settings)
@@ -292,7 +293,7 @@ class Bot::Alegre < BotUser
   end
 
   def self.get_threshold_for_query(media_type, pm, automatic = false)
-    self.get_similarity_methods_and_models_given_media_type_and_team_id(media_type, pm.team_id, !pm.nil?).collect do |similarity_method, model_name|
+    self.get_similarity_methods_and_models_given_media_type_and_team_id(media_type, pm&.team_id, !pm.nil?).collect do |similarity_method, model_name|
       key, value = self.get_matching_key_value(pm, media_type, similarity_method, automatic, model_name)
       { value: value.to_f, key: key, automatic: automatic, model: model_name}
     end

--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -256,11 +256,11 @@ class Bot::Alegre < BotUser
     end
   end
 
-  def self.get_matching_key_value(pm, media_type, similarity_method, automatic, model_name)
+  def self.get_threshold_given_model_settings(team_id, media_type, similarity_method, automatic, model_name)
+    tbi = self.get_alegre_tbi(team_id)
     similarity_level = automatic ? 'matching' : 'suggestion'
     generic_key = "#{media_type}_#{similarity_method}_#{similarity_level}_threshold"
     specific_key = "#{media_type}_#{similarity_method}_#{model_name}_#{similarity_level}_threshold"
-    tbi = self.get_alegre_tbi(pm&.team_id)
     settings = tbi.alegre_settings unless tbi.nil?
     outkey = ""
     value = nil
@@ -274,17 +274,25 @@ class Bot::Alegre < BotUser
     return [outkey, value]
   end
 
-  def self.get_threshold_for_query(media_type, pm, automatic = false)
+  def self.get_matching_key_value(pm, media_type, similarity_method, automatic, model_name)
+    self.get_threshold_given_model_settings(team_id, media_type, similarity_method, automatic, model_name)
+  end
+
+  def self.get_similarity_methods_and_models_given_media_type_and_team_id(media_type, team_id, get_vector_settings)
     similarity_methods = media_type == 'text' ? ['elasticsearch'] : ['hash']
     models = similarity_methods.dup
-    if media_type == 'text' && !pm.nil?
-      models_to_use = [self.matching_model_to_use(pm.team_id)].flatten-[Bot::Alegre::ELASTICSEARCH_MODEL]
+    if media_type == 'text' && get_vector_settings
+      models_to_use = [self.matching_model_to_use(team_id)].flatten-[Bot::Alegre::ELASTICSEARCH_MODEL]
       models_to_use.each do |model|
         similarity_methods << 'vector'
         models << model
       end
     end
-    similarity_methods.zip(models).collect do |similarity_method, model_name|
+    return similarity_methods.zip(models)
+  end
+
+  def self.get_threshold_for_query(media_type, pm, automatic = false)
+    self.get_similarity_methods_and_models_given_media_type_and_team_id(media_type, pm.team_id, !pm.nil?).collect do |similarity_method, model_name|
       key, value = self.get_matching_key_value(pm, media_type, similarity_method, automatic, model_name)
       { value: value.to_f, key: key, automatic: automatic, model: model_name}
     end

--- a/app/models/explainer.rb
+++ b/app/models/explainer.rb
@@ -65,7 +65,7 @@ class Explainer < ApplicationRecord
       explainer_id: explainer.id
     }
 
-    models_thresholds = Explainer.get_alegre_models_and_thresholds(explainer.team_id).collect{|m| m[:model]}
+    models_thresholds = Explainer.get_alegre_models_and_thresholds(explainer.team_id).keys
     # Index title
     params = {
       content_hash: Bot::Alegre.content_hash_for_value(explainer.title),
@@ -111,7 +111,7 @@ class Explainer < ApplicationRecord
     context[:language] = language unless language.nil?
     params = {
       text: text,
-      models: models_thresholds.collect{|m| m[:model]},
+      models: models_thresholds.keys,
       per_model_threshold: models_thresholds,
       context: context
 
@@ -123,10 +123,12 @@ class Explainer < ApplicationRecord
   end
 
   def self.get_alegre_models_and_thresholds(team_id)
+    models_thresholds = {}
     Bot::Alegre.get_similarity_methods_and_models_given_media_type_and_team_id("text", team_id, true).map do |similarity_method, model_name|
       _, value = Bot::Alegre.get_threshold_given_model_settings(team_id, "text", similarity_method, true, model_name)
-      {model: model_name, value: value}
+      models_thresholds[model_name] = value
     end
+    models_thresholds
   end
 
   private

--- a/app/models/explainer.rb
+++ b/app/models/explainer.rb
@@ -65,7 +65,7 @@ class Explainer < ApplicationRecord
       explainer_id: explainer.id
     }
 
-    models_thresholds = Explainer.get_alegre_models_and_thresholds(explainer.team_id).keys
+    models_thresholds = Explainer.get_alegre_models_and_thresholds(explainer.team_id).collect{|m| m[:model]}
     # Index title
     params = {
       content_hash: Bot::Alegre.content_hash_for_value(explainer.title),
@@ -111,7 +111,7 @@ class Explainer < ApplicationRecord
     context[:language] = language unless language.nil?
     params = {
       text: text,
-      models: models_thresholds.keys,
+      models: models_thresholds.collect{|m| m[:model]},
       per_model_threshold: models_thresholds,
       context: context
 

--- a/app/models/explainer.rb
+++ b/app/models/explainer.rb
@@ -1,12 +1,6 @@
 class Explainer < ApplicationRecord
   include Article
 
-  # FIXME: Read from workspace settings
-  # ALEGRE_MODELS_AND_THRESHOLDS = {
-  #   # Bot::Alegre::ELASTICSEARCH_MODEL => 0.8 # Sometimes this is easier for local development
-  #   Bot::Alegre::PARAPHRASE_MULTILINGUAL_MODEL => 0.7
-  # }
-
   belongs_to :team
 
   has_annotations
@@ -128,7 +122,7 @@ class Explainer < ApplicationRecord
 
   def self.get_alegre_models_and_thresholds(team_id)
     tbi = Bot::Alegre.get_alegre_tbi(team_id)
-    tbi.get_alegre_models_and_thresholds || { Bot::Alegre::PARAPHRASE_MULTILINGUAL_MODEL => 0.7 }
+    tbi&.get_alegre_models_and_thresholds || { Bot::Alegre::PARAPHRASE_MULTILINGUAL_MODEL => 0.7 }
   end
 
   private

--- a/app/models/explainer.rb
+++ b/app/models/explainer.rb
@@ -123,8 +123,10 @@ class Explainer < ApplicationRecord
   end
 
   def self.get_alegre_models_and_thresholds(team_id)
-    tbi = Bot::Alegre.get_alegre_tbi(team_id)
-    tbi&.get_alegre_models_and_thresholds || { Bot::Alegre::PARAPHRASE_MULTILINGUAL_MODEL => 0.7 }
+    Bot::Alegre.get_similarity_methods_and_models_given_media_type_and_team_id("text", team_id, true).map do |similarity_method, model_name|
+      _, value = Bot::Alegre.get_threshold_given_model_settings(team_id, "text", similarity_method, true, model_name)
+      {model: model_name, value: value}
+    end
   end
 
   private

--- a/test/models/explainer_test.rb
+++ b/test/models/explainer_test.rb
@@ -153,4 +153,10 @@ class ExplainerTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should get alegre models_and_thresholds in hash formatt" do
+    ex = create_explainer
+    models_thresholds = Explainer.get_alegre_models_and_thresholds(ex.team_id)
+    assert_kind_of Hash, models_thresholds
+  end
 end


### PR DESCRIPTION
## Description

Use workspace similarity settings for explainers instead of hard-coded 

References: CV2-5617

## How has this been tested?

Re-run automated tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

