### PR TITLE
CV2-6079: Fix N+1 query for BotUser query

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -75,7 +75,7 @@ class Bot::Smooch < BotUser
 
           # A relationship created by the Smooch Bot or Alegre Bot is related to search results (unless it's a suggestion that was confirmed), so the user has already received the report as a search result... no need to send another report
           # Only send a report for (1) Confirmed matches created manually OR (2) Suggestions accepted
-          created_by_bot = [BotUser.smooch_user&.id, BotUser.alegre_user&.id].include?(relationship.user_id)
+          created_by_bot = BotUser.where(login: ['alegre', 'smooch'], id: relationship.user_id).exists?
           ::Bot::Smooch.send_report_from_parent_to_child(parent.id, target.id) if !created_by_bot || relationship.confirmed_by
         end
       end


### PR DESCRIPTION
## Description

Fix N+1 query by implemented a single query to get alegre & smooch bots.

References: CV2-6079

## How has this been tested?

Re-run automated tests.


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

