### PR TITLE
CV2-6395: Truncate title field to stay safely under maximum.

### DIFF
--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -639,7 +639,9 @@ module ProjectMediaCachedFields
       else
         self.update_column(:custom_title, title)
       end
-      title.to_s
+      # Ensure the field value does not exceed ~32KB (ref: CV2-6395);
+      # truncate at 30_000 to stay safely under 32KB as the maximum size should be 32 * 1024 bytes.
+      title.to_s.truncate(30_000)
     end
 
     def recalculate_status


### PR DESCRIPTION
## Description

Ensure the field value does not exceed ~32KB  so truncate at 30_000 to stay safely under 32KB as the maximum size should be 32 * 1024 bytes.

References: CV2-6395

## How to test?

Manually create a new item with same [title here]( https://checkmedia.org/rumour-tracking-chequeabolivia-/media/3338473?tab=articles)

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
