### PR TITLE
CV2-5789 dont send null values out to presto from check-api

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -153,10 +153,10 @@ class Bot::Alegre < BotUser
         Rails.logger.info("[Alegre Bot] [ProjectMedia ##{pm.id}] This item was just created, processing...")
         self.get_language(pm)
         if ['audio', 'image', 'video'].include?(self.get_pm_type(pm))
-          self.relate_project_media_async(pm)
+          self.relate_project_media_async(pm) if self.media_file_url(pm)
         else
-          self.relate_project_media_async(pm, 'original_title')
-          self.relate_project_media_async(pm, 'original_description')
+          self.relate_project_media_async(pm, 'original_title') if pm.original_title
+          self.relate_project_media_async(pm, 'original_description') if pm.original_description
         end
         self.get_extracted_text(pm)
         self.get_flags(pm)


### PR DESCRIPTION
## Description

We have a minor, persistent Sentry error where we are sending null items from Check API to Alegre (and eventually Presto) to match them for similarity. This ticket skips those cases, as it ought to, to stop unnecessary work and stop the minor error stream.

References: CV2-5789

## How has this been tested?

I added a PR and deployed for Presto to get more instrumentation with regards to the origin of null vectorization requests. They came through as vanilla requests for encoding against `original_title` and `original_description` fields as we do in these lines. This is likely the predominant candidate for where this happens. I tried to look for a more "unified" approach but couldn't quite come up with some generic preflight check that didn't end up just adding more complexity than was warranted.

## Things to pay attention to during code review

Any other candidates? I'm of the opinion that we solve these ones and see if we see more cases rather than hunt them all down pre-emptively but I can be persuaded!

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

