### PR TITLE
CV2-6125: Fix has_claim filter

### DIFF
--- a/app/models/concerns/article.rb
+++ b/app/models/concerns/article.rb
@@ -51,11 +51,8 @@ module Article
 
   protected
 
-  def index_in_elasticsearch(data)
-    # touch project media to update `updated_at` date
-    pm = self.project_media
-    return if pm.nil?
-    pm = ProjectMedia.find_by_id(pm.id)
+  def index_in_elasticsearch(pm_id, data)
+    pm = ProjectMedia.find_by_id(pm_id)
     unless pm.nil?
       updated_at = Time.now
       pm.update_columns(updated_at: updated_at)

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -152,7 +152,7 @@ class FactCheck < ApplicationRecord
   end
 
   def article_elasticsearch_data(action = 'create_or_update')
-    return if self.disable_es_callbacks || RequestStore.store[:disable_es_callbacks]
+    return if self.project_media.nil? || self.disable_es_callbacks || RequestStore.store[:disable_es_callbacks]
     data = action == 'destroy' ? {
         'fact_check_title' => '',
         'fact_check_summary' => '',
@@ -164,7 +164,7 @@ class FactCheck < ApplicationRecord
         'fact_check_url' => self.url,
         'fact_check_languages' => [self.language]
       }
-    self.index_in_elasticsearch(data)
+    self.index_in_elasticsearch(self.project_media.id, data)
   end
 
   def set_initial_rating

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -617,9 +617,6 @@ class ProjectMedia < ApplicationRecord
   end
 
   def add_nested_objects(ms)
-    # comments
-    comments = self.annotations('comment')
-    ms.attributes[:comments] = comments.collect{|c| {id: c.id, text: c.text}}
     # tags
     tags = self.get_annotations('tag').map(&:load)
     ms.attributes[:tags] = tags.collect{|t| {id: t.id, tag: t.tag_text}}

--- a/app/workers/elastic_search_worker.rb
+++ b/app/workers/elastic_search_worker.rb
@@ -15,6 +15,7 @@ class ElasticSearchWorker
         ops = {
           'create_doc' => 'create_elasticsearch_doc_bg',
           'update_doc' => 'update_elasticsearch_doc_bg',
+          'remove_fields' => 'remove_fields_from_elasticsearch_doc_bg',
           'update_doc_team' => 'update_elasticsearch_doc_team_bg',
           'create_update_doc_nested' => 'create_update_nested_obj_bg',
           'destroy_doc' => 'destroy_elasticsearch_doc',

--- a/lib/tasks/data/project_media.rake
+++ b/lib/tasks/data/project_media.rake
@@ -67,18 +67,6 @@ namespace :check do
         pm_responses
       end
 
-      def self.comments(_team, pm_ids)
-        pm_comments = Hash.new {|hash, key| hash[key] = [] }
-        Comment.where(annotation_type: 'comment', annotated_id: pm_ids, annotated_type: 'ProjectMedia')
-        .find_each do |c|
-          pm_comments[c.annotated_id] << {
-            id: c.id,
-            text: c.text
-          }
-        end
-        pm_comments
-      end
-
       def self.tags(_team, pm_ids)
         pm_tags = Hash.new {|hash, key| hash[key] = [] }
         Tag.where(annotation_type: 'tag', annotated_id: pm_ids, annotated_type: 'ProjectMedia')

--- a/test/controllers/elastic_search_9_test.rb
+++ b/test/controllers/elastic_search_9_test.rb
@@ -16,13 +16,18 @@ class ElasticSearch9Test < ActionController::TestCase
       pm2 = create_project_media team: t, disable_es_callbacks: false
       pm3 = create_project_media team: t, disable_es_callbacks: false
       pm4 = create_project_media team: t, disable_es_callbacks: false
-      create_claim_description project_media: pm, disable_es_callbacks: false
+      cd = create_claim_description project_media: pm, disable_es_callbacks: false
       create_claim_description project_media: pm3, disable_es_callbacks: false
-      sleep 2
+      sleep 1
       results = CheckSearch.new({ has_claim: ['ANY_VALUE'] }.to_json)
       assert_equal [pm.id, pm3.id], results.medias.map(&:id).sort
       results = CheckSearch.new({ has_claim: ['NO_VALUE'] }.to_json)
       assert_equal [pm2.id, pm4.id], results.medias.map(&:id).sort
+      cd.project_media_id = nil
+      cd.save!
+      sleep 1
+      results = CheckSearch.new({ has_claim: ['NO_VALUE'] }.to_json)
+      assert_equal [pm.id, pm2.id, pm4.id], results.medias.map(&:id).sort
     end
   end
 


### PR DESCRIPTION
## Description

The has_claim filter does not function correctly. Users are unable to see items that should be displayed when filtering by "Claim is Empty" so I did the following to fix this issue:

- [ ] Remove ClaimDescription fields when user remove fact-check articles
- [ ] Clear ES fact-check fields after remove ClaimDescription from ProjectMediaItem
- [ ] Clear missing codes related to ES comments

References: CV2-6125

## How has this been tested?

Implemented automated tests.


## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

