### PR TITLE
CV2-6038 refactor has claim search filter into has article filter

### DIFF
--- a/app/lib/check_elastic_search.rb
+++ b/app/lib/check_elastic_search.rb
@@ -49,13 +49,11 @@ module CheckElasticSearch
     data = get_elasticsearch_data(options[:data], options[:skip_get_data])
     fields = {}
     options[:keys].each do |k|
-      unless data[k].nil?
-        if data[k].class.to_s == 'Hash'
-          value = get_fresh_value(data[k].with_indifferent_access)
-          fields[k] = value unless value.nil?
-        else
-          fields[k] = data[k]
-        end
+      if data[k].class.to_s == 'Hash'
+        value = get_fresh_value(data[k].with_indifferent_access)
+        fields[k] = value
+      else
+        fields[k] = data[k]
       end
     end
     if fields.count

--- a/app/models/claim_description.rb
+++ b/app/models/claim_description.rb
@@ -128,7 +128,7 @@ class ClaimDescription < ApplicationRecord
 
   def log_relevant_article_results
     fc = self.fact_check
-    self.project_media.delay.log_relevant_results(fc.class.name, fc.id, User.current&.id, self.class.actor_session_id)
+    self.project_media.delay.log_relevant_results(fc.class.name, fc.id, User.current&.id, self.class.actor_session_id) unless fc.nil?
   end
 
   def cant_apply_article_to_item_if_article_is_in_the_trash

--- a/app/models/claim_description.rb
+++ b/app/models/claim_description.rb
@@ -36,12 +36,14 @@ class ClaimDescription < ApplicationRecord
 
   def article_elasticsearch_data(action = 'create_or_update')
     return if self.project_media_id.nil? || self.disable_es_callbacks || RequestStore.store[:disable_es_callbacks]
-    if action == 'destroy'
-      self.remove_fields_from_elasticsearch_doc(['claim_description_content', 'claim_description_context'], self.project_media_id)
-    else
-      data = { 'claim_description_content' => self.description, 'claim_description_context' => self.context }
-      self.index_in_elasticsearch(self.project_media_id, data)
-    end
+    data = action == 'destroy' ? {
+      'claim_description_content' => nil,
+      'claim_description_context' => nil
+    } : {
+      'claim_description_content' => self.description,
+      'claim_description_context' => self.context
+    }
+    self.index_in_elasticsearch(self.project_media_id, data)
   end
 
   def project_media_was
@@ -90,13 +92,11 @@ class ClaimDescription < ApplicationRecord
         fact_check.save!
       end
       # update ES
-      # Remove claim_description fields
-      self.remove_fields_from_elasticsearch_doc(['claim_description_content', 'claim_description_context'], pm.id)
+      # clear claim_description fields
+      data = { 'claim_description_content' => nil, 'claim_description_context' => nil }
       # clear fact-check values
-      unless self.fact_check.nil?
-        data = { 'fact_check_title' => '', 'fact_check_summary' => '', 'fact_check_url' => '', 'fact_check_languages' => [] }
-        self.fact_check.index_in_elasticsearch(pm.id, data)
-      end
+      data.merge!({ 'fact_check_title' => '', 'fact_check_summary' => '', 'fact_check_url' => '', 'fact_check_languages' => [] }) unless self.fact_check.nil?
+      self.index_in_elasticsearch(pm.id, data)
     end
   end
 

--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -214,6 +214,7 @@ module ProjectMediaCachedFields
       update_on: FACT_CHECK_EVENTS
 
     cached_field :description,
+      update_es: true,
       recalculate: :recalculate_description,
       update_on: title_or_description_update
 

--- a/app/models/concerns/project_media_getters.rb
+++ b/app/models/concerns/project_media_getters.rb
@@ -214,9 +214,9 @@ module ProjectMediaGetters
     self.claim_description&.fact_check
   end
 
-  def explainers_title
-    # Get the title for all explainer assinged to the item
-    titles = Explainer.joins(:explainer_items).where('explainer_items.project_media_id = ?', self.id).map(&:title).join(' ')
+  def explainers_titles
+    # Get the title for all explainer assigned to the item
+    titles = Explainer.joins(:explainer_items).where('explainer_items.project_media_id = ?', self.id).map(&:title).join("\n")
     titles.blank? ? nil : titles
   end
 end

--- a/app/models/concerns/project_media_getters.rb
+++ b/app/models/concerns/project_media_getters.rb
@@ -216,7 +216,7 @@ module ProjectMediaGetters
 
   def explainers_title
     # Get the title for all explainer assinged to the item
-    explainer_titles = self.explainer_items.map(&:explainer).map(&:title).join(' ')
-    explainer_titles.blank? ? nil : explainer_titles
+    titles = Explainer.joins(:explainer_items).where('explainer_items.project_media_id = ?', self.id).map(&:title).join(' ')
+    titles.blank? ? nil : titles
   end
 end

--- a/app/models/concerns/project_media_getters.rb
+++ b/app/models/concerns/project_media_getters.rb
@@ -213,4 +213,10 @@ module ProjectMediaGetters
   def fact_check
     self.claim_description&.fact_check
   end
+
+  def explainers_title
+    # Get the title for all explainer assinged to the item
+    explainer_titles = self.explainer_items.map(&:explainer).map(&:title).join(' ')
+    explainer_titles.blank? ? nil : explainer_titles
+  end
 end

--- a/app/models/explainer_item.rb
+++ b/app/models/explainer_item.rb
@@ -10,6 +10,7 @@ class ExplainerItem < ApplicationRecord
   validate :cant_apply_article_to_item_if_article_is_in_the_trash
 
   after_create :log_relevant_article_results
+  after_commit :update_elasticsearch_data
 
   def version_metadata(_changes)
     { explainer_title: self.explainer.title }.to_json
@@ -23,6 +24,17 @@ class ExplainerItem < ApplicationRecord
 
   def cant_apply_article_to_item_if_article_is_in_the_trash
     errors.add(:base, I18n.t(:cant_apply_article_to_item_if_article_is_in_the_trash)) if self.explainer&.trashed
+  end
+
+  def update_elasticsearch_data
+    return if self.disable_es_callbacks || RequestStore.store[:disable_es_callbacks]
+    pm = self.project_media
+    explainer_titles = pm.explainer_items.map(&:explainer).map(&:title).join(' ')
+    data = explainer_titles.blank? ? { explainer_title: nil } : { explainer_title: explainer_titles }
+    updated_at = Time.now
+    pm.update_columns(updated_at: updated_at)
+    data[:updated_at] = updated_at.utc
+    pm.update_elasticsearch_doc(data.keys, data, pm.id, true)
   end
 
   def log_relevant_article_results

--- a/app/models/explainer_item.rb
+++ b/app/models/explainer_item.rb
@@ -29,7 +29,6 @@ class ExplainerItem < ApplicationRecord
   def update_elasticsearch_data
     return if self.disable_es_callbacks || RequestStore.store[:disable_es_callbacks]
     pm = self.project_media
-    explainer_titles = pm.explainer_items.map(&:explainer).map(&:title).join(' ')
     # touch item to update `updated_at` date
     if ProjectMedia.exists?(pm.id)
       updated_at = Time.now

--- a/app/models/explainer_item.rb
+++ b/app/models/explainer_item.rb
@@ -35,7 +35,7 @@ class ExplainerItem < ApplicationRecord
       pm.update_columns(updated_at: updated_at)
       data = { updated_at: updated_at.utc }
       data['explainer_title'] = {
-        method: "explainers_title",
+        method: "explainers_titles",
         klass: pm.class.name,
         id: pm.id,
         default: nil,

--- a/app/repositories/media_search.rb
+++ b/app/repositories/media_search.rb
@@ -132,5 +132,7 @@ class MediaSearch
     indexes :negative_tipline_search_results_count, { type: 'long' }
 
     indexes :tipline_search_results_count, { type: 'long' }
+
+    indexes :explainer_title, { type: 'text', analyzer: 'check' }
   end
 end

--- a/app/workers/elastic_search_worker.rb
+++ b/app/workers/elastic_search_worker.rb
@@ -15,7 +15,6 @@ class ElasticSearchWorker
         ops = {
           'create_doc' => 'create_elasticsearch_doc_bg',
           'update_doc' => 'update_elasticsearch_doc_bg',
-          'remove_fields' => 'remove_fields_from_elasticsearch_doc_bg',
           'update_doc_team' => 'update_elasticsearch_doc_team_bg',
           'create_update_doc_nested' => 'create_update_nested_obj_bg',
           'destroy_doc' => 'destroy_elasticsearch_doc',

--- a/db/migrate/20250205224319_add_mapping_for_explainer_title_field.rb
+++ b/db/migrate/20250205224319_add_mapping_for_explainer_title_field.rb
@@ -1,0 +1,13 @@
+class AddMappingForExplainerTitleField < ActiveRecord::Migration[6.1]
+  def change
+    options = {
+      index: CheckElasticSearchModel.get_index_alias,
+      body: {
+        properties: {
+          explainer_title: { type: 'text', analyzer: 'check' },
+        }
+      }
+    }
+    $repository.client.indices.put_mapping options
+  end
+end

--- a/lib/check_search.rb
+++ b/lib/check_search.rb
@@ -469,8 +469,7 @@ class CheckSearch
     return [] if @options["keyword"].blank? || @options["keyword"].class.name != 'String'
     set_keyword_fields
     keyword_c = []
-    field_conditions = build_keyword_conditions_media_fields
-    keyword_c.concat field_conditions
+    keyword_c.concat build_keyword_conditions_media_fields
     # Search in requests
     [['request_username', 'username'], ['request_identifier', 'identifier'], ['request_content', 'content']].each do |pair|
       keyword_c << {
@@ -497,7 +496,7 @@ class CheckSearch
   def build_keyword_conditions_media_fields
     es_fields = []
     conditions = []
-    %w(title description url claim_description_content fact_check_title fact_check_summary claim_description_context fact_check_url source_name).each do |f|
+    %w(title description url claim_description_content fact_check_title fact_check_summary claim_description_context fact_check_url source_name explainer_title).each do |f|
       es_fields << f if should_include_keyword_field?(f)
     end
     es_fields << 'analysis_title' if should_include_keyword_field?('title')

--- a/lib/tasks/migrate/20250205224319_add_mapping_for_explainer_title_field.rake
+++ b/lib/tasks/migrate/20250205224319_add_mapping_for_explainer_title_field.rake
@@ -9,8 +9,7 @@ namespace :check do
         next if skip_pmids.include?(raw.project_media_id)
         pm = raw.project_media
         doc_id =  Base64.encode64("ProjectMedia/#{pm.id}")
-        explainers_title = pm.explainers_title
-        fields = { 'explainer_title' => pm.explainers_title }
+        fields = { 'explainer_title' => pm.explainers_titles }
         es_body << { update: { _index: index_alias, _id: doc_id, retry_on_conflict: 3, data: { doc: fields } } }
         skip_pmids << pm.id
       end

--- a/lib/tasks/migrate/20250205224319_add_mapping_for_explainer_title_field.rake
+++ b/lib/tasks/migrate/20250205224319_add_mapping_for_explainer_title_field.rake
@@ -1,0 +1,22 @@
+namespace :check do
+  namespace :migrate do
+    task project_media_explainer_title: :environment do
+      started = Time.now.to_i
+      index_alias = CheckElasticSearchModel.get_index_alias
+      skip_pmids = []
+      es_body = []
+      ExplainerItem.find_each do |raw|
+        next if skip_pmids.include?(raw.project_media_id)
+        pm = raw.project_media
+        doc_id =  Base64.encode64("ProjectMedia/#{pm.id}")
+        explainers_title = pm.explainers_title
+        fields = { 'explainer_title' => pm.explainers_title }
+        es_body << { update: { _index: index_alias, _id: doc_id, retry_on_conflict: 3, data: { doc: fields } } }
+        skip_pmids << pm.id
+      end
+      $repository.client.bulk body: es_body unless es_body.blank?
+      minutes = ((Time.now.to_i - started) / 60).to_i
+      puts "[#{Time.now}] Done in #{minutes} minutes."
+    end
+  end
+end

--- a/test/controllers/elastic_search_9_test.rb
+++ b/test/controllers/elastic_search_9_test.rb
@@ -34,16 +34,16 @@ class ElasticSearch9Test < ActionController::TestCase
       assert_equal [pm5.id], results.medias.map(&:id).sort
       # remove explainer
       ExplainerItem.where(explainer_id: ex2_a.id, project_media_id: pm2.id).destroy_all
-      ExplainerItem.where(explainer_id: ex3.id, project_media_id: pm2.id).destroy_all
-      cd4.project_id = nil
+      ExplainerItem.where(explainer_id: ex3.id, project_media_id: pm3.id).destroy_all
+      cd4.project_media_id = nil
       cd4.save!
       sleep 1
       results = CheckSearch.new({ has_article: ['ANY_VALUE'] }.to_json)
-      assert_equal [pm.id, pm2.id, pm4], results.medias.map(&:id).sort
+      assert_equal [pm.id, pm2.id, pm4.id], results.medias.map(&:id).sort
       results = CheckSearch.new({ has_article: ['NO_VALUE'] }.to_json)
       assert_equal [pm3.id, pm5.id], results.medias.map(&:id).sort
       # remove fact-check and explainer
-      cd.project_id = nil
+      cd.project_media_id = nil
       cd.save!
       ExplainerItem.where(explainer_id: ex2_b.id, project_media_id: pm2.id).destroy_all
       ExplainerItem.where(explainer_id: ex4.id, project_media_id: pm4.id).destroy_all
@@ -53,12 +53,12 @@ class ElasticSearch9Test < ActionController::TestCase
       results = CheckSearch.new({ has_article: ['NO_VALUE'] }.to_json)
       assert_equal [pm.id, pm2.id, pm3.id, pm4.id, pm5.id], results.medias.map(&:id).sort
       # re-assing fact or explainer
-      cd.project_id = pm2.id
+      cd.project_media_id = pm2.id
       cd.save!
-      pm5.explainers << ex
+      pm5.explainers << ex4
       sleep 1
       results = CheckSearch.new({ has_article: ['ANY_VALUE'] }.to_json)
-      assert_equal [pm2.id, pm5], results.medias.map(&:id).sort
+      assert_equal [pm2.id, pm5.id], results.medias.map(&:id).sort
       results = CheckSearch.new({ has_article: ['NO_VALUE'] }.to_json)
       assert_equal [pm.id, pm3.id, pm4.id], results.medias.map(&:id).sort
     end

--- a/test/controllers/elastic_search_9_test.rb
+++ b/test/controllers/elastic_search_9_test.rb
@@ -12,7 +12,7 @@ class ElasticSearch9Test < ActionController::TestCase
     u = create_user
     create_team_user team: t, user: u, role: 'admin'
     with_current_user_and_team(u ,t) do
-      pm = create_project_media team: t, disable_es_callbacks: false
+      pm = create_project_media team: t, quote: 'explainer_search', disable_es_callbacks: false
       pm2 = create_project_media team: t, disable_es_callbacks: false
       pm3 = create_project_media team: t, disable_es_callbacks: false
       pm4 = create_project_media team: t, disable_es_callbacks: false
@@ -24,7 +24,7 @@ class ElasticSearch9Test < ActionController::TestCase
       pm2.explainers << ex2_a
       pm2.explainers << ex2_b
       pm3.explainers << ex3
-      ex4 = create_explainer team: t
+      ex4 = create_explainer team: t, title: 'explainer_search'
       cd4 = create_claim_description project_media: pm4, disable_es_callbacks: false
       pm4.explainers << ex4
       sleep 1
@@ -61,6 +61,11 @@ class ElasticSearch9Test < ActionController::TestCase
       assert_equal [pm2.id, pm5.id], results.medias.map(&:id).sort
       results = CheckSearch.new({ has_article: ['NO_VALUE'] }.to_json)
       assert_equal [pm.id, pm3.id, pm4.id], results.medias.map(&:id).sort
+      # Verify search by explainer_title field
+      result = CheckSearch.new({keyword: 'explainer_search'}.to_json, nil, t.id)
+      assert_equal [pm.id, pm5.id], result.medias.map(&:id).sort
+      result = CheckSearch.new({keyword: 'explainer_search', keyword_fields: {fields: ['explainer_title']}}.to_json, nil, t.id)
+      assert_equal [pm5.id], result.medias.map(&:id)
     end
   end
 

--- a/test/controllers/elastic_search_9_test.rb
+++ b/test/controllers/elastic_search_9_test.rb
@@ -6,7 +6,7 @@ class ElasticSearch9Test < ActionController::TestCase
     setup_elasticsearch
   end
 
-  test "should filter items by has_claim" do
+  test "should filter items by has_article" do
     t = create_team
     p = create_project team: t
     u = create_user
@@ -19,10 +19,68 @@ class ElasticSearch9Test < ActionController::TestCase
       create_claim_description project_media: pm, disable_es_callbacks: false
       create_claim_description project_media: pm3, disable_es_callbacks: false
       sleep 2
-      results = CheckSearch.new({ has_claim: ['ANY_VALUE'] }.to_json)
+      results = CheckSearch.new({ has_article: ['ANY_VALUE'] }.to_json)
       assert_equal [pm.id, pm3.id], results.medias.map(&:id).sort
-      results = CheckSearch.new({ has_claim: ['NO_VALUE'] }.to_json)
+      results = CheckSearch.new({ has_article: ['NO_VALUE'] }.to_json)
       assert_equal [pm2.id, pm4.id], results.medias.map(&:id).sort
+    end
+  end
+
+  test "should filter items by has_article 2" do
+    t = create_team
+    p = create_project team: t
+    u = create_user
+    create_team_user team: t, user: u, role: 'admin'
+    with_current_user_and_team(u ,t) do
+      pm = create_project_media team: t, disable_es_callbacks: false
+      pm2 = create_project_media team: t, disable_es_callbacks: false
+      pm3 = create_project_media team: t, disable_es_callbacks: false
+      pm4 = create_project_media team: t, disable_es_callbacks: false
+      pm5 = create_project_media team: t, disable_es_callbacks: false
+      cd = create_claim_description project_media: pm, disable_es_callbacks: false
+      ex2_a = create_explainer team: t
+      ex2_b = create_explainer team: t
+      ex3 = create_explainer team: t
+      pm2.explainers << ex2_a
+      pm2.explainers << ex2_b
+      pm3.explainers << ex3
+      ex4 = create_explainer team: t
+      cd4 = create_claim_description project_media: pm4, disable_es_callbacks: false
+      pm4.explainers << ex4
+      sleep 1
+      results = CheckSearch.new({ has_article: ['ANY_VALUE'] }.to_json)
+      assert_equal [pm.id, pm2.id, pm3.id, pm4.id], results.medias.map(&:id).sort
+      results = CheckSearch.new({ has_article: ['NO_VALUE'] }.to_json)
+      assert_equal [pm5.id], results.medias.map(&:id).sort
+      # remove explainer
+      ExplainerItem.where(explainer_id: ex2_a.id, project_media_id: pm2.id).destroy_all
+      ExplainerItem.where(explainer_id: ex3.id, project_media_id: pm2.id).destroy_all
+      cd4.project_id = nil
+      cd4.save!
+      sleep 1
+      results = CheckSearch.new({ has_article: ['ANY_VALUE'] }.to_json)
+      assert_equal [pm.id, pm2.id, pm4], results.medias.map(&:id).sort
+      results = CheckSearch.new({ has_article: ['NO_VALUE'] }.to_json)
+      assert_equal [pm3.id, pm5.id], results.medias.map(&:id).sort
+      # remove fact-check and explainer
+      cd.project_id = nil
+      cd.save!
+      ExplainerItem.where(explainer_id: ex2_b.id, project_media_id: pm2.id).destroy_all
+      ExplainerItem.where(explainer_id: ex4.id, project_media_id: pm4.id).destroy_all
+      sleep 1
+      results = CheckSearch.new({ has_article: ['ANY_VALUE'] }.to_json)
+      assert_empty results.medias.map(&:id)
+      results = CheckSearch.new({ has_article: ['NO_VALUE'] }.to_json)
+      assert_equal [pm.id, pm2.id, pm3.id, pm4.id, pm5.id], results.medias.map(&:id).sort
+      # re-assing fact or explainer
+      cd.project_id = pm2.id
+      cd.save!
+      pm5.explainers << ex
+      sleep 1
+      results = CheckSearch.new({ has_article: ['ANY_VALUE'] }.to_json)
+      assert_equal [pm2.id, pm5], results.medias.map(&:id).sort
+      results = CheckSearch.new({ has_article: ['NO_VALUE'] }.to_json)
+      assert_equal [pm.id, pm3.id, pm4.id], results.medias.map(&:id).sort
     end
   end
 


### PR DESCRIPTION
## Description

Refactor has_claim filter to include both FactCheck & Explainer

- [x] Add a field for the explainer title to the ES doc
- [x] Add/update the explainer information to ElasticSearch when explainer is added/updated.
- [x] Remove the explainer information when an explainer is deleted or remove from an item.
- [x] Rename `has_claim`  filter to `has_article`
- [x] Include explainer title in keyword search
- [x] Add rake task to migrate existing data

References: Cv2 6038

## How has this been tested?

Implemented automated tests.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

