### PR TITLE
Fix N+1 query issue in bot_user method by using find_by

### DIFF
--- a/app/models/team_bot_installation.rb
+++ b/app/models/team_bot_installation.rb
@@ -65,7 +65,7 @@ class TeamBotInstallation < TeamUser
   end
 
   def bot_user
-    BotUser.where(id: self.user_id).last
+    @bot_user ||= BotUser.find_by(id: self.user_id)
   end
 
   def apply_default_settings

--- a/test/models/team_bot_installation_test.rb
+++ b/test/models/team_bot_installation_test.rb
@@ -251,15 +251,13 @@ class TeamBotInstallationTest < ActiveSupport::TestCase
   test "should not trigger additional queries when accessing bot_user" do
     team_bot = create_team_bot set_approved: true
     team_bot_installation = create_team_bot_installation(user_id: team_bot.id)
-  
+
     initial_query_count = ActiveRecord::Base.connection.query_cache.size
-  
-    team_bot_installation.bot_user
-  
-    assert_no_queries do
+
+    assert_queries(0) do
       team_bot_installation.bot_user
     end
-  
+
     assert_equal initial_query_count, ActiveRecord::Base.connection.query_cache.size
   end
 end

--- a/test/models/team_bot_installation_test.rb
+++ b/test/models/team_bot_installation_test.rb
@@ -247,4 +247,19 @@ class TeamBotInstallationTest < ActiveSupport::TestCase
       assert_equal 'def456', tbi.reload.get_turnio_token
     end
   end
+
+  test "should not trigger additional queries when accessing bot_user" do
+    team_bot = create_team_bot set_approved: true
+    team_bot_installation = create_team_bot_installation(user_id: team_bot.id)
+  
+    initial_query_count = ActiveRecord::Base.connection.query_cache.size
+  
+    team_bot_installation.bot_user
+  
+    assert_no_queries do
+      team_bot_installation.bot_user
+    end
+  
+    assert_equal initial_query_count, ActiveRecord::Base.connection.query_cache.size
+  end
 end


### PR DESCRIPTION
## Description

The bot_user method in the TeamBotInstallation model was previously using the `where(...).last` approach to fetch the BotUser, which could result in unnecessary database queries when called multiple times. This fix optimizes the method by replacing `where(...).last` with `find_by(id: ...)`, ensuring only a single query is executed per call.

Changes:
- Replaced `where(...).last` with `find_by(id: ...)` in the `bot_user` method.
- Added a test to verify that no extra queries are triggered when calling `bot_user`.

References: CV2-5848

## How has this been tested?

A test has been added to verify that no additional queries are triggered when accessing the `bot_user` method multiple times on the same instance, ensuring that the optimized code works as expected and prevents potential N+1 query issues.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

