### PR TITLE
Adding a `statistics_platforms` field to GraphQL `TeamType`.

### DIFF
--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -402,6 +402,8 @@ class TeamType < DefaultObject
     TeamStatistics.new(object, period, language, platform)
   end
 
+  field :statistics_platforms, [GraphQL::Types::String], null: true, description: 'List of tipline platforms for which we have data.'
+
   field :bot_query, [TiplineSearchResultType], null: true do
     argument :search_text, GraphQL::Types::String, required: true
     argument :threshold, GraphQL::Types::Float, required: false

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -635,6 +635,11 @@ class Team < ApplicationRecord
     data
   end
 
+  # Platforms for which statistics are available (e.g., at least one media request)
+  def statistics_platforms
+    TiplineRequest.joins(:project_media).where('project_medias.team_id' => self.id).group('platform').count.keys
+  end
+
   # private
   #
   # Please add private methods to app/models/concerns/team_private.rb

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -13417,6 +13417,11 @@ type Team implements Node {
   sources_count(keyword: String): Int
   spam_count: Int
   statistics(language: String, period: String!, platform: String): TeamStatistics
+
+  """
+  List of tipline platforms for which we have data.
+  """
+  statistics_platforms: [String!]
   tag_texts(
     """
     Returns the elements in the list that come after the specified cursor.

--- a/public/relay.json
+++ b/public/relay.json
@@ -71007,6 +71007,28 @@
               "deprecationReason": null
             },
             {
+              "name": "statistics_platforms",
+              "description": "List of tipline platforms for which we have data.",
+              "args": [
+
+              ],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "tag_texts",
               "description": null,
               "args": [

--- a/test/models/team_2_test.rb
+++ b/test/models/team_2_test.rb
@@ -1597,6 +1597,7 @@ class Team2Test < ActiveSupport::TestCase
     assert_equal [], t.statistics_platforms
     create_tipline_request team_id: t.id, platform: 'telegram', associated: pm
     create_tipline_request team_id: t.id, platform: 'whatsapp', associated: pm
+    create_tipline_request team_id: t.id, platform: 'whatsapp', associated: pm
     assert_equal ['telegram', 'whatsapp'], t.reload.statistics_platforms.sort
   end
 end

--- a/test/models/team_2_test.rb
+++ b/test/models/team_2_test.rb
@@ -1590,4 +1590,13 @@ class Team2Test < ActiveSupport::TestCase
     t = create_team
     assert_equal [], t.search_for_similar_articles('Test')
   end
+
+  test "should return platforms for which statistics are available" do
+    t = create_team
+    pm = create_project_media team: t
+    assert_equal [], t.statistics_platforms
+    create_tipline_request team_id: t.id, platform: 'telegram', associated: pm
+    create_tipline_request team_id: t.id, platform: 'whatsapp', associated: pm
+    assert_equal ['telegram', 'whatsapp'], t.reload.statistics_platforms.sort
+  end
 end


### PR DESCRIPTION
## Description

The field returns the platforms for which analytics are available. The logic is: there is at least one media request for that platform.

Reference: CV2-5821.

## How to test?

I implemented an automated test for that.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).