### PR TITLE
CV2-4795: Add a deprecation for createProjectMedia mutation

### DIFF
--- a/app/graph/types/mutation_type.rb
+++ b/app/graph/types/mutation_type.rb
@@ -25,7 +25,7 @@ class MutationType < BaseObject
   field :createAccountSource, mutation: AccountSourceMutations::Create
   field :destroyAccountSource, mutation: AccountSourceMutations::Destroy
 
-  field :createProjectMedia, mutation: ProjectMediaMutations::Create, deprecation_reason: "Use `createFactCheck` instead."
+  field :createProjectMedia, mutation: ProjectMediaMutations::Create, deprecation_reason: "If you're creating an item of type 'blank' with an attached fact-check, please use the createFactCheck mutation instead. This mutation will not support that case in the near future."
   field :updateProjectMedia, mutation: ProjectMediaMutations::Update
   field :updateProjectMedias, mutation: ProjectMediaMutations::Bulk::Update
   field :replaceProjectMedia, mutation: ProjectMediaMutations::Replace

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -9235,7 +9235,7 @@ type MutationType {
     Parameters for CreateProjectMedia
     """
     input: CreateProjectMediaInput!
-  ): CreateProjectMediaPayload @deprecated(reason: "Use `createFactCheck` instead.")
+  ): CreateProjectMediaPayload @deprecated(reason: "If you're creating an item of type 'blank' with an attached fact-check, please use the createFactCheck mutation instead. This mutation will not support that case in the near future.")
   createProjectMediaUser(
     """
     Parameters for CreateProjectMediaUser

--- a/public/relay.json
+++ b/public/relay.json
@@ -49181,7 +49181,7 @@
                 "ofType": null
               },
               "isDeprecated": true,
-              "deprecationReason": "Use `createFactCheck` instead."
+              "deprecationReason": "If you're creating an item of type 'blank' with an attached fact-check, please use the createFactCheck mutation instead. This mutation will not support that case in the near future."
             },
             {
               "name": "createProjectMediaUser",


### PR DESCRIPTION
## Description

Add a deprecation warning about this endpoint (for new partners, we should now use the createFactCheck GraphQL mutation)

References: CV2-4795

## How to test?

Re-run automated tests

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
