### PR TITLE
feature – 6021 – Store original claim in Media object

### DIFF
--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -100,7 +100,7 @@ module ProjectMediaCreators
   end
 
   def create_claim_media(text)
-    Claim.create!(quote: text, original_claim: text)
+    Claim.find_by(original_claim: text) || Claim.create!(quote: text, original_claim: text)
   end
 
   def create_link_media(url)

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -82,11 +82,17 @@ module ProjectMediaCreators
   def create_media_from_url(type, url, ext)
     klass = type.constantize
     file = download_file(url, ext)
-    m = klass.new
-    m.original_claim = url
-    m.file = file
-    m.save!
-    m
+    existing_media = klass.find_by(original_claim: url)
+
+    if existing_media
+      existing_media
+    else
+      m = klass.new
+      m.original_claim = url
+      m.file = file
+      m.save!
+      m
+    end
   end
 
   def download_file(url, ext)

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -83,6 +83,7 @@ module ProjectMediaCreators
     klass = type.constantize
     file = download_file(url, ext)
     m = klass.new
+    m.original_claim = url
     m.file = file
     m.save!
     m
@@ -99,14 +100,14 @@ module ProjectMediaCreators
   end
 
   def create_claim_media(text)
-    Claim.create!(quote: text)
+    Claim.create!(quote: text, original_claim: text)
   end
 
   def create_link_media(url)
     team = self.team || Team.current
     pender_key = team.get_pender_key if team
     url_from_pender = Link.normalized(url, pender_key)
-    Link.find_by(url: url_from_pender) || Link.create!(url: url, pender_key: pender_key)
+    Link.find_by(url: url_from_pender) || Link.create!(url: url, pender_key: pender_key, original_claim: url)
   end
 
   def set_quote_metadata

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -54,67 +54,7 @@ module ProjectMediaCreators
 
   def create_original_claim
     claim = self.set_original_claim.strip
-    if claim.match?(/\A#{URI::DEFAULT_PARSER.make_regexp(['http', 'https'])}\z/)
-      uri = URI.parse(claim)
-      content_type = fetch_content_type(uri)
-      ext = File.extname(uri.path)
-
-      case content_type
-      when /^image\//
-        self.media = create_media_from_url('UploadedImage', claim, ext)
-      when /^video\//
-        self.media = create_media_from_url('UploadedVideo', claim, ext)
-      when /^audio\//
-        self.media = create_media_from_url('UploadedAudio', claim, ext)
-      else
-        self.media = create_link_media(claim)
-      end
-    else
-      self.media = create_claim_media(claim)
-    end
-  end
-
-  def fetch_content_type(uri)
-    response = Net::HTTP.get_response(uri)
-    response['content-type']
-  end
-
-  def create_media_from_url(type, url, ext)
-    klass = type.constantize
-    file = download_file(url, ext)
-    existing_media = klass.find_by(original_claim_hash: Digest::MD5.hexdigest(url))
-
-    if existing_media
-      existing_media
-    else
-      m = klass.new
-      m.original_claim = url
-      m.original_claim_hash = Digest::MD5.hexdigest(url)
-      m.file = file
-      m.save!
-      m
-    end
-  end
-
-  def download_file(url, ext)
-    raise "Invalid URL when creating media from original claim attribute" unless url =~ /\A#{URI::DEFAULT_PARSER.make_regexp(['http', 'https'])}\z/
-
-    file = Tempfile.new(['download', ext])
-    file.binmode
-    file.write(URI(url).open.read)
-    file.rewind
-    file
-  end
-
-  def create_claim_media(text)
-    Claim.find_by(original_claim_hash: Digest::MD5.hexdigest(text)) || Claim.create!(quote: text, original_claim: text, original_claim_hash: Digest::MD5.hexdigest(text))
-  end
-
-  def create_link_media(url)
-    team = self.team || Team.current
-    pender_key = team.get_pender_key if team
-    url_from_pender = Link.normalized(url, pender_key)
-    Link.find_by(url: url_from_pender) || Link.find_by(original_claim_hash: Digest::MD5.hexdigest(url)) || Link.create!(url: url, pender_key: pender_key, original_claim: url, original_claim_hash: Digest::MD5.hexdigest(url))
+    self.media = Media.find_or_create_from_original_claim(claim, self.team)
   end
 
   def set_quote_metadata

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -82,13 +82,14 @@ module ProjectMediaCreators
   def create_media_from_url(type, url, ext)
     klass = type.constantize
     file = download_file(url, ext)
-    existing_media = klass.find_by(original_claim: url)
+    existing_media = klass.find_by(original_claim_hash: Digest::MD5.hexdigest(url))
 
     if existing_media
       existing_media
     else
       m = klass.new
       m.original_claim = url
+      m.original_claim_hash = Digest::MD5.hexdigest(url)
       m.file = file
       m.save!
       m
@@ -106,14 +107,14 @@ module ProjectMediaCreators
   end
 
   def create_claim_media(text)
-    Claim.find_by(original_claim: text) || Claim.create!(quote: text, original_claim: text)
+    Claim.find_by(original_claim_hash: Digest::MD5.hexdigest(text)) || Claim.create!(quote: text, original_claim: text, original_claim_hash: Digest::MD5.hexdigest(text))
   end
 
   def create_link_media(url)
     team = self.team || Team.current
     pender_key = team.get_pender_key if team
     url_from_pender = Link.normalized(url, pender_key)
-    Link.find_by(url: url_from_pender) || Link.create!(url: url, pender_key: pender_key, original_claim: url)
+    Link.find_by(url: url_from_pender) || Link.find_by(original_claim_hash: Digest::MD5.hexdigest(url)) || Link.create!(url: url, pender_key: pender_key, original_claim: url, original_claim_hash: Digest::MD5.hexdigest(url))
   end
 
   def set_quote_metadata

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -85,16 +85,16 @@ class Media < ApplicationRecord
 
       case content_type
       when /^image\//
-        create_uploaded_file_media_from_original_claim('UploadedImage', claim, ext)
+        find_or_create_uploaded_file_media_from_original_claim('UploadedImage', claim, ext)
       when /^video\//
-        create_uploaded_file_media_from_original_claim('UploadedVideo', claim, ext)
+        find_or_create_uploaded_file_media_from_original_claim('UploadedVideo', claim, ext)
       when /^audio\//
-        create_uploaded_file_media_from_original_claim('UploadedAudio', claim, ext)
+        find_or_create_uploaded_file_media_from_original_claim('UploadedAudio', claim, ext)
       else
-        create_link_media_from_original_claim(claim, project_media_team)
+        find_or_create_link_media_from_original_claim(claim, project_media_team)
       end
     else
-      create_claim_media_from_original_claim(claim)
+      find_or_create_claim_media_from_original_claim(claim)
     end
   end
 
@@ -130,7 +130,7 @@ class Media < ApplicationRecord
     self.original_claim_hash = Digest::MD5.hexdigest(original_claim) unless self.original_claim.blank?
   end
 
-  def self.create_uploaded_file_media_from_original_claim(media_type, url, ext)
+  def self.find_or_create_uploaded_file_media_from_original_claim(media_type, url, ext)
     klass = media_type.constantize
     existing_media = klass.find_by(original_claim_hash: Digest::MD5.hexdigest(url))
     
@@ -152,11 +152,11 @@ class Media < ApplicationRecord
     file
   end
 
-  def self.create_claim_media_from_original_claim(text)
+  def self.find_or_create_claim_media_from_original_claim(text)
     Claim.find_by(original_claim_hash: Digest::MD5.hexdigest(text)) || Claim.create!(quote: text, original_claim: text)
   end
 
-  def self.create_link_media_from_original_claim(url, project_media_team)
+  def self.find_or_create_link_media_from_original_claim(url, project_media_team)
     pender_key = project_media_team.get_pender_key if project_media_team
     url_from_pender = Link.normalized(url, pender_key)
     Link.find_by(url: url_from_pender) || Link.find_by(original_claim_hash: Digest::MD5.hexdigest(url)) || Link.create!(url: url, pender_key: pender_key, original_claim: url)

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -80,7 +80,7 @@ class Media < ApplicationRecord
   def self.find_or_create_from_original_claim(claim, project_media_team)
     if claim.match?(/\A#{URI::DEFAULT_PARSER.make_regexp(['http', 'https'])}\z/)
       uri = URI.parse(claim)
-      content_type = fetch_content_type(uri)
+      content_type = Net::HTTP.get_response(uri)['content-type']
       ext = File.extname(uri.path)
 
       case content_type
@@ -128,11 +128,6 @@ class Media < ApplicationRecord
 
   def set_original_claim_hash
     self.original_claim_hash = Digest::MD5.hexdigest(original_claim) unless self.original_claim.blank?
-  end
-
-  def self.fetch_content_type(uri)
-    response = Net::HTTP.get_response(uri)
-    response['content-type']
   end
 
   def self.create_uploaded_file_media_from_original_claim(media_type, url, ext)

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -133,7 +133,7 @@ class Media < ApplicationRecord
   def self.find_or_create_uploaded_file_media_from_original_claim(media_type, url, ext)
     klass = media_type.constantize
     existing_media = klass.find_by(original_claim_hash: Digest::MD5.hexdigest(url))
-    
+
     if existing_media
       existing_media
     else

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -84,16 +84,16 @@ class Media < ApplicationRecord
 
       case content_type
       when /^image\//
-        create_uploaded_file_media_from_url('UploadedImage', claim, ext)
+        create_uploaded_file_media_from_original_claim('UploadedImage', claim, ext)
       when /^video\//
-        create_uploaded_file_media_from_url('UploadedVideo', claim, ext)
+        create_uploaded_file_media_from_original_claim('UploadedVideo', claim, ext)
       when /^audio\//
-        create_uploaded_file_media_from_url('UploadedAudio', claim, ext)
+        create_uploaded_file_media_from_original_claim('UploadedAudio', claim, ext)
       else
-        create_link_media(claim, project_media_team)
+        create_link_media_from_original_claim(claim, project_media_team)
       end
     else
-      create_claim_media(claim)
+      create_claim_media_from_original_claim(claim)
     end
   end
 
@@ -134,7 +134,7 @@ class Media < ApplicationRecord
     response['content-type']
   end
 
-  def self.create_uploaded_file_media_from_url(media_type, url, ext)
+  def self.create_uploaded_file_media_from_original_claim(media_type, url, ext)
     klass = media_type.constantize
     file = download_file(url, ext)
     existing_media = klass.find_by(original_claim_hash: Digest::MD5.hexdigest(url))
@@ -156,11 +156,11 @@ class Media < ApplicationRecord
     file
   end
 
-  def self.create_claim_media(text)
+  def self.create_claim_media_from_original_claim(text)
     Claim.find_by(original_claim_hash: Digest::MD5.hexdigest(text)) || Claim.create!(quote: text, original_claim: text)
   end
 
-  def self.create_link_media(url, project_media_team)
+  def self.create_link_media_from_original_claim(url, project_media_team)
     pender_key = project_media_team.get_pender_key if project_media_team
     url_from_pender = Link.normalized(url, pender_key)
     Link.find_by(url: url_from_pender) || Link.find_by(original_claim_hash: Digest::MD5.hexdigest(url)) || Link.create!(url: url, pender_key: pender_key, original_claim: url)

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -132,12 +132,12 @@ class Media < ApplicationRecord
 
   def self.create_uploaded_file_media_from_original_claim(media_type, url, ext)
     klass = media_type.constantize
-    file = download_file(url, ext)
     existing_media = klass.find_by(original_claim_hash: Digest::MD5.hexdigest(url))
-
+    
     if existing_media
       existing_media
     else
+      file = download_file(url, ext)
       klass.create!(file: file, original_claim: url)
     end
   end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -20,6 +20,7 @@ class Media < ApplicationRecord
   end
 
   validates_inclusion_of :type, in: Media.types
+  validates_uniqueness_of :original_claim_hash, allow_nil: true
 
   def class_name
     'Media'

--- a/db/migrate/20250122171640_add_original_claim_to_medias.rb
+++ b/db/migrate/20250122171640_add_original_claim_to_medias.rb
@@ -1,6 +1,0 @@
-class AddOriginalClaimToMedias < ActiveRecord::Migration[6.1]
-  def change
-    add_column :medias, :original_claim, :string, null: true
-    add_index :medias, :original_claim, unique: true
-  end
-end

--- a/db/migrate/20250122171640_add_original_claim_to_medias.rb
+++ b/db/migrate/20250122171640_add_original_claim_to_medias.rb
@@ -1,0 +1,6 @@
+class AddOriginalClaimToMedias < ActiveRecord::Migration[6.1]
+  def change
+    add_column :medias, :original_claim, :string, null: true
+    add_index :medias, :original_claim, unique: true
+  end
+end

--- a/db/migrate/20250124155814_add_original_claim_to_media.rb
+++ b/db/migrate/20250124155814_add_original_claim_to_media.rb
@@ -1,0 +1,7 @@
+class AddOriginalClaimToMedia < ActiveRecord::Migration[6.1]
+  def change
+    add_column :medias, :original_claim, :text, null: true
+	  add_column :medias, :original_claim_hash, :string, null: true
+	  add_index :medias, :original_claim_hash, unique: true
+  end
+end

--- a/db/migrate/20250124155814_add_original_claim_to_media.rb
+++ b/db/migrate/20250124155814_add_original_claim_to_media.rb
@@ -1,7 +1,7 @@
 class AddOriginalClaimToMedia < ActiveRecord::Migration[6.1]
   def change
     add_column :medias, :original_claim, :text, null: true
-	  add_column :medias, :original_claim_hash, :string, null: true
-	  add_index :medias, :original_claim_hash, unique: true
+    add_column :medias, :original_claim_hash, :string, null: true
+    add_index :medias, :original_claim_hash, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_01_22_171640) do
+ActiveRecord::Schema.define(version: 2025_01_24_155814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -457,8 +457,9 @@ ActiveRecord::Schema.define(version: 2025_01_22_171640) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "uuid", default: 0, null: false
-    t.string "original_claim"
-    t.index ["original_claim"], name: "index_medias_on_original_claim", unique: true
+    t.text "original_claim"
+    t.string "original_claim_hash"
+    t.index ["original_claim_hash"], name: "index_medias_on_original_claim_hash", unique: true
     t.index ["url"], name: "index_medias_on_url", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_01_13_174153) do
+ActiveRecord::Schema.define(version: 2025_01_22_171640) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -457,6 +457,8 @@ ActiveRecord::Schema.define(version: 2025_01_13_174153) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "uuid", default: 0, null: false
+    t.string "original_claim"
+    t.index ["original_claim"], name: "index_medias_on_original_claim", unique: true
     t.index ["url"], name: "index_medias_on_url", unique: true
   end
 
@@ -1005,6 +1007,6 @@ ActiveRecord::Schema.define(version: 2025_01_13_174153) do
   add_foreign_key "requests", "feeds"
 
   create_trigger :enforce_relationships, sql_definition: <<-SQL
-      CREATE TRIGGER enforce_relationships BEFORE INSERT ON public.relationships FOR EACH ROW EXECUTE PROCEDURE validate_relationships()
+      CREATE TRIGGER enforce_relationships BEFORE INSERT ON public.relationships FOR EACH ROW EXECUTE FUNCTION validate_relationships()
   SQL
 end

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -630,7 +630,7 @@ class MediaTest < ActiveSupport::TestCase
 
   test "Claim Media: should save the original_claim and original_claim_hash when created from original claim" do
     claim = 'This is a claim.'
-    claim_media = Media.create_claim_media_from_original_claim(claim)
+    claim_media = Media.find_or_create_claim_media_from_original_claim(claim)
 
     assert_not_nil claim_media.original_claim_hash
     assert_not_nil claim_media.original_claim
@@ -645,7 +645,7 @@ class MediaTest < ActiveSupport::TestCase
 
   test "Claim Media: should not create duplicate media if media with original_claim_hash exists" do
     assert_difference 'Claim.count', 1 do
-      2.times { Media.create_claim_media_from_original_claim('This is a claim.') }
+      2.times { Media.find_or_create_claim_media_from_original_claim('This is a claim.') }
     end
   end
 
@@ -664,7 +664,7 @@ class MediaTest < ActiveSupport::TestCase
     }.to_json
     WebMock.stub_request(:get, pender_url).with(query: { url: link_url }).to_return(body: link_response)
 
-    link_media = Media.create_link_media_from_original_claim(link_url, team)
+    link_media = Media.find_or_create_link_media_from_original_claim(link_url, team)
 
     assert_not_nil link_media.original_claim_hash
     assert_not_nil link_media.original_claim
@@ -706,7 +706,7 @@ class MediaTest < ActiveSupport::TestCase
     WebMock.stub_request(:get, pender_url).with(query: { url: link_url }).to_return(body: link_response)
 
     assert_difference 'Link.count', 1 do
-      2.times { Media.create_link_media_from_original_claim(link_url, team) }
+      2.times { Media.find_or_create_link_media_from_original_claim(link_url, team) }
     end
   end
 
@@ -718,7 +718,7 @@ class MediaTest < ActiveSupport::TestCase
       ext = File.extname(URI.parse(audio_url).path)
       WebMock.stub_request(:get, audio_url).to_return(body: file.read, headers: { 'Content-Type' => 'audio/mp3' })
 
-      uploaded_media = Media.create_uploaded_file_media_from_original_claim('UploadedAudio', audio_url, ext)
+      uploaded_media = Media.find_or_create_uploaded_file_media_from_original_claim('UploadedAudio', audio_url, ext)
 
       assert_not_nil uploaded_media.original_claim_hash
       assert_not_nil uploaded_media.original_claim
@@ -742,7 +742,7 @@ class MediaTest < ActiveSupport::TestCase
       WebMock.stub_request(:get, audio_url).to_return(body: file.read, headers: { 'Content-Type' => 'audio/mp3' })
 
       assert_difference 'UploadedAudio.count', 1 do
-        2.times { Media.create_uploaded_file_media_from_original_claim('UploadedAudio', audio_url, ext) }
+        2.times { Media.find_or_create_uploaded_file_media_from_original_claim('UploadedAudio', audio_url, ext) }
       end
     end
   end

--- a/test/models/project_media_7_test.rb
+++ b/test/models/project_media_7_test.rb
@@ -249,7 +249,7 @@ class ProjectMedia7Test < ActiveSupport::TestCase
   test "should check if the original_claim text exists and return that instance when trying to create claim media" do
     text = 'This is a claim.'
 
-    claim = Claim.create!(quote: text, original_claim: text, original_claim_hash: Digest::MD5.hexdigest(text))
+    claim = Claim.create!(quote: text, original_claim: text)
     pm = create_project_media(set_original_claim: text)
 
     assert_equal claim.id, pm.media.id
@@ -262,7 +262,7 @@ class ProjectMedia7Test < ActiveSupport::TestCase
       audio_url = "http://example.com/#{file.path.split('/').last}"
       WebMock.stub_request(:get, audio_url).to_return(body: file.read, headers: { 'Content-Type' => 'audio/mp3' })
 
-      audio = UploadedAudio.create!(file: file, original_claim: audio_url, original_claim_hash: Digest::MD5.hexdigest(audio_url))
+      audio = UploadedAudio.create!(file: file, original_claim: audio_url)
       pm = create_project_media(set_original_claim: audio_url)
 
       assert_equal audio.id, pm.media.id

--- a/test/models/project_media_7_test.rb
+++ b/test/models/project_media_7_test.rb
@@ -198,8 +198,6 @@ class ProjectMedia7Test < ActiveSupport::TestCase
   end
 
   test "should save the original_claim url and original_claim_hash when Link Media is created from original_claim" do
-    setup_elasticsearch
-
     # Mock Pender response for Link
     link_url = 'https://example.com'
     pender_url = CheckConfig.get('pender_url_private') + '/api/medias'

--- a/test/models/project_media_7_test.rb
+++ b/test/models/project_media_7_test.rb
@@ -91,7 +91,7 @@ class ProjectMedia7Test < ActiveSupport::TestCase
     end
   end
 
-  test "should create duplicate media from original claim URL as UploadedImage" do
+  test "should not create duplicate media from original claim URL as UploadedImage" do
     Tempfile.create(['test_image', '.jpg']) do |file|
       file.write(File.read(File.join(Rails.root, 'test', 'data', 'rails.png')))
       file.rewind
@@ -101,17 +101,17 @@ class ProjectMedia7Test < ActiveSupport::TestCase
       t = create_team
       create_project team: t
 
-      assert_difference 'ProjectMedia.count', 2 do
+      assert_raise RuntimeError do
         2.times { create_project_media(team: t, set_original_claim: image_url) }
       end
     end
   end
 
-  test "should create duplicate media from original claim URL as Claim" do
+  test "should not create duplicate media from original claim URL as Claim" do
     t = create_team
     create_project team: t
 
-    assert_difference 'ProjectMedia.count', 2 do
+    assert_raise RuntimeError do
       2.times { create_project_media(team: t, set_original_claim: 'This is a claim.') }
     end
   end

--- a/test/models/project_media_7_test.rb
+++ b/test/models/project_media_7_test.rb
@@ -243,14 +243,12 @@ class ProjectMedia7Test < ActiveSupport::TestCase
     end
   end
 
-  # For whatever reason this last test is actually creating 4 Medias: 2 Claims and 2 Links
-  # I don't think it should create the Link Medias
   test "should check if the original_claim exists and return that instance when trying to create media" do
-    t = create_team
-    create_project team: t
+    text = 'This is a claim.'
 
-    assert_difference 'Media.count', 1 do
-      2.times { create_project_media(team: t, set_original_claim: 'This is a claim.') }
-    end
+    claim = Claim.create!(quote: text, original_claim: text)
+    pm = create_project_media(set_original_claim: text)
+
+    assert_equal claim.id, pm.media.id
   end
 end

--- a/test/models/project_media_7_test.rb
+++ b/test/models/project_media_7_test.rb
@@ -243,12 +243,26 @@ class ProjectMedia7Test < ActiveSupport::TestCase
     end
   end
 
-  test "should check if the original_claim exists and return that instance when trying to create media" do
+  test "should check if the original_claim text exists and return that instance when trying to create claim media" do
     text = 'This is a claim.'
 
     claim = Claim.create!(quote: text, original_claim: text)
     pm = create_project_media(set_original_claim: text)
 
     assert_equal claim.id, pm.media.id
+  end
+
+  test "should check if the original_claim url exists and return that instance when trying to create UploadedAudio media" do
+    Tempfile.create(['test_audio', '.mp3']) do |file|
+      file.write(File.read(File.join(Rails.root, 'test', 'data', 'rails.mp3')))
+      file.rewind
+      audio_url = "http://example.com/#{file.path.split('/').last}"
+      WebMock.stub_request(:get, audio_url).to_return(body: file.read, headers: { 'Content-Type' => 'audio/mp3' })
+
+      audio = UploadedAudio.create!(file: file, original_claim: audio_url)
+      pm = create_project_media(set_original_claim: audio_url)
+
+      assert_equal audio.id, pm.media.id
+    end
   end
 end


### PR DESCRIPTION
## Description

To debug items created using the API (e.g., through the Zapier integration), improve performance, and avoid duplications, it is important to store the `original_claim_url` in the `Media` object created when this attribute is present.

When a `ProjectMedia` is created (e.g., via a GraphQL mutation) and the `original_claim` attribute (a URL) is provided, a new `Media` instance is created from that URL and associated with the `ProjectMedia` instance. Currently, the reference between the original claim and the created media is lost. This reference needs to be stored.

References: CV2-6021

## How has this been tested?

### `project_media_7_test.rb`

"should save the original_claim url and original_claim_hash when Link Media is created from original_claim"
`rails test test/models/project_media_7_test.rb:200`

"should save the original_claim text and original_claim_hash when Claim media is created from original_claim"
`rails test test/models/project_media_7_test.rb:222`

"should save the original_claim url and original_claim_hash when UploadedAudio Media is created from original_claim"
`rails test test/models/project_media_7_test.rb:231`

"should check if the original_claim text exists and return that instance when trying to create claim media"
`rails test test/models/project_media_7_test.rb:247`

"should check if the original_claim url exists and return that instance when trying to create UploadedAudio media"
`rails test test/models/project_media_7_test.rb:256`

### `media_test.rb`

"Claim Media: should save the original_claim and original_claim_hash when created from original claim"
`rails test test/models/media_test.rb:631`

"Claim Media: should not save original_claim and original_claim_hash when not created from original claim"
`rails test test/models/media_test.rb:640`

"Claim Media: should not create duplicate media if media with original_claim_hash exists"
`rails test test/models/media_test.rb:646`

"Link Media: should save the original_claim and original_claim_hash when created from original claim"
`rails test test/models/media_test.rb:652`

"Link Media: should not save original_claim and original_claim_hash when not created from original claim"
`rails test test/models/media_test.rb:674`

"Link Media: should not create duplicate media if media with original_claim_hash exists"
`rails test test/models/media_test.rb:693`

"Uploaded Media: should save the original_claim and original_claim_hash when created from original claim"
`rails test test/models/media_test.rb:713`

"Uploaded Media: should not save original_claim and original_claim_hash when not created from original claim"
`rails test test/models/media_test.rb:729`

"Uploaded Media: should not create duplicate media if media with original_claim_hash exists"
`rails test test/models/media_test.rb:736`

## Things to pay attention to during code review

Please describe parts of the change that require extra attention during code review, for example:

- File FFFF, line LL: This refactoring does this and this. Is it consistent with how it’s implemented elsewhere?
- Etc.

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

