### PR TITLE
Truncate articles summary when sending them as tipline search results.

### DIFF
--- a/app/lib/tipline_search_result.rb
+++ b/app/lib/tipline_search_result.rb
@@ -48,7 +48,7 @@ class TiplineSearchResult
   def text(language = nil, hide_body = false)
     text = []
     text << "*#{self.title.strip}*" unless self.title.blank?
-    text << self.body.to_s unless hide_body
+    text << self.body.to_s.truncate(900 - self.title.to_s.size - self.url.to_s.size) unless hide_body
     text << self.url unless self.url.blank?
     unless language.nil?
       footer = self.footer(language)


### PR DESCRIPTION
## Description

Updating the truncation logic for tipline search results to truncate article texts, matching the behavior used in WhatsApp template messages, Fetch / batch imports and the UI.

Reference: CV2-6321.

## How to test?

Existing tests should cover this.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).