### PR TITLE
User join query to get max date

### DIFF
--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -550,9 +550,18 @@ module ProjectMediaCachedFields
     def recalculate_last_seen
       # If it’s a main/parent item, last_seen is related to any tipline request to that own ProjectMedia or any similar/child ProjectMedia
       # If it’s not a main item (so, single or child, a.k.a. “confirmed match” or “suggestion”), then last_seen is related only to tipline requests related to that ProjectMedia.
-      ids = self.is_parent ? self.related_items_ids : self.id
-      v1 = TiplineRequest.where(associated_type: 'ProjectMedia', associated_id: ids).order('created_at DESC').first&.created_at || 0
-      v2 = ProjectMedia.where(id: ids).order('created_at DESC').first&.created_at || 0
+      if self.is_parent
+        result = Relationship.select('MAX(pm.created_at) as pm_c, MAX(tr.created_at) as tr_c')
+        .where(relationship_type: Relationship.confirmed_type, source_id: self.id)
+        .joins("INNER JOIN project_medias pm ON pm.id = relationships.target_id")
+        .joins("INNER JOIN tipline_requests tr ON tr.associated_id = relationships.target_id AND tr.associated_type = 'ProjectMedia'")
+      else
+        result = ProjectMedia.select('MAX(project_medias.created_at) as pm_c, MAX(tr.created_at) as tr_c')
+        .where(id: self.id)
+        .joins("INNER JOIN tipline_requests tr ON tr.associated_id = project_medias.id AND tr.associated_type = 'ProjectMedia'")
+      end
+      v1 = result.map(&:tr_c).first || 0
+      v2 = result.map(&:pm_c).first || 0
       [v1, v2].max.to_i
     end
 


### PR DESCRIPTION
## Description

Rewrite the last_seen query to improve performance by using JOIN instead of executing three separate queries. I observed that we begin with a Relationship query to obtain the IDs, followed by a query for ProjectMedia and another for TiplineRequest. Therefore, I consolidated these queries into a single query and conducted a benchmark on both cases.

Before: 0.010803   0.000000   0.010803 (  0.920993)
After:    0.003609   0.000000   0.003609 (  0.006699)

References: CV2-5856

## How has this been tested?

Re-run automated tests.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

