### PR TITLE
Fixing CodeQL warnings

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,2 @@
+paths-ignore:
+  - "data/**" # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,8 +74,8 @@ jobs:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
-        paths-ignore:
-          - "data/**"
+        paths-ignore: |
+          data/**
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,7 +74,7 @@ jobs:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         paths-ignore:
-          - "data/**/plurals.rb" # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
+        - "data/**" # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
         debug: true
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,8 +74,7 @@ jobs:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
-        paths-ignore:
-          - data/**
+        paths-ignore: "data/**"
         debug: true
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,8 +73,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        paths-ignore:
-        - "data/**" # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
+        config-file: ./.github/codeql/codeql-config.yml
         debug: true
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,8 +49,6 @@ jobs:
           build-mode: none
         - language: ruby
           build-mode: none
-          paths-ignore:
-            - data # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -75,6 +73,8 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
+        paths-ignore:
+          - data # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,9 @@ on:
   schedule:
     - cron: '31 22 * * 0'
 
+paths-ignore:
+  - data # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,8 +74,8 @@ jobs:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
-        paths-ignore: |
-          data/
+        paths-ignore:
+          - "data/**"
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,7 +73,8 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        paths-ignore: "data/**/plurals.rb" # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
+        paths-ignore:
+          - "data/**/plurals.rb" # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
         debug: true
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
@@ -102,5 +103,3 @@ jobs:
       uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"
-        exclude:
-          - "data/**/plurals.rb" # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,7 +74,7 @@ jobs:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
-        paths-ignore: "data/**/plurals.rb"
+        paths-ignore: "data/*/plurals.rb"
         debug: true
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,9 +19,6 @@ on:
   schedule:
     - cron: '31 22 * * 0'
 
-paths-ignore:
-  - data # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
-
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
@@ -52,6 +49,8 @@ jobs:
           build-mode: none
         - language: ruby
           build-mode: none
+          paths-ignore:
+            - data # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,8 +74,9 @@ jobs:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
-        paths-ignore: |
-          data/**
+        paths-ignore:
+          - data/**
+        debug: true
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,8 +73,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
-        paths-ignore: "data/*/plurals.rb"
+        paths-ignore: "data/**/plurals.rb" # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
         debug: true
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
@@ -103,3 +102,5 @@ jobs:
       uses: github/codeql-action/analyze@v3
       with:
         category: "/language:${{matrix.language}}"
+        exclude:
+          - "data/**/plurals.rb" # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -74,7 +74,7 @@ jobs:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
-        paths-ignore: "data/**"
+        paths-ignore: "data/**/plurals.rb"
         debug: true
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -73,8 +73,9 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        paths-ignore:
-          - data # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
+        # Ignore the localization data directory, which contains unusual characters that cause parsing to fail.
+        paths-ignore: |
+          data/
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.

--- a/app/models/bot/tagger.rb
+++ b/app/models/bot/tagger.rb
@@ -2,15 +2,16 @@ require 'json'
 
 class Bot::Tagger < BotUser
   check_settings
+
   class Error < ::StandardError
   end
 
   def self.get_tag_text(tag_id, auto_tag_prefix, ignore_autotags)
-    tag=TagText.find_by_id(tag_id)&.text
-    if tag.nil? || (ignore_autotags && tag[0]==auto_tag_prefix)
+    tag = TagText.find_by_id(tag_id)&.text
+    if tag.nil? || (ignore_autotags && tag[0] == auto_tag_prefix)
       return nil
     else
-      tag[0]==auto_tag_prefix ? tag[1..] : tag
+      tag[0] == auto_tag_prefix ? tag[1..] : tag
     end
   end
 
@@ -23,62 +24,60 @@ class Bot::Tagger < BotUser
   def self.run(body)
     self.log("Received event with body of #{body}", nil, Logger::INFO)
     if CheckConfig.get('alegre_host').blank?
-      self.log("Skipping events because `alegre_host` config is blank", nil, Logger::DEBUG)
+      self.log("Skipping events because alegre_host config is blank", nil, Logger::DEBUG)
       return false
     end
 
     handled = false
     pm = nil
     begin
-      settings=JSON.parse(body[:settings])
-      auto_tag_prefix=settings["auto_tag_prefix"]
-      threshold=settings["threshold"]/100.0
-      ignore_autotags=settings["ignore_autotags"]
+      settings = JSON.parse(body[:settings])
+      auto_tag_prefix = settings["auto_tag_prefix"]
+      threshold = settings["threshold"] / 100.0
+      ignore_autotags = settings["ignore_autotags"]
       pm = ProjectMedia.where(id: body.dig(:data, :dbid)).last
       if body.dig(:event) == 'create_project_media' && !pm.nil?
         self.log("This item was just created, processing...", pm.id, Logger::INFO)
-        # Search all text fields for all items in the workspace using only the cofigured vector model
 
-        search_texts = ['original_title', 'original_description',
-          'extracted_text', 'transcription', 'claim_description_content'
-        ].map{|field| pm.send(field) if !pm.nil? && pm.respond_to?(field)}
+        # Search all text fields for all items in the workspace using only the configured vector model
+        search_texts = ['original_title', 'original_description', 'extracted_text', 'transcription', 'claim_description_content'].map{ |field| pm.send(field) if !pm.nil? && pm.respond_to?(field) }
+
         # Remove duplicate and nil values
-        search_texts = search_texts.uniq.compact.reject{|q| q.length==0}
+        search_texts = search_texts.uniq.compact.reject{ |q| q.length == 0 }
         self.log("Query values are: #{search_texts}", pm.id, Logger::INFO)
 
-        # Search for each text field in `search_texts`
+        # Search for each text field in search_texts
         # Do not use Elasticsearch. The threshold to use comes from the Tagger bot settings.
         # Method signature: get_items_with_similar_text(pm, fields, threshold, query_text, models, team_ids = [pm&.team_id])
-        results=[]
+        results = []
         search_texts.each do |query|
-          results<<Bot::Alegre.get_items_with_similar_text(pm, Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS,
-            [{ value: threshold }], query, [Bot::Alegre.matching_model_to_use(pm.team_id)].flatten.reject{|m| m==Bot::Alegre::ELASTICSEARCH_MODEL})
-            #self.debug("Results (#{query}): #{results}", pm.id, Logger::INFO)
+          results << Bot::Alegre.get_items_with_similar_text(pm, Bot::Alegre::ALL_TEXT_SIMILARITY_FIELDS, [{ value: threshold }], query, [Bot::Alegre.matching_model_to_use(pm.team_id)].flatten.reject{ |m| m == Bot::Alegre::ELASTICSEARCH_MODEL })
+          # self.debug("Results (#{query}): #{results}", pm.id, Logger::INFO)
         end
         # Combine the list of hashes into one hash
-        results=results.reduce({}, :merge!)
+        results = results.reduce({}, :merge!)
         self.log("#{results.length} nearest neighbors #{results.keys()}", pm.id, Logger::INFO)
         self.log("Results: #{results}", pm.id, Logger::INFO)
 
         # For each nearest neighbor, get the tags.
-        tag_counts=results.map{|nn_pm,_| ProjectMedia.find(nn_pm).get_annotations('tag')}.flatten
+        tag_counts = results.map{ |nn_pm, _| ProjectMedia.find(nn_pm).get_annotations('tag') }.flatten
         # Transform from tag objects to strings
         # .compact removes any nil values returned by get_tag_text
-        tag_counts=tag_counts.map{|t| self.get_tag_text(t[:data][:tag],auto_tag_prefix,ignore_autotags)}.compact
+        tag_counts = tag_counts.map{ |t| self.get_tag_text(t[:data][:tag],auto_tag_prefix, ignore_autotags) }.compact
         # Convert to counts and sort by the counts (low to high)
-        tag_counts=tag_counts.group_by(&:itself).transform_values(&:count).sort_by{|_k,v| v}
+        tag_counts = tag_counts.group_by(&:itself).transform_values(&:count).sort_by{ |_k, v| v }
         # tag_counts is now an array of arrays with counts e.g., [['nature', 1], ['sport', 2]]
         self.log("Tag distribution #{tag_counts}", pm.id, Logger::INFO)
         if tag_counts.length > 0
-          max_count=tag_counts.last[1]
-          if max_count<settings["minimum_count"]
+          max_count = tag_counts.last[1]
+          if max_count < settings["minimum_count"]
             self.log("Max count #{max_count} is less than minimum required to apply a tag", pm.id, Logger::INFO)
             return false
           end
-          most_common_tags=tag_counts.reject{|_k,v| v < max_count}
+          most_common_tags = tag_counts.reject{ |_k, v| v < max_count }
           self.log("Most common tags #{most_common_tags}", pm.id, Logger::INFO)
           most_common_tags.each do |tag|
-            Tag.create!(annotated:pm, annotator: BotUser.get_user('tagger'), tag: auto_tag_prefix+tag[0])
+            Tag.create!(annotated: pm, annotator: BotUser.get_user('tagger'), tag: auto_tag_prefix + tag[0])
           end
         else
           self.log("No most common tag", pm.id, Logger::INFO)
@@ -87,11 +86,10 @@ class Bot::Tagger < BotUser
       end
     rescue StandardError => e
       error = Error.new(e)
-      Rails.logger.error("[AutoTagger Bot] Exception for event `#{body['event']}`: #{error.class} - #{error.message}")
+      Rails.logger.error("[AutoTagger Bot] Exception for event #{body['event']}: #{error.class} - #{error.message}")
       CheckSentry.notify(error, bot: self.name, body: body)
     end
 
     handled
   end
-
 end


### PR DESCRIPTION
## Description

Fixing CodeQL Ruby warnings. Changes:

- [x] Exclude localization data from analysis (files under `data/`).
- [x] Fix syntax in `Tagger` model.

Reference: CV2-6167.

## How to test?

CodeQL should run without any warnings: https://github.com/meedan/check-api/actions/runs/13462695643/job/37621549981?pr=2231.

![Captura de tela de 2025-02-21 15-15-10](https://github.com/user-attachments/assets/fab4d7e4-4aca-4828-8fb3-23caf6eac584)

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).