### PR TITLE
6139 – Update to the latest version of the pender_client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ group :development do
 end
 
 gem 'webmock'
-gem 'pender_client', git: 'https://github.com/meedan/pender-client.git', ref: 'ad74fad'
+gem 'pender_client', git: 'https://github.com/meedan/pender-client.git', ref: 'a57737b'
 gem 'lograge'
 gem 'rails', '~> 6.1.7'
 gem 'pg', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,8 +40,8 @@ GIT
 
 GIT
   remote: https://github.com/meedan/pender-client.git
-  revision: ad74fadd10af2fdd359ab1f5e7a71362a47f9eff
-  ref: ad74fad
+  revision: a57737be5a63bf1575ae33eba304300568ad86cf
+  ref: a57737b
   specs:
     pender_client (0.0.4)
 


### PR DESCRIPTION
## Description

Update to the latest version of the `pender-client` gem, so we can send a timeout value.

Relates to: https://github.com/meedan/check-api/pull/2279, https://github.com/meedan/pender-client/pull/2
References: CV2-5995, CV2-6139

## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
