### PR TITLE
CV2-6550: N+1 query (BotUser)

### DIFF
--- a/app/models/bot_user.rb
+++ b/app/models/bot_user.rb
@@ -340,9 +340,11 @@ class BotUser < User
   def self.notify_bots(event, team_id, object_class, object_id, target_bot, request_actor_session_id = nil)
     RequestStore[:actor_session_id] = request_actor_session_id unless request_actor_session_id.nil?
     object = object_class.constantize.where(id: object_id).first
-    return if object.nil? # return to avoid query TeamBotInstallation in case object is nil
+    return if object.nil? # return to avoid query Team in case object is nil
     # Use includes to avoid N+1 query when calling team_bot_installation.bot_user
-    TeamBotInstallation.includes(:bot_user).where(team_id: team_id).find_each do |team_bot_installation|
+    team = Team.includes(team_bot_installations: :bot_user).find_by_id(team_id)
+    return if team.nil?
+    team.team_bot_installations.each do |team_bot_installation|
       bot = team_bot_installation.bot_user
       begin
         bot.notify_about_event(event, object, team, team_bot_installation) if bot.subscribed_to?(event) && (target_bot.blank? || bot.id == target_bot.id)

--- a/app/models/concerns/team_associations.rb
+++ b/app/models/concerns/team_associations.rb
@@ -6,6 +6,7 @@ module TeamAssociations
   included do
     has_many :accounts # No "dependent: :destroy" because they will be anonymized
     has_many :team_users, dependent: :destroy
+    has_many :team_bot_installations, class_name: "TeamBotInstallation"
     has_many :users, through: :team_users
     has_many :sources # No "dependent: :destroy" because they will be anonymized
     has_many :tag_texts, dependent: :destroy

--- a/app/models/team_bot_installation.rb
+++ b/app/models/team_bot_installation.rb
@@ -1,6 +1,8 @@
 class TeamBotInstallation < TeamUser
   include CustomLock
 
+  belongs_to :bot_user, class_name: "BotUser", foreign_key: :user_id
+
   has_paper_trail on: [:create, :update, :destroy], save_changes: true, ignore: [:updated_at, :created_at], versions: { class_name: 'Version' }, if: proc { |_x| User.current.present? }
 
   mount_uploaders :file, ImageUploader


### PR DESCRIPTION
## Description

We are encountering an N+1 query issue when loading `team_bot_installations.bot_user`. The code requires both `team_bot_installation` and `team_bot_installations.bot_user`, so I can't load the data with a single query. One suggestion to avoid the N+1 query is to use `.includes` when loading the team object.

References: CV2-6550

## How to test?

Re-run automated tests

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
