### PR TITLE
CV2-5935: Indexing issues on lists

### DIFF
--- a/app/models/bot/alegre.rb
+++ b/app/models/bot/alegre.rb
@@ -213,8 +213,7 @@ class Bot::Alegre < BotUser
   def self.unarchive_if_archived(pm)
     if pm&.archived == CheckArchivedFlags::FlagCodes::PENDING_SIMILARITY_ANALYSIS
       pm.update_column(:archived, CheckArchivedFlags::FlagCodes::NONE)
-      sources_count = Relationship.where(target_id: pm.id).where('relationship_type = ?', Relationship.confirmed_type.to_yaml).count
-      pm.update_elasticsearch_doc(['archived', 'sources_count'], { 'archived' => CheckArchivedFlags::FlagCodes::NONE, 'sources_count' => sources_count }, pm.id)
+      pm.update_elasticsearch_doc(['archived'], { 'archived' => CheckArchivedFlags::FlagCodes::NONE }, pm.id)
     end
   end
 

--- a/app/models/concerns/relationship_bulk.rb
+++ b/app/models/concerns/relationship_bulk.rb
@@ -105,7 +105,7 @@ module RelationshipBulk
         end
         # Send report if needed
         if extra_options['action'] == 'accept'
-          Relationship.smooch_send_report(r.id)
+          begin Relationship.smooch_send_report(r.id) rescue nil end
           Relationship.replicate_status_to_children(r.source_id, whodunnit, team_id)
         end
       end

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -139,17 +139,19 @@ class Relationship < ApplicationRecord
   end
 
   def update_counters
-    return if self.is_default? || self.source.nil? || self.target.nil?
-    source = self.source
-    target = self.target
-
-    target.skip_check_ability = true
-    target.sources_count = Relationship.where(target_id: target.id).where('relationship_type = ?', Relationship.confirmed_type.to_yaml).count
-    target.save!
-
-    source.skip_check_ability = true
-    source.targets_count = Relationship.where(source_id: source.id).where('relationship_type = ? OR relationship_type = ?', Relationship.confirmed_type.to_yaml, Relationship.suggested_type.to_yaml).count
-    source.save!
+    return if self.is_default?
+    unless self.target_id.nil?
+      target = self.target
+      target.skip_check_ability = true
+      target.sources_count = Relationship.where(target_id: target.id).where('relationship_type = ?', Relationship.confirmed_type.to_yaml).count
+      target.save!
+    end
+    unless self.source_id.nil?
+      source = self.source
+      source.skip_check_ability = true
+      source.targets_count = Relationship.where(source_id: source.id).where('relationship_type = ? OR relationship_type = ?', Relationship.confirmed_type.to_yaml, Relationship.suggested_type.to_yaml).count
+      source.save!
+    end
   end
 
   def create_or_update_parent_id

--- a/app/models/relationship.rb
+++ b/app/models/relationship.rb
@@ -229,6 +229,7 @@ class Relationship < ApplicationRecord
     s = item.last_status_obj
     unless s.nil? || s.status == status
       s.status = status
+      s.skip_trashed_validation = true
       s.bypass_status_publish_check = true
       s.save!
     end


### PR DESCRIPTION
## Description

Try to catch the cases that status and sources_count not synced.

- [ ] alegre.rb: Removed sources_count since this field does not change based on archived value
- [ ] Changed the logic to check for source and target separately as based on [this code](https://github.com/meedan/check-api/blob/develop/app/models/relationship.rb#L293-L300) these is an assumption that either the source or target can be nil
- [ ] Skip trashed_validation for bulk-accept relationship

References: CV2-5935

## How to test?

Re-run automated tests

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
