### PR TITLE
CV2-6290: Add rake task to delete team tags

### DIFF
--- a/lib/tasks/data/delete_team_tags.rake
+++ b/lib/tasks/data/delete_team_tags.rake
@@ -1,0 +1,17 @@
+namespace :check do
+  namespace :team do
+    desc 'Delete all team tags'
+    # bundle exec rails check:team:delete_tags[slug-1,slug-2,...,slug-N]
+    task delete_tags: :environment do |_t, params|
+      slugs = params.to_a
+      Team.where(slug: slugs).find_each do |team|
+        count = team.tag_texts.count
+        puts "Deleting tags [#{count}] for team #{team.slug}"
+        team.tag_texts.in_batches(of: 500) do |batch|
+          print '.'
+          batch.destroy_all
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Add rake task to delete all team tags.
`bundle exec rails check:team:delete_tags[slug-1,slug-2,...,slug-N]`

References: CV2-6290

## How to test?

Run rake task locally

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
