### PR TITLE
Make sure that the current relationship user overwrites the previous user when moving targets to a new source

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -312,7 +312,7 @@ class Relationship < ApplicationRecord
     Relationship.where(source_id: self.target_id).find_each do |old_relationship|
       old_relationship.delete
       options = {
-        user_id: old_relationship.user_id,
+        user_id: User.current&.id || old_relationship.user_id,
         weight: old_relationship.weight
       }
       Relationship.create_unless_exists(self.source_id, old_relationship.target_id, old_relationship.relationship_type, options)

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,1 +1,1 @@
-VERSION = '0.0.1'
+VERSION = 'v0.185.3'

--- a/test/models/relationship_2_test.rb
+++ b/test/models/relationship_2_test.rb
@@ -488,4 +488,19 @@ class Relationship2Test < ActiveSupport::TestCase
     assert Relationship.where(source: a, target: b).exists?
     assert !Relationship.where(source: a, target: c).exists?
   end
+
+  test "should set current user when moving targets to new source" do
+    t = create_team
+    u1 = create_user is_admin: true
+    u2 = create_user is_admin: true
+    a = create_project_media team: t
+    b = create_project_media team: t
+    c = create_project_media team: t
+    create_relationship source: b, target: c, user: u1
+    with_current_user_and_team(u2, t) do
+      create_relationship source: a, target: b
+    end
+    r = Relationship.where(source: a, target: c).last
+    assert_equal u2, r.reload.user
+  end
 end


### PR DESCRIPTION
## Description

Imagine we have items A and B. B has a similar item C. If B is added as similar to A, then C will also be moved from B to A.

Previously, in that operation, the user who created the relationship between B and C would be set as the user who created the relationship between A and C, but that's problematic - for example, it can prevent reports from being sent.

The fix here is to set that the user who created the new relationship between A and C is not the same user who created the relationship between B and C, but instead, it's the user who created the relationship between A and B.

Fixes: CV2-5837.

## How has this been tested?

TDD. I was able to reproduce in a unit test:

```
Failure:
Relationship2Test#test_should_set_current_user_when_moving_targets_to_new_source [test/models/relationship_2_test.rb:504]:
--- expected
+++ actual
@@ -1 +1 @@
-#<User cached_teams: [12], id: 27, name: "YSDZLODIPL", login: "ASIQPWNQZC", token: "SRCZBLHNWLWZMKBADFMGZBLMPMMCWKVYWZEPBTFJJVVCIYLFGD", default: false, email: "vmihcojpgo@wgzfrshfdb.com", raw_invitation_token: nil, last_accepted_terms_at: nil, image: nil, source_id: 39, is_active: true, is_admin: true, current_project_id: nil, integer: nil, settings: nil, last_active_at: nil, current_team_id: 12, completed_signup: true, api_key_id: nil, created_at: "2024-12-20 23:02:09.560842000 +0000", updated_at: "2024-12-20 23:02:15.975821796 +0000", encrypted_otp_secret: nil, encrypted_otp_secret_iv: nil, encrypted_otp_secret_salt: nil, consumed_timestep: nil, otp_required_for_login: nil, otp_backup_codes: nil, last_received_terms_email_at: "2024-12-20 23:02:09.560934000 +0000", otp_secret: nil>
+#<User id: 26, name: "FPOWDUNFFE", login: "ARDREYTZNX", token: "BVHKRHQIZAVPCBIVVGNJYNGJOFFVIRVWFEPLSPPCJJXUKXZMKR", default: false, email: "lmnmgxlxhc@ixaqivtnck.com", raw_invitation_token: nil, last_accepted_terms_at: nil, image: nil, source_id: 38, is_active: true, is_admin: true, current_project_id: nil, integer: nil, settings: nil, last_active_at: nil, cached_teams: [], current_team_id: nil, completed_signup: true, api_key_id: nil, created_at: "2024-12-20 23:02:09.465272000 +0000", updated_at: "2024-12-20 23:02:09.544906000 +0000", encrypted_otp_secret: nil, encrypted_otp_secret_iv: nil, encrypted_otp_secret_salt: nil, consumed_timestep: nil, otp_required_for_login: nil, otp_backup_codes: nil, last_received_terms_email_at: "2024-12-20 23:02:09.465413000 +0000", otp_secret: nil>
```

The test passed after the fix.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)