### PR TITLE
(5995) Implement timeout and fallback for `original_claim` URL processing

### DIFF
--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -150,7 +150,7 @@ module ProjectMediaCreators
         begin
           [media_type, Media.downloaded_file(original_claim), { has_original_claim: true, original_claim_url: original_claim }]
         rescue Timeout::Error, Net::ReadTimeout, Net::OpenTimeout
-          Rails.logger.warn("[Media Download] Timeout error while trying to create a File Media from #{original_claim}. a Claim Media was created instead.")
+          Rails.logger.warn("[Media Download] Timeout error while trying to download a file from #{original_claim}. A Claim Media will be created instead.")
           ['Claim', original_claim, { has_original_claim: true }]
         end
       when 'Claim'

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -147,7 +147,12 @@ module ProjectMediaCreators
     if original_claim.present?
       case media_type
       when 'UploadedImage', 'UploadedVideo', 'UploadedAudio'
-        [media_type, Media.downloaded_file(original_claim), { has_original_claim: true, original_claim_url: original_claim }]
+        begin
+          [media_type, Media.downloaded_file(original_claim), { has_original_claim: true, original_claim_url: original_claim }]
+        rescue Timeout::Error, Net::ReadTimeout, Net::OpenTimeout
+          Rails.logger.warn("[Media Download] Timeout error while trying to create a File Media from #{original_claim}. a Claim Media was created instead.")
+          ['Claim', original_claim, { has_original_claim: true }]
+        end
       when 'Claim'
         [media_type, original_claim, { has_original_claim: true }]
       when 'Link'

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -147,7 +147,7 @@ module ProjectMediaCreators
     if original_claim.present?
       case media_type
       when 'UploadedImage', 'UploadedVideo', 'UploadedAudio'
-        [media_type, original_claim, { has_original_claim: true }]
+        [media_type, Media.downloaded_file(original_claim), { has_original_claim: true, original_claim_url: original_claim }]
       when 'Claim'
         [media_type, original_claim, { has_original_claim: true }]
       when 'Link'

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -84,7 +84,12 @@ class Media < ApplicationRecord
     when 'Claim'
       find_or_create_claim_media(media_content, additional_args)
     when 'Link'
-      find_or_create_link_media(media_content, additional_args)
+      begin
+        find_or_create_link_media(media_content, additional_args)
+      rescue Timeout::Error
+        Rails.logger.warn("[Link Media Creation] Timeout error while trying to create a Link Media from #{media_content}. A Claim Media will be created instead.")
+        find_or_create_claim_media(media_content, additional_args)
+      end
     when 'Blank'
       Blank.create!
     end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -125,13 +125,13 @@ class Media < ApplicationRecord
   def self.downloaded_file(url)
     raise "Invalid URL when creating media from original claim attribute" unless url =~ /\A#{URI::DEFAULT_PARSER.make_regexp(['http', 'https'])}\z/
     uri = URI.parse(url)
-    ext = File.extname(uri.path)
-    file = Tempfile.new(['download', ext])
-    file.binmode
+    extension = File.extname(uri.path)
+    filename = "download-#{SecureRandom.uuid}#{extension}"
+    filepath = File.join(Rails.root, 'tmp', filename)
     content = URI.open(uri, open_timeout: 5, read_timeout: 30).read
-    file.write(content)
-    file.rewind
-    file
+
+    File.atomic_write(filepath) { |file| file.write(content) }
+    File.open(filepath)
   end
 
   def self.find_or_create_uploaded_file_media(file_media, media_type, additional_args = {})

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -128,9 +128,12 @@ class Media < ApplicationRecord
     extension = File.extname(uri.path)
     filename = "download-#{SecureRandom.uuid}#{extension}"
     filepath = File.join(Rails.root, 'tmp', filename)
-    content = URI.open(uri, open_timeout: 5, read_timeout: 30).read
 
-    File.atomic_write(filepath) { |file| file.write(content) }
+    request = Net::HTTP::Get.new(uri)
+    response = Net::HTTP.start(uri.hostname, uri.port, open_timeout: 5, read_timeout: 30, use_ssl: uri.scheme == 'https') { |http| http.request(request) }
+    body = response.body
+
+    File.atomic_write(filepath) { |file| file.write(body) }
     File.open(filepath)
   end
 

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -127,9 +127,10 @@ class Media < ApplicationRecord
     uri = URI.parse(url)
     ext = File.extname(uri.path)
     file = Tempfile.new(['download', ext])
+    content = URI.open(url, open_timeout: 5, read_timeout: 30).read
 
     file.binmode
-    file.write(URI(url).open.read)
+    file.write(content)
     file.rewind
     file
   end

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -127,9 +127,8 @@ class Media < ApplicationRecord
     uri = URI.parse(url)
     ext = File.extname(uri.path)
     file = Tempfile.new(['download', ext])
-    content = URI.open(url, open_timeout: 5, read_timeout: 30).read
-
     file.binmode
+    content = URI.open(uri, open_timeout: 5, read_timeout: 30).read
     file.write(content)
     file.rewind
     file

--- a/lib/pender_data.rb
+++ b/lib/pender_data.rb
@@ -12,6 +12,8 @@ module PenderData
       pender_key = get_pender_key
       begin
         result = PenderClient::Request.get_medias(CheckConfig.get('pender_url_private'), params, pender_key)
+      rescue Timeout::Error, Net::ReadTimeout, Net::OpenTimeout
+        raise Timeout::Error
       rescue StandardError => e
         Rails.logger.error("[Pender] Exception for URL #{self.url}: #{e.message}")
         CheckSentry.notify(PenderRequestError.new('Could not parse URL using Pender'), params: params, error: e)

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -716,31 +716,33 @@ class MediaTest < ActiveSupport::TestCase
       file.rewind
       audio_url = "http://example.com/#{file.path.split('/').last}"
       WebMock.stub_request(:get, audio_url).to_return(body: file.read, headers: { 'Content-Type' => 'audio/mp3' })
+      downloaded_file = Media.downloaded_file(audio_url)
 
-      uploaded_media = Media.find_or_create_uploaded_file_media(audio_url, 'UploadedAudio', { has_original_claim: true })
+      uploaded_media = Media.find_or_create_uploaded_file_media(downloaded_file, 'UploadedAudio', { has_original_claim: true, original_claim_url: audio_url })
 
       assert_not_nil uploaded_media.original_claim_hash
       assert_not_nil uploaded_media.original_claim
       assert_equal audio_url, uploaded_media.original_claim
     end
   end
-
+  
   test "Uploaded Media: should not save original_claim and original_claim_hash when not created from original claim" do
     uploaded_media = create_uploaded_audio
-
+    
     assert_nil uploaded_media.original_claim_hash
     assert_nil uploaded_media.original_claim
   end
-
+  
   test "Uploaded Media: should not create duplicate media if media with original_claim_hash exists" do
     Tempfile.create(['test_audio', '.mp3']) do |file|
       file.write(File.read(File.join(Rails.root, 'test', 'data', 'rails.mp3')))
       file.rewind
       audio_url = "http://example.com/#{file.path.split('/').last}"
       WebMock.stub_request(:get, audio_url).to_return(body: file.read, headers: { 'Content-Type' => 'audio/mp3' })
+      downloaded_file = Media.downloaded_file(audio_url)
 
       assert_difference 'UploadedAudio.count', 1 do
-        2.times { Media.find_or_create_uploaded_file_media(audio_url, 'UploadedAudio', { has_original_claim: true }) }
+        2.times { Media.find_or_create_uploaded_file_media(downloaded_file, 'UploadedAudio', { has_original_claim: true, original_claim_url: audio_url }) }
       end
     end
   end

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -725,14 +725,14 @@ class MediaTest < ActiveSupport::TestCase
       assert_equal audio_url, uploaded_media.original_claim
     end
   end
-  
+
   test "Uploaded Media: should not save original_claim and original_claim_hash when not created from original claim" do
     uploaded_media = create_uploaded_audio
-    
+
     assert_nil uploaded_media.original_claim_hash
     assert_nil uploaded_media.original_claim
   end
-  
+
   test "Uploaded Media: should not create duplicate media if media with original_claim_hash exists" do
     Tempfile.create(['test_audio', '.mp3']) do |file|
       file.write(File.read(File.join(Rails.root, 'test', 'data', 'rails.mp3')))

--- a/test/models/project_media_7_test.rb
+++ b/test/models/project_media_7_test.rb
@@ -267,8 +267,8 @@ class ProjectMedia7Test < ActiveSupport::TestCase
     end
   end
 
-  test "should create a Claim media instead of UploadedAudio media if a Timeout is raised when creating from original claim" do
   # this error is expected when trying to dowload the file
+  test "should create a Claim media instead of UploadedAudio media if a Timeout is raised when creating from original claim" do
     Tempfile.create(['test_audio', '.mp3']) do |file|
       file.write(File.read(File.join(Rails.root, 'test', 'data', 'rails.mp3')))
       file.rewind
@@ -285,8 +285,8 @@ class ProjectMedia7Test < ActiveSupport::TestCase
     end
   end
 
-  test "should create a Claim media instead of Link media if a Timeout is raised" do
   # this error is expected when Pender tries to parse the link, so during media creation
+  test "should create a Claim media instead of Link media if a Timeout is raised" do
     # Mock Pender response for Link
     link_url = 'https://example.com'
     pender_url = CheckConfig.get('pender_url_private') + '/api/medias'

--- a/test/models/project_media_7_test.rb
+++ b/test/models/project_media_7_test.rb
@@ -266,4 +266,21 @@ class ProjectMedia7Test < ActiveSupport::TestCase
       assert_equal audio.id, pm.media.id
     end
   end
+
+  test "should create a Claim media instead of UploadedAudio media if a Timeout is raised when creating from original claim" do
+    Tempfile.create(['test_audio', '.mp3']) do |file|
+      file.write(File.read(File.join(Rails.root, 'test', 'data', 'rails.mp3')))
+      file.rewind
+      audio_url = "http://example.com/#{file.path.split('/').last}"
+      WebMock.stub_request(:get, audio_url).to_return(body: file.read, headers: { 'Content-Type' => 'audio/mp3' })
+
+      Media.stubs(:downloaded_file).raises(Net::OpenTimeout)
+
+      pm = create_project_media(set_original_claim: audio_url)
+
+      assert_equal 'Claim', pm.media.type
+      assert_equal audio_url, pm.media.quote
+      assert_not_empty pm.media.original_claim
+    end
+  end
 end


### PR DESCRIPTION
## Description

### Context
The current implementation for processing original_claim URLs in Check API does not account for situations where external URLs take an extended time to process. This can result in delays or failures if processing exceeds the gateway timeout (currently set at 60 seconds).

This mostly happens when we try to create an `UploadedFile` `Media` from an `original_claim`. So we see this a lot in our zapier integrations, where we might get `app took too long too respond` response. This happens somewhat frequently, and could obscure real issues.

### How
- We configured a Timeout (shorter than 60s), 
- if that is exceeded, we create a `ClaimMedia` instead of `Audio/Image/VideoMedia`.

### Notes
**Rethink how we `find_or_create_uploaded_file_media`**
I realized we would sometimes send the file, and sometimes send the url. Then the method would need to figure out what to do. With that implementation, we would need to add a `begin/rescue` to this method, so it could then call `find_or_create_claim_media` if the download failed.

1. I think we should always send the same thing to `find_or_create_uploaded_file_media`, so we should always send a file.
2. If `ProjectMedia` is downloading the file, it can decide from the start where to send it, instead of sending it to one method and that redirecting to another one.
3. So `ProjectMedia` tries to download the file, and decides which method to call, 
4. `find_or_create_uploaded_file_media` and `find_or_create_claim_media` only worry about creating the Media

**To be added in a future PR**
We added this fallback to the creation of files, but we probably should add it to the creation of links as well.

References: CV2-5995

## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
