### PR TITLE
CV2-6476: Create ProjectMedia from createFactCheck mutation

### DIFF
--- a/app/graph/mutations/fact_check_mutations.rb
+++ b/app/graph/mutations/fact_check_mutations.rb
@@ -21,6 +21,7 @@ module FactCheckMutations
     argument :summary, GraphQL::Types::String, required: true
     argument :claim_description_id, GraphQL::Types::Int, required: false, camelize: false
     argument :claim_description_text, GraphQL::Types::String, required: false, camelize: false
+    argument :set_original_claim, GraphQL::Types::String, required: false, camelize: false
     argument :imported, GraphQL::Types::Boolean, required: false
   end
 

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -2437,6 +2437,7 @@ input CreateFactCheckInput {
   imported: Boolean
   language: String
   rating: String
+  set_original_claim: String
   summary: String!
   tags: [String]
   title: String!

--- a/public/relay.json
+++ b/public/relay.json
@@ -14445,6 +14445,18 @@
               "deprecationReason": null
             },
             {
+              "name": "set_original_claim",
+              "description": null,
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "defaultValue": null,
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "imported",
               "description": null,
               "type": {


### PR DESCRIPTION
## Description

Pass a new argument to createFactCheck mutation to enforce create ProjectMedia.

References: CV2-6476

## How to test?

Implemented automated tests.

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
