### PR TITLE
3942 – Avoid unwanted TeamBotInstallations when duplicating workspaces

### DIFF
--- a/app/models/concerns/team_duplication.rb
+++ b/app/models/concerns/team_duplication.rb
@@ -23,7 +23,6 @@ module TeamDuplication
           @clones << { original: original, clone: copy }
           self.alter_copy_by_type(original, copy)
         }
-        self.process_team_bot_installations(t, team)
         team = self.modify_settings(t, team)
         team = self.update_team_rules(team)
         self.adjust_team_tasks(team)
@@ -114,17 +113,6 @@ module TeamDuplication
         end
       end
       new_team
-    end
-
-    def self.process_team_bot_installations(t, team)
-      t.team_bot_installations.each do |tbi|
-        new_tbi = TeamBotInstallation.where(team: team, user: tbi.user).first || tbi.deep_dup
-        next if new_tbi.user.name == 'Smooch'
-        new_tbi.team = team
-        new_tbi.skip_check_ability = true
-        new_tbi.save(validate: false)
-        @bot_ids << new_tbi.user_id
-      end
     end
 
     def self.store_clones

--- a/app/models/concerns/team_private.rb
+++ b/app/models/concerns/team_private.rb
@@ -28,7 +28,6 @@ module TeamPrivate
   end
 
   def add_default_bots_to_team
-    return if self.is_being_copied
     BotUser.where(default: true).map do |bot_user|
       bot_user.install_to!(self) if bot_user.get_approved
     end

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -901,14 +901,14 @@ class TeamTest < ActiveSupport::TestCase
   end
 
   test "should not duplicate original team bots, should install default bots when duplicating a team" do
+    # Currently both Smooch and Alegre are default bots, meaning the are installed automatically for every team
     create_bot_user(name: 'Smooch', login: 'smooch', default: true, approved: true)
-    alegre_bot = create_bot_user(name: 'Alegre', login: 'alegre', default: false, approved: true)
+    create_bot_user(name: 'Alegre', login: 'alegre', default: true, approved: true)
     team_bot = create_bot_user(name: 'Team Bot', login: 'team_bot', default: false, approved: true)
 
     original_team = create_team(name: 'original_team')
 
-    # Install Alegre and Team Bot manually, since Smooch is default it will be installed automatically
-    alegre_bot.install_to!(original_team)
+    # Install team_bot manually, since it is not a default bot
     team_bot.install_to!(original_team)
 
     # Verify bots installed on the original team
@@ -924,7 +924,7 @@ class TeamTest < ActiveSupport::TestCase
 
     # Verify bots installed on the duplicated team
     tbi = TeamBotInstallation.where(team: duplicate_team)
-    assert_equal ['smooch'], tbi.map(&:user).map(&:login)
+    assert_equal ['alegre', 'smooch'], tbi.map(&:user).map(&:login).sort
   end
 
   test "should duplicate team with non english default language" do

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -527,7 +527,7 @@ class TeamTest < ActiveSupport::TestCase
     pm3 = create_project_media user: u
     assert_equal ['test'], pm1.get_annotations('tag').map(&:load).map(&:tag_text)
     assert_empty pm2.get_annotations('tag')
-    assert_empty pm3.get_annotations('tag')                      
+    assert_empty pm3.get_annotations('tag')
   end
 
   test "should set default language when creating team" do
@@ -900,20 +900,31 @@ class TeamTest < ActiveSupport::TestCase
     end
   end
 
-  test "should duplicate team with Bots" do
-    setup_smooch_bot(true)
-    alegre_bot = create_alegre_bot(name: "alegre", login: "alegre")
-    alegre_bot.approve!
-    alegre_bot.install_to!(@team)
-    tbi = TeamBotInstallation.where(team: @team)
-    assert_equal ['alegre', 'smooch'], tbi.map(&:user).map(&:login).sort
+  test "should not duplicate original team bots, should install default bots when duplicating a team" do
+    create_bot_user(name: 'Smooch', login: 'smooch', default: true, approved: true)
+    alegre_bot = create_bot_user(name: 'Alegre', login: 'alegre', default: false, approved: true)
+    team_bot = create_bot_user(name: 'Team Bot', login: 'team_bot', default: false, approved: true)
+
+    original_team = create_team(name: 'original_team')
+
+    # Install Alegre and Team Bot manually, since Smooch is default it will be installed automatically
+    alegre_bot.install_to!(original_team)
+    team_bot.install_to!(original_team)
+
+    # Verify bots installed on the original team
+    tbi = TeamBotInstallation.where(team: original_team)
+    assert_equal ['alegre', 'smooch', 'team_bot'], tbi.map(&:user).map(&:login).sort
+
+    # Duplicate the team
     duplicate_team = nil
     assert_nothing_raised do
-      duplicate_team = Team.duplicate(@team)
+      duplicate_team = Team.duplicate(original_team)
     end
     assert_not_nil duplicate_team
+
+    # Verify bots installed on the duplicated team
     tbi = TeamBotInstallation.where(team: duplicate_team)
-    assert_equal ['alegre'], tbi.map(&:user).map(&:login)
+    assert_equal ['smooch'], tbi.map(&:user).map(&:login)
   end
 
   test "should duplicate team with non english default language" do
@@ -1335,7 +1346,7 @@ class TeamTest < ActiveSupport::TestCase
     assert_equal 2, t.filtered_fact_checks(trashed: false, channel: "manual").count
     assert_equal 1, t.filtered_fact_checks(trashed: false, channel: "api").count
   end
-  
+
   test "should count articles by channel" do
     t = create_team
     create_explainer team: t, channel: "manual", trashed: false


### PR DESCRIPTION
## Description

When duplicating teams, we were copying the bots from the original team into the new team. But that was causing issues, e.g.:
- We create a team with a bot that has an API key to import items
- We duplicate the team, which duplicates the bot and API key
- Now we might think we are importing items to the original team, but we are actually importing them to the duplicated team

In order to avoid different teams with same API keys, instead of copying the original team's bots, we want to just install any default bots. To do that, we just need to run the `add_default_bots_to_team` `after_create` callback even if `is_being_copied`.

References: CV2-3942 , CV2-5876

## How to test?

```ruby
#   test "should not duplicate original team bots, should install default bots when duplicating a team"
rails test test/models/team_test.rb:903
```

Note: I replaced `setup_smooch_bot` with `create_bot_user`, since the former is slower and we are only testing the installation, and not the bot itself.

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
