### PR TITLE
Fix nil:NilClass error when parsing Link smooch messages

### DIFF
--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -441,6 +441,7 @@ module SmoochMessages
         # Text words equal the number of words - 1(which is the link size)
         text_words = ::Bot::Alegre.get_number_of_words(message['text']) - 1
         if text_words > self.min_number_of_words_for_tipline_long_text
+          # Remove link from text
           link = self.extract_url(message['text'])
           if link  && link.respond_to?(:url)
             message['text'] = message['text'].remove(link.url)

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -443,7 +443,7 @@ module SmoochMessages
         if text_words > self.min_number_of_words_for_tipline_long_text
           # Remove link from text
           link = self.extract_url(message['text'])
-          if link  && link.respond_to?(:url)
+          if link && link.respond_to?(:url)
             message['text'] = message['text'].remove(link.url)
           end
           self.relate_item_and_text(message, associated, app_id, author, request_type, associated_obj, Relationship.confirmed_type)

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -441,12 +441,9 @@ module SmoochMessages
         # Text words equal the number of words - 1(which is the link size)
         text_words = ::Bot::Alegre.get_number_of_words(message['text']) - 1
         if text_words > self.min_number_of_words_for_tipline_long_text
-          # Remove link from text
           link = self.extract_url(message['text'])
           if link  && link.respond_to?(:url)
             message['text'] = message['text'].remove(link.url)
-          else
-            Rails.logger.error "Link is nil or does not respond to `url` for message: #{message['text']}"
           end
           self.relate_item_and_text(message, associated, app_id, author, request_type, associated_obj, Relationship.confirmed_type)
         end

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -443,7 +443,11 @@ module SmoochMessages
         if text_words > self.min_number_of_words_for_tipline_long_text
           # Remove link from text
           link = self.extract_url(message['text'])
-          message['text'] = message['text'].remove(link.url)
+          if link  && link.respond_to?(:url)
+            message['text'] = message['text'].remove(link.url)
+          else
+            Rails.logger.error "Link is nil or does not respond to `url` for message: #{message['text']}"
+          end
           self.relate_item_and_text(message, associated, app_id, author, request_type, associated_obj, Relationship.confirmed_type)
         end
       end

--- a/test/models/bot/smooch_3_test.rb
+++ b/test/models/bot/smooch_3_test.rb
@@ -781,7 +781,7 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
     Bot::Smooch.stubs(:save_user_information).returns(nil)
   end
 
-  test "should return error when link is nil" do
+  test "should not throw exception when extract_url fails" do
     # Temporarily redefine extract_url to check the caller stack
     original_extract_url = Bot::Smooch.method(:extract_url)
   

--- a/test/models/bot/smooch_3_test.rb
+++ b/test/models/bot/smooch_3_test.rb
@@ -782,45 +782,46 @@ class Bot::Smooch3Test < ActiveSupport::TestCase
   end
 
   test "should return error when link is nil" do
-    uid = random_string
-    payload = {
-      trigger: 'message:appUser',
-      app: {
-        '_id': @app_id
-      },
-      version: 'v1.1',
-      messages: [message],
-      appUser: {
-        '_id': random_string,
-        'conversationStarted': true
-      }
-    }
-    Sidekiq::Testing.fake! do
-      # 2) Send link with long text
-      long_text = []
-      15.times{ long_text << random_string }
-      link_long_text = @link_url.concat(' ').concat(long_text.join(' ')).concat
-      Bot::Smooch.stubs(:extract_url).with(link_long_text).returns(nil)
-      message = {
-        '_id': random_string,
-        authorId: uid,
-        type: 'text',
-        source: { type: "whatsapp" },
-        text: link_long_text,
-      }
-      payload[:messages] = [message]
-      Bot::Smooch.run(payload.to_json)
-      sleep 1
-      pm_id = ProjectMedia.last.id
-      assert_difference 'ProjectMedia.count', 2 do
-        assert_difference 'Claim.count' do
-          assert_difference 'Link.count' do
-            assert_difference 'Relationship.count' do
-              Sidekiq::Worker.drain_all
-            end
-          end
+    # Temporarily redefine extract_url to check the caller stack
+    original_extract_url = Bot::Smooch.method(:extract_url)
+  
+    Bot::Smooch.define_singleton_method(:extract_url) do |text|
+      if caller.any? { |c| c.include?('smooch_relate_items_for_same_message') }
+        Rails.logger.debug "Returning nil for extract_url from smooch_relate_items_for_same_message"
+        nil
+      else
+        original_extract_url.call(text) # Call the original method for other cases
+      end
+    end
+  
+    begin
+      uid = random_string
+      payload = {
+        trigger: 'message:appUser',
+        app: { '_id': @app_id },
+        version: 'v1.1',
+        messages: [
+          {
+            '_id': random_string,
+            authorId: uid,
+            type: 'text',
+            source: { type: "whatsapp" },
+            text: "#{@link_url} This is a long message with a link."
+          }
+        ],
+        appUser: { '_id': random_string, 'conversationStarted': true }
+      }.to_json
+  
+      Sidekiq::Testing.fake! do
+        Bot::Smooch.run(payload)
+  
+        assert_no_difference 'Relationship.count' do
+          Sidekiq::Worker.drain_all
         end
       end
+    ensure
+      # Restore the original extract_url method
+      Bot::Smooch.define_singleton_method(:extract_url, original_extract_url)
     end
   end
 end


### PR DESCRIPTION
## Description

Fixing an  error that happens when the URL cannot be parsed. Instead of throwing an exception, we are now checking whether the link contains a URL first before attempting to use the URL.

References: CV2-5927

## How has this been tested?

- Confirmed that tests pass successfully 


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

