### PR TITLE
Don't crash when a GraphQL-requested workspace (with the `random` argument) doesn't exist

### DIFF
--- a/app/graph/types/query_type.rb
+++ b/app/graph/types/query_type.rb
@@ -82,11 +82,12 @@ class QueryType < BaseObject
 
   def team(id: nil, slug: nil, random: nil)
     tid = id.to_i
+    team = nil
     unless slug.blank?
       team = Team.where(slug: slug).first
       tid = team.id unless team.nil?
     end
-    team.reload if random
+    team.reload if team && random
     tid = Team.current&.id || User.current&.teams&.first&.id if tid === 0
     GraphqlCrudOperations.load_if_can(Team, tid.to_i, context)
   end


### PR DESCRIPTION
## Description

Don't crash when a GraphQL-requested workspace (with the `random` argument) doesn't exist.

Reported by Sentry.

Fixes: CV2-6151.

## How has this been tested?

TDD. Reproduced in a unit test that passed after the fix:

```
Failure:
GraphqlController11Test#test_should_not_crash_if_workspace_doesn't_exist [test/controllers/graphql_controller_11_test.rb:397]:
Expected response to be a <2XX: success>, but was a <400: Bad Request>
Response body: {"errors":[{"message":"undefined method `reload' for nil:NilClass","code":5,"data":{}}]}
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)