### PR TITLE
Only save the report sent timestamp when the report is actually sent.

### DIFF
--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -1046,7 +1046,7 @@ class Bot::Smooch < BotUser
       data = tr.smooch_data
       self.get_platform_from_message(data)
       self.get_installation(self.installation_setting_id_keys, data['app_id']) if self.config.blank?
-      self.send_report_to_user(tr.tipline_user_uid, data, parent, tr.language, 'fact_check_report')
+      self.send_report_to_user(tr.tipline_user_uid, data, parent, tr.language, 'fact_check_report', nil, tr)
     end
   end
 

--- a/app/models/bot/smooch.rb
+++ b/app/models/bot/smooch.rb
@@ -981,7 +981,7 @@ class Bot::Smooch < BotUser
     Rails.logger.info "[Smooch Bot] Trying to send report to user #{uid} for item with ID #{pm.id}..."
 
     # Only send a report if these conditions are met
-    should_send_report_in_language = report.should_send_report_in_this_language?(lang)
+    should_send_report_in_language = !!report&.should_send_report_in_this_language?(lang)
     if report&.get_field_value('state') == 'published' && [CheckArchivedFlags::FlagCodes::NONE, CheckArchivedFlags::FlagCodes::UNCONFIRMED].include?(parent.archived) && should_send_report_in_language
 
       # Map the template name to a ticker field

--- a/app/models/concerns/smooch_strings.rb
+++ b/app/models/concerns/smooch_strings.rb
@@ -13,7 +13,7 @@ module SmoochStrings
       # - Menu item description: 72 characters
       # - Button label: 20 characters
       # - Body: 1024 characters
-      string = [TIPLINE_STRINGS.dig(language, key), TIPLINE_STRINGS.dig(language.gsub(/[-_].*$/, ''), key), TIPLINE_STRINGS.dig('en', key)].find{ |s| !s.blank? }
+      string = [TIPLINE_STRINGS.dig(language, key), TIPLINE_STRINGS.dig(language.to_s.gsub(/[-_].*$/, ''), key), TIPLINE_STRINGS.dig('en', key)].find{ |s| !s.blank? }
       string = key if string.blank?
       string.to_s.truncate(truncate_at)
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_04_08_164959) do
+ActiveRecord::Schema.define(version: 2025_04_11_153835) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1019,6 +1019,6 @@ ActiveRecord::Schema.define(version: 2025_04_08_164959) do
   add_foreign_key "requests", "feeds"
 
   create_trigger :enforce_relationships, sql_definition: <<-SQL
-      CREATE TRIGGER enforce_relationships BEFORE INSERT ON public.relationships FOR EACH ROW EXECUTE FUNCTION validate_relationships()
+      CREATE TRIGGER enforce_relationships BEFORE INSERT ON public.relationships FOR EACH ROW EXECUTE PROCEDURE validate_relationships()
   SQL
 end

--- a/test/models/bot/smooch_8_test.rb
+++ b/test/models/bot/smooch_8_test.rb
@@ -1,0 +1,46 @@
+require_relative '../../test_helper'
+require 'sidekiq/testing'
+
+class Bot::Smooch8Test < ActiveSupport::TestCase
+  def setup
+    Sidekiq::Testing.fake!
+    RequestStore.store[:skip_cached_field_update] = true
+    @team = create_team
+    @bot = create_smooch_bot
+    @installation = create_team_bot_installation user_id: @bot.id, team_id: @team.id
+    Bot::Smooch.get_installation('team_bot_installation_id', @installation.id) { |i| i.id == @installation.id }
+  end
+
+  def teardown
+  end
+
+  test "should update ticker only when report is actually sent" do
+    RequestStore.store[:smooch_bot_provider] = 'CAPI'
+    Bot::Smooch.stubs(:send_message_to_user).returns(OpenStruct.new({ body: { messages: [{ id: random_string }] }.to_json }))
+    Bot::Smooch.stubs(:send_final_messages_to_user).returns(OpenStruct.new({ body: { messages: [{ id: random_string }] }.to_json }))
+
+    pm = create_project_media team: @team
+    tr = create_tipline_request team_id: @team.id
+    r = publish_report(pm)
+    r.set_fields = { state: 'paused' }.to_json
+    r.save!
+
+    assert_equal 0, tr.reload.smooch_report_sent_at
+    assert_equal 0, tr.reload.smooch_report_correction_sent_at
+    
+    Bot::Smooch.send_correction_to_user({}, pm, tr, nil, 'publish', 0)
+    assert_equal 0, tr.reload.smooch_report_sent_at
+    assert_equal 0, tr.reload.smooch_report_correction_sent_at
+
+    r.set_fields = { state: 'published' }.to_json
+    r.save!
+
+    Bot::Smooch.send_correction_to_user({}, pm, tr, nil, 'publish', 0)
+    assert_not_equal 0, tr.reload.smooch_report_sent_at
+    assert_equal 0, tr.reload.smooch_report_correction_sent_at
+
+    Bot::Smooch.send_correction_to_user({}, pm, tr, Time.now.since(1.minute), 'publish', 1)
+    assert_not_equal 0, tr.reload.smooch_report_sent_at
+    assert_not_equal 0, tr.reload.smooch_report_correction_sent_at
+  end
+end


### PR DESCRIPTION
## Description

Previously, the report sent timestamp was saved before the report was actually sent, which could result in a situation where a report was not sent but the information was incorrectly recorded as if it had been. This PR fixes the issue by ensuring that the report sent timestamp is stored in the tipline request only when, and after, the report is actually sent.

Fixes: CV2-6317.

## How to test?

Reproduced in a unit test:

```
Failure:
Bot::Smooch8Test#test_should_update_ticker_only_when_report_is_actually_sent [test/models/bot/smooch_8_test.rb:25]:
Expected: 0
  Actual: 1744732878
```

Manually:

- Send a report to a user
- Send a report correction to a user
- Send a report from the parent to the child

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
