### PR TITLE
5995/6287 – Update pender_client gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ group :development do
 end
 
 gem 'webmock'
-gem 'pender_client', git: 'https://github.com/meedan/pender-client.git', ref: '89c9072'
+gem 'pender_client', git: 'https://github.com/meedan/pender-client.git', ref: 'ad74fad'
 gem 'lograge'
 gem 'rails', '~> 6.1.7'
 gem 'pg', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1036,4 +1036,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.5.23
+   2.4.19

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,8 +40,8 @@ GIT
 
 GIT
   remote: https://github.com/meedan/pender-client.git
-  revision: 89c9072b5399bda616ad3955ec140a2a8c196d1d
-  ref: 89c9072
+  revision: ad74fadd10af2fdd359ab1f5e7a71362a47f9eff
+  ref: ad74fad
   specs:
     pender_client (0.0.4)
 
@@ -1036,4 +1036,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.4.19
+   2.5.23


### PR DESCRIPTION
## Description

As part of implementing timeout and fallback for original_claim URL processing, we update read and open timeouts in the pender_client gem. So we need to update it in check-api's gemfile.

References: CV2-5995, CV2-6287
Relates to: PR https://github.com/meedan/check-api/pull/2243, PR https://github.com/meedan/pender-client/pull/1

## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
