### PR TITLE
Notify Sentry when request to Alegre fails.

### DIFF
--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -129,6 +129,7 @@ module AlegreV2
           self.request(method, path, params, retries - 1)
         end
         Rails.logger.error("[Alegre Bot] Alegre error: (#{method}, #{path}, #{params.inspect}, #{retries}), #{e.inspect} #{e.message}")
+        CheckSentry.notify(e, bot: 'alegre', method: method, path: path, params: params, retries: retries)
         { 'type' => 'error', 'data' => { 'message' => e.message } }
       end
     end

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -125,10 +125,10 @@ module AlegreV2
         parsed_response
       rescue StandardError => e
         if retries > 0
+          Rails.logger.error("[Alegre Bot] Alegre error: (#{method}, #{path}, #{params.inspect}, #{retries}), #{e.inspect} #{e.message}")
           sleep 1
           self.request(method, path, params, retries - 1)
         end
-        Rails.logger.error("[Alegre Bot] Alegre error: (#{method}, #{path}, #{params.inspect}, #{retries}), #{e.inspect} #{e.message}")
         CheckSentry.notify(e, bot: 'alegre', method: method, path: path, params: params, retries: retries)
         { 'type' => 'error', 'data' => { 'message' => e.message } }
       end

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -124,12 +124,12 @@ module AlegreV2
         Rails.logger.info("[Alegre Bot] Alegre response: #{parsed_response.inspect}")
         parsed_response
       rescue StandardError => e
+        Rails.logger.error("[Alegre Bot] Alegre error: (#{method}, #{path}, #{params.inspect}, #{retries}), #{e.inspect} #{e.message}")
+        CheckSentry.notify(e, bot: 'alegre', method: method, path: path, params: params, retries: retries)
         if retries > 0
-          Rails.logger.error("[Alegre Bot] Alegre error: (#{method}, #{path}, #{params.inspect}, #{retries}), #{e.inspect} #{e.message}")
           sleep 1
           self.request(method, path, params, retries - 1)
         end
-        CheckSentry.notify(e, bot: 'alegre', method: method, path: path, params: params, retries: retries)
         { 'type' => 'error', 'data' => { 'message' => e.message } }
       end
     end


### PR DESCRIPTION
## Description

Notify Sentry when request to Alegre fails.

Fixes: CV2-6070.

## How has this been tested?

Tested locally. The most important thing is to test on QA once merged.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [x] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)