### PR TITLE
Make sure that the URL shortening setting returns as "enabled" even when it's not explicitly enabled but there are active RSS newsletters

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -596,6 +596,10 @@ class Team < ApplicationRecord
     items
   end
 
+  def get_shorten_outgoing_urls
+    self.settings.to_h.with_indifferent_access[:shorten_outgoing_urls] || self.tipline_newsletters.where(content_type: 'rss', enabled: true).exists?
+  end
+
   # private
   #
   # Please add private methods to app/models/concerns/team_private.rb

--- a/lib/url_rewriter.rb
+++ b/lib/url_rewriter.rb
@@ -22,6 +22,7 @@ class UrlRewriter
 
   def self.shorten_and_utmize_urls(input_text, source = nil, owner = nil)
     text = input_text
+    return text if text.blank?
     # Encode URLs in Arabic which are not detected by the URL extraction methods
     text = text.gsub(/https?:\/\/[\S]+/) { |url| url =~ /\p{Arabic}/ ? Addressable::URI.escape(url) : url } if input_text =~ /\p{Arabic}/
     entities = Twitter::TwitterText::Extractor.extract_urls_with_indices(text, extract_url_without_protocol: true)

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -1300,4 +1300,19 @@ class TeamTest < ActiveSupport::TestCase
     assert_equal 2, t.filtered_fact_checks(trashed: false).count
     assert_equal 1, t.filtered_fact_checks(trashed: true).count
   end
+
+  test "should return that URL shortening is enabled if there are active RSS newsletters" do
+    t = create_team
+    assert !t.get_shorten_outgoing_urls
+    t.set_shorten_outgoing_urls = true
+    t.save!
+    assert t.get_shorten_outgoing_urls
+    t.set_shorten_outgoing_urls = false
+    t.save!
+    assert !t.get_shorten_outgoing_urls
+    tn = create_tipline_newsletter team: t, enabled: true, content_type: 'rss', rss_feed_url: random_url
+    assert t.get_shorten_outgoing_urls
+    tn.destroy!
+    assert !t.get_shorten_outgoing_urls
+  end
 end


### PR DESCRIPTION
## Description

Make sure that the URL shortening setting returns as "enabled" even when it's not explicitly enabled but there are active RSS newsletters.

Fixes: CV2-5998.

## How has this been tested?

TDD. I implemented a unit test that reproduces the error.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

