### PR TITLE
Add Helper Method to Create and Publish Standalone Fact Checks for Check Web Testing

### DIFF
--- a/app/controllers/test_controller.rb
+++ b/app/controllers/test_controller.rb
@@ -243,19 +243,19 @@ class TestController < ApplicationController
       team: team
     )
 
-   # Set up FactCheck
-  fact_check = FactCheck.new(
-    claim_description: claim_description,
-    title: title,
-    summary: summary,
-    url: url,
-    language: language,
-    user: user,
-    publish_report: true,
-    report_status: 'published'
-  )
-  fact_check.save!
-  render_success 'fact_check', fact_check
+    # Set up FactCheck
+    fact_check = FactCheck.new(
+      claim_description: claim_description,
+      title: title,
+      summary: summary,
+      url: url,
+      language: language,
+      user: user,
+      publish_report: true,
+      report_status: 'published'
+    )
+    fact_check.save!
+    render_success 'fact_check', fact_check
   end
 
   def random

--- a/app/controllers/test_controller.rb
+++ b/app/controllers/test_controller.rb
@@ -225,6 +225,39 @@ class TestController < ApplicationController
     render_success 'suggest_similarity', pm1
   end
 
+  def create_imported_standalone_fact_check
+    team = Team.current = Team.find(params[:team_id])
+    user = User.where(email: params[:email]).last
+    description = params[:description]
+    context = params[:context]
+    title = params[:title]
+    summary = params[:summary]
+    url = params[:url]
+    language = params[:language] || 'en'
+
+    # Create ClaimDescription
+    claim_description = ClaimDescription.create!(
+      description: description,
+      context: context,
+      user: user,
+      team: team
+    )
+
+   # Set up FactCheck
+  fact_check = FactCheck.new(
+    claim_description: claim_description,
+    title: title,
+    summary: summary,
+    url: url,
+    language: language,
+    user: user,
+    publish_report: true,
+    report_status: 'published'
+  )
+  fact_check.save!
+  render_success 'fact_check', fact_check
+  end
+
   def random
     render html: "<!doctype html><html><head><title>Test #{rand(100000).to_i}</title></head><body>Test</body></html>".html_safe
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,5 +79,6 @@ Rails.application.routes.draw do
   match '/test/suggest_similarity' => 'test#suggest_similarity_item', via: :get
   match '/test/install_bot' => 'test#install_bot', via: :get
   match '/test/add_team_user' => 'test#add_team_user', via: :get
+  match '/test/create_imported_standalone_fact_check' => 'test#create_imported_standalone_fact_check', via: :get
   match '/test/random' => 'test#random', via: :get
 end

--- a/test/controllers/test_controller_test.rb
+++ b/test/controllers/test_controller_test.rb
@@ -499,16 +499,18 @@ class TestControllerTest < ActionController::TestCase
     user = create_user
     create_team_user(user: user, team: team)
 
-    get :create_imported_standalone_fact_check, params: {
-      team_id: team.id,
-      email: user.email,
-      description: 'Test description',
-      context: 'Test context',
-      title: 'Test title',
-      summary: 'Test summary',
-      url: 'http://example.com',
-      language: 'en'
-    }
+    assert_difference 'FactCheck.count' do
+      get :create_imported_standalone_fact_check, params: {
+        team_id: team.id,
+        email: user.email,
+        description: 'Test description',
+        context: 'Test context',
+        title: 'Test title',
+        summary: 'Test summary',
+        url: 'http://example.com',
+        language: 'en'
+      }
+    end
 
     assert_response :success
   end
@@ -521,16 +523,18 @@ class TestControllerTest < ActionController::TestCase
     user = create_user
     create_team_user(user: user, team: team)
 
-    get :create_imported_standalone_fact_check, params: {
-      team_id: team.id,
-      email: user.email,
-      description: 'Test description',
-      context: 'Test context',
-      title: 'Test title',
-      summary: 'Test summary',
-      url: 'http://example.com',
-      language: 'en'
-    }
+    assert_no_difference 'FactCheck.count' do
+      get :create_imported_standalone_fact_check, params: {
+        team_id: team.id,
+        email: user.email,
+        description: 'Test description',
+        context: 'Test context',
+        title: 'Test title',
+        summary: 'Test summary',
+        url: 'http://example.com',
+        language: 'en'
+      }
+    end
 
     assert_response 400
     Rails.unstub(:env)

--- a/test/controllers/test_controller_test.rb
+++ b/test/controllers/test_controller_test.rb
@@ -493,6 +493,49 @@ class TestControllerTest < ActionController::TestCase
     Rails.unstub(:env)
   end
 
+  test "should create standalone fact check and associate with the team" do
+    # Test setup
+    team = create_team
+    user = create_user
+    create_team_user(user: user, team: team)
+
+    get :create_imported_standalone_fact_check, params: {
+      team_id: team.id,
+      email: user.email,
+      description: 'Test description',
+      context: 'Test context',
+      title: 'Test title',
+      summary: 'Test summary',
+      url: 'http://example.com',
+      language: 'en'
+    }
+
+    assert_response :success
+  end
+
+  test "should not create standalone fact check and associate with the team" do
+    Rails.stubs(:env).returns('development')
+
+    # Test setup
+    team = create_team
+    user = create_user
+    create_team_user(user: user, team: team)
+
+    get :create_imported_standalone_fact_check, params: {
+      team_id: team.id,
+      email: user.email,
+      description: 'Test description',
+      context: 'Test context',
+      title: 'Test title',
+      summary: 'Test summary',
+      url: 'http://example.com',
+      language: 'en'
+    }
+
+    assert_response 400
+    Rails.unstub(:env)
+  end
+
   test "should get a random number in HTML" do
     get :random
     assert_response :success


### PR DESCRIPTION
## Description

- Create_imported_standalone_fact_check method in TestController to create a standalone and published fact check and associate it with a team.
- Updated `routes.rb` to include the new endpoint for fact checks.
- Added tests for the create_imported_standalone_fact_check

Reference: CV2-5737

## How has this been tested?
- tested with unit tests for the new method 

## Checklist

- [ ] I have performed a self-review of my own code
- [X] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

