### PR TITLE
Add `smooch_default_messages` field to `TeamBotInstallationType` in GraphQL API

### DIFF
--- a/app/graph/types/team_bot_installation_type.rb
+++ b/app/graph/types/team_bot_installation_type.rb
@@ -52,4 +52,10 @@ class TeamBotInstallationType < DefaultObject
       I18n.t(:cant_preview_rss_feed)
     end
   end
+
+  field :smooch_default_messages, JsonStringType, null: true
+
+  def smooch_default_messages
+    object.smooch_default_messages
+  end
 end

--- a/app/models/concerns/smooch_strings.rb
+++ b/app/models/concerns/smooch_strings.rb
@@ -1,4 +1,3 @@
-
 require 'active_support/concern'
 
 TIPLINE_STRINGS = YAML.load(File.read(File.join(Rails.root, 'config', 'tipline_strings.yml'))).with_indifferent_access

--- a/app/models/concerns/smooch_team_bot_installation.rb
+++ b/app/models/concerns/smooch_team_bot_installation.rb
@@ -117,6 +117,14 @@ module SmoochTeamBotInstallation
           api_instance.delete_integration(self.get_smooch_app_id, integration_id) unless integration_id.blank?
         end
       end
+
+      def smooch_default_messages
+        messages = {}
+        self.team.get_languages.to_a.each do |language|
+          messages[language] = TIPLINE_STRINGS[language] if TIPLINE_STRINGS.has_key?(language)
+        end
+        messages
+      end
     end
   end
 end

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -13662,6 +13662,7 @@ type TeamBotInstallation implements Node {
   lock_version: Int
   permissions: String
   smooch_bot_preview_rss_feed(number_of_articles: Int!, rss_feed_url: String!): String
+  smooch_default_messages: JsonStringType
   smooch_enabled_integrations(force: Boolean): JsonStringType
   team: Team
   updated_at: String

--- a/public/relay.json
+++ b/public/relay.json
@@ -72089,6 +72089,20 @@
               "deprecationReason": null
             },
             {
+              "name": "smooch_default_messages",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "JsonStringType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "smooch_enabled_integrations",
               "description": null,
               "args": [

--- a/test/controllers/graphql_controller_7_test.rb
+++ b/test/controllers/graphql_controller_7_test.rb
@@ -462,6 +462,22 @@ class GraphqlController7Test < ActionController::TestCase
     assert_response :success
   end
 
+  test "should get Smooch default messages" do
+    t = create_team private: true
+    t.set_languages = ['es', 'fr']
+    t.save!
+    b = create_team_bot login: 'smooch', set_approved: true
+    app_id = random_string
+    tbi = create_team_bot_installation team_id: t.id, user_id: b.id, settings: { smooch_app_id: app_id }
+    u = create_user
+    create_team_user user: u, team: t, role: 'admin'
+
+    authenticate_with_user(u)
+    query = "query { team(slug: \"#{t.slug}\") { team_bot_installations(first: 1) { edges { node { smooch_default_messages } } } } }"
+    post :create, params: { query: query }
+    assert_equal ['es', 'fr'].sort, json_response.dig('data', 'team', 'team_bot_installations', 'edges', 0, 'node', 'smooch_default_messages').keys
+  end
+
   protected
 
   def assert_error_message(expected)


### PR DESCRIPTION
## Description

This new field returns the translated default messages for supported workspace languages.

Reference: CV2-4994.

## How to test?

I implemented an automated test for this.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
