### PR TITLE
CV2-5668: fix user_action and selected_count values

### DIFF
--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -517,7 +517,7 @@ class ProjectMedia < ApplicationRecord
     data = begin JSON.parse(Rails.cache.read("relevant-items-#{self.id}")) rescue {} end
     type = klass.underscore
     unless data[type].blank?
-      user_action = data[type].include?(article.id) ? 'relevant_articles' : 'article_search'
+      user_action = data[type].keys.map(&:to_i).include?(article.id) ? 'relevant_articles' : 'article_search'
       tbi = Bot::Alegre.get_alegre_tbi(self.team_id)
       similarity_settings = tbi&.settings&.to_h || {}
       # Retrieve the user's selection, which can be either FactCheck or Explainer,
@@ -525,9 +525,9 @@ class ProjectMedia < ApplicationRecord
       # i.e selected_count either 0/1
       items = data[type]
       items.keys.each_with_index do |value, index|
-        selected_count = (value == article.id).to_i
+        selected_count = (value.to_i == article.id).to_i
         fields = {
-          article_id: article.id,
+          article_id: value,
           article_type: article.class.name,
           matched_media_id: items[value],
           selected_count: selected_count,

--- a/test/models/relevant_results_item_test.rb
+++ b/test/models/relevant_results_item_test.rb
@@ -71,6 +71,11 @@ class RelevantResultsItemTest < ActiveSupport::TestCase
       assert_equal 2, RelevantResultsItem.where(query_media_parent_id: pm1.id, article_type: 'Explainer').count
       assert_equal 2, RelevantResultsItem.where(query_media_parent_id: pm1.id, article_type: 'FactCheck').count
       assert_equal 4, RelevantResultsItem.where(query_media_parent_id: pm1.id, relevant_results_render_id: Digest::MD5.hexdigest("#{actor_session_id}-#{now.to_i}")).count
+      # Verify user action value
+      assert_equal ['relevant_articles'], RelevantResultsItem.where(query_media_parent_id: pm1.id).map(&:user_action).uniq
+      # Verified selected_count value
+      assert_equal [1], RelevantResultsItem.where(query_media_parent_id: pm1.id, article_type: 'Explainer', article_id: ex2.id).map(&:selected_count)
+      assert_equal [0], RelevantResultsItem.where(query_media_parent_id: pm1.id, article_type: 'Explainer').where.not(article_id: ex2.id).map(&:selected_count).uniq
       Time.unstub(:now)
       RequestStore.unstub(:[])
       assert_nil Rails.cache.read("relevant-items-#{pm1.id}")


### PR DESCRIPTION
## Description

Logged two issues while testing on QA.

- user_action value: should be `relevant_articles` for relevant search selection
- selected_count: should be 1 for the selected article otherwise 0

References: CV2-5668

## How has this been tested?

Implemented automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

