### PR TITLE
Bug – 5926 – Update foreign key on explainer

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,7 @@ class User < ApplicationRecord
   has_many :feed_invitations
   has_many :tipline_requests
   has_many :api_keys
+  has_many :explainers
 
   devise :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :confirmable,

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1409,4 +1409,15 @@ class UserTest < ActiveSupport::TestCase
     assert_match /sawy/, u2.reload.source.name
     Team.unstub(:current)
   end
+
+  test "when merging should be able to destroy a user even if they created an explainer" do
+    u = create_user
+    create_explainer user: u
+
+    u2 = create_user
+
+    assert_nothing_raised do
+      u2.merge_with(u)
+    end
+  end
 end


### PR DESCRIPTION
## Description

When we have a user sign in with their email, and then sign in using multiauth we need to merge the users. When the user had created an explainer this was causing an issue, which was fixed by adding `has_many :explainers` to the User model.

This fixes it, because of these two lines we run in `merge_with`:
```
all_associations = User.reflect_on_all_associations(:has_many).select{|a| a.foreign_key == 'user_id'}
all_associations.each do |assoc|
  assoc.class_name.constantize.where(assoc.foreign_key => user.id).update_all(assoc.foreign_key => self.id)
end
```

References: CV2-5926

## How has this been tested?

We create a test inside user_test.rb "when merging should be able to destroy a user even if they created an explainer": `rails test test/models/user_test.rb:1413`

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

