### PR TITLE
Fixing the media origin for an item added to a media cluster by the Smooch Bot

### DIFF
--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -750,7 +750,7 @@ module ProjectMediaCachedFields
           origin[:origin] = CheckMediaClusterOrigins::OriginCodes::USER_MATCHED
           origin[:user_id] = relationship.confirmed_by
           origin[:timestamp] = relationship.confirmed_at.to_i
-        elsif relationship.user == BotUser.alegre_user
+        elsif relationship.user.is_a?(BotUser)
           origin[:origin] = CheckMediaClusterOrigins::OriginCodes::AUTO_MATCHED
           origin[:user_id] = relationship.user_id
           origin[:timestamp] = relationship.created_at.to_i

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -105,7 +105,7 @@ class ProjectMedia8Test < ActiveSupport::TestCase
     assert_equal r2.confirmed_at.to_i, pm3.media_cluster_origin_timestamp(true)
     assert_equal u3.id, pm3.media_cluster_origin_user_id(true)
 
-    # AUTO_MATCHED
+    # AUTO_MATCHED (Alegre)
     pm4 = create_project_media team: t, user: u1
     r3 = create_relationship source: pm1, target: pm4, user: b2
     assert_equal CheckMediaClusterOrigins::OriginCodes::TIPLINE_SUBMITTED, pm1.media_cluster_origin(true)
@@ -114,5 +114,15 @@ class ProjectMedia8Test < ActiveSupport::TestCase
     assert_equal CheckMediaClusterOrigins::OriginCodes::AUTO_MATCHED, pm4.media_cluster_origin(true)
     assert_equal r3.created_at.to_i, pm4.media_cluster_origin_timestamp(true)
     assert_equal b2.id, pm4.media_cluster_origin_user_id(true)
+
+    # AUTO_MATCHED (Smooch)
+    pm5 = create_project_media team: t, user: u1
+    r4 = create_relationship source: pm1, target: pm5, user: b1
+    assert_equal CheckMediaClusterOrigins::OriginCodes::TIPLINE_SUBMITTED, pm1.media_cluster_origin(true)
+    assert_equal pm1.created_at.to_i, pm1.media_cluster_origin_timestamp(true)
+    assert_equal b1.id, pm1.media_cluster_origin_user_id(true)
+    assert_equal CheckMediaClusterOrigins::OriginCodes::AUTO_MATCHED, pm5.media_cluster_origin(true)
+    assert_equal r4.created_at.to_i, pm5.media_cluster_origin_timestamp(true)
+    assert_equal b1.id, pm5.media_cluster_origin_user_id(true)
   end
 end

--- a/test/models/relationship_test.rb
+++ b/test/models/relationship_test.rb
@@ -441,12 +441,13 @@ class RelationshipTest < ActiveSupport::TestCase
     Sidekiq::Testing.inline!
     RequestStore.store[:skip_cached_field_update] = false
     u = create_user is_admin: true
+    b = create_bot_user login: 'alegre'
 
     # Create suggestion
     t = create_team
     pm1 = create_project_media team: t
     pm2 = create_project_media team: t
-    r = create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.suggested_type
+    r = create_relationship source_id: pm1.id, target_id: pm2.id, relationship_type: Relationship.suggested_type, user: b
     assert_equal CheckMediaClusterOrigins::OriginCodes::AUTO_MATCHED, pm2.media_cluster_origin
 
     # Accept suggestion


### PR DESCRIPTION
## Description

The media origin for a media item added to a media cluster by the Smooch Bot was set to "user merged" when it should have been "auto merged," since the Smooch Bot is, after all, a bot. The fix expands the "auto merged" case to include not only the Alegre Bot but any bot.

Fixes: CV2-6205.

## How to test?

TDD. I was able to reproduce the bug in a unit test.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).