### PR TITLE
Set version pins for Python 3.7.7 docker image.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -37,10 +37,10 @@ deploy_qa:
   script:
     - pip install setuptools==68.0.0
     - pip install urllib3==2.0.6
-    - pip install botocore==1.34.162
-    - pip install boto3==1.34.162
-    - pip install ecs-deploy==1.15.0
-    - pip install awscli==1.33.44
+    - pip install botocore==1.33.13
+    - pip install boto3==1.33.13
+    - pip install ecs-deploy==1.14.0
+    - pip install awscli==1.29.59
     - alias aws='docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION --rm amazon/aws-cli'
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /qa/check-api/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/qa/check-api/##' > env.qa.names
     - for NAME in `cat env.qa.names`; do echo -n "-s qa-check-api-migration $NAME /qa/check-api/$NAME " >> qa-check-api-migration.env.args; done
@@ -109,10 +109,10 @@ deploy_live:
   script:
     - pip install setuptools==68.0.0
     - pip install urllib3==2.0.6
-    - pip install botocore==1.34.162
-    - pip install boto3==1.34.162
-    - pip install ecs-deploy==1.15.0
-    - pip install awscli==1.33.44
+    - pip install botocore==1.33.13
+    - pip install boto3==1.33.13
+    - pip install ecs-deploy==1.14.0
+    - pip install awscli==1.29.59
     - alias aws='docker run -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION --rm amazon/aws-cli'
     - aws ssm get-parameters-by-path --region $AWS_DEFAULT_REGION --path /live/check-api/ --recursive --with-decryption --output text --query "Parameters[].[Name]" | sed -E 's#/live/check-api/##' > env.live.names
     - for NAME in `cat env.live.names`; do echo -n "-s live-check-api-migration $NAME /live/check-api/$NAME " >> live-check-api-migration.env.args; done


### PR DESCRIPTION
## Description

Due to issues with Python and package repositories in this Docker image, we have to revert version pins back a major version. Attempting to update pip itself, which is also out of date, did not resolve the issue.

References: https://meedan.atlassian.net/browse/CV2-6218

## How to test?

Verify with a successful deployment to QA.

## Checklist

- [X] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
