### PR TITLE
Return early from method if the item doesn't exist anymore.

### DIFF
--- a/app/models/annotations/dynamic.rb
+++ b/app/models/annotations/dynamic.rb
@@ -166,6 +166,7 @@ class Dynamic < ApplicationRecord
       task = self.annotated
       if task&.annotated_type == 'ProjectMedia'
         pm = task.project_media
+        return if pm.nil?
         key = "project_media:annotated_by:#{pm.id}"
         uids = []
         if Rails.cache.exist?(key)


### PR DESCRIPTION
## Description

If a `ProjectMedia` is deleted, handling task information about it is useless. So, return early in this case.

Fixes: CV2-5989.

## How has this been tested?

Existing tests should still pass.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

