### PR TITLE
Fixing some issues with original claim timeout handling

### DIFF
--- a/app/models/concerns/project_association.rb
+++ b/app/models/concerns/project_association.rb
@@ -157,7 +157,7 @@ module ProjectAssociation
     protected
 
     def set_media
-      unless self.url.blank? && self.quote.blank? && self.file.blank? && self.media_type != 'Blank'
+      unless self.url.blank? && self.quote.blank? && self.file.blank? && self.media_type != 'Blank' && self.set_original_claim.blank?
         self.create_media!
         self.media_id unless self.media_id.nil?
       end

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -122,7 +122,13 @@ module ProjectMediaCreators
 
     if original_claim && original_claim.match?(/\A#{URI::DEFAULT_PARSER.make_regexp(['http', 'https'])}\z/)
       uri = URI.parse(original_claim)
-      content_type = Net::HTTP.get_response(uri)['content-type']
+      content_type = nil
+      begin
+        content_type = Net::HTTP.start(uri.host, uri.port, open_timeout: 3, read_timeout: 3, use_ssl: uri.scheme == 'https') { |http| http.request(Net::HTTP::Head.new(uri)) }['content-type']
+      rescue
+        self.media_type = 'Claim'
+        return
+      end
 
       case content_type
       when /^image\//

--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -124,7 +124,7 @@ module ProjectMediaCreators
       uri = URI.parse(original_claim)
       content_type = nil
       begin
-        content_type = Net::HTTP.start(uri.host, uri.port, open_timeout: 3, read_timeout: 3, use_ssl: uri.scheme == 'https') { |http| http.request(Net::HTTP::Head.new(uri)) }['content-type']
+        content_type = Net::HTTP.start(uri.host, uri.port, open_timeout: 3, read_timeout: 3, use_ssl: uri.scheme == 'https') { |http| http.request_head(uri) }['content-type']
       rescue
         self.media_type = 'Claim'
         return

--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -135,7 +135,7 @@ class Media < ApplicationRecord
     filepath = File.join(Rails.root, 'tmp', filename)
 
     request = Net::HTTP::Get.new(uri)
-    response = Net::HTTP.start(uri.hostname, uri.port, open_timeout: 5, read_timeout: CheckConfig.get('short_request_timeout', 25, :integer), use_ssl: uri.scheme == 'https') { |http| http.request(request) }
+    response = Net::HTTP.start(uri.hostname, uri.port, open_timeout: 3, read_timeout: CheckConfig.get('short_request_timeout', 20, :integer), use_ssl: uri.scheme == 'https') { |http| http.request(request) }
     body = response.body
 
     File.atomic_write(filepath) { |file| file.write(body) }

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -32,7 +32,6 @@ class ProjectMedia < ApplicationRecord
   validates_presence_of :custom_title, if: proc { |pm| pm.title_field == 'custom_title' }
 
   before_validation :set_team_id, :set_channel, :set_project_id, on: :create
-  before_validation :create_media!, if: proc { |pm| pm.set_original_claim.present? }, on: :create
   after_create :create_annotation, :create_metrics_annotation, :send_slack_notification, :create_relationship, :create_team_tasks, :create_claim_description_and_fact_check, :create_tags_in_background
   after_create :add_source_creation_log, unless: proc { |pm| pm.source_id.blank? }
   after_commit :apply_rules_and_actions_on_create, :set_quote_metadata, :notify_team_bots_create, on: [:create]

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -281,7 +281,7 @@ development: &default
   header_file_video_max_size_check: 10 # Megabytes, should be less than WhatsApp limit
   url_max_size: 2000
   min_number_of_words_for_tipline_long_text: 10
-  short_request_timeout: 25
+  short_request_timeout: 20
 
   # Session
   #


### PR DESCRIPTION
## Description

- The method `create_media!` was being called twice - once from the method `set_media` in `app/models/concerns/project_association.rb`, and again from a `before_validation` callback in `app/models/project_media.rb`. When the first one was called, the `media_type` was changed from `Blank` to something else, which then caused the conditions for the second call to be met as well.

- We could get a timeout from the `Net::HTTP.get_response` call we use to get the content type, since no timeout was set. I replaced that with `Net::HTTP.start`, which allows us to set a timeout and use a HEAD request instead, since we're only interested in the content type. It's much faster, so I hardcoded the timeouts. If a timeout occurs at that point, the type is set as `claim`.

- I added an automated test for both cases (timeout and no-timeout).

Fixes: CV2-6319.

## How to test?

I implemented an automated test for this, but it's possible to try it locally as well.

First, save the contents below as `config.ru` and start the service with `rackup --host 0.0.0.0 --port 4567` from your host machine:

```ruby
require 'net/http'
require 'uri'

app = Proc.new do |env|
  req = Rack::Request.new(env)

  if env['REQUEST_METHOD'] == 'GET' && req.path_info == '/image'
    delay = req.params['delay']&.to_i || 5
    sleep delay

    uri = URI('https://picsum.photos/200/300')
    res = Net::HTTP.get_response(uri)

    if res.is_a?(Net::HTTPRedirection)
      res = Net::HTTP.get_response(URI(res['location']))
    end

    if res.is_a?(Net::HTTPSuccess)
      [200, { 'content-type' => 'image/jpeg' }, [res.body]]
    else
      [502, { 'content-type' => 'text/plain' }, ['Failed to fetch image']]
    end

  elsif env['REQUEST_METHOD'] == 'HEAD' && req.path_info == '/image'
    [200, { 'content-type' => 'image/jpeg' }, []]

  else
    [404, { 'content-type' => 'text/plain' }, ['Not found']]
  end
end

run app
```

Then make a GraphQL API call like:

```bash
#!/bin/bash
curl \
-s -w "Total time: %{time_total}s\n" \
-H 'X-Check-Token: api-key-access-token' \
-H 'X-Check-Team: team-slug' \
-F query='mutation create { createProjectMedia(input: { media_type: "Blank", channel: { main: 1 }, set_status: "undetermined", set_claim_description: "-", set_original_claim: "http://host.docker.internal:4567/image?delay=50", set_fact_check: { title: "Test", summary: "Test", language: "en", publish_report: false } }) { project_media { type } } }' \
"http://localhost:3000/api/graphql"
echo
```

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
