### PR TITLE
CV2-6526: Messenger response after 24h only shows summary (missing title & links)

### DIFF
--- a/app/models/concerns/smooch_resend.rb
+++ b/app/models/concerns/smooch_resend.rb
@@ -208,14 +208,11 @@ module SmoochResend
       unless report.nil?
         language, query_date, introduction, text, image, url, title = report.values_at(:language, :query_date, :introduction, :text, :image, :url, :title)
         uid = message['appUser']['_id']
+        full_text = [title, text, url].compact.join("\n\n")
         last_smooch_response = nil
         last_smooch_response = self.send_message_to_user(uid, introduction, self.message_tags_payload(introduction)) if introduction
         last_smooch_response = self.send_message_to_user(uid, 'Visual Card', self.message_tags_payload(nil, image)) if image
-        last_smooch_response = self.send_message_to_user(
-          uid,
-          [title, text, url].compact.join("\n\n"),
-          self.message_tags_payload([title, text, url].compact.join("\n\n"))
-        ) if text
+        last_smooch_response = self.send_message_to_user(uid, full_text, self.message_tags_payload(full_text)) if text
         self.save_smooch_response(last_smooch_response, pm, query_date, 'fact_check_report', language)
         return true
       end


### PR DESCRIPTION
## Description

Previously, when resending reports via Facebook Messenger after the 24-hour window, some fields from the report were not being included in the message.

- [X] Added title and URL extraction in get_report_data_to_be_resent

References: CV2-6526

## Checklist

- [X] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
