### PR TITLE
4916 – Change 'listed' attribute so we do not display Fetch

### DIFF
--- a/db/migrate/20250312190444_set_listed_to_false_for_fetch_bot.rb
+++ b/db/migrate/20250312190444_set_listed_to_false_for_fetch_bot.rb
@@ -1,7 +1,7 @@
 class SetListedToFalseForFetchBot < ActiveRecord::Migration[6.1]
   def change
     # Fetch should not be marked as "listed", so it does not appear on the UI
-    BotUser.where(login: ['fetch']).each do |bot|
+    BotUser.where(login: 'fetch').each do |bot|
       bot.set_listed = false
       bot.save!
     end

--- a/db/migrate/20250312190444_set_listed_to_false_for_fetch_bot.rb
+++ b/db/migrate/20250312190444_set_listed_to_false_for_fetch_bot.rb
@@ -1,0 +1,9 @@
+class SetListedToFalseForFetchBot < ActiveRecord::Migration[6.1]
+  def change
+    # Fetch should not be marked as "listed", so it does not appear on the UI
+    BotUser.where(login: ['fetch']).each do |bot|
+      bot.set_listed = false
+      bot.save!
+    end
+  end
+end


### PR DESCRIPTION
## Description

Fetch is deprecated and should not be shown in the workspace. We have already removed Fetch specific code from Check-Web. But it still renders the generic parts, if the `api` sends it.

We have a boolean attribute called `listed`. Which was implemented [here](https://github.com/meedan/check-api/commit/d0cd2747bc035aebbd33a9bae3bf60fc5ebe15b8). `Listed` bots are the ones that are displayed to users so they can install in their workspaces.

Since we don't want to show Fetch we can update it's `listed` attribute to "false", so it won't be displayed anymore. Note that Fetch `listed` attribute is already set to `false` in check live. We want it to be set t false regardless of environment.

References: CV2-4916

## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
