### PR TITLE
Do not get similar items for text items that are just a URL

### DIFF
--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -403,6 +403,9 @@ module AlegreV2
     def get_items(project_media, field, confirmed=false, initial_threshold=nil)
       relationship_type = confirmed ? Relationship.confirmed_type : Relationship.suggested_type
       type = get_type(project_media)
+      if type=="text" && Alegre::BOT::BAD_TITLE_REGEX =~ project_media.send(field)
+        return {}
+      end
       if initial_threshold.nil?
         initial_threshold = get_threshold_for_query(type, project_media, confirmed)
       end
@@ -417,6 +420,9 @@ module AlegreV2
 
     def get_items_async(project_media, field, confirmed=false, initial_threshold=nil)
       type = get_type(project_media)
+      if type=="text" && Alegre::BOT::BAD_TITLE_REGEX =~ project_media.send(field)
+        return {}
+      end
       if initial_threshold.nil?
         initial_threshold = get_threshold_for_query(type, project_media, confirmed)
       end

--- a/app/models/concerns/alegre_v2.rb
+++ b/app/models/concerns/alegre_v2.rb
@@ -403,9 +403,7 @@ module AlegreV2
     def get_items(project_media, field, confirmed=false, initial_threshold=nil)
       relationship_type = confirmed ? Relationship.confirmed_type : Relationship.suggested_type
       type = get_type(project_media)
-      if type=="text" && Alegre::BOT::BAD_TITLE_REGEX =~ project_media.send(field)
-        return {}
-      end
+      return {} if type == 'text' && Bot::Alegre::BAD_TITLE_REGEX =~ project_media.send(field)
       if initial_threshold.nil?
         initial_threshold = get_threshold_for_query(type, project_media, confirmed)
       end
@@ -420,9 +418,7 @@ module AlegreV2
 
     def get_items_async(project_media, field, confirmed=false, initial_threshold=nil)
       type = get_type(project_media)
-      if type=="text" && Alegre::BOT::BAD_TITLE_REGEX =~ project_media.send(field)
-        return {}
-      end
+      return {} if type == 'text' && Bot::Alegre::BAD_TITLE_REGEX =~ project_media.send(field)
       if initial_threshold.nil?
         initial_threshold = get_threshold_for_query(type, project_media, confirmed)
       end


### PR DESCRIPTION
## Description

Ensure we don't get similar items (both sync and async) for text items that are just a URL.

References: CV2-6298

## How to test?

Automated test implemented.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).