### PR TITLE
6319 – Update timeout when creating Media

### DIFF
--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -135,7 +135,7 @@ class Media < ApplicationRecord
     filepath = File.join(Rails.root, 'tmp', filename)
 
     request = Net::HTTP::Get.new(uri)
-    response = Net::HTTP.start(uri.hostname, uri.port, open_timeout: 5, read_timeout: 30, use_ssl: uri.scheme == 'https') { |http| http.request(request) }
+    response = Net::HTTP.start(uri.hostname, uri.port, open_timeout: 5, read_timeout: 25, use_ssl: uri.scheme == 'https') { |http| http.request(request) }
     body = response.body
 
     File.atomic_write(filepath) { |file| file.write(body) }

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -135,7 +135,7 @@ class Media < ApplicationRecord
     filepath = File.join(Rails.root, 'tmp', filename)
 
     request = Net::HTTP::Get.new(uri)
-    response = Net::HTTP.start(uri.hostname, uri.port, open_timeout: 5, read_timeout: CheckConfig.get('short_request_timeout'), use_ssl: uri.scheme == 'https') { |http| http.request(request) }
+    response = Net::HTTP.start(uri.hostname, uri.port, open_timeout: 5, read_timeout: CheckConfig.get('short_request_timeout', 25, :integer), use_ssl: uri.scheme == 'https') { |http| http.request(request) }
     body = response.body
 
     File.atomic_write(filepath) { |file| file.write(body) }

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -135,7 +135,7 @@ class Media < ApplicationRecord
     filepath = File.join(Rails.root, 'tmp', filename)
 
     request = Net::HTTP::Get.new(uri)
-    response = Net::HTTP.start(uri.hostname, uri.port, open_timeout: 5, read_timeout: 25, use_ssl: uri.scheme == 'https') { |http| http.request(request) }
+    response = Net::HTTP.start(uri.hostname, uri.port, open_timeout: 5, read_timeout: CheckConfig.get('short_request_timeout'), use_ssl: uri.scheme == 'https') { |http| http.request(request) }
     body = response.body
 
     File.atomic_write(filepath) { |file| file.write(body) }

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -281,6 +281,7 @@ development: &default
   header_file_video_max_size_check: 10 # Megabytes, should be less than WhatsApp limit
   url_max_size: 2000
   min_number_of_words_for_tipline_long_text: 10
+  short_request_timeout: 25
 
   # Session
   #

--- a/lib/pender_data.rb
+++ b/lib/pender_data.rb
@@ -11,7 +11,8 @@ module PenderData
       result = { type: 'error', data: { code: -1 } }.with_indifferent_access
       pender_key = get_pender_key
       begin
-        result = PenderClient::Request.get_medias(CheckConfig.get('pender_url_private'), params, pender_key)
+        timeout = 25 if self.original_claim.present?
+        result = PenderClient::Request.get_medias(CheckConfig.get('pender_url_private'), params, pender_key, timeout)
       rescue Timeout::Error, Net::ReadTimeout, Net::OpenTimeout
         raise Timeout::Error
       rescue StandardError => e

--- a/lib/pender_data.rb
+++ b/lib/pender_data.rb
@@ -11,7 +11,7 @@ module PenderData
       result = { type: 'error', data: { code: -1 } }.with_indifferent_access
       pender_key = get_pender_key
       begin
-        timeout = 25 if self.original_claim.present?
+        timeout = CheckConfig.get('short_request_timeout') if self.original_claim.present?
         result = PenderClient::Request.get_medias(CheckConfig.get('pender_url_private'), params, pender_key, timeout)
       rescue Timeout::Error, Net::ReadTimeout, Net::OpenTimeout
         raise Timeout::Error

--- a/lib/pender_data.rb
+++ b/lib/pender_data.rb
@@ -11,7 +11,7 @@ module PenderData
       result = { type: 'error', data: { code: -1 } }.with_indifferent_access
       pender_key = get_pender_key
       begin
-        timeout = CheckConfig.get('short_request_timeout') if self.original_claim.present?
+        timeout = CheckConfig.get('short_request_timeout') if self.is_a?(Media) && self.original_claim.present?
         result = PenderClient::Request.get_medias(CheckConfig.get('pender_url_private'), params, pender_key, timeout)
       rescue Timeout::Error, Net::ReadTimeout, Net::OpenTimeout
         raise Timeout::Error

--- a/lib/pender_data.rb
+++ b/lib/pender_data.rb
@@ -11,7 +11,7 @@ module PenderData
       result = { type: 'error', data: { code: -1 } }.with_indifferent_access
       pender_key = get_pender_key
       begin
-        timeout = CheckConfig.get('short_request_timeout') if self.is_a?(Media) && self.original_claim.present?
+        timeout = CheckConfig.get('short_request_timeout', 25, :integer) if self.is_a?(Media) && self.original_claim.present?
         result = PenderClient::Request.get_medias(CheckConfig.get('pender_url_private'), params, pender_key, timeout)
       rescue Timeout::Error, Net::ReadTimeout, Net::OpenTimeout
         raise Timeout::Error

--- a/test/models/account_test.rb
+++ b/test/models/account_test.rb
@@ -368,8 +368,8 @@ class AccountTest < ActiveSupport::TestCase
   test "should send specific token to parse url on pender" do
     params1 = { url: random_url }
     params2 = { url: random_url }
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), params1, CheckConfig.get('pender_key')).returns({"type" => "media","data" => {"url" => params1[:url], "type" => "profile", "author_name" => "Default token"}})
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), params2, 'specific_token').returns({"type" => "media","data" => {"url" => params2[:url], "type" => "profile", "author_name" => "Specific token"}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), params1, CheckConfig.get('pender_key'), nil).returns({"type" => "media","data" => {"url" => params1[:url], "type" => "profile", "author_name" => "Default token"}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), params2, 'specific_token', nil).returns({"type" => "media","data" => {"url" => params2[:url], "type" => "profile", "author_name" => "Specific token"}})
 
     a = Account.new url: params1[:url]
     a.valid?
@@ -387,9 +387,8 @@ class AccountTest < ActiveSupport::TestCase
     t = create_team
     a = create_account team: t
 
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: a.url, refresh: '1' }, CheckConfig.get('pender_key')).returns({"type" => "media","data" => {"url" => a.url, "type" => "profile", "title" => "Default token", "author_name" => 'Author with default token'}})
-
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: a.url, refresh: '1' }, 'specific_token').returns({"type" => "media","data" => {"url" => a.url, "type" => "profile", "title" => "Author with specific token", "author_name" => 'Author with specific token'}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: a.url, refresh: '1' }, CheckConfig.get('pender_key'), nil).returns({"type" => "media","data" => {"url" => a.url, "type" => "profile", "title" => "Default token", "author_name" => 'Author with default token'}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: a.url, refresh: '1' }, 'specific_token', nil).returns({"type" => "media","data" => {"url" => a.url, "type" => "profile", "title" => "Author with specific token", "author_name" => 'Author with specific token'}})
 
     a.refresh_account = true
     a.save!

--- a/test/models/media_test.rb
+++ b/test/models/media_test.rb
@@ -527,8 +527,8 @@ class MediaTest < ActiveSupport::TestCase
   test "should send specific token to parse url on pender" do
     params1 = { url: random_url }
     params2 = { url: random_url }
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), params1, CheckConfig.get('pender_key')).returns({"type" => "media","data" => {"url" => params1[:url], "type" => "item", "title" => "Default token"}})
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), params2, 'specific_token').returns({"type" => "media","data" => {"url" => params2[:url], "type" => "item", "title" => "Specific token"}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), params1, CheckConfig.get('pender_key'), nil).returns({"type" => "media","data" => {"url" => params1[:url], "type" => "item", "title" => "Default token"}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), params2, 'specific_token', nil).returns({"type" => "media","data" => {"url" => params2[:url], "type" => "item", "title" => "Specific token"}})
 
     l = Link.new url: params1[:url]
     l.valid?

--- a/test/models/project_media_5_test.rb
+++ b/test/models/project_media_5_test.rb
@@ -803,13 +803,13 @@ class ProjectMedia5Test < ActiveSupport::TestCase
 
     url1 = random_url
     author_url1 = random_url
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: url1 }, CheckConfig.get('pender_key')).returns({"type" => "media","data" => {"url" => url1, "type" => "item", "title" => "Default token", "author_url" => author_url1}})
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: author_url1 }, CheckConfig.get('pender_key')).returns({"type" => "media","data" => {"url" => author_url1, "type" => "profile", "title" => "Default token", "author_name" => 'Author with default token'}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: url1 }, CheckConfig.get('pender_key'), nil).returns({"type" => "media","data" => {"url" => url1, "type" => "item", "title" => "Default token", "author_url" => author_url1}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: author_url1 }, CheckConfig.get('pender_key'), nil).returns({"type" => "media","data" => {"url" => author_url1, "type" => "profile", "title" => "Default token", "author_name" => 'Author with default token'}})
 
     url2 = random_url
     author_url2 = random_url
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: url2 }, 'specific_token').returns({"type" => "media","data" => {"url" => url2, "type" => "item", "title" => "Specific token", "author_url" => author_url2}})
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: author_url2 }, 'specific_token').returns({"type" => "media","data" => {"url" => author_url2, "type" => "profile", "title" => "Specific token", "author_name" => 'Author with specific token'}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: url2 }, 'specific_token', nil).returns({"type" => "media","data" => {"url" => url2, "type" => "item", "title" => "Specific token", "author_url" => author_url2}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: author_url2 }, 'specific_token', nil).returns({"type" => "media","data" => {"url" => author_url2, "type" => "profile", "title" => "Specific token", "author_name" => 'Author with specific token'}})
 
     pm = ProjectMedia.create url: url1, team: t
     assert_equal 'Default token', ProjectMedia.find(pm.id).media.metadata['title']
@@ -832,11 +832,11 @@ class ProjectMedia5Test < ActiveSupport::TestCase
     pm = create_project_media media: l, project: create_project(team: t)
 
     author_url1 = random_url
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: l.url, refresh: '1' }, CheckConfig.get('pender_key')).returns({"type" => "media","data" => {"url" => l.url, "type" => "item", "title" => "Default token", "author_url" => author_url1}})
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: author_url1 }, CheckConfig.get('pender_key')).returns({"type" => "media","data" => {"url" => author_url1, "type" => "profile", "title" => "Default token", "author_name" => 'Author with default token'}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: l.url, refresh: '1' }, CheckConfig.get('pender_key'), nil).returns({"type" => "media","data" => {"url" => l.url, "type" => "item", "title" => "Default token", "author_url" => author_url1}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: author_url1 }, CheckConfig.get('pender_key'), nil).returns({"type" => "media","data" => {"url" => author_url1, "type" => "profile", "title" => "Default token", "author_name" => 'Author with default token'}})
 
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: l.url, refresh: '1' }, 'specific_token').returns({"type" => "media","data" => {"url" => l.url, "type" => "item", "title" => "Specific token", "author_url" => author_url1}})
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: author_url1 }, 'specific_token').returns({"type" => "media","data" => {"url" => author_url1, "type" => "profile", "title" => "Author with specific token", "author_name" => 'Author with specific token'}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: l.url, refresh: '1' }, 'specific_token', nil).returns({"type" => "media","data" => {"url" => l.url, "type" => "item", "title" => "Specific token", "author_url" => author_url1}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: author_url1 }, 'specific_token', nil).returns({"type" => "media","data" => {"url" => author_url1, "type" => "profile", "title" => "Author with specific token", "author_name" => 'Author with specific token'}})
 
     assert pm.media.metadata['title'].blank?
 
@@ -956,7 +956,7 @@ class ProjectMedia5Test < ActiveSupport::TestCase
     url = 'https://twitter.com/meedan/status/1321600654750613505'
     response = {"type" => "media","data" => {"url" => url, "type" => "item", "metrics" => {"facebook"=> {"reaction_count" => 2, "comment_count" => 5, "share_count" => 10, "comment_plugin_count" => 0 }}}}
 
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: url }, CheckConfig.get('pender_key')).returns(response)
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: url }, CheckConfig.get('pender_key'), nil).returns(response)
     pm = create_project_media media: nil, url: url
     assert_equal response['data']['metrics'], JSON.parse(pm.get_annotations('metrics').last.load.get_field_value('metrics_data'))
     PenderClient::Request.unstub(:get_medias)

--- a/test/models/source_test.rb
+++ b/test/models/source_test.rb
@@ -449,9 +449,8 @@ class SourceTest < ActiveSupport::TestCase
     s = create_source team: t
     s.accounts << a
 
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: a.url, refresh: '1' }, CheckConfig.get('pender_key')).returns({"type" => "media","data" => {"url" => a.url, "type" => "profile", "title" => "Default token", "author_name" => 'Author with default token'}})
-
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: a.url, refresh: '1' }, 'specific_token').returns({"type" => "media","data" => {"url" => a.url, "type" => "profile", "title" => "Author with specific token", "author_name" => 'Author with specific token'}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: a.url, refresh: '1' }, CheckConfig.get('pender_key'), nil).returns({"type" => "media","data" => {"url" => a.url, "type" => "profile", "title" => "Default token", "author_name" => 'Author with default token'}})
+    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: a.url, refresh: '1' }, 'specific_token', nil).returns({"type" => "media","data" => {"url" => a.url, "type" => "profile", "title" => "Author with specific token", "author_name" => 'Author with specific token'}})
 
     s.refresh_accounts = true
     s.save!


### PR DESCRIPTION
## Description

When we create a media instance through Zapier (`original_claim`) we often hit a Timeout, specially when creanting Link media or File media instances. So for those cases we want our timeout to be shorter. 

References: CV2-6319, CV2-5995

## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
