### PR TITLE
6251 – Bug – Fix "Quote can't be blank" error

### DIFF
--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -133,7 +133,7 @@ module ProjectMediaCreators
       else
         self.media_type = 'Link'
       end
-    elsif original_claim || self.quote.present?
+    elsif original_claim.present? || self.quote.present?
       self.media_type = 'Claim'
     elsif self.url.present?
       self.media_type = 'Link'
@@ -144,7 +144,7 @@ module ProjectMediaCreators
     media_type = self.media_type
     original_claim = self.set_original_claim&.strip
 
-    if original_claim
+    if original_claim.present?
       case media_type
       when 'UploadedImage', 'UploadedVideo', 'UploadedAudio'
         [media_type, original_claim, { has_original_claim: true }]

--- a/test/controllers/graphql_controller_12_test.rb
+++ b/test/controllers/graphql_controller_12_test.rb
@@ -702,6 +702,7 @@ class GraphqlController12Test < ActionController::TestCase
                 set_tags: ["science", "science", "#science"],
                 set_status: "verified",
                 set_claim_description: "Claim #1.",
+                set_original_claim: "",
                 set_fact_check: {
                   title: "Title #1",
                   language: "en",


### PR DESCRIPTION

## Description
In a request set_original_claim might not be present at all, or it might
be present, but be an empty string. So we need to check for both of those.

I added set_original_claim: "" to a test, whioch makes sure we are now
testing for this as well.

References: CV2-6251

## How to test?

`rails test test/controllers/graphql_controller_12_test.rb:688`

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
