### PR TITLE
5271 – 6369 – Refactor to make current feed list explicitly a media list

### DIFF
--- a/app/controllers/test_controller.rb
+++ b/app/controllers/test_controller.rb
@@ -286,7 +286,7 @@ class TestController < ApplicationController
       user: user,
       team: team,
       published: true,
-      saved_search: saved_search,
+      media_saved_search: saved_search,
       licenses: [1],
       last_clusterized_at: Time.now,
       data_points: [1, 2]

--- a/app/graph/mutations/feed_mutations.rb
+++ b/app/graph/mutations/feed_mutations.rb
@@ -8,7 +8,7 @@ module FeedMutations
     included do
       argument :description, GraphQL::Types::String, required: false
       argument :tags, [GraphQL::Types::String, null: true], required: false
-      argument :saved_search_id, GraphQL::Types::Int, required: false, camelize: false
+      argument :saved_search_id, GraphQL::Types::Int, required: false, camelize: false, as: :media_saved_search_id
       argument :published, GraphQL::Types::Boolean, required: false, camelize: false
       argument :discoverable, GraphQL::Types::Boolean, required: false, camelize: false
     end

--- a/app/graph/mutations/feed_team_mutations.rb
+++ b/app/graph/mutations/feed_team_mutations.rb
@@ -3,7 +3,7 @@ module FeedTeamMutations
   PARENTS = ['feed'].freeze
 
   class Update < Mutations::UpdateMutation
-    argument :saved_search_id, GraphQL::Types::Int, required: false, camelize: false
+    argument :saved_search_id, GraphQL::Types::Int, required: false, camelize: false, as: :media_saved_search_id
     argument :shared, GraphQL::Types::Boolean, required: false
     argument :requests_filters, JsonStringType, required: false, camelize: false
   end

--- a/app/graph/types/feed_team_type.rb
+++ b/app/graph/types/feed_team_type.rb
@@ -5,7 +5,7 @@ class FeedTeamType < DefaultObject
 
   field :dbid, GraphQL::Types::Int, null: true
   field :filters, JsonStringType, null: true
-  field :saved_search_id, GraphQL::Types::Int, null: true
+  field :saved_search_id, GraphQL::Types::Int, null: true, method: :media_saved_search_id
   field :team, PublicTeamType, null: true
   field :feed, FeedType, null: true
   field :team_id, GraphQL::Types::Int, null: true
@@ -17,6 +17,6 @@ class FeedTeamType < DefaultObject
     object.get_requests_filters
   end
 
-  field :saved_search, SavedSearchType, null: true
+  field :saved_search, SavedSearchType, null: true, method: :media_saved_search
   field :saved_search_was, SavedSearchType, null: true
 end

--- a/app/graph/types/feed_type.rb
+++ b/app/graph/types/feed_type.rb
@@ -16,13 +16,13 @@ class FeedType < DefaultObject
   field :root_requests_count, GraphQL::Types::Int, null: true
   field :tags, [GraphQL::Types::String, null: true], null: true
   field :licenses, [GraphQL::Types::Int, null: true], null: true
-  field :saved_search_id, GraphQL::Types::Int, null: true
+  field :saved_search_id, GraphQL::Types::Int, null: true, method: :media_saved_search_id
   field :discoverable, GraphQL::Types::Boolean, null: true
   field :last_clusterized_at, GraphQL::Types::String, null: true
   field :user, UserType, null: true
 
   field :team, PublicTeamType, null: true
-  field :saved_search, SavedSearchType, null: true
+  field :saved_search, SavedSearchType, null: true, method: :media_saved_search
   field :saved_search_was, SavedSearchType, null: true
 
   field :requests, RequestType.connection_type, null: true do

--- a/app/graph/types/saved_search_type.rb
+++ b/app/graph/types/saved_search_type.rb
@@ -18,12 +18,12 @@ class SavedSearchType < DefaultObject
   field :is_part_of_feeds, GraphQL::Types::Boolean, null: true
 
   def is_part_of_feeds
-    Feed.where(saved_search_id: object.id).exists? || FeedTeam.where(saved_search_id: object.id).exists?
+    Feed.where(media_saved_search_id: object.id).exists? || FeedTeam.where(media_saved_search_id: object.id).exists?
   end
 
   field :feeds, FeedType.connection_type, null: true
 
   def feeds
-    Feed.where(saved_search_id: object.id)
+    Feed.where(media_saved_search_id: object.id)
   end
 end

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -9,7 +9,7 @@ class Feed < ApplicationRecord
   has_many :feed_invitations, dependent: :destroy
   has_many :clusters
   belongs_to :user, optional: true
-  belongs_to :saved_search, optional: true
+  belongs_to :media_saved_search, class_name: 'SavedSearch', optional: true
   belongs_to :team, optional: true
 
   before_validation :set_user_and_team, :set_uuid, on: :create

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -49,11 +49,11 @@ class Feed < ApplicationRecord
     conditions = { shared: true }
     conditions[:team_id] = feed_team_ids if feed_team_ids.is_a?(Array)
     self.feed_teams.where(conditions).find_each do |ft|
-      saved_search = self.team_id == ft.team_id ? self.saved_search : ft.saved_search
-      if saved_search.blank? # Do not share anything from this team if they haven't chosen a list yet
+      media_saved_search = self.team_id == ft.team_id ? self.media_saved_search : ft.media_saved_search
+      if media_saved_search.blank? # Do not share anything from this team if they haven't chosen a list yet
         filters << { 'team_id' => ft.team_id, 'report_status' => ['none'] }
       else
-        filters << saved_search.filters.to_h.reject{ |k, _v| PROHIBITED_FILTERS.include?(k.to_s) }.merge({ 'team_id' => ft.team_id })
+        filters << media_saved_search.filters.to_h.reject{ |k, _v| PROHIBITED_FILTERS.include?(k.to_s) }.merge({ 'team_id' => ft.team_id })
       end
     end
     filters
@@ -170,7 +170,7 @@ class Feed < ApplicationRecord
   end
 
   def saved_search_was
-    SavedSearch.find_by_id(self.saved_search_id_before_last_save)
+    SavedSearch.find_by_id(self.media_saved_search_id_before_last_save)
   end
 
   def get_exported_data(filters)
@@ -222,8 +222,8 @@ class Feed < ApplicationRecord
   end
 
   def saved_search_belongs_to_feed_teams
-    unless saved_search_id.blank?
-      errors.add(:saved_search_id, I18n.t(:"errors.messages.invalid_feed_saved_search_value")) unless self.get_team_ids.include?(self.saved_search.team_id)
+    unless media_saved_search_id.blank?
+      errors.add(:media_saved_search_id, I18n.t(:"errors.messages.invalid_feed_saved_search_value")) unless self.get_team_ids.include?(self.media_saved_search.team_id)
     end
   end
 

--- a/app/models/feed_team.rb
+++ b/app/models/feed_team.rb
@@ -3,7 +3,7 @@ class FeedTeam < ApplicationRecord
 
   belongs_to :team
   belongs_to :feed
-  belongs_to :saved_search, optional: true
+  belongs_to :media_saved_search, class_name: 'SavedSearch', optional: true
 
   validates_presence_of :team_id, :feed_id
   validate :saved_search_belongs_to_feed_team

--- a/app/models/feed_team.rb
+++ b/app/models/feed_team.rb
@@ -16,18 +16,18 @@ class FeedTeam < ApplicationRecord
   end
 
   def filters
-    self.saved_search&.filters.to_h
+    self.media_saved_search&.filters.to_h
   end
 
   def saved_search_was
-    SavedSearch.find_by_id(self.saved_search_id_before_last_save)
+    SavedSearch.find_by_id(self.media_saved_search_id_before_last_save)
   end
 
   private
 
   def saved_search_belongs_to_feed_team
-    unless saved_search_id.blank?
-      errors.add(:saved_search_id, I18n.t(:"errors.messages.invalid_feed_saved_search_value")) if self.team_id != self.saved_search.team_id
+    unless media_saved_search_id.blank?
+      errors.add(:media_saved_search_id, I18n.t(:"errors.messages.invalid_feed_saved_search_value")) if self.team_id != self.media_saved_search.team_id
     end
   end
 

--- a/db/migrate/20250515134234_rename_saved_search_id_to_media_saved_search_id.rb
+++ b/db/migrate/20250515134234_rename_saved_search_id_to_media_saved_search_id.rb
@@ -1,0 +1,6 @@
+class RenameSavedSearchIdToMediaSavedSearchId < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :feeds, :saved_search_id, :media_saved_search_id
+    rename_column :feed_teams, :saved_search_id, :media_saved_search_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_05_13_075639) do
+ActiveRecord::Schema.define(version: 2025_05_15_134234) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -349,7 +349,7 @@ ActiveRecord::Schema.define(version: 2025_05_13_075639) do
     t.string "tags", default: [], array: true
     t.boolean "trashed", default: false
     t.bigint "author_id"
-    t.integer "channel", null: false
+    t.integer "channel"
     t.index "date_trunc('day'::text, created_at)", name: "explainer_created_at_day"
     t.index ["author_id"], name: "index_explainers_on_author_id"
     t.index ["channel"], name: "index_explainers_on_channel"
@@ -376,7 +376,7 @@ ActiveRecord::Schema.define(version: 2025_05_13_075639) do
     t.boolean "imported", default: false
     t.boolean "trashed", default: false
     t.bigint "author_id"
-    t.integer "channel", null: false
+    t.integer "channel"
     t.index "date_trunc('day'::text, created_at)", name: "fact_check_created_at_day"
     t.index ["author_id"], name: "index_fact_checks_on_author_id"
     t.index ["channel"], name: "index_fact_checks_on_channel"
@@ -411,9 +411,9 @@ ActiveRecord::Schema.define(version: 2025_05_13_075639) do
     t.boolean "shared", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "saved_search_id"
+    t.bigint "media_saved_search_id"
     t.index ["feed_id"], name: "index_feed_teams_on_feed_id"
-    t.index ["saved_search_id"], name: "index_feed_teams_on_saved_search_id"
+    t.index ["media_saved_search_id"], name: "index_feed_teams_on_media_saved_search_id"
     t.index ["team_id", "feed_id"], name: "index_feed_teams_on_team_id_and_feed_id", unique: true
     t.index ["team_id"], name: "index_feed_teams_on_team_id"
   end
@@ -424,7 +424,7 @@ ActiveRecord::Schema.define(version: 2025_05_13_075639) do
     t.boolean "published", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "saved_search_id"
+    t.bigint "media_saved_search_id"
     t.bigint "user_id"
     t.bigint "team_id"
     t.text "description"
@@ -434,7 +434,7 @@ ActiveRecord::Schema.define(version: 2025_05_13_075639) do
     t.integer "data_points", default: [], array: true
     t.string "uuid", default: "", null: false
     t.datetime "last_clusterized_at"
-    t.index ["saved_search_id"], name: "index_feeds_on_saved_search_id"
+    t.index ["media_saved_search_id"], name: "index_feeds_on_media_saved_search_id"
     t.index ["team_id"], name: "index_feeds_on_team_id"
     t.index ["user_id"], name: "index_feeds_on_user_id"
     t.index ["uuid"], name: "index_feeds_on_uuid"
@@ -1022,6 +1022,6 @@ ActiveRecord::Schema.define(version: 2025_05_13_075639) do
   add_foreign_key "requests", "feeds"
 
   create_trigger :enforce_relationships, sql_definition: <<-SQL
-      CREATE TRIGGER enforce_relationships BEFORE INSERT ON public.relationships FOR EACH ROW EXECUTE PROCEDURE validate_relationships()
+      CREATE TRIGGER enforce_relationships BEFORE INSERT ON public.relationships FOR EACH ROW EXECUTE FUNCTION validate_relationships()
   SQL
 end

--- a/test/controllers/elastic_search_10_test.rb
+++ b/test/controllers/elastic_search_10_test.rb
@@ -438,11 +438,11 @@ class ElasticSearch10Test < ActionController::TestCase
     create_project_media team: t1, disable_es_callbacks: false
     create_project_media team: t1, disable_es_callbacks: false
     ss1 = create_saved_search team: t1, filters: {}
-    f = create_feed team: t1, saved_search: nil, data_points: [1, 2], published: true
+    f = create_feed team: t1, media_saved_search: nil, data_points: [1, 2], published: true
     t2 = create_team
     create_project_media team: t2, disable_es_callbacks: false
     ss2 = create_saved_search team: t2, filters: {}
-    ft = create_feed_team feed: f, team: t2, saved_search: nil, shared: true
+    ft = create_feed_team feed: f, team: t2, media_saved_search: nil, shared: true
     sleep 2
     Team.current = t1
     query = { feed_id: f.id, feed_view: 'media', show_similar: true }
@@ -451,21 +451,21 @@ class ElasticSearch10Test < ActionController::TestCase
     assert_equal 0, CheckSearch.new(query.to_json, nil, t1.id).number_of_results
 
     # Only the first workspace has chosen a list
-    f.saved_search = ss1
+    f.media_saved_search = ss1
     f.save!
     assert_equal 2, CheckSearch.new(query.to_json, nil, t1.id).number_of_results
 
     # Only the second workspace has chosen a list
-    f.saved_search = nil
+    f.media_saved_search = nil
     f.save!
-    ft.saved_search = ss2
+    ft.media_saved_search = ss2
     ft.save!
     assert_equal 1, CheckSearch.new(query.to_json, nil, t1.id).number_of_results
 
     # Both workspaces have chosen a list
-    f.saved_search = ss1
+    f.media_saved_search = ss1
     f.save!
-    ft.saved_search = ss2
+    ft.media_saved_search = ss2
     ft.save!
     assert_equal 3, CheckSearch.new(query.to_json, nil, t1.id).number_of_results
 

--- a/test/controllers/graphql_controller_7_test.rb
+++ b/test/controllers/graphql_controller_7_test.rb
@@ -189,7 +189,7 @@ class GraphqlController7Test < ActionController::TestCase
     assert_not data['is_part_of_feeds']
     assert_empty data['feeds']['edges']
     # add list to feed
-    f.saved_search_id = ss.id
+    f.media_saved_search_id = ss.id
     f.skip_check_ability = true
     f.save!
     query = "query { team(slug: \"#{t.slug}\") { saved_searches(first: 1, list_type: \"media\") { edges { node { filters, is_part_of_feeds, feeds(first: 1) { edges { node { dbid }}} } } } } }"

--- a/test/controllers/graphql_controller_8_test.rb
+++ b/test/controllers/graphql_controller_8_test.rb
@@ -245,7 +245,7 @@ class GraphqlController8Test < ActionController::TestCase
     assert_equal ss.id, data.dig('saved_search', 'dbid')
   end
 
-  test "should get feed and feed team saved search" do
+  test "should get feed team saved search" do
     t = create_team
     u = create_user
     create_team_user user: u, team: t, role: 'admin'

--- a/test/lib/list_export_test.rb
+++ b/test/lib/list_export_test.rb
@@ -76,7 +76,7 @@ class ListExportTest < ActiveSupport::TestCase
       r.save!
     end
     ss = create_saved_search team: t
-    f = create_feed team: t, data_points: [1], saved_search: ss, published: true
+    f = create_feed team: t, data_points: [1], media_saved_search: ss, published: true
 
     sleep 2 # Wait for indexing
 

--- a/test/models/bot/smooch_5_test.rb
+++ b/test/models/bot/smooch_5_test.rb
@@ -48,11 +48,11 @@ class Bot::Smooch5Test < ActiveSupport::TestCase
     FeedTeam.update_all(shared: true)
     ft = FeedTeam.last
     ft_ss = create_saved_search team: t2, filters: {}
-    ft.saved_search = ft_ss
+    ft.media_saved_search = ft_ss
     ft.save!
     f1.teams << t3
     f_ss = create_saved_search team: t1, filters: { keyword: 'Bar' }
-    f1.saved_search = f_ss
+    f1.media_saved_search = f_ss
     f1.save!
     u = create_bot_user
     [t1, t2, t3, t4].each { |t| TeamUser.create!(user: u, team: t, role: 'editor') }

--- a/test/models/feed_team_test.rb
+++ b/test/models/feed_team_test.rb
@@ -30,17 +30,17 @@ class FeedTeamTest < ActiveSupport::TestCase
     f = create_feed
     ss = create_saved_search team: t
     assert_difference 'FeedTeam.count' do
-      create_feed_team saved_search: ss, team_id: t.id, feed: f
+      create_feed_team media_saved_search: ss, team_id: t.id, feed: f
     end
     assert_raises ActiveRecord::RecordInvalid do
-      create_feed_team saved_search: create_saved_search, feed: f
+      create_feed_team media_saved_search: create_saved_search, feed: f
     end
   end
 
   test "should get filters" do
     t = create_team
     ss = create_saved_search team: t, filters: { foo: 'bar'}
-    ft = create_feed_team team_id: t.id, saved_search_id: ss.id
+    ft = create_feed_team team_id: t.id, media_saved_search_id: ss.id
     assert_equal 'bar', ft.reload.filters['foo']
   end
 
@@ -86,8 +86,8 @@ class FeedTeamTest < ActiveSupport::TestCase
     t = create_team
     ss1 = create_saved_search team: t
     ss2 = create_saved_search team: t
-    ft = create_feed_team team: t, saved_search: ss1
-    ft.saved_search = ss2
+    ft = create_feed_team team: t, media_saved_search: ss1
+    ft.media_saved_search = ss2
     ft.save!
     assert_equal ss1, ft.saved_search_was
   end

--- a/test/models/feed_test.rb
+++ b/test/models/feed_test.rb
@@ -72,10 +72,10 @@ class FeedTest < ActiveSupport::TestCase
     ss = create_saved_search team: t
     Team.stubs(:current).returns(t)
     assert_difference 'Feed.count' do
-      create_feed saved_search: ss, team: t
+      create_feed media_saved_search: ss, team: t
     end
     assert_raises ActiveRecord::RecordInvalid do
-      create_feed saved_search: create_saved_search
+      create_feed media_saved_search: create_saved_search
     end
     Team.unstub(:current)
   end
@@ -84,7 +84,7 @@ class FeedTest < ActiveSupport::TestCase
     t = create_team
     ss = create_saved_search team: t, filters: { foo: 'bar' }
     Team.stubs(:current).returns(t)
-    f = create_feed saved_search: ss, team: t
+    f = create_feed media_saved_search: ss, team: t
     assert_equal({}, f.reload.filters)
     Team.unstub(:current)
   end
@@ -213,8 +213,8 @@ class FeedTest < ActiveSupport::TestCase
     t = create_team
     ss1 = create_saved_search team: t
     ss2 = create_saved_search team: t
-    f = create_feed team: t, saved_search: ss1
-    f.saved_search = ss2
+    f = create_feed team: t, media_saved_search: ss1
+    f.media_saved_search = ss2
     f.save!
     assert_equal ss1, f.saved_search_was
   end

--- a/test/models/request_test.rb
+++ b/test/models/request_test.rb
@@ -260,9 +260,9 @@ class RequestTest < ActiveSupport::TestCase
     ss2 = create_saved_search team: t2, filters: {}
     ss3 = create_saved_search team: t3, filters: {}
     ss4 = create_saved_search team: t4, filters: {}
-    FeedTeam.where(team: t2, feed: f).update_all(saved_search_id: ss2.id)
-    FeedTeam.where(team: t3, feed: f).update_all(saved_search_id: ss3.id)
-    FeedTeam.where(team: t4, feed: f).update_all(saved_search_id: ss4.id)
+    FeedTeam.where(team: t2, feed: f).update_all(media_saved_search_id: ss2.id)
+    FeedTeam.where(team: t3, feed: f).update_all(media_saved_search_id: ss3.id)
+    FeedTeam.where(team: t4, feed: f).update_all(media_saved_search_id: ss4.id)
     FeedTeam.update_all(shared: true)
     f.teams << t5
     m = create_uploaded_image


### PR DESCRIPTION
## Description

This is the first part of the work to add Articles as Available Data to Share when creating a shared feed. This is a refactoring to rename `saved_search` to `media_saved_search`. We did this because `Feed` and `FeedTeam` can store a single reference to a list (saved search), which is assumed to be a media list. We want Feeds to be able to reference `media_saved_search` and `article_saved_search`. We had to make changes in the model and graphql layer.

This is a refactoring to keep the current behavior, we didn't change how the API works, so nothing should change in the frontend. Though, we need to test thoroughly to make sure nothing broke.

References: CV2-5271, CV2-6369

## How to test?

I added to new tests to confirm we could get the saved_search and saved_search_id from Feed and FeedTeam:
- rails test test/controllers/graphql_controller_8_test.rb:223
- rails test test/controllers/graphql_controller_8_test.rb:248

These are the tests that broke when we first changed the column:
- unit
	- rails test test/models/feed_invitation_test.rb
	- rails test test/models/feed_test.rb 
	- rails test test/models/feed_team_test.rb 
	- rails test test/models/cluster_project_media_test.rb 
	- rails test test/lib/list_export_test.rb 
	- rails test test/models/bot/smooch_4_test.rb
	- rails test test/models/bot/smooch_5_test.rb:18 *(this test takes ±8 minutes to run)*
	- rails test test/models/bot/smooch_7_test.rb:420 
	- rails test test/models/team_test.rb 
	- rails test test/models/project_media_test.rb 
	- rails test test/models/request_test.rb:247 
- controllers
	- rails test test/controllers/graphql_controller_5_test.rb 
	- rails test test/controllers/graphql_controller_6_test.rb:126 
	- rails test test/controllers/graphql_controller_7_test.rb:179 
	- rails test test/controllers/graphql_controller_8_test.rb 
	- rails test test/controllers/graphql_controller_12_test.rb 
	- rails test test/controllers/feeds_controller_test.rb 
	- rails test test/controllers/test_controller_test.rb:544 
	- rails test test/controllers/elastic_search_10_test.rb:436 

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
