### PR TITLE
6039 – Make sure the channel is set correctly

### DIFF
--- a/db/migrate/20250328140809_allow_nil_article_channel.rb
+++ b/db/migrate/20250328140809_allow_nil_article_channel.rb
@@ -1,0 +1,6 @@
+class AllowNilArticleChannel < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default :explainers, :channel, from: 1, to: nil
+    change_column_default :fact_checks, :channel, from: 1, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_02_19_110106) do
+ActiveRecord::Schema.define(version: 2025_03_28_140809) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -349,7 +349,7 @@ ActiveRecord::Schema.define(version: 2025_02_19_110106) do
     t.string "tags", default: [], array: true
     t.boolean "trashed", default: false
     t.bigint "author_id"
-    t.integer "channel", default: 1, null: false
+    t.integer "channel"
     t.index "date_trunc('day'::text, created_at)", name: "explainer_created_at_day"
     t.index ["author_id"], name: "index_explainers_on_author_id"
     t.index ["channel"], name: "index_explainers_on_channel"
@@ -376,7 +376,7 @@ ActiveRecord::Schema.define(version: 2025_02_19_110106) do
     t.boolean "imported", default: false
     t.boolean "trashed", default: false
     t.bigint "author_id"
-    t.integer "channel", default: 1, null: false
+    t.integer "channel"
     t.index "date_trunc('day'::text, created_at)", name: "fact_check_created_at_day"
     t.index ["author_id"], name: "index_fact_checks_on_author_id"
     t.index ["channel"], name: "index_fact_checks_on_channel"
@@ -1018,6 +1018,6 @@ ActiveRecord::Schema.define(version: 2025_02_19_110106) do
   add_foreign_key "requests", "feeds"
 
   create_trigger :enforce_relationships, sql_definition: <<-SQL
-      CREATE TRIGGER enforce_relationships BEFORE INSERT ON public.relationships FOR EACH ROW EXECUTE PROCEDURE validate_relationships()
+      CREATE TRIGGER enforce_relationships BEFORE INSERT ON public.relationships FOR EACH ROW EXECUTE FUNCTION validate_relationships()
   SQL
 end


### PR DESCRIPTION
## Description

While QA'ing we noticed that the channel for `Explainer` was set to `manual` even when it was create by a `BotUser`.

This happened because `default` is apllied when the object is instantiated. So we are removing the constraint from the database and allowing nil values.

References: CV2-6039

## How to test?

```ruby
# test "should create explainer with api channel when created by Bot"
rails test test/controllers/graphql_controller_12_test.rb:1023
```

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
