### PR TITLE
Adding a couple of new tipline statistics data points: number of incoming messages and number of outgoing messages

### DIFF
--- a/app/graph/types/team_statistics_type.rb
+++ b/app/graph/types/team_statistics_type.rb
@@ -17,6 +17,8 @@ class TeamStatisticsType < DefaultObject
   # For tiplines
 
   field :number_of_messages, GraphQL::Types::Int, null: true
+  field :number_of_incoming_messages, GraphQL::Types::Int, null: true
+  field :number_of_outgoing_messages, GraphQL::Types::Int, null: true
   field :number_of_conversations, GraphQL::Types::Int, null: true
   field :number_of_messages_by_date, JsonStringType, null: true
   field :number_of_conversations_by_date, JsonStringType, null: true

--- a/lib/check_data_points.rb
+++ b/lib/check_data_points.rb
@@ -4,9 +4,10 @@ class CheckDataPoints
     GRANULARITY_VALUES = ['year', 'quarter', 'month', 'week', 'day']
 
     # Number of tipline messages
-    def tipline_messages(team_id, start_date, end_date, granularity = nil, platform = nil, language = nil)
+    def tipline_messages(team_id, start_date, end_date, granularity = nil, platform = nil, language = nil, direction = nil)
       start_date, end_date = parse_start_end_dates(start_date, end_date)
       query = TiplineMessage.where(team_id: team_id, created_at: start_date..end_date, state: ['sent', 'received'])
+      query = query.where(direction: direction) unless direction.nil?
       query_based_on_granularity(query, platform, language, granularity)
     end
 

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -13748,6 +13748,7 @@ type TeamStatistics implements Node {
   number_of_explainers_created: Int
   number_of_fact_checks_by_rating: JsonStringType
   number_of_fact_checks_created: Int
+  number_of_incoming_messages: Int
   number_of_matched_results_by_article_type: JsonStringType
   number_of_media_received_by_media_type: JsonStringType
   number_of_messages: Int
@@ -13755,6 +13756,7 @@ type TeamStatistics implements Node {
   number_of_new_subscribers: Int
   number_of_newsletters_delivered: Int
   number_of_newsletters_sent: Int
+  number_of_outgoing_messages: Int
   number_of_published_fact_checks: Int
   number_of_returning_users: Int
   number_of_search_results_by_feedback_type: JsonStringType

--- a/lib/team_statistics.rb
+++ b/lib/team_statistics.rb
@@ -108,6 +108,14 @@ class TeamStatistics
     CheckDataPoints.tipline_messages(@team.id, @start_date_str, @end_date_str, nil, @platform_name, @language)
   end
 
+  def number_of_incoming_messages
+    CheckDataPoints.tipline_messages(@team.id, @start_date_str, @end_date_str, nil, @platform_name, @language, 'incoming')
+  end
+
+  def number_of_outgoing_messages
+    CheckDataPoints.tipline_messages(@team.id, @start_date_str, @end_date_str, nil, @platform_name, @language, 'outgoing')
+  end
+
   def number_of_conversations
     CheckDataPoints.tipline_requests(@team.id, @start_date_str, @end_date_str, nil, @platform, @language)
   end

--- a/public/relay.json
+++ b/public/relay.json
@@ -72539,6 +72539,20 @@
               "deprecationReason": null
             },
             {
+              "name": "number_of_incoming_messages",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "number_of_matched_results_by_article_type",
               "description": null,
               "args": [
@@ -72624,6 +72638,20 @@
             },
             {
               "name": "number_of_newsletters_sent",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "number_of_outgoing_messages",
               "description": null,
               "args": [
 

--- a/test/lib/team_statistics_test.rb
+++ b/test/lib/team_statistics_test.rb
@@ -112,7 +112,7 @@ class TeamStatisticsTest < ActiveSupport::TestCase
     pm2 = create_project_media team: team
 
     travel_to Time.parse('2024-01-01') do
-      2.times { create_tipline_message team_id: @team.id, language: 'en', platform: 'WhatsApp' }
+      2.times { |i| create_tipline_message team_id: @team.id, language: 'en', platform: 'WhatsApp', direction: (i % 2 == 0 ? 'incoming' : 'outgoing') }
       create_tipline_message team_id: @team.id, language: 'en', platform: 'Telegram'
       create_tipline_message team_id: @team.id, language: 'pt', platform: 'WhatsApp'
       create_tipline_message team_id: team.id, language: 'en', platform: 'WhatsApp'
@@ -124,7 +124,7 @@ class TeamStatisticsTest < ActiveSupport::TestCase
     end
 
     travel_to Time.parse('2024-01-03') do
-      3.times { create_tipline_message team_id: @team.id, language: 'en', platform: 'WhatsApp' }
+      3.times { |i| create_tipline_message team_id: @team.id, language: 'en', platform: 'WhatsApp', direction: (i % 2 == 0 ? 'incoming' : 'outgoing') }
       create_tipline_message team_id: @team.id, language: 'en', platform: 'Telegram'
       create_tipline_message team_id: @team.id, language: 'pt', platform: 'WhatsApp'
       create_tipline_message team_id: team.id, language: 'en', platform: 'WhatsApp'
@@ -138,6 +138,8 @@ class TeamStatisticsTest < ActiveSupport::TestCase
     travel_to Time.parse('2024-01-08') do
       object = TeamStatistics.new(@team, 'past_week', 'en', 'whatsapp')
       assert_equal 5, object.number_of_messages
+      assert_equal 2, object.number_of_outgoing_messages
+      assert_equal 3, object.number_of_incoming_messages
       assert_equal({ '2024-01-01' => 2, '2024-01-02' => 0, '2024-01-03' => 3, '2024-01-04' => 0, '2024-01-05' => 0, '2024-01-06' => 0, '2024-01-07' => 0, '2024-01-08' => 0 },
                    object.number_of_messages_by_date)
       assert_equal 3, object.number_of_conversations


### PR DESCRIPTION
## Description

- [x] Refactor Check tipline data point `number_of_messages` to be able to filter by `direction` (`incoming` or `outgoing`).
- [x] Add team statistics method `number_of_incoming_messages`.
- [x] Add team statistics method `number_of_outgoing_messages`.
- [x] Expose new fields in GraphQL API.
- [x] Add unit tests.

Reference: CV2-5849.

## How to test?

A unit test was updated to cover these two new fields. The total number of messages (existing field) should correspond to the sum of incoming plus outgoing messages (two new fields added by this PR).

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).