### PR TITLE
CV2-6342: Refactor SavedSearch to accept list_type

### DIFF
--- a/app/graph/mutations/saved_search_mutations.rb
+++ b/app/graph/mutations/saved_search_mutations.rb
@@ -15,6 +15,7 @@ module SavedSearchMutations
 
     argument :title, GraphQL::Types::String, required: true
     argument :team_id, GraphQL::Types::Int, required: true, camelize: false
+    argument :list_type, GraphQL::Types::String, required: true, camelize: false
   end
 
   class Update < Mutations::UpdateMutation

--- a/app/graph/types/saved_search_type.rb
+++ b/app/graph/types/saved_search_type.rb
@@ -8,6 +8,7 @@ class SavedSearchType < DefaultObject
   field :team_id, GraphQL::Types::Int, null: true
   field :team, PublicTeamType, null: true
   field :items_count, GraphQL::Types::Int, null: true
+  field :list_type, GraphQL::Types::String, null: true
   field :filters, GraphQL::Types::String, null: true
 
   def filters

--- a/app/models/saved_search.rb
+++ b/app/models/saved_search.rb
@@ -1,6 +1,8 @@
 class SavedSearch < ApplicationRecord
   attr_accessor :is_being_copied
 
+  enum list_type: { media: 0, article: 1 }
+
   validates_presence_of :title, :team_id
   validates :title, uniqueness: { scope: :team_id }, unless: proc { |ss| ss.is_being_copied }
 

--- a/db/migrate/20250419100047_add_list_type_to_saved_search.rb
+++ b/db/migrate/20250419100047_add_list_type_to_saved_search.rb
@@ -1,0 +1,6 @@
+class AddListTypeToSavedSearch < ActiveRecord::Migration[6.1]
+  def change
+    add_column :saved_searches, :list_type, :integer, null: false, default: 0
+    add_index :saved_searches, :list_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_04_11_153835) do
+ActiveRecord::Schema.define(version: 2025_04_19_100047) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -680,6 +680,8 @@ ActiveRecord::Schema.define(version: 2025_04_11_153835) do
     t.json "filters"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "list_type", default: 0, null: false
+    t.index ["list_type"], name: "index_saved_searches_on_list_type"
     t.index ["team_id"], name: "index_saved_searches_on_team_id"
   end
 
@@ -1019,6 +1021,6 @@ ActiveRecord::Schema.define(version: 2025_04_11_153835) do
   add_foreign_key "requests", "feeds"
 
   create_trigger :enforce_relationships, sql_definition: <<-SQL
-      CREATE TRIGGER enforce_relationships BEFORE INSERT ON public.relationships FOR EACH ROW EXECUTE PROCEDURE validate_relationships()
+      CREATE TRIGGER enforce_relationships BEFORE INSERT ON public.relationships FOR EACH ROW PROCEDURE FUNCTION validate_relationships()
   SQL
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1021,6 +1021,6 @@ ActiveRecord::Schema.define(version: 2025_04_19_100047) do
   add_foreign_key "requests", "feeds"
 
   create_trigger :enforce_relationships, sql_definition: <<-SQL
-      CREATE TRIGGER enforce_relationships BEFORE INSERT ON public.relationships FOR EACH ROW PROCEDURE FUNCTION validate_relationships()
+      CREATE TRIGGER enforce_relationships BEFORE INSERT ON public.relationships FOR EACH ROW EXECUTE PROCEDURE validate_relationships()
   SQL
 end

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -2673,6 +2673,7 @@ input CreateSavedSearchInput {
   """
   clientMutationId: String
   filters: JsonStringType
+  list_type: String!
   team_id: Int!
   title: String!
 }
@@ -12290,6 +12291,7 @@ type SavedSearch implements Node {
   id: ID!
   is_part_of_feeds: Boolean
   items_count: Int
+  list_type: String
   permissions: String
   team: PublicTeam
   team_id: Int

--- a/public/relay.json
+++ b/public/relay.json
@@ -16275,6 +16275,22 @@
               "deprecationReason": null
             },
             {
+              "name": "list_type",
+              "description": null,
+              "type": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "clientMutationId",
               "description": "A unique identifier for the client performing the mutation.",
               "type": {
@@ -64932,6 +64948,20 @@
               "type": {
                 "kind": "SCALAR",
                 "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
+              "name": "list_type",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
                 "ofType": null
               },
               "isDeprecated": false,

--- a/test/models/saved_search_test.rb
+++ b/test/models/saved_search_test.rb
@@ -12,6 +12,15 @@ class SavedSearchTest < ActiveSupport::TestCase
     end
   end
 
+  test "should set list type" do
+    ss = create_saved_search
+    assert_equal 'media', ss.list_type
+    create_saved_search list_type: 'article'
+    assert_raises ArgumentError do
+      create_saved_search list_type: 'invalid'
+    end
+  end
+
   test "should not create saved search if title is not present" do
     assert_no_difference 'SavedSearch.count' do
       assert_raises ActiveRecord::RecordInvalid do


### PR DESCRIPTION
## Description

Refactor the SavedSearch model to include a list_type attribute. This attribute should accept either media or article as values.

- [x] Add a list_type attribute to the SavedSearch model.
- [x] The list_type should be an enum with values media and article.
- [x] Set the default value of list_type to media.
- [x] Add a required list_type argument to the saved_searches GraphQL field..

References: CV2-6342

## How to test?

Implemented automated tests

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
