### PR TITLE
CV2-6262: return nil if parent not exists

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -981,6 +981,7 @@ class Bot::Smooch < BotUser
 
   def self.send_report_to_user(uid, data, pm, lang = 'en', fallback_template = nil, pre_message = nil)
     parent = Relationship.confirmed_parent(pm)
+    return if parent.nil?
     report = parent.get_dynamic_annotation('report_design')
     Rails.logger.info "[Smooch Bot] Sending report to user #{uid} for item with ID #{pm.id}..."
     if report&.get_field_value('state') == 'published' && [CheckArchivedFlags::FlagCodes::NONE, CheckArchivedFlags::FlagCodes::UNCONFIRMED].include?(parent.archived) && report.should_send_report_in_this_language?(lang)


### PR DESCRIPTION
## Description

Fix sentry error by return nil if parent not exists

References: CV2-6262

## How to test?

Re-run automated tests.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
