### PR TITLE
CV2-6280: Use diff to compare two arrays instead of equal operator

### DIFF
--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -143,7 +143,8 @@ class Feed < ApplicationRecord
     query = self.clusters.joins(:project_media)
 
     # Filter by workspace
-    query = query.where.not("ARRAY[?] && team_ids", self.team_ids - team_ids.to_a.map(&:to_i)) if !team_ids.blank? && team_ids != self.team_ids
+    diff = self.team_ids - team_ids.to_a.map(&:to_i)
+    query = query.where.not("ARRAY[?] && team_ids", diff) unless team_ids.blank? || diff.empty?
     query = query.where(team_ids: []) if team_ids&.empty? # Invalidate the query
 
     # Filter by channel


### PR DESCRIPTION
## Description

Comparing two arrays by using equal operator ( i.e `team_ids != self.team_ids` ) require same sort for two arrays.
for example [5, 73] != [73, 5] return wrong result so I replaced this code by diff i.e (team_ids - self.team_ids).empty?

References: CV2-6280

## How to test?

Re-run automated tests.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
