### PR TITLE
Adding an accessor `enable_create_blank_media` to the `ClaimDescription` model.

### DIFF
--- a/app/graph/mutations/claim_description_mutations.rb
+++ b/app/graph/mutations/claim_description_mutations.rb
@@ -9,6 +9,7 @@ module ClaimDescriptionMutations
       argument :description, GraphQL::Types::String, required: false
       argument :context, GraphQL::Types::String, required: false, as: :claim_context
       argument :project_media_id, GraphQL::Types::Int, required: false, camelize: false
+      argument :enable_create_blank_media, GraphQL::Types::Boolean, required: false, camelize: false
     end
   end
 

--- a/app/models/claim_description.rb
+++ b/app/models/claim_description.rb
@@ -1,20 +1,21 @@
 class ClaimDescription < ApplicationRecord
-  attr_accessor :disable_replace_media
+  attr_accessor :disable_replace_media, :enable_create_blank_media
 
   include Article
 
   has_paper_trail on: [:create, :update], ignore: [:updated_at, :created_at], if: proc { |_x| User.current.present? }, versions: { class_name: 'Version' }
 
-  before_validation :set_team, on: :create
   belongs_to :project_media, optional: true
   belongs_to :team
   has_one :fact_check, dependent: :destroy
 
   accepts_nested_attributes_for :fact_check, reject_if: proc { |attributes| attributes['summary'].blank? }
 
+  before_validation :set_team, on: :create
   validates_presence_of :team
   validates_uniqueness_of :project_media_id, allow_nil: true
   validate :cant_apply_article_to_item_if_article_is_in_the_trash
+  before_create :create_blank_media_if_needed
   after_commit :update_fact_check, on: [:update]
   after_update :update_report
   after_update :reset_item_rating_if_removed
@@ -134,6 +135,12 @@ class ClaimDescription < ApplicationRecord
         status.status = default_status
         status.save
       end
+    end
+  end
+
+  def create_blank_media_if_needed
+    if self.enable_create_blank_media && self.project_media_id.blank?
+      self.project_media = ProjectMedia.create!(media: Blank.create!, team: self.team)
     end
   end
 end

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -1180,6 +1180,7 @@ input CreateClaimDescriptionInput {
   clientMutationId: String
   context: String
   description: String
+  enable_create_blank_media: Boolean
   project_media_id: Int
 }
 
@@ -14187,6 +14188,7 @@ input UpdateClaimDescriptionInput {
   clientMutationId: String
   context: String
   description: String
+  enable_create_blank_media: Boolean
   id: ID
   project_media_id: Int
 }

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -900,7 +900,8 @@ module SampleData
       description: random_string,
       context: random_string,
       user: options[:user] || create_user,
-      project_media: options.has_key?(:project_media) ? options[:project_media] : create_project_media
+      project_media: options.has_key?(:project_media) ? options[:project_media] : create_project_media,
+      enable_create_blank_media: options[:enable_create_blank_media]
     }.merge(options))
   end
 

--- a/public/relay.json
+++ b/public/relay.json
@@ -5908,6 +5908,18 @@
               "deprecationReason": null
             },
             {
+              "name": "enable_create_blank_media",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
               "type": {
@@ -75351,6 +75363,18 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "enable_create_blank_media",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "Boolean",
                 "ofType": null
               },
               "defaultValue": null,

--- a/test/models/claim_description_test.rb
+++ b/test/models/claim_description_test.rb
@@ -213,17 +213,21 @@ class ClaimDescriptionTest < ActiveSupport::TestCase
   test "should create blank media if needed" do
     t = create_team
     pm = create_project_media team: t
+    cd = nil
 
     assert_no_difference 'Blank.count' do
-      create_claim_description project_media: nil, team: t
+      cd = create_claim_description project_media: nil, team: t
     end
+    assert_nil cd.project_media
 
     assert_no_difference 'Blank.count' do
-      create_claim_description project_media: pm, team: t, enable_create_blank_media: true
+      cd = create_claim_description project_media: pm, team: t, enable_create_blank_media: true
     end
+    assert_equal pm, cd.project_media
 
     assert_difference 'Blank.count' do
-      create_claim_description project_media: nil, team: t, enable_create_blank_media: true
+      cd = create_claim_description project_media: nil, team: t, enable_create_blank_media: true
     end
+    assert cd.project_media.media.is_a?(Blank)
   end
 end

--- a/test/models/claim_description_test.rb
+++ b/test/models/claim_description_test.rb
@@ -209,4 +209,21 @@ class ClaimDescriptionTest < ActiveSupport::TestCase
       cd.save!
     end
   end
+
+  test "should create blank media if needed" do
+    t = create_team
+    pm = create_project_media team: t
+
+    assert_no_difference 'Blank.count' do
+      create_claim_description project_media: nil, team: t
+    end
+
+    assert_no_difference 'Blank.count' do
+      create_claim_description project_media: pm, team: t, enable_create_blank_media: true
+    end
+
+    assert_difference 'Blank.count' do
+      create_claim_description project_media: nil, team: t, enable_create_blank_media: true
+    end
+  end
 end


### PR DESCRIPTION
## Description

Adding an accessor `enable_create_blank_media` to the `ClaimDescription` model, and a `before_create` callback that reads that accessor value and creates and associate the claim with a blank item if needed. When set to `true` (default is `false`), the claim is associated with a blank item when it's not associated to any item.

Also exposed as an argument for the claim description GraphQL mutations.

Reference: CV2-5900.

## How has this been tested?

Automated test added.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

