### PR TITLE
Adding a rake task to migrate standalone fact-checks by adding a blank media them

### DIFF
--- a/lib/tasks/migrate/20250113231210_add_blank_media_to_standalone_fact_checks.rake
+++ b/lib/tasks/migrate/20250113231210_add_blank_media_to_standalone_fact_checks.rake
@@ -1,0 +1,21 @@
+# rake check:migrate:add_blank_media_to_standalone_fact_checks
+namespace :check do
+  namespace :migrate do
+    task add_blank_media_to_standalone_fact_checks: :environment do
+      started = Time.now.to_i
+      query = FactCheck.joins(:claim_description).where(imported: false).where('claim_descriptions.project_media_id' => nil)
+      n = query.count
+      i = 0
+      query.find_each do |fact_check|
+        i += 1
+        claim = fact_check.claim_description
+        claim.enable_create_blank_media = true
+        claim.send(:create_blank_media_if_needed)
+        claim.save!
+        puts "[#{Time.now}] [#{i}/#{n}] Added blank media to claim ##{claim.id}"
+      end
+      minutes = ((Time.now.to_i - started) / 60).to_i
+      puts "[#{Time.now}] Done in #{minutes} minutes. Number of standalone fact-checks without blank media: #{query.count}"
+    end
+  end
+end


### PR DESCRIPTION
## Description

Adding a rake task to migrate standalone fact-checks by adding blank media to them. How to run the rake task:

```
rake check:migrate:add_blank_media_to_standalone_fact_checks
```

Reference: CV2-5900.

## How has this been tested?

I executed the rake task locally and migrated 104 fact-checks:

```
$ rake check:migrate:add_blank_media_to_standalone_fact_checks
[2025-01-14 02:21:27 +0000] [1/104] Added blank media to claim #425
... 102 lines ...
[2025-01-14 02:27:00 +0000] [104/104] Added blank media to claim #643
[2025-01-14 02:27:00 +0000] Done in 5 minutes. Number of standalone fact-checks without blank media: 0
```

Running it a second time shouldn't find any case to migrate.

## Things to pay attention to during code review

- I didn't bother to improve the performance too much, or do migrate per team, since in production we have just a few cases (see referenced ticket for exact number).
- The rake task is naturally Idempotent, so we don't need to store in Redis the last migrated ID.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)