### PR TITLE
Media cluster origin

### DIFF
--- a/app/graph/types/about_type.rb
+++ b/app/graph/types/about_type.rb
@@ -29,4 +29,5 @@ class AboutType < BaseObject
 
   field :channels, JsonStringType, "List check channels", null: true
   field :countries, JsonStringType, "List of workspace countries", null: true
+  field :media_cluster_origins, JsonStringType, "List of media cluster origins", null: true
 end

--- a/app/graph/types/project_media_type.rb
+++ b/app/graph/types/project_media_type.rb
@@ -406,4 +406,11 @@ class ProjectMediaType < DefaultObject
   def relevant_articles_count
     object.get_similar_articles.count
   end
+
+  field :media_cluster_origin, GraphQL::Types::Int, null: true
+
+  # FIXME: Replace by actual implementation (temporary placeholder to unblock frontend work)
+  def media_cluster_origin
+    [CheckMediaClusterOrigins::OriginCodes::ALL, nil].flatten.sample
+  end
 end

--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -50,7 +50,8 @@ class QueryType < BaseObject
           "#{SizeValidator.config("max_width")}x#{SizeValidator.config("max_height")}",
         languages_supported: CheckCldr.localized_languages.to_json,
         terms_last_updated_at: User.terms_last_updated_at,
-        channels: CheckChannels::ChannelCodes.all_channels
+        channels: CheckChannels::ChannelCodes.all_channels,
+        media_cluster_origins: CheckMediaClusterOrigins::OriginCodes.all_origins
       }
     )
   end

--- a/app/lib/check_media_cluster_origins.rb
+++ b/app/lib/check_media_cluster_origins.rb
@@ -1,5 +1,12 @@
 module CheckMediaClusterOrigins
   class OriginCodes
+    TIPLINE_SUBMITTED = 0
+    USER_ADDED = 1
+    USER_MERGED = 2
+    USER_MATCHED = 3
+    AUTO_MATCHED = 4
+    ALL = [TIPLINE_SUBMITTED, USER_ADDED, USER_MERGED, USER_MATCHED, AUTO_MATCHED]
+
     def self.all_origins
       {
         'TIPLINE_SUBMITTED' => TIPLINE_SUBMITTED, # First media of a cluster, submitted through a tipline
@@ -9,11 +16,5 @@ module CheckMediaClusterOrigins
         'AUTO_MATCHED' => AUTO_MATCHED # When a bot creates a relationship
       }
     end
-    TIPLINE_SUBMITTED = 0
-    USER_ADDED => 1,
-    USER_MERGED => 2,
-    USER_MATCHED => 3,
-    AUTO_MATCHED => 4,
-    ALL = [TIPLINE_SUBMITTED, USER_ADDED, USER_MERGED, USER_MATCHED, AUTO_MATCHED]
   end
 end

--- a/app/lib/check_media_cluster_origins.rb
+++ b/app/lib/check_media_cluster_origins.rb
@@ -1,0 +1,19 @@
+module CheckMediaClusterOrigins
+  class OriginCodes
+    def self.all_origins
+      {
+        'TIPLINE_SUBMITTED' => TIPLINE_SUBMITTED, # First media of a cluster, submitted through a tipline
+        'USER_ADDED' => USER_ADDED, # First media of a cluster, uploaded manually using Check Web
+        'USER_MERGED' => USER_MERGED, # When a user manually-creates a relationship
+        'USER_MATCHED' => USER_MATCHED, # When a user confirms a suggestion
+        'AUTO_MATCHED' => AUTO_MATCHED # When a bot creates a relationship
+      }
+    end
+    TIPLINE_SUBMITTED = 0
+    USER_ADDED => 1,
+    USER_MERGED => 2,
+    USER_MATCHED => 3,
+    AUTO_MATCHED => 4,
+    ALL = [TIPLINE_SUBMITTED, USER_ADDED, USER_MERGED, USER_MATCHED, AUTO_MATCHED]
+  end
+end

--- a/config/initializers/plugins.rb
+++ b/config/initializers/plugins.rb
@@ -1,2 +1,2 @@
 # Load classes on boot, in production, that otherwise wouldn't be auto-loaded by default
-CcDeville && Bot::Keep && Workflow::Workflow.workflows && CheckS3 && Bot::Tagger && Bot::Fetch && Bot::Smooch && Bot::Slack && Bot::Alegre && CheckChannels && RssFeed && UrlRewriter && ClusterTeam && ListExport && TeamStatistics && CheckDataPoints
+CcDeville && Bot::Keep && Workflow::Workflow.workflows && CheckS3 && Bot::Tagger && Bot::Fetch && Bot::Smooch && Bot::Slack && Bot::Alegre && CheckChannels && RssFeed && UrlRewriter && ClusterTeam && ListExport && TeamStatistics && CheckDataPoints && CheckMediaClusterOrigins

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -54,6 +54,11 @@ type About implements Node {
   languages_supported: String
 
   """
+  List of media cluster origins
+  """
+  media_cluster_origins: JsonStringType
+
+  """
   Application name
   """
   name: String
@@ -11653,6 +11658,7 @@ type ProjectMedia implements Node {
     who_dunnit: [String]
   ): VersionConnection
   media: Media
+  media_cluster_origin: Int
   media_id: Int
   media_slug: String
   oembed_metadata: String

--- a/public/relay.json
+++ b/public/relay.json
@@ -167,6 +167,20 @@
               "deprecationReason": null
             },
             {
+              "name": "media_cluster_origins",
+              "description": "List of media cluster origins",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "JsonStringType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "name",
               "description": "Application name",
               "args": [
@@ -61404,6 +61418,20 @@
               "type": {
                 "kind": "OBJECT",
                 "name": "Media",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "media_cluster_origin",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
                 "ofType": null
               },
               "isDeprecated": false,


### PR DESCRIPTION
## Description

Adding a cached field to `ProjectMedia` items, also exposed in the GraphQL `ProjectMediaType`, called `media_cluster_origin`, which explains how that media ended up in that particular media cluster. 

Steps:

- [x] Media cluster origin library, with all possible values represented by different constants.
- [x] Expose in GraphQL `ProjectMediaType`.
- [ ] Implement logic as cached field for the different cases:
  - [ ] Initial / Empty state.
  - [ ] Tipline submission.
  - [ ] User submitted.
  - [ ] User merged.
  - [ ] User confirmed.
  - [ ] Auto matched.
- [ ] Implement automated tests.

References: CV2-5933.

## How has this been tested?

Automated tests implemented for 100% code coverage.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [x] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

