### PR TITLE
CV2-5106: Tipline language must be updated when default workspace language is deleted

### DIFF
--- a/app/models/concerns/team_private.rb
+++ b/app/models/concerns/team_private.rb
@@ -115,6 +115,17 @@ module TeamPrivate
     end
   end
 
+  def update_tipline_if_default_language_changed
+    language = self.settings.to_h.with_indifferent_access[:language]
+    language_were = self.settings_before_last_save.to_h.with_indifferent_access[:language]
+    if language != language_were
+      tbi = self.team_bot_installations.where(user: BotUser.smooch_user).last
+      w = tbi.get_smooch_workflows[0]
+      w['smooch_workflow_language'] = language
+      tbi.save!
+    end
+  end
+
   def empty_data_structure
     data_structure = MonthlyTeamStatistic.new.formatted_hash
     data_structure["Language"] = self.default_language

--- a/app/models/concerns/team_private.rb
+++ b/app/models/concerns/team_private.rb
@@ -115,14 +115,16 @@ module TeamPrivate
     end
   end
 
-  def update_tipline_if_default_language_changed
-    language = self.settings.to_h.with_indifferent_access[:language]
-    language_were = self.settings_before_last_save.to_h.with_indifferent_access[:language]
-    if language != language_were
-      tbi = self.team_bot_installations.where(user: BotUser.smooch_user).last
+  def update_tipline_if_default_language_deleted
+    tbi = self.team_bot_installations.where(user: BotUser.smooch_user).last
+    unless tbi.nil?
+      languages = self.settings.to_h.with_indifferent_access[:languages]
       w = tbi.get_smooch_workflows[0]
-      w['smooch_workflow_language'] = language
-      tbi.save!
+      # Update tipline language if the tipline's default language has been deleted
+      unless languages.include?(w['smooch_workflow_language'])
+        w['smooch_workflow_language'] = self.get_language
+        tbi.save!
+      end
     end
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -30,9 +30,7 @@ class Team < ApplicationRecord
   before_validation :set_default_language, on: :create
   before_validation :set_default_fieldsets, on: :create
   after_create :add_user_to_team, :add_default_bots_to_team
-  after_update :archive_or_restore_projects_if_needed
-  after_update :update_reports_if_labels_changed
-  after_update :update_reports_if_languages_changed
+  after_update :archive_or_restore_projects_if_needed, :update_reports_if_labels_changed, :update_reports_if_languages_changed, :update_tipline_if_default_language_changed
   before_destroy :anonymize_sources_and_accounts
   after_destroy :reset_current_team
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -30,7 +30,7 @@ class Team < ApplicationRecord
   before_validation :set_default_language, on: :create
   before_validation :set_default_fieldsets, on: :create
   after_create :add_user_to_team, :add_default_bots_to_team
-  after_update :archive_or_restore_projects_if_needed, :update_reports_if_labels_changed, :update_reports_if_languages_changed, :update_tipline_if_default_language_changed
+  after_update :archive_or_restore_projects_if_needed, :update_reports_if_labels_changed, :update_reports_if_languages_changed, :update_tipline_if_default_language_deleted
   before_destroy :anonymize_sources_and_accounts
   after_destroy :reset_current_team
 

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -1043,6 +1043,12 @@ class TeamTest < ActiveSupport::TestCase
     tbi = TeamBotInstallation.where(team: @team, user: BotUser.smooch_user).last
     w = tbi.get_smooch_workflows[0]
     assert_equal 'en', w['smooch_workflow_language']
+    @team.set_languages = ['en', 'fr']
+    @team.set_language = 'fr'
+    @team.save!
+    tbi = tbi.reload
+    w = tbi.get_smooch_workflows[0]
+    assert_equal 'en', w['smooch_workflow_language']
     @team.set_languages = ['fr']
     @team.set_language = 'fr'
     @team.save!

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -1038,6 +1038,19 @@ class TeamTest < ActiveSupport::TestCase
     assert_equal 'Custom Status 2 Changed', r.reload.data.dig('options', 'status_label')
   end
 
+  test "should update tipline languge if default language changed" do
+    setup_smooch_bot(true)
+    tbi = TeamBotInstallation.where(team: @team, user: BotUser.smooch_user).last
+    w = tbi.get_smooch_workflows[0]
+    assert_equal 'en', w['smooch_workflow_language']
+    @team.set_languages = ['fr']
+    @team.set_language = 'fr'
+    @team.save!
+    tbi = tbi.reload
+    w = tbi.get_smooch_workflows[0]
+    assert_equal 'fr', w['smooch_workflow_language']
+  end
+
   test "should add trash link to duplicated team" do
     m = create_valid_media
     t1 = create_team


### PR DESCRIPTION
## Description

Reset tipline language to the default if the tipline language is deleted.

References: CV2-5106

## How to test?

Implement a unit test.

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
