### PR TITLE
CV2-6552:  N+1 query (Annotation & TagText)

### DIFF
--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -644,7 +644,8 @@ module ProjectMediaCachedFields
     end
 
     def recalculate_tags_as_sentence
-      self.get_annotations('tag').map(&:load).map(&:tag_text).uniq.join(', ')
+      tag_text_ids = Tag.where(annotation_type: 'tag', annotated_type: 'ProjectMedia', annotated_id: self.id).collect{|t| t.data['tag']}
+      TagText.where(id: tag_text_ids).map(&:text).join(', ')
     end
 
     def recalculate_sources_as_sentence


### PR DESCRIPTION
## Description

Fix N+1 query for the cached field `tags_as_sentence` by running direct query instead of using `&:map` method to load Tag and TagText

References: CV2-6552, CV2-6552

## How to test?

Re-run automated tests

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
