### PR TITLE
Exposing `dbid` in GraphQL `ExplainerItemType` and including child items when sending explainers

### DIFF
--- a/app/graph/types/explainer_item_type.rb
+++ b/app/graph/types/explainer_item_type.rb
@@ -3,6 +3,7 @@ class ExplainerItemType < DefaultObject
 
   implements GraphQL::Types::Relay::Node
 
+  field :dbid, GraphQL::Types::Int, null: true
   field :explainer_id, GraphQL::Types::Int, null: false
   field :project_media_id, GraphQL::Types::Int, null: false
   field :explainer, ExplainerType, null: false

--- a/app/models/explainer_item.rb
+++ b/app/models/explainer_item.rb
@@ -17,7 +17,7 @@ class ExplainerItem < ApplicationRecord
   end
 
   def send_explainers_to_previous_requests(range)
-    ids = ProjectMedia.where(id: self.project_media.related_items_ids).map(&:id) # Including child items
+    ids = ProjectMedia.where(id: self.project_media.related_items_ids).pluck(:id) # Including child items
     # Keep track of UIDs so we don't send the same explainer to the same user more than once.
     # We could use GROUP BY or DISTINCT ON, but it would be more complex for the average number of requests we have.
     uids = []

--- a/app/models/explainer_item.rb
+++ b/app/models/explainer_item.rb
@@ -17,7 +17,14 @@ class ExplainerItem < ApplicationRecord
   end
 
   def send_explainers_to_previous_requests(range)
-    TiplineRequest.no_articles_sent(self.project_media_id).where(created_at: Time.now.ago(range.days)..Time.now).find_each do |tipline_request|
+    ids = ProjectMedia.where(id: self.project_media.related_items_ids).map(&:id) # Including child items
+    # Keep track of UIDs so we don't send the same explainer to the same user more than once.
+    # We could use GROUP BY or DISTINCT ON, but it would be more complex for the average number of requests we have.
+    uids = []
+    TiplineRequest.no_articles_sent(ids).where(created_at: Time.now.ago(range.days)..Time.now).find_each do |tipline_request|
+      uid = tipline_request.tipline_user_uid
+      next if uids.include?(uid)
+      uids << uid
       Bot::Smooch.delay_for(1.second, { queue: 'smooch_priority', retry: 0 }).send_explainer_to_user(self.id, tipline_request.id)
     end
   end

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -555,8 +555,9 @@ class ProjectMedia < ApplicationRecord
   end
 
   def has_tipline_requests_that_never_received_articles
+    ids = ProjectMedia.where(id: self.related_items_ids).map(&:id) # Including child items
     # As we check against the range with 1, 7 and 30 days so I check the exists with the max range (30 days)
-    TiplineRequest.no_articles_sent(self.id).where(created_at: Time.now.ago(30.days)..Time.now).exists?
+    TiplineRequest.no_articles_sent(ids).where(created_at: Time.now.ago(30.days)..Time.now).exists?
   end
 
   def number_of_tipline_requests_that_never_received_articles_by_time

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -561,8 +561,9 @@ class ProjectMedia < ApplicationRecord
 
   def number_of_tipline_requests_that_never_received_articles_by_time
     data = {}
+    ids = ProjectMedia.where(id: self.related_items_ids).map(&:id) # Including child items
     [1, 7, 30].each do |number_of_days|
-      data[number_of_days] = TiplineRequest.no_articles_sent(self.id).where(created_at: Time.now.ago(number_of_days.days)..Time.now).count
+      data[number_of_days] = TiplineRequest.no_articles_sent(ids).where(created_at: Time.now.ago(number_of_days.days)..Time.now).count
     end
     data
   end

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -555,14 +555,14 @@ class ProjectMedia < ApplicationRecord
   end
 
   def has_tipline_requests_that_never_received_articles
-    ids = ProjectMedia.where(id: self.related_items_ids).map(&:id) # Including child items
+    ids = ProjectMedia.where(id: self.related_items_ids).pluck(:id) # Including child items
     # As we check against the range with 1, 7 and 30 days so I check the exists with the max range (30 days)
     TiplineRequest.no_articles_sent(ids).where(created_at: Time.now.ago(30.days)..Time.now).exists?
   end
 
   def number_of_tipline_requests_that_never_received_articles_by_time
     data = {}
-    ids = ProjectMedia.where(id: self.related_items_ids).map(&:id) # Including child items
+    ids = ProjectMedia.where(id: self.related_items_ids).pluck(:id) # Including child items
     [1, 7, 30].each do |number_of_days|
       data[number_of_days] = TiplineRequest.no_articles_sent(ids).where(created_at: Time.now.ago(number_of_days.days)..Time.now).count
     end

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -8225,6 +8225,7 @@ Explainer item type
 """
 type ExplainerItem implements Node {
   created_at: String
+  dbid: Int
   explainer: Explainer!
   explainer_id: Int!
   id: ID!

--- a/public/relay.json
+++ b/public/relay.json
@@ -44588,6 +44588,20 @@
               "deprecationReason": null
             },
             {
+              "name": "dbid",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "explainer",
               "description": null,
               "args": [


### PR DESCRIPTION
## Description

- Exposing `dbid` in GraphQL `ExplainerItemType`.
- De-duplicating requests, so the same user doesn't receive the same explainer more than once.
- Including child items when sending explainers to previous requests.

Reference: CV2-6335.

## How to test?

Existing tests should cover this.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
