### PR TITLE
Change status sorting to alphabetical order

### DIFF
--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -163,7 +163,10 @@ class TeamType < DefaultObject
     # We sometimes call this method and somehow object is nil despite self.object being available
     object ||= self.object
     object = object.reload if items_count_for_status || published_reports_count_for_status
-    object.verification_statuses("media", nil, items_count_for_status, published_reports_count_for_status)
+    statuses = object.verification_statuses("media", nil, items_count_for_status, published_reports_count_for_status)
+    # Sort the statuses by the 'label' field
+    statuses["statuses"] = statuses["statuses"].sort_by { |status| status["label"] }
+    statuses
   end
 
   field :team_bot_installation, TeamBotInstallationType, null: true do


### PR DESCRIPTION
## Description

Adds a sort to the verification_statuses method, for return statuses ordered alphabetically by their label field

References: CV2-6325

## How to test?

tested manually through the UI 

Places to cover:
Tipline: Bulk change action button in the lists view
Tipline: Within the media cluster, the statuses button
Tipline: Report editor statuses button
Tipline:  Filter > Rating is
Articles: Within the Article statuses button
Articles: Claim & Fact-Checks > Filter > Rating is
Articles: Published > Filter > Rating is
Settings: Statuses settings page
Settings: Rules page, if condition

## Checklist

- [X] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
