### PR TITLE
CV2-6475: create ProjectMedia in case `set_original_claim` not exists

### DIFF
--- a/app/models/concerns/project_media_creators.rb
+++ b/app/models/concerns/project_media_creators.rb
@@ -115,7 +115,6 @@ module ProjectMediaCreators
 
   def set_media_type
     original_claim = self.set_original_claim&.strip
-
     if original_claim && original_claim.match?(/\A#{URI::DEFAULT_PARSER.make_regexp(['http', 'https'])}\z/)
       uri = URI.parse(original_claim)
       content_type = nil
@@ -169,6 +168,11 @@ module ProjectMediaCreators
         [media_type, self.quote, { quote_attributions: self.quote_attributions }]
       when 'Link'
         [media_type, self.url, { team: self.team }]
+      when 'Blank'
+        unless self.set_fact_check.blank?
+          fact_check = self.set_fact_check.with_indifferent_access
+          ['Claim', fact_check['title'], { quote_attributions: self.quote_attributions }]
+        end
       end
     end
   end


### PR DESCRIPTION
## Description

Handle the case for `createProjectMedia` mutation that `set_original_claim` not exists

Tested by the following query 
```
mutation create {
  createProjectMedia(input: {
    channel: { main: 1 },
    set_tags: ["6475", "Test #2.6", "pm query"],
    set_status: "false",
    set_fact_check: {
      title: "6475 – FC #2 – QA – Without an original claim",
      summary: "6475 – FC #2 – QA",
      url: "",
      language: "en",
      channel: "zapier",
      publish_report: true
    }
  }) {
    project_media {
      title
      dbid
      full_url
      claim_description {
        fact_check {
          dbid
        }
      }
      last_status_obj {
        id
      }
    }
  }
}
```

References: CV2-6475

## How to test?

Add unit test

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
