### PR TITLE
CV2-6700: expire api keys and delete webhooks for deactivated workspace

### DIFF
--- a/lib/tasks/data/team.rake
+++ b/lib/tasks/data/team.rake
@@ -35,7 +35,7 @@ namespace :check do
         webhook_installations = team.team_users.joins(:user).where('users.type' => 'BotUser', 'users.default' => false).select{ |team_user| team_user.user.events.present? && team_user.user.get_request_url.present? && !team_user.user.get_approved }
         webhook_installations.map(&:user).each do |bu|
           puts "\nDeleting webhook #{bu.name}....\n"
-          puts "\nWebhook events: #{bu.events.inspect}"
+          puts "\nWebhook settings: #{bu.settings.inspect}"
           bu.destroy
         end
         team.inactive = true

--- a/lib/tasks/data/team.rake
+++ b/lib/tasks/data/team.rake
@@ -26,7 +26,17 @@ namespace :check do
     task :deactivate, [:slugs] => :environment do |_t, args|
       slugs = args[:slugs].to_s.split('|')
       Team.where(slug: slugs, inactive: false).find_each do |team|
+        puts "\nProcessing team #{team.slug}....\n"
         print '.'
+        # Expire API keys
+        date = Time.now - 1.month
+        ApiKey.where(team_id: team.id).update_all(expire_at: date)
+        # Delete webhooks
+        webhook_installations = team.team_users.joins(:user).where('users.type' => 'BotUser', 'users.default' => false).select{ |team_user| team_user.user.events.present? && team_user.user.get_request_url.present? && !team_user.user.get_approved }
+        webhook_installations.map(&:user).each do |bu|
+          puts "Deleting webhook #{bu.login}....\n"
+          bu.destroy
+        end
         team.inactive = true
         team.save!
       end

--- a/lib/tasks/data/team.rake
+++ b/lib/tasks/data/team.rake
@@ -34,7 +34,8 @@ namespace :check do
         # Delete webhooks
         webhook_installations = team.team_users.joins(:user).where('users.type' => 'BotUser', 'users.default' => false).select{ |team_user| team_user.user.events.present? && team_user.user.get_request_url.present? && !team_user.user.get_approved }
         webhook_installations.map(&:user).each do |bu|
-          puts "Deleting webhook #{bu.login}....\n"
+          puts "\nDeleting webhook #{bu.name}....\n"
+          puts "\nWebhook events: #{bu.events.inspect}"
           bu.destroy
         end
         team.inactive = true


### PR DESCRIPTION
## Description

Before deactivate workspace I run the following actions:

- [x] Expire ApiKeys
- [x] Delete webhooks

References: CV2-6700

## How to test?

Run rake task locally 

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
