### PR TITLE
CV2-6041: update suggested relation if new one is confirmed

### DIFF
--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -161,7 +161,7 @@ class Relationship < ApplicationRecord
     r = Relationship.where(target_id: target_id).where.not(source_id: source_id).last
     return r unless r.nil?
     # otherwise we should get the existing relationship based on source, target and type
-    r = Relationship.where(source_id: source_id, target_id: target_id).where('relationship_type = ?', relationship_type.to_yaml).last
+    r = Relationship.where(source_id: source_id, target_id: target_id).last
     exception_message = nil
     exception_class = nil
     if r.nil?
@@ -196,6 +196,9 @@ class Relationship < ApplicationRecord
         exception_message = e.message
         exception_class = e.class.name
       end
+    elsif r.relationship_type != relationship_type && relationship_type == Relationship.confirmed_type
+      r.relationship_type = relationship_type
+      r.save!
     end
     if r.nil?
       Rails.logger.error("[Relationship::create_unless_exists] returning nil: source_id #{source_id}, target_id #{target_id}, relationship_type #{relationship_type}.")

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -341,7 +341,7 @@ class RelationshipTest < ActiveSupport::TestCase
     assert_no_difference 'Relationship.count' do
       r2 = Relationship.create_unless_exists(source.id, target.id, Relationship.confirmed_type)
     end
-    assert_nil Relationship.where(id: r.id).last
+    assert_equal r.id, r2.id
     assert_equal Relationship.confirmed_type, r2.relationship_type
     Relationship.any_instance.stubs(:save!).raises(ActiveRecord::RecordNotUnique)
     target = create_project_media team: t


### PR DESCRIPTION
## Description

There is a case for `create_unless_exists` that attempts to establish a confirmed relationship and there is a suggested relationship for the same source and target, and also go through [this case](https://github.com/meedan/check-api/blob/develop/app/models/relationship.rb#L168-L173).

so it same relationship exists but suggested then I'll update existing one to be confirmed.

References: CV2-6041

## How to test?

Implemented unit test

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
