### PR TITLE
Update default Smooch Bot settings.

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -13,6 +13,9 @@ class Bot::Smooch < BotUser
   SUPPORTED_INTEGRATION_NAMES = { 'whatsapp' => 'WhatsApp', 'messenger' => 'Facebook Messenger', 'twitter' => 'Twitter', 'telegram' => 'Telegram', 'viber' => 'Viber', 'line' => 'LINE', 'instagram' => 'Instagram' }
   SUPPORTED_INTEGRATIONS = SUPPORTED_INTEGRATION_NAMES.keys
   SUPPORTED_TRIGGER_MAPPING = { 'message:appUser' => :incoming, 'message:delivery:channel' => :outgoing }
+  TIPLINE_CUSTOMIZABLE_MESSAGES = ['smooch_message_smooch_bot_greetings', 'submission_prompt', 'add_more_details_state', 'ask_if_ready_state',
+                                   'search_state', 'search_no_results', 'search_result_state', 'search_result_is_relevant', 'search_submit',
+                                   'newsletter_optin_optout', 'option_not_available', 'timeout', 'smooch_message_smooch_bot_disabled']
 
   check_settings
 
@@ -1107,5 +1110,29 @@ class Bot::Smooch < BotUser
       end
     end
     team_bot_installation
+  end
+
+  def self.default_settings
+    settings = [
+      {
+        'smooch_workflow_language' => 'en',
+        'smooch_state_main' => {
+          'smooch_menu_message' => '',
+          'smooch_menu_options' => []
+        },
+        'smooch_state_secondary' => {
+          'smooch_menu_message' => '',
+          'smooch_menu_options' => []
+        },
+        'smooch_state_query' => {
+          'smooch_menu_message' => '',
+          'smooch_menu_options' => []
+        },
+      }
+    ]
+    ::Bot::Smooch::TIPLINE_CUSTOMIZABLE_MESSAGES.each do |key|
+      settings[0][key] = ''
+    end
+    settings
   end
 end

--- a/app/models/concerns/smooch_team_bot_installation.rb
+++ b/app/models/concerns/smooch_team_bot_installation.rb
@@ -120,9 +120,7 @@ module SmoochTeamBotInstallation
 
       def smooch_default_messages
         messages = {}
-        keys = ['smooch_message_smooch_bot_greetings', 'submission_prompt', 'add_more_details_state', 'ask_if_ready_state',
-                'search_state', 'search_no_results', 'search_result_state', 'search_result_is_relevant', 'search_submit',
-                'newsletter_optin_optout', 'option_not_available', 'timeout', 'smooch_message_smooch_bot_disabled']
+        keys = ::Bot::Smooch::TIPLINE_CUSTOMIZABLE_MESSAGES
         self.team.get_languages.to_a.each do |language|
           messages[language] = {}
           keys.each { |key| messages[language][key.to_s] = TIPLINE_STRINGS.dig(language, key) || TIPLINE_STRINGS.dig('en', key) }

--- a/db/migrate/20250411153835_update_smooch_bot_default_settings.rb
+++ b/db/migrate/20250411153835_update_smooch_bot_default_settings.rb
@@ -1,0 +1,14 @@
+class UpdateSmoochBotDefaultSettings < ActiveRecord::Migration[6.1]
+  def change
+    tb = BotUser.smooch_user
+    unless tb.nil?
+      settings = tb.get_settings.clone || []
+      i = settings.find_index{ |s| s['name'] == 'smooch_workflows' }
+      if i >= 0
+        settings[i]['default'] = ::Bot::Smooch.default_settings.clone 
+        tb.set_settings(settings)
+        tb.save!
+      end
+    end
+  end
+end

--- a/test/models/team_2_test.rb
+++ b/test/models/team_2_test.rb
@@ -1623,4 +1623,12 @@ class Team2Test < ActiveSupport::TestCase
     create_explainer title: 'Test explainer', team: t
     assert_equal 2, t.filtered_articles(text: 'Test?').count
   end
+
+  test "should install tipline when workspace is created" do
+    settings = [{ 'name' => 'smooch_workflows', 'default' => ::Bot::Smooch.default_settings.clone }]
+    bot = create_team_bot name: 'Smooch', login: 'smooch', set_approved: true, set_settings: settings, set_events: [], default: true, set_request_url: "#{CheckConfig.get('checkdesk_base_url_private')}/api/bots/smooch"
+    assert_difference "TeamBotInstallation.where(user_id: #{bot.id}).count" do
+      create_team
+    end
+  end
 end


### PR DESCRIPTION
## Description

Ensure that no customized strings are set when the tipline is automatically installed for a newly created workspace.

Reference: CV2-4994.

## How to test?

I implemented an automated test, but here's how to test it manually: Create a new workspace using Check Web, go to the tipline settings and make sure that no messages show as "customized":

![CV2-4994](https://github.com/user-attachments/assets/4110c905-d6eb-4e1a-bc7c-95f5fe7cec15)

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).

[CV2-4994]: https://meedan.atlassian.net/browse/CV2-4994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ