### PR TITLE
CV2-6363: Add periodic check for MonthlyTeamStatistic

### DIFF
--- a/app/workers/tipline_statistics_periodic_check_worker.rb
+++ b/app/workers/tipline_statistics_periodic_check_worker.rb
@@ -1,0 +1,14 @@
+class TiplineStatisticsPeriodicCheckWorker
+  include Sidekiq::Worker
+
+  sidekiq_options retry: 0
+
+  def perform
+    if CheckConfig.get('ENABLE_TIPLINE_STATS_MONITORING', true)
+      periodic_check = Time.now.ago(1.day)
+      count = MonthlyTeamStatistic.where('created_at > ? OR updated_at > ?', periodic_check, periodic_check).count
+      error_msg = StandardError.new('No MonthlyTeamStatistic updated or created in the last 24 hours')
+      CheckSentry.notify(error_msg) if count == 0
+    end
+  end
+end

--- a/app/workers/tipline_statistics_periodic_check_worker.rb
+++ b/app/workers/tipline_statistics_periodic_check_worker.rb
@@ -4,10 +4,8 @@ class TiplineStatisticsPeriodicCheckWorker
   sidekiq_options retry: 0
 
   def perform
-    if CheckConfig.get('ENABLE_TIPLINE_STATS_MONITORING', true)
-      periodic_check = Time.now.ago(1.day)
-      count = MonthlyTeamStatistic.where('created_at > ? OR updated_at > ?', periodic_check, periodic_check).count
-      CheckSentry.notify(StandardError.new('No MonthlyTeamStatistic updated or created in the last 24 hours')) if count == 0
-    end
+    periodic_check = Time.now.ago(26.hours)
+    count = MonthlyTeamStatistic.where('created_at > ? OR updated_at > ?', periodic_check, periodic_check).count
+    CheckSentry.notify(StandardError.new('No MonthlyTeamStatistic updated or created in the last 24 hours')) if count == 0
   end
 end

--- a/app/workers/tipline_statistics_periodic_check_worker.rb
+++ b/app/workers/tipline_statistics_periodic_check_worker.rb
@@ -4,7 +4,8 @@ class TiplineStatisticsPeriodicCheckWorker
   sidekiq_options retry: 0
 
   def perform
-    periodic_check = Time.now.ago(26.hours)
+    # adding a buffer of one hour to our expected 24 hours interval
+    periodic_check = Time.now.ago(25.hours)
     count = MonthlyTeamStatistic.where('created_at > ? OR updated_at > ?', periodic_check, periodic_check).count
     CheckSentry.notify(StandardError.new('No MonthlyTeamStatistic updated or created in the last 24 hours')) if count == 0
   end

--- a/app/workers/tipline_statistics_periodic_check_worker.rb
+++ b/app/workers/tipline_statistics_periodic_check_worker.rb
@@ -7,8 +7,7 @@ class TiplineStatisticsPeriodicCheckWorker
     if CheckConfig.get('ENABLE_TIPLINE_STATS_MONITORING', true)
       periodic_check = Time.now.ago(1.day)
       count = MonthlyTeamStatistic.where('created_at > ? OR updated_at > ?', periodic_check, periodic_check).count
-      error_msg = StandardError.new('No MonthlyTeamStatistic updated or created in the last 24 hours')
-      CheckSentry.notify(error_msg) if count == 0
+      CheckSentry.notify(StandardError.new('No MonthlyTeamStatistic updated or created in the last 24 hours')) if count == 0
     end
   end
 end

--- a/test/workers/tipline_statistics_periodic_check_worker_test.rb
+++ b/test/workers/tipline_statistics_periodic_check_worker_test.rb
@@ -1,0 +1,30 @@
+require_relative '../test_helper'
+
+class TiplineStatisticsPeriodicCheckWorkerTest < ActiveSupport::TestCase
+  test "should notify Sentry for missing tipline statistics updates in last 24 hours" do
+    t = create_team
+    # Verify both created/updated dates
+    Time.stubs(:now).returns(Time.new - 3.days)
+    ms = create_monthly_team_statistic team: t
+    Time.unstub(:now)
+    CheckSentry.expects(:notify).once
+    TiplineStatisticsPeriodicCheckWorker.new.perform
+    # Verify config option
+    stub_configs({ 'ENABLE_TIPLINE_STATS_MONITORING' => false }) do
+      CheckSentry.expects(:notify).never
+      TiplineStatisticsPeriodicCheckWorker.new.perform
+    end
+    # Verify updated date
+    ms.updated_at = Time.now
+    ms.save!
+    CheckSentry.expects(:notify).never
+    TiplineStatisticsPeriodicCheckWorker.new.perform
+    ms.destroy
+    CheckSentry.expects(:notify).once
+    TiplineStatisticsPeriodicCheckWorker.new.perform
+    # Verify both created/updated dates
+    create_monthly_team_statistic team: t
+    CheckSentry.expects(:notify).never
+    TiplineStatisticsPeriodicCheckWorker.new.perform
+  end
+end

--- a/test/workers/tipline_statistics_periodic_check_worker_test.rb
+++ b/test/workers/tipline_statistics_periodic_check_worker_test.rb
@@ -4,9 +4,10 @@ class TiplineStatisticsPeriodicCheckWorkerTest < ActiveSupport::TestCase
   test "should notify Sentry for missing tipline statistics updates in last 24 hours" do
     t = create_team
     # Verify both created/updated dates
-    Time.stubs(:now).returns(Time.new - 3.days)
-    ms = create_monthly_team_statistic team: t
-    Time.unstub(:now)
+    ms = nil
+    travel_to 3.days.ago do
+      ms = create_monthly_team_statistic team: t
+    end
     CheckSentry.expects(:notify).once
     TiplineStatisticsPeriodicCheckWorker.new.perform
     # Verify updated date

--- a/test/workers/tipline_statistics_periodic_check_worker_test.rb
+++ b/test/workers/tipline_statistics_periodic_check_worker_test.rb
@@ -9,11 +9,6 @@ class TiplineStatisticsPeriodicCheckWorkerTest < ActiveSupport::TestCase
     Time.unstub(:now)
     CheckSentry.expects(:notify).once
     TiplineStatisticsPeriodicCheckWorker.new.perform
-    # Verify config option
-    stub_configs({ 'ENABLE_TIPLINE_STATS_MONITORING' => false }) do
-      CheckSentry.expects(:notify).never
-      TiplineStatisticsPeriodicCheckWorker.new.perform
-    end
     # Verify updated date
     ms.updated_at = Time.now
     ms.save!


### PR DESCRIPTION
## Description

Add Sentry notification for missing tipline statistics updates in last 24 hours

References: CV2-6363

## How to test?

Implemented automated tests

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
