### PR TITLE
Returning the list of default tipline strings in different languages.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,7 +10,7 @@ checks:
     enabled: false
   method-complexity:
     config:
-      threshold: 25
+      threshold: 26
   method-count:
     config:
       threshold: 65

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -224,7 +224,7 @@ Metrics/CyclomaticComplexity:
                  A complexity metric that is strongly correlated to the number
                  of test cases needed to validate a method.
   Enabled: true
-  Max: 14
+  Max: 15
 
 Metrics/LineLength:
   Description: 'Limit lines to 80 characters.'

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -27,7 +27,7 @@ module ProjectMediaCreators
         report_status: (fact_check['publish_report'] ? 'published' : 'unpublished'),
         rating: self.set_status,
         tags: self.set_tags.to_a.map(&:strip),
-        channel: fact_check['channel'], 
+        channel: fact_check['channel'],
         skip_check_ability: true
       })
     end

--- a/app/models/concerns/smooch_team_bot_installation.rb
+++ b/app/models/concerns/smooch_team_bot_installation.rb
@@ -120,8 +120,10 @@ module SmoochTeamBotInstallation
 
       def smooch_default_messages
         messages = {}
+        keys = I18n.t('tipline.messages', default: {}).keys
         self.team.get_languages.to_a.each do |language|
-          messages[language] = TIPLINE_STRINGS[language] if TIPLINE_STRINGS.has_key?(language)
+          messages[language] = {}
+          keys.each { |key| messages[language][key.to_s] = I18n.t("tipline.messages.#{key}", locale: language) }
         end
         messages
       end

--- a/app/models/concerns/smooch_team_bot_installation.rb
+++ b/app/models/concerns/smooch_team_bot_installation.rb
@@ -120,10 +120,12 @@ module SmoochTeamBotInstallation
 
       def smooch_default_messages
         messages = {}
-        keys = I18n.t('tipline.messages', default: {}).keys
+        keys = ['smooch_message_smooch_bot_greetings', 'submission_prompt', 'add_more_details_state', 'ask_if_ready_state',
+                'search_state', 'search_no_results', 'search_result_state', 'search_result_is_relevant', 'search_submit',
+                'newsletter_optin_optout', 'option_not_available', 'timeout', 'smooch_message_smooch_bot_disabled']
         self.team.get_languages.to_a.each do |language|
           messages[language] = {}
-          keys.each { |key| messages[language][key.to_s] = I18n.t("tipline.messages.#{key}", locale: language) }
+          keys.each { |key| messages[language][key.to_s] = TIPLINE_STRINGS.dig(language, key) || TIPLINE_STRINGS.dig('en', key) }
         end
         messages
       end

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,1 +1,1 @@
-VERSION = 'v0.187.0'
+VERSION = 'v0.188.0'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -859,3 +859,18 @@ en:
       moved_to_private_folder: '"%{item_title}" has been moved to a folder you do
         not have access to.'
       add_warning_cover_by_rule: Added a warning cover to sensitive item "%{item_title}"
+  tipline:
+    messages:
+      smooch_message_smooch_bot_greetings: 'Welcome to our fact-checking bot. Use the main menu to navigate.'
+      submission_prompt: 'Please enter the question, link, picture, or video that you want to be fact-checked.'
+      add_more_details_state: 'Please add more content.'
+      ask_if_ready_state: 'Are you ready to submit?'
+      search_state: 'Thank you! Looking for fact-checks, it may take a minute.'
+      search_no_results: 'No fact-checks have been found. Journalists on our team have been notified and you will receive an update in this thread if the information is fact-checked.'
+      search_result_state: 'Are these fact-checks answering your question?'
+      search_result_is_relevant: 'Thank you! Spread the word about this tipline to help us fight misinformation!'
+      search_submit: 'Thank you for your feedback. Journalists on our team have been notified and you will receive an update in this thread if a new fact-check is published.'
+      newsletter_optin_optout: 'Subscribe now to get the most important facts delivered directly on WhatsApp, every week. {subscription_status}.'
+      option_not_available: "I'm sorry, I didn't understand your message."
+      timeout: 'Thank you for reaching out to us! Type any key to start a new conversation.'
+      smooch_message_smooch_bot_disabled: 'Our bot is currently inactive.'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -859,18 +859,3 @@ en:
       moved_to_private_folder: '"%{item_title}" has been moved to a folder you do
         not have access to.'
       add_warning_cover_by_rule: Added a warning cover to sensitive item "%{item_title}"
-  tipline:
-    messages:
-      smooch_message_smooch_bot_greetings: 'Welcome to our fact-checking bot. Use the main menu to navigate.'
-      submission_prompt: 'Please enter the question, link, picture, or video that you want to be fact-checked.'
-      add_more_details_state: 'Please add more content.'
-      ask_if_ready_state: 'Are you ready to submit?'
-      search_state: 'Thank you! Looking for fact-checks, it may take a minute.'
-      search_no_results: 'No fact-checks have been found. Journalists on our team have been notified and you will receive an update in this thread if the information is fact-checked.'
-      search_result_state: 'Are these fact-checks answering your question?'
-      search_result_is_relevant: 'Thank you! Spread the word about this tipline to help us fight misinformation!'
-      search_submit: 'Thank you for your feedback. Journalists on our team have been notified and you will receive an update in this thread if a new fact-check is published.'
-      newsletter_optin_optout: 'Subscribe now to get the most important facts delivered directly on WhatsApp, every week. {subscription_status}.'
-      option_not_available: "I'm sorry, I didn't understand your message."
-      timeout: 'Thank you for reaching out to us! Type any key to start a new conversation.'
-      smooch_message_smooch_bot_disabled: 'Our bot is currently inactive.'

--- a/config/tipline_strings.yml
+++ b/config/tipline_strings.yml
@@ -341,6 +341,19 @@ en:
   unsubscribed: You are currently not subscribed to our newsletter.
   nlu_disambiguation: "Choose one of the options below:"
   nlu_cancel: "Back to menu"
+  smooch_message_smooch_bot_greetings: 'Welcome to our fact-checking bot. Use the main menu to navigate.'
+  submission_prompt: 'Please enter the question, link, picture, or video that you want to be fact-checked.'
+  add_more_details_state: 'Please add more content.'
+  ask_if_ready_state: 'Are you ready to submit?'
+  search_state: 'Thank you! Looking for fact-checks, it may take a minute.'
+  search_no_results: 'No fact-checks have been found. Journalists on our team have been notified and you will receive an update in this thread if the information is fact-checked.'
+  search_result_state: 'Are these fact-checks answering your question?'
+  search_result_is_relevant: 'Thank you! Spread the word about this tipline to help us fight misinformation!'
+  search_submit: 'Thank you for your feedback. Journalists on our team have been notified and you will receive an update in this thread if a new fact-check is published.'
+  newsletter_optin_optout: 'Subscribe now to get the most important facts delivered directly on WhatsApp, every week. {subscription_status}.'
+  option_not_available: "I'm sorry, I didn't understand your message."
+  timeout: 'Thank you for reaching out to us! Type any key to start a new conversation.'
+  smooch_message_smooch_bot_disabled: 'Our bot is currently inactive.'
 fil:
   add_more_details_state_button_label: Dagdagan pa
   ask_if_ready_state_button_label: Kanselahin

--- a/lib/tasks/migrate/20250326140624_add_channel_to_articles.rake
+++ b/lib/tasks/migrate/20250326140624_add_channel_to_articles.rake
@@ -10,7 +10,7 @@ namespace :check do
         count = query.count
         puts "[#{Time.now}] Number of instances to update channel to api: #{count}."
         i = 0
-        query.in_batches(of: 5) do |batch|
+        query.in_batches(of: 1000) do |batch|
           i += 1
           batch.update_all(channel: 'api')
           puts "[#{Time.now}] Updated channel for batch ##{i}."

--- a/lib/tasks/migrate/20250326140624_add_channel_to_articles.rake
+++ b/lib/tasks/migrate/20250326140624_add_channel_to_articles.rake
@@ -4,27 +4,33 @@ namespace :check do
   namespace :migrate do
     desc 'Add channel to Articles(FactChecks and Explainers)'
     task add_channel_to_articles: :environment do
-      puts "[#{Time.now}] Starting to add channels to Articles"
-      started = Time.now.to_i
-      TOTAL = []
+      ActiveRecord::Base.logger = nil
 
-      [FactCheck, Explainer].each do |model|
-        query = model.joins(:user).where('users.type' => 'BotUser').where(channel: 'manual')
-        TOTAL << query.count
-        puts "[#{Time.now}] Total of instances of #{model} to update channel to api: #{query.count}."
-  
+      def update_channel_for_query(query)
+        count = query.count
+        puts "[#{Time.now}] Number of instances to update channel to api: #{count}."
         i = 0
-        query.in_batches(of: 1000) do |batch|
+        query.in_batches(of: 5) do |batch|
           i += 1
           batch.update_all(channel: 'api')
-          puts "[#{Time.now}] Updated channel for batch ##{i} of instances of model #{model}."
+          puts "[#{Time.now}] Updated channel for batch ##{i}."
         end
+        count
+      end
+
+      puts "[#{Time.now}] Starting to add channels to Articles"
+      started = Time.now.to_i
+
+      [FactCheck, Explainer].each do |model|
+        query1 = model.joins(:author).where('users.type' => 'BotUser').where(channel: 'manual')
+        count1 = update_channel_for_query(query1)
+        query2 = model.joins(:user).where('users.type' => 'BotUser').where(author_id: nil).where(channel: 'manual')
+        count2 = update_channel_for_query(query2)
+        puts "[#{Time.now}] Updated channel for #{count1 + count2} instances of #{model}'s."
       end
 
       minutes = ((Time.now.to_i - started) / 60).to_i
       puts "[#{Time.now}] Done in #{minutes} minutes."
-      puts "Updated FactChecks: #{TOTAL.first}"
-      puts "Updated Explainers: #{TOTAL.last}"
     end
   end
 end


### PR DESCRIPTION
## Description

Previously, we were returning the hard-coded tipline strings. Now, we're returning the list of customizable tipline strings.

Reference: CV2-6304.

## How to test?

Check the `smooch_default_messages` method of a `TeamBotInstallation` object (or the respective GraphQL field).

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
