### PR TITLE
Adding `social_media` value to media type search filter.

### DIFF
--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -22,6 +22,7 @@ class CheckSearch
     @options['esoffset'] ||= 0
     adjust_es_window_size
 
+    adjust_show_filter
     adjust_channel_filter
     adjust_numeric_range_filter
     adjust_archived_filter
@@ -426,6 +427,13 @@ class CheckSearch
     if @options['channels'].is_a?(Array) && @options['channels'].include?('any_tipline')
       channels = @options['channels'] - ['any_tipline']
       @options['channels'] = channels.map(&:to_i).concat(CheckChannels::ChannelCodes::TIPLINE).uniq
+    end
+  end
+
+  def adjust_show_filter
+    if @options['show'].is_a?(Array) && @options['show'].include?('social_media')
+      @options['show'].concat(%w[twitter youtube tiktok instagram facebook telegram]).delete('social_media')
+      @options['show'].uniq!
     end
   end
 

--- a/test/lib/check_search_test.rb
+++ b/test/lib/check_search_test.rb
@@ -26,4 +26,9 @@ class CheckSearchTest < ActiveSupport::TestCase
     search = CheckSearch.new({ users: [1, nil] }.to_json, nil, @team.id)
     assert_not_nil search.send(:doc_conditions)
   end
+
+  test "should adjust social media filter" do
+    search = CheckSearch.new({ show: ['social_media', 'images'] }.to_json, nil, @team.id)
+    assert_equal ['images', 'twitter', 'youtube', 'tiktok', 'instagram', 'facebook', 'telegram'].sort, search.instance_variable_get('@options')['show'].sort
+  end
 end


### PR DESCRIPTION
## Description

This new value `social_media` is basically a shortcut for all the possible social media types.

Reference: CV2-4980.

## How has this been tested?

I implemented a unit test for that.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)