### PR TITLE
CV2-5779: Use the same sort for FactCheck and explainer

### DIFF
--- a/app/models/explainer.rb
+++ b/app/models/explainer.rb
@@ -117,7 +117,7 @@ class Explainer < ApplicationRecord
       context: context
     }
     response = Bot::Alegre.query_sync_with_params(params, "text")
-    results = response['result'].to_a.sort_by{ |result| result['_score'] }
+    results = response['result'].to_a.sort_by{ |result| [result['model'] != Bot::Alegre::ELASTICSEARCH_MODEL ? 1 : 0, result['_score']] }.reverse
     explainer_ids = results.collect{ |result| result.dig('context', 'explainer_id').to_i }.uniq.first(limit)
     explainer_ids.empty? ? Explainer.none : Explainer.where(team_id: team_id, id: explainer_ids)
   end


### PR DESCRIPTION
## Description

Utilize fact-check sorting based on the search model and score to standardize the sorting for FactCheck and Explainer.

References: CV2-5779

## How has this been tested?

Re-run automated tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

