### PR TITLE
CV2-6040: Enforce change the status while the report is published

### DIFF
--- a/app/models/annotations/dynamic.rb
+++ b/app/models/annotations/dynamic.rb
@@ -6,7 +6,7 @@ class Dynamic < ApplicationRecord
   mount_uploaders :file, ImageUploader
   serialize :file, JSON
 
-  attr_accessor :set_fields, :set_attribution, :action, :action_data
+  attr_accessor :set_fields, :set_attribution, :action, :action_data, :bypass_status_publish_check
 
   belongs_to :annotation_type_object, class_name: 'DynamicAnnotation::AnnotationType', foreign_key: 'annotation_type', primary_key: 'annotation_type', optional: true
   has_many :fields, class_name: 'DynamicAnnotation::Field', foreign_key: 'annotation_id', primary_key: 'id', dependent: :destroy
@@ -235,6 +235,7 @@ class Dynamic < ApplicationRecord
         next if value.blank?
         f = fields.select{ |x| x.field_name == field }.last || create_field(field, nil)
         f.value = value
+        f.bypass_status_publish_check = self.bypass_status_publish_check
         f.skip_check_ability = self.skip_check_ability unless self.skip_check_ability.nil?
         begin
           f.save!

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -69,10 +69,9 @@ class Bot::Smooch < BotUser
           s = target.annotations.where(annotation_type: 'verification_status').last&.load
           status = parent.last_verification_status
           if !s.nil? && s.status != status
-            RequestStore.store[:bypass_status_publish_check] = true
             s.status = status
+            s.bypass_status_publish_check = true
             s.save
-            RequestStore.store[:bypass_status_publish_check] = false
           end
 
           # A relationship created by the Smooch Bot or Alegre Bot is related to search results (unless it's a suggestion that was confirmed), so the user has already received the report as a search result... no need to send another report

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -69,8 +69,10 @@ class Bot::Smooch < BotUser
           s = target.annotations.where(annotation_type: 'verification_status').last&.load
           status = parent.last_verification_status
           if !s.nil? && s.status != status
+            RequestStore.store[:bypass_status_publish_check] = true
             s.status = status
             s.save
+            RequestStore.store[:bypass_status_publish_check] = false
           end
 
           # A relationship created by the Smooch Bot or Alegre Bot is related to search results (unless it's a suggestion that was confirmed), so the user has already received the report as a search result... no need to send another report

--- a/app/models/dynamic_annotation/field.rb
+++ b/app/models/dynamic_annotation/field.rb
@@ -2,7 +2,7 @@ class DynamicAnnotation::Field < ApplicationRecord
   include CheckElasticSearch
   has_paper_trail on: [:create, :update], save_changes: true, ignore: [:updated_at, :created_at], if: proc { |f| User.current.present? && (['verification_status_status', 'team_bot_response_formatted_data', 'language'].include?(f.field_name) || f.annotation_type == 'archiver' || f.annotation_type =~ /^task_response/) }, versions: { class_name: 'Version' }
 
-  attr_accessor :disable_es_callbacks
+  attr_accessor :disable_es_callbacks, :bypass_status_publish_check
 
   belongs_to :annotation, optional: true
   belongs_to :annotation_type_object, class_name: 'DynamicAnnotation::AnnotationType', foreign_key: 'annotation_type', primary_key: 'annotation_type', optional: true

--- a/app/models/workflow/verification_status.rb
+++ b/app/models/workflow/verification_status.rb
@@ -82,7 +82,7 @@ class Workflow::VerificationStatus < Workflow::Base
     end
 
     def check_if_item_is_published
-      return if RequestStore.store[:bypass_status_publish_check]
+      return if self.bypass_status_publish_check
       published = begin (self.annotation.annotated.get_annotations('report_design').last.load.get_field_value('state') == 'published') rescue false end
       if published
         error = {

--- a/app/models/workflow/verification_status.rb
+++ b/app/models/workflow/verification_status.rb
@@ -82,6 +82,7 @@ class Workflow::VerificationStatus < Workflow::Base
     end
 
     def check_if_item_is_published
+      return if RequestStore.store[:bypass_status_publish_check]
       published = begin (self.annotation.annotated.get_annotations('report_design').last.load.get_field_value('state') == 'published') rescue false end
       if published
         error = {

--- a/test/models/bot/smooch_2_test.rb
+++ b/test/models/bot/smooch_2_test.rb
@@ -131,10 +131,9 @@ class Bot::Smooch2Test < ActiveSupport::TestCase
     s.save!
     publish_report(pm_t)
     s = s.reload
-    RequestStore.store[:bypass_status_publish_check] = true
     s.status = 'in_progress'
+    s.bypass_status_publish_check = true
     s.save!
-    RequestStore.store[:bypass_status_publish_check] = false
     assert_equal 'in_progress', s.reload.status
   end
 

--- a/test/models/bot/smooch_2_test.rb
+++ b/test/models/bot/smooch_2_test.rb
@@ -122,6 +122,22 @@ class Bot::Smooch2Test < ActiveSupport::TestCase
     end
   end
 
+  test "should inherit status from parent even child is published" do
+    pm_s = create_project_media team: @team
+    pm_t = create_project_media team: @team
+    r = create_relationship source_id: pm_s.id, target_id: pm_t.id, relationship_type: Relationship.confirmed_type
+    s = pm_t.annotations.where(annotation_type: 'verification_status').last.load
+    s.status = 'verified'
+    s.save!
+    publish_report(pm_t)
+    s = s.reload
+    RequestStore.store[:bypass_status_publish_check] = true
+    s.status = 'in_progress'
+    s.save!
+    RequestStore.store[:bypass_status_publish_check] = false
+    assert_equal 'in_progress', s.reload.status
+  end
+
   test "should send message to user when status changes" do
     u = create_user is_admin: true
     uid = random_string


### PR DESCRIPTION
## Description

Add a flag to enforce change the status while the report is published.

References: CV2-6040

## How has this been tested?

Implemented automated tests.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [ ] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [ ] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

