### PR TITLE
Log and notify Sentry when relevant articles are not retrieved.

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -565,10 +565,14 @@ class Team < ApplicationRecord
     query.where(Arel.sql("#{tsvector} @@ #{tsquery}"))
   end
 
+  def similar_articles_search_limit(pm = nil)
+    pm.nil? ? CheckConfig.get('most_relevant_team_limit', 3, :integer) : CheckConfig.get('most_relevant_item_limit', 10, :integer)
+  end
+
   def search_for_similar_articles(query, pm = nil)
     # query:  expected to be text
     # pm: to request a most relevant to specific item and also include both FactCheck & Explainer
-    limit = pm.nil? ? CheckConfig.get('most_relevant_team_limit', 3, :integer) : CheckConfig.get('most_relevant_item_limit', 10, :integer)
+    limit = self.similar_articles_search_limit(pm)
     threads = []
     fc_items = []
     ex_items = []

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -599,7 +599,7 @@ class Team < ApplicationRecord
     items = fc_items
     # Get Explainers if no fact-check returned or get similar_articles for a ProjectMedia
     items += ex_items if items.blank? || !pm.nil?
-    Rails.logger.info("No relevant articles found for team slug #{self.slug}, project media with ID #{pm&.id} and query #{query}.") if items.empty?
+    Rails.logger.info("Relevant articles found for team slug #{self.slug}, project media with ID #{pm&.id} and query #{query}: #{items.map(&:graphql_id)}")
     items
   rescue StandardError => e
     Rails.logger.warn("Error when trying to retrieve relevant articles for team slug #{self.slug}, project media with ID #{pm&.id} and query #{query}.")

--- a/test/models/team_2_test.rb
+++ b/test/models/team_2_test.rb
@@ -1583,4 +1583,11 @@ class Team2Test < ActiveSupport::TestCase
     end
     Bot::Smooch.unstub(:search_for_explainers)
   end
+
+  test "should notify Sentry if it fails to retrieve relevant articles" do
+    Bot::Smooch.stubs(:search_for_similar_published_fact_checks_no_cache).raises(StandardError)
+    CheckSentry.expects(:notify).once
+    t = create_team
+    assert_equal [], t.search_for_similar_articles('Test')
+  end
 end


### PR DESCRIPTION
## Description

This PR implements two things:

* Case 1: Info-level logging when no relevant articles are returned.
* Case 2: Notify Sentry when there is an error retrieving relevant articles. In that case:
  * Catch the error and return an empty list, so it doesn't crash the frontend, which can then fallback to recent articles.
  * Log a warning.
  * Notify Sentry. The Sentry message is static and implements a custom exception class, so similar notifications can be grouped together automatically, but includes all information we need in order to debug.

Reference: CV2-5932.

## How has this been tested?

Automated test implemented. I tested it manually too.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

