### PR TITLE
Fixing how published fact-checks are filtered for bot preview query.

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -577,14 +577,10 @@ class Team < ApplicationRecord
     fc_items = []
     ex_items = []
     threads << Thread.new {
-      result_ids = Bot::Smooch.search_for_similar_published_fact_checks_no_cache('text', query, [self.id], limit, nil, nil, language, false, settings).map(&:id)
+      result_ids = Bot::Smooch.search_for_similar_published_fact_checks_no_cache('text', query, [self.id], limit, nil, nil, language, pm.nil?, settings).map(&:id)
       unless result_ids.blank?
         fc_items = FactCheck.joins(claim_description: :project_media).where('project_medias.id': result_ids)
-        if pm.nil?
-          # This means we obtain relevant items for the Bot preview, so we should limit FactChecks to published articles;
-          # otherwise, relevant articles for ProjectMedia should include all FactChecks.
-          fc_items = fc_items.where(report_status: 'published')
-        elsif !pm.fact_check_id.nil?
+        if !pm&.fact_check_id.nil?
           # Exclude the ones already applied to a target item if exists.
           fc_items = fc_items.where.not('fact_checks.id' => pm.fact_check_id) unless pm&.fact_check_id.nil?
         end


### PR DESCRIPTION
## Description

Previously, both published and unpublished fact-checks were returned by the Smooch Bot query and then re-filtered in PostgreSQL. The problem with this approach was that if the query returned three results - two published and one unpublished - only the two published fact-checks would remain after re-filtering. This change also makes the code behave more similarly to the real tipline search.

Fixes: CV2-5572.

## How has this been tested?

Manually.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

