### PR TITLE
Removes the feature flag from the data dashboard.

### DIFF
--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -397,7 +397,6 @@ class TeamType < DefaultObject
   end
 
   def statistics(period:, language: nil, platform: nil)
-    return nil unless User.current&.is_admin
     TeamStatistics.new(object, period, language, platform)
   end
 

--- a/test/controllers/graphql_controller_11_test.rb
+++ b/test/controllers/graphql_controller_11_test.rb
@@ -201,8 +201,8 @@ class GraphqlController11Test < ActionController::TestCase
     end
   end
 
-  test "should get team statistics if super admin" do
-    user = create_user is_admin: true
+  test "should get team statistics" do
+    user = create_user
     team = create_team
     create_team_user user: user, team: team, role: 'admin'
 
@@ -244,28 +244,6 @@ class GraphqlController11Test < ActionController::TestCase
 
     post :create, params: { query: query }
     assert_response :success
-    assert_not_nil JSON.parse(@response.body).dig('data', 'team', 'statistics')
-  end
-
-  test "should not get team statistics if not super admin" do
-    user = create_user is_admin: false
-    team = create_team
-    create_team_user user: user, team: team, role: 'admin'
-
-    authenticate_with_user(user)
-    query = <<~GRAPHQL
-      query {
-        team(slug: "#{team.slug}") {
-          statistics(period: "past_week", platform: "whatsapp", language: "en") {
-            number_of_articles_created_by_date
-          }
-        }
-      }
-    GRAPHQL
-
-    post :create, params: { query: query }
-    assert_response :success
-    assert_nil JSON.parse(@response.body).dig('data', 'team', 'statistics')
   end
 
   test "should not get requests if interval is more than one month" do


### PR DESCRIPTION
## Description

Removes the feature flag from the data dashboard GraphQL field.

This reverts commit ca41cdcf52fd41a91c2d1b827dc9f4c20781fadd.

Reference: CV2-5788.

## How has this been tested?

Automated test updated.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

