### PR TITLE
CV2-6038: add rake task to migrate existing FactCheck

### DIFF
--- a/app/models/claim_description.rb
+++ b/app/models/claim_description.rb
@@ -95,7 +95,7 @@ class ClaimDescription < ApplicationRecord
       # clear claim_description fields
       data = { 'claim_description_content' => nil, 'claim_description_context' => nil }
       # clear fact-check values
-      data.merge!({ 'fact_check_title' => '', 'fact_check_summary' => '', 'fact_check_url' => '', 'fact_check_languages' => [] }) unless self.fact_check.nil?
+      data.merge!({ 'fact_check_title' => nil, 'fact_check_summary' => nil, 'fact_check_url' => nil, 'fact_check_languages' => [] }) unless self.fact_check.nil?
       self.index_in_elasticsearch(pm.id, data)
     end
   end

--- a/app/models/concerns/team_associations.rb
+++ b/app/models/concerns/team_associations.rb
@@ -22,6 +22,7 @@ module TeamAssociations
     has_many :tipline_newsletters
     has_many :tipline_requests, as: :associated
     has_many :explainers, dependent: :destroy
+    has_many :claim_descriptions
     has_many :api_keys
 
     has_annotations

--- a/app/models/fact_check.rb
+++ b/app/models/fact_check.rb
@@ -154,9 +154,9 @@ class FactCheck < ApplicationRecord
   def article_elasticsearch_data(action = 'create_or_update')
     return if self.project_media.nil? || self.disable_es_callbacks || RequestStore.store[:disable_es_callbacks]
     data = action == 'destroy' ? {
-        'fact_check_title' => '',
-        'fact_check_summary' => '',
-        'fact_check_url' => '',
+        'fact_check_title' => nil,
+        'fact_check_summary' => nil,
+        'fact_check_url' => nil,
         'fact_check_languages' => []
       } : {
         'fact_check_title' => self.title,

--- a/lib/tasks/migrate/20230130074014_add_mapping_for_keyword_search_fields.rake
+++ b/lib/tasks/migrate/20230130074014_add_mapping_for_keyword_search_fields.rake
@@ -9,7 +9,7 @@ namespace :check do
       client = $repository.client
       last_team_id = Rails.cache.read('check:migrate:index_fact_check_fields:team_id') || 0
       Team.where('id > ?', last_team_id).find_each do |team|
-        team.claim_descriptions.find_in_batches(:batch_size => 1000) do |cds|
+        team.claim_descriptions.joins(:project_media).find_in_batches(:batch_size => 1000) do |cds|
           es_body = []
           ids = cds.map(&:id)
           ClaimDescription.select('claim_descriptions.project_media_id as pm_id, claim_descriptions.description, claim_descriptions.context, fact_checks.*')

--- a/lib/tasks/migrate/20250205224319_add_mapping_for_explainer_title_field.rake
+++ b/lib/tasks/migrate/20250205224319_add_mapping_for_explainer_title_field.rake
@@ -17,5 +17,33 @@ namespace :check do
       minutes = ((Time.now.to_i - started) / 60).to_i
       puts "[#{Time.now}] Done in #{minutes} minutes."
     end
+
+    task project_media_initiate_fact_check: :environment do
+      started = Time.now.to_i
+      Team.find_each do |team|
+        params = {
+          claim_description_content:nil,
+          claim_description_context:nil,
+          fact_check_title:nil,
+          fact_check_summary:nil,
+          fact_check_url:nil,
+          fact_check_languages:[]
+        }
+        options = {
+          index: CheckElasticSearchModel.get_index_alias,
+          conflicts: 'proceed',
+          body: {
+            script: {
+              source: "ctx._source.claim_description_content = params.claim_description_content;ctx._source.claim_description_context = params.claim_description_context;ctx._source.fact_check_title=params.fact_check_title;ctx._source.fact_check_summary=params.fact_check_summary;ctx._source.fact_check_url=params.fact_check_url;ctx._source.fact_check_languages=params.fact_check_languages",
+              params: params
+            },
+            query: { term: { team_id: { value: team.id } } }
+          }
+        }
+        $repository.client.update_by_query options
+      end
+      minutes = ((Time.now.to_i - started) / 60).to_i
+      puts "[#{Time.now}] Done in #{minutes} minutes."
+    end
   end
 end


### PR DESCRIPTION
## Description

Add rake tasks to migrate existing FactCheck.

- [x] Initiate all existing items with null values
- [x] Migrate existing fact-checks 

References: CV2-6038

## How to test?

Re-run automated tests

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
