### PR TITLE
6468 – 6496 – Remove PERSIST_DIRS from Dockerfile

### DIFF
--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -9,7 +9,6 @@ ENV DEPLOYUSER=checkdeploy \
     PRODUCT=check \
     APP=check-api \
     TERM=xterm \
-    PERSIST_DIRS="uploads project_export memebuster team_dump" \
     MALLOC_ARENA_MAX=2
     # MALLOC_ARENA MAX is needed because of https://www.mikeperham.com/2018/04/25/taming-rails-memory-bloat/
 


### PR DESCRIPTION
## Description
We used those directories before we switched to S3 for uploads.

### Notes
1. This all seems to have been relevant before we started using S3:
    - https://github.com/meedan/check-api/commit/b325fecc8adb7e9b51ee560e724254361d67dafd 
    - https://github.com/meedan/check-api/commit/40d404b7f27678ecc776bb40efbca5e4214d8e91
      - https://github.com/meedan/check-api/blob/40d404b7f27678ecc776bb40efbca5e4214d8e91/lib/tasks/migrate/20190807004123_move_files_to_s3.rake

2. I checked Check-API in QA, and we have none of those directories. 

3. I also looked through code. While all are present in the production Dockerfile, they don't seem to have a presence in code, but are present in:
    - uploads: .dockerignore, .gitignore, s3 migration rake. This one is present in `FileUploader.store_dir` (but that isn't called anywhere).
    - project_export: .gitignore
    - memebuster: old migrations, relay.json, dynamic annotations CSVs. So this seems to have been related to annotations.
    - team_dump: .gitignore and .yml files for locales (that are not used anywhere).


References: CV2-6496

## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
