### PR TITLE
CV2-6141: Update options for existing relationship

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -693,7 +693,7 @@ class Bot::Alegre < BotUser
 
   def self.report_exception_if_bad_relationship(relationship, pm_id_scores, relationship_type)
     if relationship.model.nil? || relationship.weight.nil? || relationship.source_field.nil? || relationship.target_field.nil? || self.relationship_model_not_allowed(relationship.model)
-      CheckSentry.notify(Bot::Alegre::Error.new("[Alegre] Bad relationship was stored without required metadata"), **{trace: Thread.current.backtrace.join("\n"), relationship: relationship.attributes, relationship_type: relationship_type, pm_id_scores: pm_id_scores})
+      CheckSentry.notify(Bot::Alegre::Error.new("[Alegre] Bad relationship with ID [#{relationship.id}] was stored without required metadata"), **{trace: Thread.current.backtrace.join("\n"), relationship: relationship.attributes, relationship_type: relationship_type, pm_id_scores: pm_id_scores})
     end
   end
 

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -159,6 +159,13 @@ class Relationship < ApplicationRecord
   def self.create_unless_exists(source_id, target_id, relationship_type, options = {})
     # Verify that the target is not part of another source; in this case, we should return the existing relationship.
     r = Relationship.where(target_id: target_id).where.not(source_id: source_id).last
+    # should update options if exists
+    unless r.nil? || !options.blank?
+      options.each do |key, value|
+        r.send("#{key}=", value) if r.respond_to?("#{key}=")
+      end
+      r.save!
+    end
     return r unless r.nil?
     # otherwise we should get the existing relationship based on source, target and type
     r = Relationship.where(source_id: source_id, target_id: target_id).where('relationship_type = ?', relationship_type.to_yaml).last

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -159,13 +159,7 @@ class Relationship < ApplicationRecord
   def self.create_unless_exists(source_id, target_id, relationship_type, options = {})
     # Verify that the target is not part of another source; in this case, we should return the existing relationship.
     r = Relationship.where(target_id: target_id).where.not(source_id: source_id).last
-    # should update options if exists and at least on field is blank
-    if !r.nil? && !options.blank? && r.model.blank?
-      options.each do |key, value|
-        r.send("#{key}=", value) if r.respond_to?("#{key}=")
-      end
-      r.save!
-    end
+    r.update_options(options) unless r.nil?
     return r unless r.nil?
     # otherwise we should get the existing relationship based on source, target and type
     r = Relationship.where(source_id: source_id, target_id: target_id).where('relationship_type = ?', relationship_type.to_yaml).last
@@ -203,6 +197,8 @@ class Relationship < ApplicationRecord
         exception_message = e.message
         exception_class = e.class.name
       end
+    else
+      r.update_options(options)
     end
     if r.nil?
       Rails.logger.error("[Relationship::create_unless_exists] returning nil: source_id #{source_id}, target_id #{target_id}, relationship_type #{relationship_type}.")
@@ -231,6 +227,16 @@ class Relationship < ApplicationRecord
       s.status = status
       s.bypass_status_publish_check = true
       s.save!
+    end
+  end
+
+  def update_options(options)
+    # should update options if exists and at least on field has a value
+    if self.model.blank? && !options.values.compact.empty?
+      options.each do |key, value|
+        self.send("#{key}=", value) if self.respond_to?("#{key}=")
+      end
+      self.save!
     end
   end
 

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -159,8 +159,8 @@ class Relationship < ApplicationRecord
   def self.create_unless_exists(source_id, target_id, relationship_type, options = {})
     # Verify that the target is not part of another source; in this case, we should return the existing relationship.
     r = Relationship.where(target_id: target_id).where.not(source_id: source_id).last
-    # should update options if exists
-    unless r.nil? || !options.blank?
+    # should update options if exists and at least on field is blank
+    if !r.nil? && !options.blank? && r.model.blank?
       options.each do |key, value|
         r.send("#{key}=", value) if r.respond_to?("#{key}=")
       end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -326,9 +326,17 @@ class RelationshipTest < ActiveSupport::TestCase
     target = create_project_media team: t
     r = nil
     assert_difference 'Relationship.count' do
-      r = Relationship.create_unless_exists(source.id, target.id, Relationship.confirmed_type, { user_id: u.id })
+      r = Relationship.create_unless_exists(source.id, target.id, Relationship.confirmed_type)
     end
-    assert_equal u.id, r.user_id
+    # should update options if relationship already exists
+    assert_nil r.model
+    another_source = create_project_media team: t
+    r2 = nil
+    assert_no_difference 'Relationship.count' do
+      r2 = Relationship.create_unless_exists(another_source.id, target.id, Relationship.confirmed_type, { model: 'elasticsearch' })
+    end
+    assert_equal r, r2
+    assert_equal 'elasticsearch', r2.model
     r2 = nil
     assert_no_difference 'Relationship.count' do
       r2 = Relationship.create_unless_exists(source.id, target.id, Relationship.confirmed_type)


### PR DESCRIPTION
## Description

After debugging various cases on Live, I discovered that metadata already exists, but the target is already part of another source. Therefore, based on our [method for creating relationships](https://github.com/meedan/check-api/blob/develop/app/models/relationship.rb#L161-L162), it returns the existing one without setting metadata options.

- [x] Add relationship ID to the logged message.
- [x] Update options for existing relationship.

References: CV2-6141

## How to test?

Re-run automated tests

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
