### PR TITLE
CV2-6566: Bot::Smooch::CapiUnhandledMessageWarning

### DIFF
--- a/app/models/concerns/smooch_capi.rb
+++ b/app/models/concerns/smooch_capi.rb
@@ -171,7 +171,7 @@ module SmoochCapi
         }.with_indifferent_access
 
       # User didn't receive message (for example, because 24 hours have passed since the last message from the user)
-      elsif json.dig('entry', 0, 'changes', 0, 'value', 'statuses', 0, 'status') == 'failed'
+      elsif ['failed', 'unknown'].include?(json.dig('entry', 0, 'changes', 0, 'value', 'statuses', 0, 'status'))
         status = json.dig('entry', 0, 'changes', 0, 'value', 'statuses', 0)
         error_code = status.dig('errors', 0, 'code')
         error_message = status.dig('errors', 0, 'message')


### PR DESCRIPTION
## Description

For the received message, we handle two statuses: `delivered` and `failed`. However, we recently encountered an unknown status via Sentry, so I am treating the `unknown` status the same as the failed one.

References: CV2-6566

## How to test?

Re-run automated tests

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
