### PR TITLE
CV2-6510: Require authentication for all graphql quires except `query Me`

### DIFF
--- a/app/controllers/api/v1/graphql_controller.rb
+++ b/app/controllers/api/v1/graphql_controller.rb
@@ -149,7 +149,7 @@ module Api
       private
 
       def authenticate_graphql_user
-        params[:query].to_s.match(/^((query )|(mutation[^\{#]*{\s*(resetPassword|changePassword|resendConfirmation|userDisconnectLoginAccount)\())/).nil? ? authenticate_user! : authenticate_user
+        !!(params[:query].to_s.match(/^(query\s+Me\s*\{|(mutation[^{#]*{\s*(resetPassword|changePassword|resendConfirmation|userDisconnectLoginAccount)\())/)) ? authenticate_user : authenticate_user!
       end
 
       def load_ability

--- a/app/controllers/api/v1/graphql_controller.rb
+++ b/app/controllers/api/v1/graphql_controller.rb
@@ -168,8 +168,6 @@ module Api
           safe_mutations.include?(root_field_name)
         when 'query'
           root_field_name == 'me'
-        else
-          false
         end
       end
 

--- a/app/controllers/api/v1/graphql_controller.rb
+++ b/app/controllers/api/v1/graphql_controller.rb
@@ -168,6 +168,8 @@ module Api
           safe_mutations.include?(root_field_name)
         when 'query'
           root_field_name == 'me'
+        else
+          false
         end
       end
 

--- a/lib/permissions_loader.rb
+++ b/lib/permissions_loader.rb
@@ -5,15 +5,6 @@ class PermissionsLoader < GraphQL::Batch::Loader
     @ability = ability
   end
 
-  def load_permissions_for_anonymous_user(objs)
-    first = objs.first
-    first.cached_permissions = first.permissions
-    objs.each do |obj|
-      obj.cached_permissions ||= first.cached_permissions
-      fulfill(obj.id, obj)
-    end
-  end
-
   def load_permissions_for_single_item(objs)
     only = objs.first
     only.cached_permissions = only.permissions
@@ -40,11 +31,6 @@ class PermissionsLoader < GraphQL::Batch::Loader
 
     if objs.size == 1
       load_permissions_for_single_item(objs)
-      return
-    end
-
-    if User.current&.id.nil?
-      load_permissions_for_anonymous_user(objs)
       return
     end
 

--- a/test/controllers/elastic_search_2_test.rb
+++ b/test/controllers/elastic_search_2_test.rb
@@ -164,18 +164,17 @@ class ElasticSearch2Test < ActionController::TestCase
   test "should adjust ES window size" do
     t = create_team
     u = create_user
+    create_team_user team: t, user: u, role: 'admin'
     pm = create_project_media quote: 'claim a', disable_es_callbacks: false
     sleep 2
-    create_team_user team: t, user: u, role: 'admin'
-    with_current_user_and_team(u ,t) do
-      assert_nothing_raised do
-        query = 'query Search { search(query: "{\"keyword\":\"claim\",\"eslimit\":20000,\"esoffset\":0}") {medias(first:20){edges{node{dbid}}}}}'
-        post :create, params: { query: query }
-        assert_response :success
-        query = 'query Search { search(query: "{\"keyword\":\"claim\",\"eslimit\":10000,\"esoffset\":20}") {medias(first:20){edges{node{dbid}}}}}'
-        post :create, params: { query: query }
-        assert_response :success
-      end
+    authenticate_with_user(u)
+    assert_nothing_raised do
+      query = 'query Search { search(query: "{\"keyword\":\"claim\",\"eslimit\":20000,\"esoffset\":0}") {medias(first:20){edges{node{dbid}}}}}'
+      post :create, params: { query: query, team: t.slug }
+      assert_response :success
+      query = 'query Search { search(query: "{\"keyword\":\"claim\",\"eslimit\":10000,\"esoffset\":20}") {medias(first:20){edges{node{dbid}}}}}'
+      post :create, params: { query: query, team: t.slug }
+      assert_response :success
     end
   end
 

--- a/test/controllers/elastic_search_7_test.rb
+++ b/test/controllers/elastic_search_7_test.rb
@@ -14,6 +14,7 @@ class ElasticSearch7Test < ActionController::TestCase
     tt = create_team_task team_id: t.id, type: 'single_choice', options: ['ans_a', 'ans_b', 'ans_c']
     tt2 = create_team_task team_id: t.id, type: 'multiple_choice', options: ['ans_a', 'ans_b', 'ans_c']
     tt3 = create_team_task team_id: t.id, type: 'free_text'
+    authenticate_with_user(u)
     with_current_user_and_team(u ,t) do
       pm = create_project_media team: t, disable_es_callbacks: false
       pm2 = create_project_media team: t, disable_es_callbacks: false

--- a/test/controllers/elastic_search_9_test.rb
+++ b/test/controllers/elastic_search_9_test.rb
@@ -197,6 +197,7 @@ class ElasticSearch9Test < ActionController::TestCase
     pm2 = create_project_media team: t, quote: 'claim b', disable_es_callbacks: false
     sleep 2
     create_team_user team: t, user: u, role: 'admin'
+    authenticate_with_user(u)
     with_current_user_and_team(u ,t) do
       # Hit ES with option id
       # A) id is array (should ignore)

--- a/test/controllers/graphql_controller_10_test.rb
+++ b/test/controllers/graphql_controller_10_test.rb
@@ -657,58 +657,6 @@ class GraphqlController10Test < ActionController::TestCase
     assert_response :success
   end
 
-  test "should not search without permission" do
-    t1 = create_team private: true
-    t2 = create_team private: true
-    t3 = create_team private: false
-    u = create_user
-    create_team_user team: t2, user: u
-    pm1 = create_project_media team: t1
-    pm2 = create_project_media team: t2
-    pm3a = create_project_media team: t3
-    pm3b = create_project_media team: t3
-    query = 'query { search(query: "{}") { number_of_results, medias(first: 10) { edges { node { dbid, permissions } } } } }'
-
-    # Anonymous user searching across all teams
-    post :create, params: { query: query }
-    assert_response :success
-    assert_nil JSON.parse(@response.body)['data']['search']
-    assert_not_nil JSON.parse(@response.body)['errors']
-
-    # Anonymous user searching for a public team
-    post :create, params: { query: query, team: t3.slug }
-    assert_response :success
-    assert_not_nil JSON.parse(@response.body)['data']['search']
-    assert_nil JSON.parse(@response.body)['errors']
-
-    # Anonymous user searching for a team
-    post :create, params: { query: query, team: t1.slug }
-    assert_response :success
-    assert_nil JSON.parse(@response.body)['data']['search']
-    assert_not_nil JSON.parse(@response.body)['errors']
-
-    # Unpermissioned user searching across all teams
-    authenticate_with_user(u)
-    post :create, params: { query: query, team: t1.slug }
-    assert_response :success
-    assert_nil JSON.parse(@response.body)['data']['search']
-    assert_not_nil JSON.parse(@response.body)['errors']
-
-    # Unpermissioned user searching for a team
-    authenticate_with_user(u)
-    post :create, params: { query: query, team: t1.slug }
-    assert_response :success
-    assert_nil JSON.parse(@response.body)['data']['search']
-    assert_not_nil JSON.parse(@response.body)['errors']
-
-    # Permissioned user searching for a team
-    authenticate_with_user(u)
-    post :create, params: { query: query, team: t2.slug }
-    assert_response :success
-    assert_not_nil JSON.parse(@response.body)['data']['search']
-    assert_nil JSON.parse(@response.body)['errors']
-  end
-
   test "should filter by unmatched" do
     u = create_user
     t = create_team

--- a/test/controllers/graphql_controller_12_test.rb
+++ b/test/controllers/graphql_controller_12_test.rb
@@ -1075,4 +1075,15 @@ class GraphqlController12Test < ActionController::TestCase
     assert_instance_of BotUser, explainer.user
     assert_equal "api", result["channel"]
   end
+
+  test "should require authentication to run search query" do
+    t = create_team
+    query = 'query { getRecentUpdates(query: "{\"keyword\":\"Test\",\"operator\":\"or\"}") { number_of_results } }'
+    post :create, params: { query: query, team: t.slug }
+    assert_response 401
+    authenticate_with_user(@u)
+    query = 'query { getRecentUpdates(query: "{\"keyword\":\"Test\",\"operator\":\"or\"}") { number_of_results } }'
+    post :create, params: { query: query, team: t.slug }
+    assert_response :success
+  end
 end

--- a/test/controllers/graphql_controller_2_test.rb
+++ b/test/controllers/graphql_controller_2_test.rb
@@ -390,7 +390,7 @@ class GraphqlController2Test < ActionController::TestCase
     output = "Foo\nhttp://foo\n\nBar\nhttp://bar"
     query = 'query { node(id: "' + tbi.graphql_id + '") { ... on TeamBotInstallation { smooch_bot_preview_rss_feed(rss_feed_url: "' + url + '", number_of_articles: 3) } } }'
     post :create, params: { query: query, team: t.slug }
-    assert_match /Sorry/, @response.body
+    assert_response 401
   end
 
   test "should return similar items" do

--- a/test/controllers/graphql_controller_8_test.rb
+++ b/test/controllers/graphql_controller_8_test.rb
@@ -818,6 +818,8 @@ class GraphqlController8Test < ActionController::TestCase
   test "should not access GraphQL query if not authenticated" do
     post :create, params: { query: 'query Query { about { name, version } }' }
     assert_response 401
+    post :create, params: { query: 'subscription Other { others { name, version } }' }
+    assert_response 401
   end
 
   test "should not access About if not authenticated" do

--- a/test/controllers/graphql_controller_8_test.rb
+++ b/test/controllers/graphql_controller_8_test.rb
@@ -240,7 +240,7 @@ class GraphqlController8Test < ActionController::TestCase
     article_saved_search = create_saved_search team: t, filters: { foo: 'bar' }, list_type: 'article'
     f = create_feed
     create_feed_team media_saved_search: media_saved_search, article_saved_search:article_saved_search, team_id: t.id, feed: f
-
+    authenticate_with_user(u)
     query = <<~GRAPHQL
       query {
         team(slug: "#{t.slug}") {

--- a/test/controllers/graphql_controller_8_test.rb
+++ b/test/controllers/graphql_controller_8_test.rb
@@ -208,7 +208,7 @@ class GraphqlController8Test < ActionController::TestCase
     media_saved_search = create_saved_search team: t, filters: { foo: 'bar' }, list_type: 'media'
     article_saved_search = create_saved_search team: t, filters: { foo: 'bar' }, list_type: 'article'
     f = create_feed media_saved_search: media_saved_search, article_saved_search:article_saved_search, team: t
-
+    authenticate_with_user(u)
     query = <<~GRAPHQL
       query {
         team(slug: "#{t.slug}") {
@@ -815,14 +815,14 @@ class GraphqlController8Test < ActionController::TestCase
     assert_equal 'Custom Status 3', r2.reload.report_design_field_value('status_label')
   end
 
-  test "should access GraphQL query if not authenticated" do
+  test "should not access GraphQL query if not authenticated" do
     post :create, params: { query: 'query Query { about { name, version } }' }
-    assert_response 200
+    assert_response 401
   end
 
-  test "should access About if not authenticated" do
+  test "should not access About if not authenticated" do
     post :create, params: { query: 'query About { about { name, version } }' }
-    assert_response :success
+    assert_response 401
   end
 
   test "should access GraphQL if authenticated" do


### PR DESCRIPTION
## Description

The existing code skips GraphQL authentications for any query start with `query  ...`  and certain mutations like `resetPassword|changePassword|resendConfirmation|userDisconnectLoginAccount`. 

I modified this behavior to only skip `query Me`  along with the existing mutations and required authentication for other graphql quires. 

References: CV2-6510

## How to test?

Re-run automated tests

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
