### PR TITLE
Ensure that null is not returned as the item when creating an imported fact-check with original media in the GraphQL API.

### DIFF
--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -430,7 +430,7 @@ class ProjectMedia < ApplicationRecord
     self.team.apply_rules_and_actions(self, rule_ids)
   end
 
-  def self.handle_fact_check_for_existing_claim(existing_pm,new_pm)
+  def self.handle_fact_check_for_existing_claim(existing_pm, new_pm)
     if existing_pm.fact_check.blank?
       existing_pm.append_fact_check_from(new_pm)
       return existing_pm
@@ -440,6 +440,7 @@ class ProjectMedia < ApplicationRecord
         return new_pm
       end
     end
+    new_pm
   end
 
   def append_fact_check_from(new_pm)

--- a/test/models/project_media_7_test.rb
+++ b/test/models/project_media_7_test.rb
@@ -163,4 +163,13 @@ class ProjectMedia7Test < ActiveSupport::TestCase
     sleep 1
     assert_equal [pm1.fact_check_id, pm2.fact_check_id, pm3.fact_check_id].sort, pm_i.get_similar_articles.map(&:id).sort
   end
+
+  test "should not return null when handling fact-check for existing media" do
+    t = create_team
+    pm1 = create_project_media team: t
+    c = create_claim_description project_media: pm1
+    create_fact_check claim_description: c, language: 'en'
+    pm2 = ProjectMedia.new team: t, set_fact_check: { 'language' => 'en' }
+    assert_not_nil ProjectMedia.handle_fact_check_for_existing_claim(pm1, pm2)
+  end
 end


### PR DESCRIPTION
## Description

When handling existing media to determine whether the imported fact-check will be added to or appended to the existing media, there was a scenario where the media already contained a fact-check in the same language being imported. In that scenario, nil was being returned. This PR fixes the issue by ensuring that a new object is returned in such cases, allowing the validations to handle whether the object is persisted or fails.

Fixes: CV2-5804.

## How has this been tested?

TDD. I added a unit test that was able to reproduce the issue.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

