### PR TITLE
CV2-5847: Use OCR information for image item

### DIFF
--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -467,8 +467,10 @@ class ProjectMedia < ApplicationRecord
       search_query = case media.type
                      when 'Claim'
                        media.quote
-                     when 'UploadedVideo', 'UploadedAudio', 'UploadedImage'
+                     when 'UploadedVideo', 'UploadedAudio'
                        self.transcription
+                     when 'UploadedImage'
+                       self.extracted_text
                      end
       search_query ||= self.title
       results = self.team.search_for_similar_articles(search_query, self)


### PR DESCRIPTION
## Description

Use OCR information for image item instead of transaction information.

References: CV2-5847

## How has this been tested?

Implemented automated tests.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

