### PR TITLE
Include manual responses when calculating average response time

### DIFF
--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -556,7 +556,7 @@ module SmoochMessages
       data = request.smooch_data
       team = Team.find_by_id(request.team_id)
       now = Time.now.to_i
-      request.update_columns(first_manual_response_at: request.first_manual_request_at || now, last_manual_response_at: now)
+      request.update_columns(first_manual_response_at: (request.first_manual_response_at > 0 ? request.first_manual_response_at : now), last_manual_response_at: now)
       self.send_custom_message_to_user(team, request.tipline_user_uid, data['received'], message, request.language)
     end
 

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -555,6 +555,8 @@ module SmoochMessages
     def reply_to_request_with_custom_message(request, message)
       data = request.smooch_data
       team = Team.find_by_id(request.team_id)
+      now = Time.now.to_i
+      request.update_columns(first_manual_response_at: request.first_manual_request_at || now, last_manual_response_at: now)
       self.send_custom_message_to_user(team, request.tipline_user_uid, data['received'], message, request.language)
     end
 

--- a/db/migrate/20250403200649_add_first_manual_response_at_and_last_manual_response_at_to_tipline_requests.rb
+++ b/db/migrate/20250403200649_add_first_manual_response_at_and_last_manual_response_at_to_tipline_requests.rb
@@ -1,0 +1,6 @@
+class AddFirstManualResponseAtAndLastManualResponseAtToTiplineRequests < ActiveRecord::Migration[6.1]
+  def change
+    add_column :tipline_requests, :first_manual_response_at, :integer, null: false, default: 0
+    add_column :tipline_requests, :last_manual_response_at, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_03_28_140809) do
+ActiveRecord::Schema.define(version: 2025_04_03_200649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -314,7 +314,7 @@ ActiveRecord::Schema.define(version: 2025_03_28_140809) do
     t.jsonb "value_json", default: "{}"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY ((ARRAY['external_id'::character varying, 'smooch_user_id'::character varying, 'verification_status_status'::character varying])::text[]))"
+    t.index "dynamic_annotation_fields_value(field_name, value)", name: "dynamic_annotation_fields_value", where: "((field_name)::text = ANY (ARRAY[('external_id'::character varying)::text, ('smooch_user_id'::character varying)::text, ('verification_status_status'::character varying)::text]))"
     t.index ["annotation_id", "field_name"], name: "index_dynamic_annotation_fields_on_annotation_id_and_field_name"
     t.index ["annotation_id"], name: "index_dynamic_annotation_fields_on_annotation_id"
     t.index ["annotation_type"], name: "index_dynamic_annotation_fields_on_annotation_type"
@@ -865,6 +865,8 @@ ActiveRecord::Schema.define(version: 2025_03_28_140809) do
     t.integer "smooch_report_sent_at", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "first_manual_response_at", default: 0, null: false
+    t.integer "last_manual_response_at", default: 0, null: false
     t.index "date_trunc('day'::text, created_at)", name: "tipline_request_created_at_day"
     t.index "date_trunc('month'::text, created_at)", name: "tipline_request_created_at_month"
     t.index "date_trunc('quarter'::text, created_at)", name: "tipline_request_created_at_quarter"
@@ -1018,6 +1020,6 @@ ActiveRecord::Schema.define(version: 2025_03_28_140809) do
   add_foreign_key "requests", "feeds"
 
   create_trigger :enforce_relationships, sql_definition: <<-SQL
-      CREATE TRIGGER enforce_relationships BEFORE INSERT ON public.relationships FOR EACH ROW EXECUTE FUNCTION validate_relationships()
+      CREATE TRIGGER enforce_relationships BEFORE INSERT ON public.relationships FOR EACH ROW EXECUTE PROCEDURE validate_relationships()
   SQL
 end

--- a/lib/check_data_points.rb
+++ b/lib/check_data_points.rb
@@ -86,10 +86,12 @@ class CheckDataPoints
 
     # Average response time
     def average_response_time(team_id, start_date, end_date, platform = nil, language = nil)
-      query = TiplineRequest.where(team_id: team_id, smooch_report_received_at: start_date.to_datetime.to_i..end_date.to_datetime.to_i)
+      query = TiplineRequest.where(team_id: team_id, created_at: start_date.to_datetime.to_i..end_date.to_datetime.to_i)
+      query = query.where('(smooch_report_received_at > 0 OR smooch_report_update_received_at > 0 OR smooch_report_sent_at > 0 OR smooch_report_correction_sent_at > 0 OR first_manual_response_at > 0)')
       query = query.where(platform: platform) unless platform.blank?
       query = query.where(language: language) unless language.blank?
-      query.average("smooch_report_received_at - CAST(DATE_PART('EPOCH', created_at::timestamp) AS INTEGER)").to_f
+      query.select('*, (SELECT MIN(x) FROM unnest(ARRAY[smooch_report_received_at, smooch_report_update_received_at, smooch_report_sent_at, smooch_report_correction_sent_at, first_manual_response_at]) AS x WHERE x IS NOT NULL AND x > 0) AS lowest_response_time')
+      query.average("lowest_response_time - CAST(DATE_PART('EPOCH', created_at::timestamp) AS INTEGER)").to_f
     end
 
     # All users

--- a/lib/check_data_points.rb
+++ b/lib/check_data_points.rb
@@ -86,12 +86,21 @@ class CheckDataPoints
 
     # Average response time
     def average_response_time(team_id, start_date, end_date, platform = nil, language = nil)
-      query = TiplineRequest.where(team_id: team_id, created_at: start_date.to_datetime.to_i..end_date.to_datetime.to_i)
+      query = TiplineRequest.where(team_id: team_id, created_at: start_date..end_date)
       query = query.where('(smooch_report_received_at > 0 OR smooch_report_update_received_at > 0 OR smooch_report_sent_at > 0 OR smooch_report_correction_sent_at > 0 OR first_manual_response_at > 0)')
       query = query.where(platform: platform) unless platform.blank?
       query = query.where(language: language) unless language.blank?
-      query.select('*, (SELECT MIN(x) FROM unnest(ARRAY[smooch_report_received_at, smooch_report_update_received_at, smooch_report_sent_at, smooch_report_correction_sent_at, first_manual_response_at]) AS x WHERE x IS NOT NULL AND x > 0) AS lowest_response_time')
-      query.average("lowest_response_time - CAST(DATE_PART('EPOCH', created_at::timestamp) AS INTEGER)").to_f
+      average = <<-SQL.squish
+        (SELECT MIN(x)
+           FROM unnest(ARRAY[smooch_report_received_at,
+                             smooch_report_update_received_at,
+                             smooch_report_sent_at,
+                             smooch_report_correction_sent_at,
+                             first_manual_response_at]) AS x
+          WHERE x IS NOT NULL AND x > 0)
+        - CAST(DATE_PART('EPOCH', created_at::timestamp) AS INTEGER)
+      SQL
+      query.average(average).to_f
     end
 
     # All users

--- a/test/controllers/graphql_controller_10_test.rb
+++ b/test/controllers/graphql_controller_10_test.rb
@@ -763,7 +763,7 @@ class GraphqlController10Test < ActionController::TestCase
   end
 
   test "should send custom message to user" do
-    Bot::Smooch.stubs(:send_message_to_user).returns(OpenStruct.new(code: 200)).once
+    Bot::Smooch.stubs(:send_message_to_user).returns(OpenStruct.new(code: 200)).twice
     u = create_user
     t = create_team
     create_team_user user: u, team: t, role: 'editor'
@@ -778,8 +778,19 @@ class GraphqlController10Test < ActionController::TestCase
 
     assert_response :success
     assert JSON.parse(@response.body)['data']['sendTiplineMessage']['success']
-    assert tr.reload.first_manual_response_at > 0
-    assert tr.reload.last_manual_response_at > 0
+    first_manual_response_at = tr.reload.first_manual_response_at
+    assert first_manual_response_at > 0
+    assert_equal first_manual_response_at, tr.reload.last_manual_response_at
+
+    sleep 1
+
+    query = "mutation { sendTiplineMessage(input: { clientMutationId: \"1\", message: \"Bye\", inReplyToId: #{tr.id} }) { success } }"
+    post :create, params: { query: query, team: t.slug }
+
+    assert_response :success
+    assert JSON.parse(@response.body)['data']['sendTiplineMessage']['success']
+    assert_equal first_manual_response_at, tr.reload.first_manual_response_at
+    assert tr.reload.last_manual_response_at > first_manual_response_at
   end
 
   test "should not send custom message to user" do

--- a/test/controllers/graphql_controller_10_test.rb
+++ b/test/controllers/graphql_controller_10_test.rb
@@ -769,6 +769,8 @@ class GraphqlController10Test < ActionController::TestCase
     create_team_user user: u, team: t, role: 'editor'
     pm = create_project_media team: t
     tr = create_tipline_request team_id: t.id, associated: pm, language: 'en', smooch_data: { authorId: '123', language: 'en', received: Time.now.to_f }
+    assert_equal 0, tr.reload.first_manual_response_at
+    assert_equal 0, tr.reload.last_manual_response_at
     authenticate_with_user(u)
 
     query = "mutation { sendTiplineMessage(input: { clientMutationId: \"1\", message: \"Hello\", inReplyToId: #{tr.id} }) { success } }"
@@ -776,6 +778,8 @@ class GraphqlController10Test < ActionController::TestCase
 
     assert_response :success
     assert JSON.parse(@response.body)['data']['sendTiplineMessage']['success']
+    assert tr.reload.first_manual_response_at > 0
+    assert tr.reload.last_manual_response_at > 0
   end
 
   test "should not send custom message to user" do

--- a/test/lib/check_data_points_test.rb
+++ b/test/lib/check_data_points_test.rb
@@ -174,4 +174,13 @@ class CheckDataPointsTest < ActiveSupport::TestCase
     Time.unstub(:now)
     assert_equal 2, CheckDataPoints.new_users(@team.id, @start_date, @end_date)
   end
+
+  test "should calculate average response time based also on custom manual messages" do
+    pm = create_project_media team: @team
+    tr = create_tipline_request team_id: @team.id, associated: pm
+    tr.update_columns(first_manual_response_at: (tr.created_at + 1.week).to_i, smooch_report_sent_at: (tr.created_at + 2.weeks).to_i)
+    tr = create_tipline_request team_id: @team.id, associated: pm
+    tr.update_columns(first_manual_response_at: (tr.created_at + 2.weeks).to_i, smooch_report_sent_at: (tr.created_at + 1.week).to_i)
+    assert_equal 7, (CheckDataPoints.average_response_time(@team.id, @start_date, @end_date).to_i / (24 * 60 * 60)).to_i # 7 days
+  end
 end


### PR DESCRIPTION
## Description

Include manual responses when calculating average response time.

- [x] Add columns first_manual_response_at and last_manual_response_at to the tipline_requests table, default null.
- [x] Fill in these columns every time a [manual response is sent](https://github.com/meedan/check-api/blob/develop/app/models/concerns/smooch_messages.rb#L555).
- [x] Update the average_response_time [method](https://github.com/meedan/check-api/blob/develop/lib/check_data_points.rb#L88) to take manual responses into account.
- [x] Update automated tests accordingly.

Reference: CV2-5996.

## How to test?

Automated tests implemented.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).