### PR TITLE
6468 – 6469 – Update Dockerfile syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM ruby:3.0-slim
-MAINTAINER Meedan <sysops@meedan.com>
+LABEL maintainer="sysops@meedan.com"
 
 # the Rails stage can be overridden from the caller
-ENV RAILS_ENV development
+ENV RAILS_ENV=development
 
 # https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat/
-ENV MALLOC_ARENA_MAX 2
+ENV MALLOC_ARENA_MAX=2
 
 # Set a UTF-8 capabable locale
-ENV LC_ALL C.UTF-8
-ENV LANG C.UTF-8
-ENV LANGUAGE C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV LANGUAGE=C.UTF-8
 
 # Setup a user account
 ENV DEPLOYUSER=checkdeploy

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -1,6 +1,6 @@
 # check-api
 FROM ruby:3.0-slim
-MAINTAINER sysops@meedan.com
+LABEL maintainer="sysops@meedan.com"
 
 ENV DEPLOYUSER=checkdeploy \
     DEPLOYDIR=/app/current \
@@ -18,9 +18,9 @@ ENV DEPLOYUSER=checkdeploy \
     # MIN_INSTANCES and MAX_POOL_SIZE control the pool size of passenger
 
 # Set a UTF-8 capable locale
-ENV LC_ALL C.UTF-8
-ENV LANG C.UTF-8
-ENV LANGUAGE C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+ENV LANGUAGE=C.UTF-8
 
 #
 # USER CONFIG


### PR DESCRIPTION
## Description
- Update key/value format
	- Legacy key/value format with whitespace separator should not be used
    ("ENV key=value" should be used instead of legacy "ENV key value" format)
- Update to use Label
	- MAINTAINER has been deprecated

References: CV2-6469

## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
