### PR TITLE
CV2-5846 updates to back-end functions to support recent to relevant

### DIFF
--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -472,8 +472,8 @@ class ProjectMedia < ApplicationRecord
                      end
       search_query ||= self.title
       results = self.team.search_for_similar_articles(search_query, self)
-      fact_check_ids = results.select{|i| i.class.name == 'FactCheck'}.map(&:id)
-      explainer_ids = results.select{|i| i.class.name == 'Explainer'}.map(&:id)
+      fact_check_ids = results.select{|article| article.is_a?(FactCheck)}.map(&:id)
+      explainer_ids = results.select{|article| article.is_a?(Explainer)}.map(&:id)
       { fact_check: fact_check_ids, explainer: explainer_ids }.to_json
     end
     if results.blank?

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -462,7 +462,7 @@ class ProjectMedia < ApplicationRecord
     # Transcription for UploadedVideo , UploadedAudio and UploadedImage
     # Title and/or description for Link
     results = []
-    items = Rails.cache.fetch("similar-articles:#{self.id}", expires_in: 2.hours) do
+    items = Rails.cache.fetch("relevant-items-#{self.id}", expires_in: 2.hours) do
       media = self.media
       search_query = case media.type
                      when 'Claim'
@@ -480,7 +480,7 @@ class ProjectMedia < ApplicationRecord
       # This indicates a cache hit, so we should retrieve the items according to the cached values while maintaining the same sort order.
       items = JSON.parse(items)
       items.each do |klass, ids|
-        results += klass.constantize.where(id: ids).sort_by { |result| ids.index(result.id) }
+        results += klass.camelize.constantize.where(id: ids).sort_by { |result| ids.index(result.id) }
       end
     end
     results

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -461,15 +461,29 @@ class ProjectMedia < ApplicationRecord
     # Quote for Claim
     # Transcription for UploadedVideo , UploadedAudio and UploadedImage
     # Title and/or description for Link
-    media = self.media
-    search_query = case media.type
-                   when 'Claim'
-                     media.quote
-                   when 'UploadedVideo', 'UploadedAudio', 'UploadedImage'
-                     self.transcription
-                   end
-    search_query ||= self.title
-    self.team.search_for_similar_articles(search_query, self)
+    results = []
+    items = Rails.cache.fetch("similar-articles:#{self.id}", expires_in: 2.hours) do
+      media = self.media
+      search_query = case media.type
+                     when 'Claim'
+                       media.quote
+                     when 'UploadedVideo', 'UploadedAudio', 'UploadedImage'
+                       self.transcription
+                     end
+      search_query ||= self.title
+      results = self.team.search_for_similar_articles(search_query, self)
+      fact_check_ids = results.select{|i| i.class.name == 'FactCheck'}.map(&:id)
+      explainer_ids = results.select{|i| i.class.name == 'Explainer'}.map(&:id)
+      { fact_check: fact_check_ids, explainer: explainer_ids }.to_json
+    end
+    if results.blank?
+      # This indicates a cache hit, so we should retrieve the items according to the cached values while maintaining the same sort order.
+      items = JSON.parse(items)
+      items.each do |klass, ids|
+        results += klass.constantize.where(id: ids).sort_by { |result| ids.index(result.id) }
+      end
+    end
+    results
   end
 
   protected

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -430,7 +430,7 @@ class ProjectMedia < ApplicationRecord
     self.team.apply_rules_and_actions(self, rule_ids)
   end
 
-  def self.handle_fact_check_for_existing_claim(existing_pm,new_pm)
+  def self.handle_fact_check_for_existing_claim(existing_pm, new_pm)
     if existing_pm.fact_check.blank?
       existing_pm.append_fact_check_from(new_pm)
       return existing_pm
@@ -440,6 +440,7 @@ class ProjectMedia < ApplicationRecord
         return new_pm
       end
     end
+    new_pm
   end
 
   def append_fact_check_from(new_pm)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -585,7 +585,7 @@ class Team < ApplicationRecord
       end
     }
     threads << Thread.new {
-      ex_items = Bot::Smooch.search_for_explainers(nil, query, self.id, limit).distinct
+      ex_items = Bot::Smooch.search_for_explainers(nil, query, self.id, limit)
       # Exclude the ones already applied to a target item
       ex_items = ex_items.where.not(id: pm.explainer_ids) unless pm&.explainer_ids.blank?
     }

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -579,13 +579,13 @@ class Team < ApplicationRecord
           # otherwise, relevant articles for ProjectMedia should include all FactChecks.
           fc_items = fc_items.where(report_status: 'published')
         elsif !pm.fact_check_id.nil?
-          # Exclude the ones already applied to a target item if exsits
+          # Exclude the ones already applied to a target item if exists.
           fc_items = fc_items.where.not('fact_checks.id' => pm.fact_check_id) unless pm&.fact_check_id.nil?
         end
       end
     }
     threads << Thread.new {
-      ex_items = Bot::Smooch.search_for_explainers(nil, query, self.id, limit)
+      ex_items = Bot::Smooch.search_for_explainers(nil, query, self.id, limit).distinct
       # Exclude the ones already applied to a target item
       ex_items = ex_items.where.not(id: pm.explainer_ids) unless pm&.explainer_ids.blank?
     }

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -567,26 +567,32 @@ class Team < ApplicationRecord
     # query:  expected to be text
     # pm: to request a most relevant to specific item and also include both FactCheck & Explainer
     limit = pm.nil? ? CheckConfig.get('most_relevant_team_limit', 3, :integer) : CheckConfig.get('most_relevant_item_limit', 10, :integer)
-    result_ids = Bot::Smooch.search_for_similar_published_fact_checks_no_cache('text', query, [self.id], limit).map(&:id)
-    items = []
-    unless result_ids.blank?
-      items = FactCheck.joins(claim_description: :project_media).where('project_medias.id': result_ids)
-      if pm.nil?
-        # This means we obtain relevant items for the Bot preview, so we should limit FactChecks to published articles;
-        # otherwise, relevant articles for ProjectMedia should include all FactChecks.
-        items = items.where(report_status: 'published')
-      elsif !pm.fact_check_id.nil?
-        # Exclude the ones already applied to a target item if exsits
-        items = items.where.not('fact_checks.id' => pm.fact_check_id) unless pm&.fact_check_id.nil?
+    threads = []
+    fc_items = []
+    ex_items = []
+    threads << Thread.new {
+      result_ids = Bot::Smooch.search_for_similar_published_fact_checks_no_cache('text', query, [self.id], limit).map(&:id)
+      unless result_ids.blank?
+        fc_items = FactCheck.joins(claim_description: :project_media).where('project_medias.id': result_ids)
+        if pm.nil?
+          # This means we obtain relevant items for the Bot preview, so we should limit FactChecks to published articles;
+          # otherwise, relevant articles for ProjectMedia should include all FactChecks.
+          fc_items = fc_items.where(report_status: 'published')
+        elsif !pm.fact_check_id.nil?
+          # Exclude the ones already applied to a target item if exsits
+          fc_items = fc_items.where.not('fact_checks.id' => pm.fact_check_id) unless pm&.fact_check_id.nil?
+        end
       end
-    end
-    if items.blank? || !pm.nil?
-      # Get Explainers if no fact-check returned or get similar_articles for a ProjectMedia
+    }
+    threads << Thread.new {
       ex_items = Bot::Smooch.search_for_explainers(nil, query, self.id, limit)
       # Exclude the ones already applied to a target item
       ex_items = ex_items.where.not(id: pm.explainer_ids) unless pm&.explainer_ids.blank?
-      items = items + ex_items
-    end
+    }
+    threads.map(&:join)
+    items = fc_items
+    # Get Explainers if no fact-check returned or get similar_articles for a ProjectMedia
+    items += ex_items if items.blank? || !pm.nil?
     items
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -585,7 +585,7 @@ class Team < ApplicationRecord
       end
     }
     threads << Thread.new {
-      ex_items = Bot::Smooch.search_for_explainers(nil, query, self.id, limit)
+      ex_items = Bot::Smooch.search_for_explainers(nil, query, self.id, limit).distinct
       # Exclude the ones already applied to a target item
       ex_items = ex_items.where.not(id: pm.explainer_ids) unless pm&.explainer_ids.blank?
     }

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -571,7 +571,7 @@ class Team < ApplicationRecord
     fc_items = []
     ex_items = []
     threads << Thread.new {
-      result_ids = Bot::Smooch.search_for_similar_published_fact_checks_no_cache('text', query, [self.id], limit).map(&:id)
+      result_ids = Bot::Smooch.search_for_similar_published_fact_checks_no_cache('text', query, [self.id], limit, nil, nil, nil, false).map(&:id)
       unless result_ids.blank?
         fc_items = FactCheck.joins(claim_description: :project_media).where('project_medias.id': result_ids)
         if pm.nil?

--- a/app/resources/api/v2/feed_resource.rb
+++ b/app/resources/api/v2/feed_resource.rb
@@ -50,7 +50,7 @@ module Api
         RequestStore.store[:pause_database_connection] = true # Release database connection during Bot::Alegre.request_api
         team_ids = ApiKey.current.bot_user.team_ids
         limit = CheckConfig.get('most_relevant_team_limit', 3, :integer)
-        Bot::Smooch.search_for_similar_published_fact_checks(type, query, team_ids, limit, after, skip_cache)
+        Bot::Smooch.search_for_similar_published_fact_checks(type, query, team_ids, limit, after, nil, nil, skip_cache)
       end
 
       def self.get_results_from_feed_teams(team_ids, feed_id, query, type, after, webhook_url, skip_save_request, skip_cache, limit)

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -26,7 +26,7 @@ class FeedsControllerTest < ActionController::TestCase
     @f = create_feed published: true
     @f.teams = [@t1, @t2]
     FeedTeam.update_all(shared: true)
-    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, nil, false).returns([@pm1, @pm2])
+    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, false).returns([@pm1, @pm2])
   end
 
   def teardown
@@ -44,7 +44,7 @@ class FeedsControllerTest < ActionController::TestCase
     b.api_key = a
     b.save!
     create_team_user team: @t1, user: b
-    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id], 3, nil, nil, nil, false).returns([@pm1])
+    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id], 3, nil, false).returns([@pm1])
 
     authenticate_with_token a
     get :index, params: { filter: { type: 'text', query: 'Foo' } }
@@ -55,7 +55,7 @@ class FeedsControllerTest < ActionController::TestCase
 
   test "should request feed data" do
     Bot::Smooch.stubs(:search_for_similar_published_fact_checks)
-             .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, nil, false)
+             .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, false)
              .returns([@pm1, @pm2])
     authenticate_with_token @a
     get :index, params: { filter: { type: 'text', query: 'Foo', feed_id: @f.id } }
@@ -68,13 +68,13 @@ class FeedsControllerTest < ActionController::TestCase
     Sidekiq::Testing.fake! do
       authenticate_with_token @a
 
-      Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, nil, false).returns([@pm1, @pm2])
+      Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, false).returns([@pm1, @pm2])
       get :index, params: { filter: { type: 'text', query: 'Foo', feed_id: @f.id } }
       assert_response :success
       assert_equal 'Foo', json_response['data'][0]['attributes']['organization']
       assert_equal 'Bar', json_response['data'][1]['attributes']['organization']
 
-      Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, nil, false).returns([@pm2, @pm1])
+      Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, false).returns([@pm2, @pm1])
       get :index, params: { filter: { type: 'text', query: 'Foo', feed_id: @f.id } }
       assert_response :success
       assert_equal 'Bar', json_response['data'][0]['attributes']['organization']
@@ -111,7 +111,7 @@ class FeedsControllerTest < ActionController::TestCase
   test "should save request query" do
     Bot::Alegre.stubs(:request).returns({})
     Bot::Smooch.stubs(:search_for_similar_published_fact_checks)
-             .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, nil, false)
+             .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, false)
              .returns([@pm1, @pm2])
     Sidekiq::Testing.inline!
     authenticate_with_token @a
@@ -129,7 +129,7 @@ class FeedsControllerTest < ActionController::TestCase
   test "should save relationship between request and results" do
     Bot::Alegre.stubs(:request).returns({})
     Bot::Smooch.stubs(:search_for_similar_published_fact_checks)
-           .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, nil, false)
+           .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, false)
            .returns([@pm1, @pm2])
     Sidekiq::Testing.inline!
     authenticate_with_token @a
@@ -143,7 +143,7 @@ class FeedsControllerTest < ActionController::TestCase
   test "should not save request when skip_save_request is true" do
     Bot::Alegre.stubs(:request).returns({})
     Bot::Smooch.stubs(:search_for_similar_published_fact_checks)
-           .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, nil, false)
+           .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, false)
            .returns([@pm1, @pm2])
     Sidekiq::Testing.inline!
     authenticate_with_token @a

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -26,7 +26,7 @@ class FeedsControllerTest < ActionController::TestCase
     @f = create_feed published: true
     @f.teams = [@t1, @t2]
     FeedTeam.update_all(shared: true)
-    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, false).returns([@pm1, @pm2])
+    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, nil, false).returns([@pm1, @pm2])
   end
 
   def teardown
@@ -44,7 +44,7 @@ class FeedsControllerTest < ActionController::TestCase
     b.api_key = a
     b.save!
     create_team_user team: @t1, user: b
-    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id], 3, nil, false).returns([@pm1])
+    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id], 3, nil, nil, nil, false).returns([@pm1])
 
     authenticate_with_token a
     get :index, params: { filter: { type: 'text', query: 'Foo' } }

--- a/test/controllers/feeds_controller_test.rb
+++ b/test/controllers/feeds_controller_test.rb
@@ -26,7 +26,7 @@ class FeedsControllerTest < ActionController::TestCase
     @f = create_feed published: true
     @f.teams = [@t1, @t2]
     FeedTeam.update_all(shared: true)
-    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, false).returns([@pm1, @pm2])
+    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, nil, false).returns([@pm1, @pm2])
   end
 
   def teardown
@@ -44,7 +44,7 @@ class FeedsControllerTest < ActionController::TestCase
     b.api_key = a
     b.save!
     create_team_user team: @t1, user: b
-    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id], 3, nil, false).returns([@pm1])
+    Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id], 3, nil, nil, nil, false).returns([@pm1])
 
     authenticate_with_token a
     get :index, params: { filter: { type: 'text', query: 'Foo' } }
@@ -55,7 +55,7 @@ class FeedsControllerTest < ActionController::TestCase
 
   test "should request feed data" do
     Bot::Smooch.stubs(:search_for_similar_published_fact_checks)
-             .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, false)
+             .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, nil, false)
              .returns([@pm1, @pm2])
     authenticate_with_token @a
     get :index, params: { filter: { type: 'text', query: 'Foo', feed_id: @f.id } }
@@ -68,13 +68,13 @@ class FeedsControllerTest < ActionController::TestCase
     Sidekiq::Testing.fake! do
       authenticate_with_token @a
 
-      Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, false).returns([@pm1, @pm2])
+      Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, nil, false).returns([@pm1, @pm2])
       get :index, params: { filter: { type: 'text', query: 'Foo', feed_id: @f.id } }
       assert_response :success
       assert_equal 'Foo', json_response['data'][0]['attributes']['organization']
       assert_equal 'Bar', json_response['data'][1]['attributes']['organization']
 
-      Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, false).returns([@pm2, @pm1])
+      Bot::Smooch.stubs(:search_for_similar_published_fact_checks).with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, nil, false).returns([@pm2, @pm1])
       get :index, params: { filter: { type: 'text', query: 'Foo', feed_id: @f.id } }
       assert_response :success
       assert_equal 'Bar', json_response['data'][0]['attributes']['organization']
@@ -111,7 +111,7 @@ class FeedsControllerTest < ActionController::TestCase
   test "should save request query" do
     Bot::Alegre.stubs(:request).returns({})
     Bot::Smooch.stubs(:search_for_similar_published_fact_checks)
-             .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, false)
+             .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, nil, false)
              .returns([@pm1, @pm2])
     Sidekiq::Testing.inline!
     authenticate_with_token @a
@@ -129,7 +129,7 @@ class FeedsControllerTest < ActionController::TestCase
   test "should save relationship between request and results" do
     Bot::Alegre.stubs(:request).returns({})
     Bot::Smooch.stubs(:search_for_similar_published_fact_checks)
-           .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, false)
+           .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, nil, false)
            .returns([@pm1, @pm2])
     Sidekiq::Testing.inline!
     authenticate_with_token @a
@@ -143,7 +143,7 @@ class FeedsControllerTest < ActionController::TestCase
   test "should not save request when skip_save_request is true" do
     Bot::Alegre.stubs(:request).returns({})
     Bot::Smooch.stubs(:search_for_similar_published_fact_checks)
-           .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, false)
+           .with('text', 'Foo', [@t1.id, @t2.id], 3, nil, @f.id, nil, false)
            .returns([@pm1, @pm2])
     Sidekiq::Testing.inline!
     authenticate_with_token @a

--- a/test/models/project_media_7_test.rb
+++ b/test/models/project_media_7_test.rb
@@ -163,4 +163,13 @@ class ProjectMedia7Test < ActiveSupport::TestCase
     sleep 1
     assert_equal [pm1.fact_check_id, pm2.fact_check_id, pm3.fact_check_id].sort, pm_i.get_similar_articles.map(&:id).sort
   end
+
+  test "should not return null when handling fact-check for existing media" do
+    t = create_team
+    pm1 = create_project_media team: t
+    c = create_claim_description project_media: pm1
+    create_fact_check claim_description: c, language: 'en'
+    pm2 = ProjectMedia.new team: t, set_fact_check: { 'language' => 'en' }
+    assert_not_nil ProjectMedia.handle_fact_check_for_existing_claim(pm1, pm2)
+  end
 end

--- a/test/models/project_media_7_test.rb
+++ b/test/models/project_media_7_test.rb
@@ -139,7 +139,7 @@ class ProjectMedia7Test < ActiveSupport::TestCase
       fc = create_fact_check claim_description: cd, title: pm.title
       fact_checks << fc.id
     end
-    [pm1, pm2, pm3].each { |pm| publish_report(pm) }
+    [pm1, pm2].each { |pm| publish_report(pm) }
     sleep 1
     fact_checks.delete(pm1.fact_check_id)
     # Should get both explainer and FactCheck

--- a/test/models/project_media_7_test.rb
+++ b/test/models/project_media_7_test.rb
@@ -143,8 +143,12 @@ class ProjectMedia7Test < ActiveSupport::TestCase
     sleep 1
     fact_checks.delete(pm1.fact_check_id)
     # Should get both explainer and FactCheck
-    assert_equal fact_checks.concat([ex2.id, ex3.id]).sort, pm1.get_similar_articles.map(&:id).sort
-    Bot::Smooch.unstub(:search_for_explainers)
+    Rails.cache.delete("relevant-items-#{pm1.id}")
+    expected_result = fact_checks.concat([ex2.id, ex3.id]).sort
+    assert_equal expected_result, pm1.get_similar_articles.map(&:id).sort
+    assert_queries '=', 0 do
+      assert_equal expected_result, pm1.get_similar_articles.map(&:id).sort
+    end
     # Test with media item
     json_schema = {
       type: 'object',
@@ -161,7 +165,8 @@ class ProjectMedia7Test < ActiveSupport::TestCase
     data = { 'job_status' => 'COMPLETED', 'transcription' => 'Foo Bar'}
     a = create_dynamic_annotation annotation_type: 'transcription', annotated: pm_i, set_fields: { text: 'Foo Bar', job_name: '0c481e87f2774b1bd41a0a70d9b70d11', last_response: data }.to_json
     sleep 1
-    assert_equal [pm1.fact_check_id, pm2.fact_check_id, pm3.fact_check_id].sort, pm_i.get_similar_articles.map(&:id).sort
+    assert_equal [pm1.fact_check_id, pm2.fact_check_id, pm3.fact_check_id].concat([ex1.id, ex2.id, ex3.id]).sort, pm_i.get_similar_articles.map(&:id).sort
+    Bot::Smooch.unstub(:search_for_explainers)
   end
 
   test "should not return null when handling fact-check for existing media" do


### PR DESCRIPTION
## Description

Apply the following changes for most relevant articles.

- [x] Cache relevant articles result.
- [x] Include both published and unpublished articles.
- [x] Run both requests (FactCheck & Explainer) in parallel. 
- [x] Get unique Explainers

References: CV2-5846

## How has this been tested?

Implemented automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

