### PR TITLE
6518 – Removes code related to Pender's deprecated social metrics feature

### DIFF
--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -5,12 +5,6 @@ require 'uri'
 module ProjectMediaCreators
   extend ActiveSupport::Concern
 
-  def create_metrics_annotation
-    unless self.media.url.blank? || self.media.metadata.dig('metrics').nil?
-      Bot::Keep.update_metrics(self.media, self.media.metadata['metrics'])
-    end
-  end
-
   def create_claim_description_and_fact_check
     cd = ClaimDescription.create!(description: self.set_claim_description, context: self.set_claim_context, project_media: self, skip_check_ability: true) unless self.set_claim_description.blank?
     fc = nil

--- a/app/models/project_media.rb
+++ b/app/models/project_media.rb
@@ -33,7 +33,7 @@ class ProjectMedia < ApplicationRecord
   validates_presence_of :custom_title, if: proc { |pm| pm.title_field == 'custom_title' }
 
   before_validation :set_team_id, :set_channel, on: :create
-  after_create :create_annotation, :create_metrics_annotation, :send_slack_notification, :create_relationship, :create_team_tasks, :create_claim_description_and_fact_check, :create_tags_in_background
+  after_create :create_annotation, :send_slack_notification, :create_relationship, :create_team_tasks, :create_claim_description_and_fact_check, :create_tags_in_background
   after_create :add_source_creation_log, unless: proc { |pm| pm.source_id.blank? }
   after_commit :apply_rules_and_actions_on_create, :set_quote_metadata, :notify_team_bots_create, on: [:create]
   after_commit :create_relationship, on: [:update]

--- a/test/models/bot/keep_test.rb
+++ b/test/models/bot/keep_test.rb
@@ -110,40 +110,6 @@ class Bot::KeepTest < ActiveSupport::TestCase
     assert !Bot::Keep.valid_request?(request)
   end
 
-  test "should update metrics" do
-    setup_elasticsearch
-    RequestStore.store[:skip_cached_field_update] = false
-    create_annotation_type_and_fields('Metrics', { 'Data' => ['JSON', false] })
-    url = 'http://test.com'
-    pender_url = CheckConfig.get('pender_url_private') + '/api/medias'
-    response = '{"type":"media","data":{"url":"' + url + '","type":"item"}}'
-    WebMock.stub_request(:get, pender_url).with({ query: { url: url } }).to_return(body: response)
-    pm = create_project_media media: nil, url: url, disable_es_callbacks: false
-    payload = { type: 'metrics', url: url, metrics: { facebook: { share_count: 123 } } }.to_json
-    request = OpenStruct.new(raw_post: nil)
-    request.raw_post = payload
-    assert_difference "Dynamic.where(annotation_type: 'metrics').count" do
-      Bot::Keep.webhook(request)
-    end
-    data = JSON.parse(pm.reload.get_annotations('metrics').last.load.get_field_value('metrics_data'))
-    assert_equal({ 'facebook' => { 'share_count' => 123 } }, data)
-    assert_equal 123, pm.reload.share_count
-    es_id = get_es_id(pm)
-    result = $repository.find(es_id)
-    assert_equal 123, result['share_count']
-    payload = { type: 'metrics', url: url, metrics: { facebook: { share_count: 321, comments_count: 456 }, twitter: { retweet_count: 789 } } }.to_json
-    request = OpenStruct.new(raw_post: nil)
-    request.raw_post = payload
-    assert_no_difference "Dynamic.where(annotation_type: 'metrics').count" do
-      Bot::Keep.webhook(request)
-    end
-    data = JSON.parse(pm.reload.get_annotations('metrics').last.load.get_field_value('metrics_data'))
-    assert_equal({ 'facebook' => { 'share_count' => 321, 'comments_count' => 456 }, 'twitter' => { 'retweet_count' => 789 } }, data)
-    assert_equal 321, pm.reload.share_count
-    result = $repository.find(es_id)
-    assert_equal 321, result['share_count']
-  end
-
   test "should return archivers enabled on a bot installation" do
     t = create_team
     t.set_limits_keep = true

--- a/test/models/project_media_5_test.rb
+++ b/test/models/project_media_5_test.rb
@@ -888,17 +888,6 @@ class ProjectMedia5Test < ActiveSupport::TestCase
     end
   end
 
-  test "should create metrics annotation after create a project media" do
-    create_annotation_type_and_fields('Metrics', { 'Data' => ['JSON', false] })
-    url = 'https://twitter.com/meedan/status/1321600654750613505'
-    response = {"type" => "media","data" => {"url" => url, "type" => "item", "metrics" => {"facebook"=> {"reaction_count" => 2, "comment_count" => 5, "share_count" => 10, "comment_plugin_count" => 0 }}}}
-
-    PenderClient::Request.stubs(:get_medias).with(CheckConfig.get('pender_url_private'), { url: url }, CheckConfig.get('pender_key'), nil).returns(response)
-    pm = create_project_media media: nil, url: url
-    assert_equal response['data']['metrics'], JSON.parse(pm.get_annotations('metrics').last.load.get_field_value('metrics_data'))
-    PenderClient::Request.unstub(:get_medias)
-  end
-
   test "should cache metadata value" do
     at = create_annotation_type annotation_type: 'task_response'
     create_field_instance annotation_type_object: at, name: 'response_test'


### PR DESCRIPTION
## Description

Removes code related to Pender's deprecated social metrics feature.

References: CV2-6518, CV2-4226

## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
