### PR TITLE
"Unsubscribe" the user from the newsletter language, not the current language

### DIFF
--- a/app/models/concerns/smooch_resend.rb
+++ b/app/models/concerns/smooch_resend.rb
@@ -118,7 +118,7 @@ module SmoochResend
         info = Rails.cache.read("smooch:original:#{quoted_id}").to_s
         begin
           original = JSON.parse(info)
-          info = ['newsletter'] if original['fallback_template'] == 'newsletter'
+          info = ['newsletter', original['language']] if original['fallback_template'] == 'newsletter'
         rescue
           info = info.split(':')
         end
@@ -138,6 +138,7 @@ module SmoochResend
         self.send_message_on_template_button_click(message, uid, language, info)
       when 'newsletter'
         team_id = self.config['team_id'].to_i
+        language = info[1] || language
         self.toggle_subscription(uid, language, team_id, self.get_platform_from_message(message), self.get_workflow(language)) if self.user_is_subscribed_to_newsletter?(uid, language, team_id)
       end
     end


### PR DESCRIPTION
## Description

When a tipline user is interacting with the bot in a certain language but clicks on the "Unsubscribe" button from a newsletter, the affected subscription should be the one related to the newsletter language, not the current language.

So, the first here is to use the language stored in the delivered message reference, not the current language, which is still used as a fallback.

Fixes: CV2-5252.

## How has this been tested?

Existing tests should cover this.

## Things to pay attention to during code review

![Captura de tela de 2024-12-04 21-09-54](https://github.com/user-attachments/assets/9088c55c-2614-422b-9841-328cd0beb7f7)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)