### PR TITLE
Adding two new data points for the data dashboards.

### DIFF
--- a/app/graph/types/team_statistics_type.rb
+++ b/app/graph/types/team_statistics_type.rb
@@ -21,6 +21,8 @@ class TeamStatisticsType < DefaultObject
   field :number_of_outgoing_messages, GraphQL::Types::Int, null: true
   field :number_of_conversations, GraphQL::Types::Int, null: true
   field :number_of_messages_by_date, JsonStringType, null: true
+  field :number_of_incoming_messages_by_date, JsonStringType, null: true
+  field :number_of_outgoing_messages_by_date, JsonStringType, null: true
   field :number_of_conversations_by_date, JsonStringType, null: true
   field :number_of_search_results_by_feedback_type, JsonStringType, null: true
   field :average_response_time, GraphQL::Types::Int, null: true

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -13749,6 +13749,7 @@ type TeamStatistics implements Node {
   number_of_fact_checks_by_rating: JsonStringType
   number_of_fact_checks_created: Int
   number_of_incoming_messages: Int
+  number_of_incoming_messages_by_date: JsonStringType
   number_of_matched_results_by_article_type: JsonStringType
   number_of_media_received_by_media_type: JsonStringType
   number_of_messages: Int
@@ -13757,6 +13758,7 @@ type TeamStatistics implements Node {
   number_of_newsletters_delivered: Int
   number_of_newsletters_sent: Int
   number_of_outgoing_messages: Int
+  number_of_outgoing_messages_by_date: JsonStringType
   number_of_published_fact_checks: Int
   number_of_returning_users: Int
   number_of_search_results_by_feedback_type: JsonStringType

--- a/lib/team_statistics.rb
+++ b/lib/team_statistics.rb
@@ -125,6 +125,16 @@ class TeamStatistics
     number_of_tipline_data_points_by_date(data)
   end
 
+  def number_of_incoming_messages_by_date
+    data = CheckDataPoints.tipline_messages(@team.id, @start_date_str, @end_date_str, 'day', @platform_name, @language, 'incoming')
+    number_of_tipline_data_points_by_date(data)
+  end
+
+  def number_of_outgoing_messages_by_date
+    data = CheckDataPoints.tipline_messages(@team.id, @start_date_str, @end_date_str, 'day', @platform_name, @language, 'outgoing')
+    number_of_tipline_data_points_by_date(data)
+  end
+
   def number_of_conversations_by_date
     data = CheckDataPoints.tipline_requests(@team.id, @start_date_str, @end_date_str, 'day', @platform, @language)
     number_of_tipline_data_points_by_date(data)

--- a/public/relay.json
+++ b/public/relay.json
@@ -72553,6 +72553,20 @@
               "deprecationReason": null
             },
             {
+              "name": "number_of_incoming_messages_by_date",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "JsonStringType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "number_of_matched_results_by_article_type",
               "description": null,
               "args": [
@@ -72659,6 +72673,20 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "number_of_outgoing_messages_by_date",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "JsonStringType",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/test/lib/team_statistics_test.rb
+++ b/test/lib/team_statistics_test.rb
@@ -142,6 +142,10 @@ class TeamStatisticsTest < ActiveSupport::TestCase
       assert_equal 3, object.number_of_incoming_messages
       assert_equal({ '2024-01-01' => 2, '2024-01-02' => 0, '2024-01-03' => 3, '2024-01-04' => 0, '2024-01-05' => 0, '2024-01-06' => 0, '2024-01-07' => 0, '2024-01-08' => 0 },
                    object.number_of_messages_by_date)
+      assert_equal({ '2024-01-01' => 1, '2024-01-02' => 0, '2024-01-03' => 1, '2024-01-04' => 0, '2024-01-05' => 0, '2024-01-06' => 0, '2024-01-07' => 0, '2024-01-08' => 0 },
+                   object.number_of_outgoing_messages_by_date)
+      assert_equal({ '2024-01-01' => 1, '2024-01-02' => 0, '2024-01-03' => 2, '2024-01-04' => 0, '2024-01-05' => 0, '2024-01-06' => 0, '2024-01-07' => 0, '2024-01-08' => 0 },
+                   object.number_of_incoming_messages_by_date)
       assert_equal 3, object.number_of_conversations
       assert_equal({ '2024-01-01' => 1, '2024-01-02' => 0, '2024-01-03' => 2, '2024-01-04' => 0, '2024-01-05' => 0, '2024-01-06' => 0, '2024-01-07' => 0, '2024-01-08' => 0 },
                    object.number_of_conversations_by_date)


### PR DESCRIPTION
## Description

The two new data points are for "number of incoming messages by day" and "number of outgoing messages by day".

Reference: CV2-5849.

## How to test?

Automated test update to cover these new data points.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
