### PR TITLE
Keep single quote when normalizing query for keyword search.

### DIFF
--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -55,7 +55,7 @@ class CheckSearch
     unless @options['keyword'].blank?
       # This regex removes all characters except letters, numbers, hashtag, search operators, emojis and whitespace
       # in any language - stripping out special characters can improve match results
-      @options['keyword'].gsub!(/[^[:word:]\s#~+\-|()"\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F700}-\u{1F77F}\u{1F780}-\u{1F7FF}\u{1F800}-\u{1F8FF}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1F1E6}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/, ' ')
+      @options['keyword'].gsub!(/[^[:word:]\s#'~+\-|()"\u{1F600}-\u{1F64F}\u{1F300}-\u{1F5FF}\u{1F680}-\u{1F6FF}\u{1F700}-\u{1F77F}\u{1F780}-\u{1F7FF}\u{1F800}-\u{1F8FF}\u{1F900}-\u{1F9FF}\u{1FA00}-\u{1FA6F}\u{1F1E6}-\u{1F1FF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/, ' ')
 
       # Set fuzzy matching for keyword search, right now with automatic Levenshtein Edit Distance
       # https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-simple-query-string-query.html

--- a/test/lib/check_search_test.rb
+++ b/test/lib/check_search_test.rb
@@ -16,5 +16,9 @@ class CheckSearchTest < ActiveSupport::TestCase
     query = 'Something is going to happen on 04/11, reportedly'
     search = CheckSearch.new({ keyword: query }.to_json, nil, @team.id)
     assert_equal 'Something is going to happen on 04 11  reportedly', search.instance_variable_get('@options')['keyword']
+
+    query = "Something is going to happen on Foo's house"
+    search = CheckSearch.new({ keyword: query }.to_json, nil, @team.id)
+    assert_equal "Something is going to happen on Foo's house", search.instance_variable_get('@options')['keyword']
   end
 end


### PR DESCRIPTION
## Description

Similarly to CV2-5672. Adding single quote (`'`) to the list of characters to keep when normalizing query for keyword search.

Fixes: CV2-5808.

## How has this been tested?

Unit test added.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

