### PR TITLE
Smooch Bot should not create a relationship between Media and TiplineResource

### DIFF
--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -430,7 +430,6 @@ module SmoochMessages
     end
 
     def smooch_relate_items_for_same_message(message, associated, app_id, author, request_type, associated_obj)
-      return unless associated_obj.is_a?(ProjectMedia)
       if !message['caption'].blank?
         # Check if message contains caption then create an item and force relationship
         self.relate_item_and_text(message, associated, app_id, author, request_type, associated_obj, Relationship.confirmed_type)
@@ -457,6 +456,7 @@ module SmoochMessages
       target = self.create_project_media_from_message(message)
       unless target.nil?
         smooch_post_save_message_actions(message, target, app_id, author, request_type, associated_obj)
+        return unless associated_obj.is_a?(ProjectMedia)
         Relationship.create_unless_exists(associated.id, target.id, relationship_type)
       end
     end

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -430,6 +430,7 @@ module SmoochMessages
     end
 
     def smooch_relate_items_for_same_message(message, associated, app_id, author, request_type, associated_obj)
+      return if associated.class.name != 'ProjectMedia'
       if !message['caption'].blank?
         # Check if message contains caption then create an item and force relationship
         self.relate_item_and_text(message, associated, app_id, author, request_type, associated_obj, Relationship.confirmed_type)

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -430,6 +430,7 @@ module SmoochMessages
     end
 
     def smooch_relate_items_for_same_message(message, associated, app_id, author, request_type, associated_obj)
+      return unless associated.is_a?(ProjectMedia)
       if !message['caption'].blank?
         # Check if message contains caption then create an item and force relationship
         self.relate_item_and_text(message, associated, app_id, author, request_type, associated_obj, Relationship.confirmed_type)
@@ -456,7 +457,6 @@ module SmoochMessages
       target = self.create_project_media_from_message(message)
       unless target.nil?
         smooch_post_save_message_actions(message, target, app_id, author, request_type, associated_obj)
-        return unless associated_obj.is_a?(ProjectMedia)
         Relationship.create_unless_exists(associated.id, target.id, relationship_type)
       end
     end

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -395,6 +395,8 @@ module SmoochMessages
     end
 
     def save_message(message_json, app_id, author = nil, request_type = 'default_requests', associated_id = nil, associated_class = nil)
+    # associated: is the the "first media" and will be the source of the Relationship
+    # associated_obj: is used for TiplineRequest (smooch_resource_id field)
       message = JSON.parse(message_json)
       return if TiplineRequest.where(smooch_message_id: message['_id']).exists?
       associated_obj = nil

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -413,13 +413,13 @@ module SmoochMessages
           associated = self.create_project_media_from_message(message)
         end
         unless associated.nil?
-          self.smoooch_post_save_message_actions(message, associated, app_id, author, request_type, associated_obj)
+          self.smooch_post_save_message_actions(message, associated, app_id, author, request_type, associated_obj)
           self.smooch_relate_items_for_same_message(message, associated, app_id, author, request_type, associated_obj)
         end
       end
     end
 
-    def smoooch_post_save_message_actions(message, associated, app_id, author, request_type, associated_obj)
+    def smooch_post_save_message_actions(message, associated, app_id, author, request_type, associated_obj)
       # Remember that we received this message.
       hash = self.message_hash(message)
       Rails.cache.write("smooch:message:#{hash}", associated.id)
@@ -456,7 +456,7 @@ module SmoochMessages
       message.delete('mediaUrl')
       target = self.create_project_media_from_message(message)
       unless target.nil?
-        smoooch_post_save_message_actions(message, target, app_id, author, request_type, associated_obj)
+        smooch_post_save_message_actions(message, target, app_id, author, request_type, associated_obj)
         Relationship.create_unless_exists(associated.id, target.id, relationship_type)
       end
     end

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -430,7 +430,7 @@ module SmoochMessages
     end
 
     def smooch_relate_items_for_same_message(message, associated, app_id, author, request_type, associated_obj)
-      return if associated.class.name != 'ProjectMedia'
+      return unless associated_obj.is_a?(ProjectMedia)
       if !message['caption'].blank?
         # Check if message contains caption then create an item and force relationship
         self.relate_item_and_text(message, associated, app_id, author, request_type, associated_obj, Relationship.confirmed_type)


### PR DESCRIPTION
## Description
We saw an error in Sentry where the creation of a `Relationship` between a `ProjectMedia` and a `TiplineResource` was attempted. The creation fails, but it should not be attempted in the first place.

**Error**
- `StandardError`
- `Unable to create new relationship as requested: Related items must exist in the same workspace`
- exception_class: `ActiveRecord::RecordInvalid`
- exception_message: `Related items must exist in the same workspace`

**For this to happen**
- The media can't be of type `text`, because we do check if it's a `ProjectMedia` in that case,
- it needs to have a `caption`,
- there needs to be an existing `ProjectMedia` with the same `id` as the `TiplineResource`,
	- if there isn't a  `ProjectMedia` with the same `id` as the `TiplineResource` we get a different error: `#<ActiveRecord::RecordNotFound:0x7ab20>`.

**Note on the error**
- The error is rescued, Sentry is notified and it's logged,
- so we need to check if Sentry was notified or/and if the error was logged to confirm it happened.

### Solution
We return early, and not even attempt to relate items if it's not a `ProjectMedia`, since `Relationship's` are only for `ProjectMedia`.

References: CV2-5676

## How has this been tested?

test "should not try to create relationship between media and tipline resource": `rails test test/models/bot/smooch_7_test.rb:636`

1. We create a `ProjectMedia`,
2. we create a `TiplineResource` and make sure it has the same id as the `ProjectMedia`,
3. we create a message that sends a video with a caption, to make sure it hits the condition we need it to hit,
4. it shouldn't notify Sentry or log an error, since it shouldn't get that far,
5. it should not try to create a Relationship between `ProjectMedia` and a `TiplineResource`

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

