### PR TITLE
Remove social metrics from cached fields

### DIFF
--- a/app/models/concerns/project_media_cached_fields.rb
+++ b/app/models/concerns/project_media_cached_fields.rb
@@ -255,22 +255,6 @@ module ProjectMediaCachedFields
           }
         }
       ]
-
-    [:share, :reaction].each do |metric|
-      cached_field "#{metric}_count".to_sym,
-        start_as: 0,
-        update_es: true,
-        recalculate: :"recalculate_#{metric}",
-        update_on: [
-          {
-            model: DynamicAnnotation::Field,
-            if: proc { |f| f.field_name == 'metrics_data' },
-            affected_ids: proc { |f| [f.annotation&.annotated_id.to_i] },
-            events: {
-              save: :recalculate
-            }
-          }
-        ]
     end
 
     cached_field :report_status,
@@ -625,18 +609,6 @@ module ProjectMediaCachedFields
 
     def recalculate_status
       self.last_verification_status
-    end
-
-    def recalculate_share
-      recalculate_metric_fields(:share)
-    end
-
-    def recalculate_reaction
-      recalculate_metric_fields(:reaction)
-    end
-
-    def recalculate_metric_fields(metric)
-      begin JSON.parse(self.get_annotations('metrics').last.load.get_field_value('metrics_data'))['facebook']["#{metric}_count"] rescue 0 end
     end
 
     def recalculate_report_status


### PR DESCRIPTION
## Description

Removes code related to Pender's deprecated social metrics feature.
We already removed part of it in this PR: https://github.com/meedan/check-api/pull/2362

References: CV2-6518, CV2-4226

## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
