### PR TITLE
Filter articles by "created" date.

### DIFF
--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -316,6 +316,7 @@ class TeamType < DefaultObject
     argument :tags, [GraphQL::Types::String, null: true], required: false, camelize: false
     argument :language, [GraphQL::Types::String, null: true], required: false, camelize: false
     argument :updated_at, GraphQL::Types::String, required: false, camelize: false # JSON
+    argument :created_at, GraphQL::Types::String, required: false, camelize: false # JSON
     argument :text, GraphQL::Types::String, required: false, camelize: false # Search by text
     argument :standalone, GraphQL::Types::Boolean, required: false, camelize: false # Not applied to any item (fact-checks only)
     argument :publisher_ids, [GraphQL::Types::Int, null: true], required: false, camelize: false
@@ -347,6 +348,7 @@ class TeamType < DefaultObject
     argument :tags, [GraphQL::Types::String, null: true], required: false, camelize: false
     argument :language, [GraphQL::Types::String, null: true], required: false, camelize: false
     argument :updated_at, GraphQL::Types::String, required: false, camelize: false # JSON
+    argument :created_at, GraphQL::Types::String, required: false, camelize: false # JSON
     argument :text, GraphQL::Types::String, required: false, camelize: false # Search by text
     argument :standalone, GraphQL::Types::Boolean, required: false, camelize: false # Not applied to any item (fact-checks only)
     argument :publisher_ids, [GraphQL::Types::Int, null: true], required: false, camelize: false

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -498,6 +498,7 @@ class Team < ApplicationRecord
 
     # Filter by date
     query = query.where(updated_at: Range.new(*format_times_search_range_filter(JSON.parse(filters[:updated_at]), nil))) unless filters[:updated_at].blank?
+    query = query.where(created_at: Range.new(*format_times_search_range_filter(JSON.parse(filters[:created_at]), nil))) unless filters[:created_at].blank?
 
     # Filter by trashed
     query = query.where(trashed: !!filters[:trashed])
@@ -529,6 +530,7 @@ class Team < ApplicationRecord
 
     # Filter by date
     query = query.where('fact_checks.updated_at' => Range.new(*format_times_search_range_filter(JSON.parse(filters[:updated_at]), nil))) unless filters[:updated_at].blank?
+    query = query.where('fact_checks.created_at' => Range.new(*format_times_search_range_filter(JSON.parse(filters[:created_at]), nil))) unless filters[:created_at].blank?
 
     # Filter by publisher
     query = query.where('fact_checks.publisher_id' => filters[:publisher_ids].to_a.map(&:to_i)) unless filters[:publisher_ids].blank?

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -13187,6 +13187,7 @@ type Team implements Node {
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
+    created_at: String
 
     """
     Returns the first _n_ elements from the list.
@@ -13213,7 +13214,7 @@ type Team implements Node {
     updated_at: String
     user_ids: [Int]
   ): ArticleUnionConnection
-  articles_count(article_type: String, imported: Boolean, language: [String], publisher_ids: [Int], rating: [String], report_status: [String], standalone: Boolean, tags: [String], target_id: Int, text: String, trashed: Boolean = false, updated_at: String, user_ids: [Int]): Int
+  articles_count(article_type: String, created_at: String, imported: Boolean, language: [String], publisher_ids: [Int], rating: [String], report_status: [String], standalone: Boolean, tags: [String], target_id: Int, text: String, trashed: Boolean = false, updated_at: String, user_ids: [Int]): Int
   available_newsletter_header_types: JsonStringType
   avatar: String
   bot_query(enableLanguageDetection: Boolean, enableLinkShortening: Boolean, maxNumberOfWords: Int, searchText: String!, shouldRestrictByLanguage: Boolean, threshold: Float, utmCode: String): [TiplineSearchResult!]

--- a/public/relay.json
+++ b/public/relay.json
@@ -69302,6 +69302,18 @@
                   "deprecationReason": null
                 },
                 {
+                  "name": "created_at",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
                   "name": "text",
                   "description": null,
                   "type": {
@@ -69484,6 +69496,18 @@
                 },
                 {
                   "name": "updated_at",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null,
+                  "isDeprecated": false,
+                  "deprecationReason": null
+                },
+                {
+                  "name": "created_at",
                   "description": null,
                   "type": {
                     "kind": "SCALAR",


### PR DESCRIPTION
## Description

Adding a new filter to the GraphQL fields `TeamType.articles` and `TeamType.articles_count`: "created" date.

Reference: CV2-5851.

## How has this been tested?

I just tested manually using the web client (branch with the same name as this). I didn't add automated tests because it's mostly declarative and/or only calls methods that are already tested.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [ ] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)