### PR TITLE
Don't try to store an Alegre package for an item of "blank" type.

### DIFF
--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -251,8 +251,10 @@ module AlegreV2
     end
 
     def store_package(project_media, field, params={})
+      type = get_type(project_media)
+      return if type.nil?
       generic_package(project_media, field).merge(
-        self.send("store_package_#{get_type(project_media)}", project_media, field, params)
+        self.send("store_package_#{type}", project_media, field, params)
       )
     end
 

--- a/test/models/bot/alegre_4_test.rb
+++ b/test/models/bot/alegre_4_test.rb
@@ -82,4 +82,11 @@ class Bot::Alegre4Test < ActiveSupport::TestCase
     end
     Bot::Alegre.unstub.stubs(:request)
   end
+
+  test "should not try to store package for blank item" do
+    pm = create_project_media media: Blank.create!
+    assert_nothing_raised do
+      Bot::Alegre.store_package(pm, 'title')
+    end
+  end
 end


### PR DESCRIPTION
## Description

This commit fixes an error reported by Sentry.

Fixes: CV2-6150.

## How has this been tested?

TDD. I reproduced it in a unit test that passed after the fix:

```
$ docker-compose exec api bundle exec ruby test/models/bot/alegre_4_test.rb -n /package/

Error:
Bot::Alegre4Test#test_should_not_try_to_store_package_for_blank_item:
NoMethodError: undefined method `store_package_' for Bot::Alegre:Class
Did you mean?  store_package
               store_package_text
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added unit and feature tests, if the PR implements a new feature or otherwise would benefit from additional testing
- [x] I have added regression tests, if the PR fixes a bug
- [ ] I have added logging, exception reporting, and custom tracing with any additional information required for debugging
- [x] I considered secure coding practices when writing this code. Any security concerns are noted above.
- [ ] I have commented my code in hard-to-understand areas, if any
- [ ] I have made needed changes to the README
- [x] My changes generate no new warnings
- [ ] If I added a third party module, I included a rationale for doing so and followed our current [guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/overview#Choose-the-%E2%80%9Cright%E2%80%9D-3rd-party-module)

