### PR TITLE
6039 – Enable API to query multiple channels at once

### DIFF
--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -326,7 +326,7 @@ class TeamType < DefaultObject
     argument :imported, GraphQL::Types::Boolean, required: false, camelize: false # Only for fact-checks
     argument :target_id, GraphQL::Types::Int, required: false, camelize: false # Exclude articles already applied to the `ProjectMedia` with this ID
     argument :trashed, GraphQL::Types::Boolean, required: false, camelize: false, default_value: false
-    argument :channel, GraphQL::Types::String, required: false, camelize: false
+    argument :channel, [GraphQL::Types::String, null: true], required: false, camelize: false
   end
 
   def articles(**args)
@@ -364,7 +364,7 @@ class TeamType < DefaultObject
     argument :imported, GraphQL::Types::Boolean, required: false, camelize: false # Only for fact-checks
     argument :target_id, GraphQL::Types::Int, required: false, camelize: false # Exclude articles already applied to the `ProjectMedia` with this ID
     argument :trashed, GraphQL::Types::Boolean, required: false, camelize: false, default_value: false
-    argument :channel, GraphQL::Types::String, required: false, camelize: false
+    argument :channel, [GraphQL::Types::String, null: true], required: false, camelize: false
   end
 
   def articles_count(**args)

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -13007,7 +13007,7 @@ type Team implements Node {
     Returns the elements in the list that come before the specified cursor.
     """
     before: String
-    channel: String
+    channel: [String]
     created_at: String
 
     """
@@ -13036,7 +13036,7 @@ type Team implements Node {
     updated_at: String
     user_ids: [Int]
   ): ArticleUnionConnection
-  articles_count(article_type: String, channel: String, created_at: String, imported: Boolean, language: [String], publisher_ids: [Int], rating: [String], report_status: [String], standalone: Boolean, tags: [String], target_id: Int, text: String, trashed: Boolean = false, updated_at: String, user_ids: [Int]): Int
+  articles_count(article_type: String, channel: [String], created_at: String, imported: Boolean, language: [String], publisher_ids: [Int], rating: [String], report_status: [String], standalone: Boolean, tags: [String], target_id: Int, text: String, trashed: Boolean = false, updated_at: String, user_ids: [Int]): Int
   available_newsletter_header_types: JsonStringType
   avatar: String
   bot_query(enableLanguageDetection: Boolean, enableLinkShortening: Boolean, maxNumberOfWords: Int, searchText: String!, shouldRestrictByLanguage: Boolean, threshold: Float, utmCode: String): [TiplineSearchResult!]

--- a/public/relay.json
+++ b/public/relay.json
@@ -68580,9 +68580,13 @@
                   "name": "channel",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,
@@ -68797,9 +68801,13 @@
                   "name": "channel",
                   "description": null,
                   "type": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
+                    "kind": "LIST",
+                    "name": null,
+                    "ofType": {
+                      "kind": "SCALAR",
+                      "name": "String",
+                      "ofType": null
+                    }
                   },
                   "defaultValue": null,
                   "isDeprecated": false,

--- a/test/controllers/graphql_controller_12_test.rb
+++ b/test/controllers/graphql_controller_12_test.rb
@@ -930,19 +930,19 @@ class GraphqlController12Test < ActionController::TestCase
     assert_equal 2, annotations_count
   end
 
-  test "should return fact_check channel in team articles query when filtered by channel" do
-    # Create two fact-checks with different channel values.
+  test "should return fact_check in team articles query when filtered by channel" do
+    # Create three fact-checks with different channel values, query for two (manual and imported)
     pm1 = create_project_media team: @t
     cd1 = create_claim_description(project_media: pm1)
-    fc_manual = create_fact_check(claim_description: cd1, channel: "manual", trashed: false)
+    create_fact_check(claim_description: cd1, channel: "manual", trashed: false)
   
     pm2 = create_project_media team: @t
     cd2 = create_claim_description(project_media: pm2)
-    fc_api = create_fact_check(claim_description: cd2, channel: "api", trashed: false)
+    create_fact_check(claim_description: cd2, channel: "api", trashed: false)
 
     pm3 = create_project_media team: @t
     cd3 = create_claim_description(project_media: pm3)
-    fc_imported = create_fact_check(claim_description: cd3, channel: "imported", trashed: false)
+    create_fact_check(claim_description: cd3, channel: "imported", trashed: false)
 
     authenticate_with_user(@u)
 
@@ -964,11 +964,9 @@ class GraphqlController12Test < ActionController::TestCase
     GRAPHQL
     post :create, params: { query: query, team: @t.slug }
     assert_response :success
-    articles = JSON.parse(@response.body)
-    # articles = JSON.parse(@response.body)['data']['team']['articles']['edges']
-    p articles
+    articles = JSON.parse(@response.body)['data']['team']['articles']['edges']
     articles.each do |edge|
-      assert_equal "manual", edge['node']['channel']
+      assert_match /manual|imported/, edge['node']['channel']
     end
   end
 


### PR DESCRIPTION
## Description

We updated the argument type to be an Array of Strings, so we are able to query for different channels at once. 

References: CV2-6039

## How to test?

```
# test "should return fact_check in team articles query when filtered by channel"
rails test test/controllers/graphql_controller_12_test.rb:933
```

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
