### PR TITLE
CV2-6146: Add a message/conversation_id placeholder

### DIFF
--- a/app/models/concerns/smooch_capi.rb
+++ b/app/models/concerns/smooch_capi.rb
@@ -228,8 +228,8 @@ module SmoochCapi
       payload = {}
       account, to = uid.split(':')
       return if account != self.config['capi_phone_number']
-      text = self.replace_placeholders(uid, text)
       if text.is_a?(String)
+        text = self.replace_placeholders(uid, text)
         payload = {
           messaging_product: 'whatsapp',
           recipient_type: 'individual',

--- a/app/models/concerns/smooch_capi.rb
+++ b/app/models/concerns/smooch_capi.rb
@@ -228,7 +228,7 @@ module SmoochCapi
       payload = {}
       account, to = uid.split(':')
       return if account != self.config['capi_phone_number']
-      text = self.replace_placeholders(text, uid)
+      text = self.replace_placeholders(uid, text)
       if text.is_a?(String)
         payload = {
           messaging_product: 'whatsapp',

--- a/app/models/concerns/smooch_capi.rb
+++ b/app/models/concerns/smooch_capi.rb
@@ -228,6 +228,7 @@ module SmoochCapi
       payload = {}
       account, to = uid.split(':')
       return if account != self.config['capi_phone_number']
+      text = self.replace_placeholders(text, uid)
       if text.is_a?(String)
         payload = {
           messaging_product: 'whatsapp',

--- a/app/models/concerns/smooch_menus.rb
+++ b/app/models/concerns/smooch_menus.rb
@@ -68,6 +68,7 @@ module SmoochMenus
       }
 
       # Set extra and fallback
+      text = self.replace_placeholders(uid, text)
       extra, fallback = self.smooch_menus_set_extra_and_fallback(main, text, language)
 
       self.send_message_to_user(uid, fallback.join("\n"), extra, false, true, event)
@@ -178,6 +179,7 @@ module SmoochMenus
     end
 
     def send_message_to_user_with_buttons(uid, text, options, event = nil)
+      text = self.replace_placeholders(uid, text)
       buttons = []
       options.each_with_index do |option, i|
         buttons << {
@@ -212,6 +214,7 @@ module SmoochMenus
     end
 
     def send_message_to_user_with_single_section_menu(uid, text, options, menu_label)
+      text = self.replace_placeholders(uid, text)
       rows = []
       options.each do |option|
         rows << {

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -570,7 +570,7 @@ module SmoochMessages
     end
 
     def replace_placeholders(uid, text)
-      external_id = TiplineMessage.where(uid: uid).last.external_id
+      external_id = TiplineMessage.where(uid: uid).last&.external_id
       text.gsub('{{message_id}}', external_id)
     end
   end

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -568,5 +568,10 @@ module SmoochMessages
       # Define a min number of words to create a media
       CheckConfig.get('min_number_of_words_for_tipline_long_text') || CheckConfig.get('min_number_of_words_for_tipline_submit_shortcut', 10, :integer)
     end
+
+    def replace_placeholders(uid, text)
+      external_id = TiplineMessage.where(uid: uid).last.external_id
+      text.gsub('{{message_id}}', external_id)
+    end
   end
 end

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -570,8 +570,18 @@ module SmoochMessages
     end
 
     def replace_placeholders(uid, text)
-      external_id = TiplineMessage.where(uid: uid).last&.external_id
-      text.gsub('{{message_id}}', external_id.to_s)
+      # Method build to contain multiple placeholders.
+      # To add a new placeholder, simply add a new key and include the replacement value in the replacements array.
+      keys = ['{{message_id}}']
+      if keys.any? { |substring| text.include?(substring) }
+        team_id = self.config['team_id'].to_i
+        external_id = TiplineMessage.where(team_id: team_id, uid: uid, direction: 'incoming', state: 'received').last&.external_id
+        replacements = { '{{message_id}}' => external_id.to_s }
+        replacements.each do |old, new|
+          text.gsub!(old, new)
+        end
+      end
+      text
     end
   end
 end

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -571,7 +571,7 @@ module SmoochMessages
 
     def replace_placeholders(uid, text)
       external_id = TiplineMessage.where(uid: uid).last&.external_id
-      text.gsub('{{message_id}}', external_id)
+      text.gsub('{{message_id}}', external_id.to_s)
     end
   end
 end

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -104,7 +104,10 @@ module SmoochMessages
     def send_message_for_state(uid, workflow, state, language, pretext = '', event = nil)
       team = Team.find(self.config['team_id'].to_i)
       message = self.get_message_for_state(workflow, state, language, uid).to_s
-      message = UrlRewriter.shorten_and_utmize_urls(message, team.get_outgoing_urls_utm_code) if team.get_shorten_outgoing_urls
+      if team.get_shorten_outgoing_urls
+        message = self.replace_placeholders(uid, message)
+        message = UrlRewriter.shorten_and_utmize_urls(message, team.get_outgoing_urls_utm_code)
+      end
       text = [pretext, message].reject{ |part| part.blank? }.join("\n\n")
       if self.is_v2?
         if self.should_ask_for_language_confirmation?(uid)
@@ -194,7 +197,10 @@ module SmoochMessages
       uid = message['authorId']
       team = Team.find(self.config['team_id'].to_i)
       text = workflow['smooch_message_smooch_bot_message_confirmed'].to_s
-      text = UrlRewriter.shorten_and_utmize_urls(text, team.get_outgoing_urls_utm_code) if team.get_shorten_outgoing_urls
+      if team.get_shorten_outgoing_urls
+        text = self.replace_placeholders(uid, text)
+        text = UrlRewriter.shorten_and_utmize_urls(text, team.get_outgoing_urls_utm_code)
+      end
       self.send_message_to_user(uid, text) if send_message && !workflow.nil?
     end
 

--- a/app/models/concerns/smooch_zendesk.rb
+++ b/app/models/concerns/smooch_zendesk.rb
@@ -52,7 +52,7 @@ module SmoochZendesk
       api_client = self.zendesk_api_client
       api_instance = SmoochApi::ConversationApi.new(api_client)
       app_id = self.config['smooch_app_id']
-      text = self.replace_placeholders(text.to_s.truncate(4096), uid)
+      text = self.replace_placeholders(uid, text.to_s.truncate(4096))
       params = { 'role' => 'appMaker', 'type' => 'text', 'text' => text }.merge(extra)
       # An error is raised by Smooch API if we set "preview_url: true" and there is no URL in the "text" parameter
       if preview_url && text.to_s.match(/https?:\/\//) && !params[:override] && params['type'] == 'text'

--- a/app/models/concerns/smooch_zendesk.rb
+++ b/app/models/concerns/smooch_zendesk.rb
@@ -52,7 +52,8 @@ module SmoochZendesk
       api_client = self.zendesk_api_client
       api_instance = SmoochApi::ConversationApi.new(api_client)
       app_id = self.config['smooch_app_id']
-      params = { 'role' => 'appMaker', 'type' => 'text', 'text' => text.to_s.truncate(4096) }.merge(extra)
+      text = self.replace_placeholders(text.to_s.truncate(4096), uid)
+      params = { 'role' => 'appMaker', 'type' => 'text', 'text' => text }.merge(extra)
       # An error is raised by Smooch API if we set "preview_url: true" and there is no URL in the "text" parameter
       if preview_url && text.to_s.match(/https?:\/\//) && !params[:override] && params['type'] == 'text'
         params.merge!({

--- a/test/models/bot/smooch_7_test.rb
+++ b/test/models/bot/smooch_7_test.rb
@@ -660,4 +660,13 @@ class Bot::Smooch7Test < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should replace message_id placeholder" do
+    uid = random_string
+    tm = create_tipline_message uid: uid
+    text = 'Foo {{message_id}} bar {{message_id}}'
+    external_id = tm.external_id
+    output = Bot::Smooch.replace_placeholders(uid, text)
+    assert_equal "Foo #{external_id} bar #{external_id}", output
+  end
 end

--- a/test/models/bot/smooch_7_test.rb
+++ b/test/models/bot/smooch_7_test.rb
@@ -662,11 +662,13 @@ class Bot::Smooch7Test < ActiveSupport::TestCase
   end
 
   test "should replace message_id placeholder" do
+    t = create_team
     uid = random_string
-    tm = create_tipline_message uid: uid
+    create_tipline_message team_id: t.id, uid: uid, state: 'received', direction: 'incoming', 'external_id': 'abc123'
+    create_tipline_message team_id: t.id, uid: uid, state: 'delivered', direction: 'outgoing'
     text = 'Foo {{message_id}} bar {{message_id}}'
-    external_id = tm.external_id
+    RequestStore.store[:smooch_bot_settings] = { 'team_id' => t.id }
     output = Bot::Smooch.replace_placeholders(uid, text)
-    assert_equal "Foo #{external_id} bar #{external_id}", output
+    assert_equal "Foo abc123 bar abc123", output
   end
 end

--- a/test/models/concerns/smooch_zendesk_test.rb
+++ b/test/models/concerns/smooch_zendesk_test.rb
@@ -9,6 +9,10 @@ class FakeSmoochZendesk
     def config
       { "smooch_app_id" => 'app-id' }
     end
+
+    def replace_placeholders(uid, text)
+      text
+    end
   end
 end
 


### PR DESCRIPTION
## Description

Create a placeholder variable like {{message_id}} that can be included in a tipline message.

- [x] Implement a method called replace_placeholders in smooch_messages concern.
- [x] Call that method in the send_message_to_user implementations we have for the Zendesk provider and for the WhatsApp Cloud API provider:
- [x] Implement automated tests for the model method and for the two cases above

References: CV2-6146

## How to test?

Implement unit test.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
