### PR TITLE
Ignore negative search result feedback when checking if a media cluster has unanswered requests.

### DIFF
--- a/app/models/tipline_request.rb
+++ b/app/models/tipline_request.rb
@@ -22,7 +22,7 @@ class TiplineRequest < ApplicationRecord
   scope :no_articles_sent, ->(project_media_id) {
     where(associated_type: 'ProjectMedia', associated_id: project_media_id, smooch_report_received_at: 0,
       smooch_report_update_received_at: 0, smooch_report_sent_at: 0, smooch_report_correction_sent_at: 0
-    ).where.not(smooch_request_type: %w(relevant_search_result_requests irrelevant_search_result_requests timeout_search_requests))
+    ).where.not(smooch_request_type: %w(relevant_search_result_requests timeout_search_requests))
   }
 
   def returned_search_results?

--- a/test/models/project_media_8_test.rb
+++ b/test/models/project_media_8_test.rb
@@ -157,7 +157,7 @@ class ProjectMedia8Test < ActiveSupport::TestCase
     tr_30a.save!
     assert pm.has_tipline_requests_that_never_received_articles
     data = pm.number_of_tipline_requests_that_never_received_articles_by_time
-    expected_result = { 1 => 1, 7 => 1, 30 => 2 }
+    expected_result = { 1 => 1, 7 => 1, 30 => 3 }
     assert_equal expected_result, data
     tr_1b.smooch_report_update_received_at = Time.now.to_i
     tr_1b.save!
@@ -165,6 +165,8 @@ class ProjectMedia8Test < ActiveSupport::TestCase
     tr_7b.save!
     tr_30b.smooch_report_correction_sent_at = Time.now.to_i
     tr_30b.save!
+    tr_7a.smooch_request_type = 'relevant_search_result_requests'
+    tr_7a.save!
     assert_not pm.has_tipline_requests_that_never_received_articles
     data = pm.number_of_tipline_requests_that_never_received_articles_by_time
     expected_result = { 1 => 0, 7 => 0, 30 => 0 }


### PR DESCRIPTION
## Description

Ignoring negative search result feedback when checking if a media cluster has unanswered requests.

Reference: CV2-6335.

## How to test?

Existing tests should cover this.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
