### PR TITLE
CV2-6416: Add new settings to skip Tipline search

### DIFF
--- a/db/migrate/20250630065844_add_smooch_skip_search_settings_to_smooch_bot.rb
+++ b/db/migrate/20250630065844_add_smooch_skip_search_settings_to_smooch_bot.rb
@@ -1,0 +1,16 @@
+class AddSmoochSkipSearchSettingsToSmoochBot < ActiveRecord::Migration[6.1]
+  def change
+    tb = BotUser.smooch_user
+    unless tb.nil?
+      settings = tb.get_settings.clone || []
+      settings << {
+        name: 'smooch_skip_search',
+        label: 'Should skip search (not use Alegre or the internal Check API search)',
+        type: 'boolean',
+        default: false
+      }
+      tb.set_settings(settings)
+      tb.save!
+    end
+  end
+end

--- a/test/models/bot/smooch_6_test.rb
+++ b/test/models/bot/smooch_6_test.rb
@@ -225,7 +225,15 @@ class Bot::Smooch6Test < ActiveSupport::TestCase
     publish_report(pm, {}, nil, { language: 'en', use_visual_card: false })
     CheckSearch.any_instance.stubs(:medias).returns([pm])
     Sidekiq::Testing.inline! do
+      # Verify no results when smooch_skip_search options enabled
+      @installation.set_smooch_skip_search = true
+      @installation.save!
       send_message 'hello', '1', '1', 'Foo bar', '1'
+      assert_state 'main'
+      # Verify results when smooch_skip_search options disabled
+      @installation.set_smooch_skip_search = false
+      @installation.save!
+      send_message '2', 'hello #2', '1', '1', 'Foo bar #2', '1'
       assert_state 'search_result'
       assert_difference 'TiplineRequest.count + ProjectMedia.count', 2 do
         send_message '1'


### PR DESCRIPTION
## Description

Add a new settings to skip tipline search and always return `No result` without hit CheckSearch or Alegre
References: CV2-6416

## How to test?

Implemented unit test

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
