### PR TITLE
Make sure that question marks in filtered articles query is not interpreted as a binding variable

### DIFF
--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -193,8 +193,10 @@ module AlegreV2
     end
 
     def delete_package(project_media, field, params={}, quiet=false)
+      type = get_type(project_media)
+      return if type.blank?
       generic_package(project_media, field).merge(
-        self.send("delete_package_#{get_type(project_media)}", project_media, field, params)
+        self.send("delete_package_#{type}", project_media, field, params)
       ).merge(
         quiet: quiet
       ).merge(params)

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -199,6 +199,7 @@ class Feed < ApplicationRecord
 
   # This makes one HTTP request for each request, so please consider calling this method in background
   def self.notify_subscribers(pm, title, summary, url)
+    return if pm.blank?
     pm.team.feeds.each do |feed|
       if feed.item_belongs_to_feed?(pm)
         # Find cluster

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -135,6 +135,7 @@ class Request < ApplicationRecord
   end
 
   def self.update_fact_checked_by(pm)
+    return if pm.blank?
     request = Request.where(media_id: pm.media_id).first
     request = request&.similar_to_request || request
     request.fact_checked_by(true) unless request.nil?

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -497,9 +497,9 @@ class Team < ApplicationRecord
     # Combine the two queries using SQL UNION
     query = <<~SQL
       SELECT type, id, title, language, created_at, updated_at FROM ( #{fact_checks.to_sql} UNION #{explainers.to_sql} ) AS articles
-      ORDER BY #{order} #{order_type} LIMIT ? OFFSET ?
+      ORDER BY #{order} #{order_type} LIMIT :limit OFFSET :offset
     SQL
-    results = ActiveRecord::Base.connection.exec_query(ActiveRecord::Base.sanitize_sql([query, limit, offset])).map{ |row| OpenStruct.new(row) }
+    results = ActiveRecord::Base.connection.exec_query(ActiveRecord::Base.sanitize_sql([query, { limit: limit, offset: offset }])).map{ |row| OpenStruct.new(row) }
 
     # Pre-load objects in memory in order to avoid an N + 1 queries problem
     preloaded_results = {}

--- a/test/models/team_2_test.rb
+++ b/test/models/team_2_test.rb
@@ -1615,4 +1615,12 @@ class Team2Test < ActiveSupport::TestCase
     t = create_team
     assert_equal [], t.statistics_platforms
   end
+
+  test "should get filtered articles by keyword" do
+    Sidekiq::Testing.fake!
+    t = create_team
+    create_fact_check title: 'Test fact-check', claim_description: create_claim_description(description: 'Claim', project_media: create_project_media(team: t))
+    create_explainer title: 'Test explainer', team: t
+    assert_equal 2, t.filtered_articles(text: 'Test?').count
+  end
 end


### PR DESCRIPTION
## Description

Also, fixing some other Sentry errors.

Reference: CV2-6250.

## How to test?

I was able to reproduce in a unit test:

```
$ docker-compose exec api bundle exec ruby test/models/team_2_test.rb -n test_should_get_filtered_articles_by_keyword

Error:
Team2Test#test_should_get_filtered_articles_by_keyword:
ActiveRecord::PreparedStatementInvalid: wrong number of bind variables (2 for 4) in: SELECT type, id, title, language, created_at, updated_at FROM ( SELECT 'FactCheck' AS type, "fact_checks"."id", "fact_checks"."title", "fact_checks"."language", "fact_checks"."created_at", "fact_checks"."updated_at" FROM "fact_checks" INNER JOIN "claim_descriptions" ON "claim_descriptions"."id" = "fact_checks"."claim_description_id" WHERE "claim_descriptions"."team_id" = 4 AND "fact_checks"."trashed" = FALSE AND (to_tsvector('simple', coalesce(fact_checks.title, '') || ' ' || coalesce(fact_checks.summary, '') || ' ' || coalesce(fact_checks.url, '') || ' ' || coalesce(claim_descriptions.description, '') || ' ' || coalesce(claim_descriptions.context, '')) @@ websearch_to_tsquery('Test?')) UNION SELECT 'Explainer' AS type, "explainers"."id", "explainers"."title", "explainers"."language", "explainers"."created_at", "explainers"."updated_at" FROM "explainers" WHERE "explainers"."team_id" = 4 AND "explainers"."trashed" = FALSE AND (to_tsvector('simple', coalesce(explainers.title, '') || ' ' || coalesce(explainers.description, '') || ' ' || coalesce(explainers.url, '')) @@ websearch_to_tsquery('Test?')) ) AS articles
ORDER BY created_at DESC LIMIT ? OFFSET ?
```

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
