### PR TITLE
CV2-6650: Support WhatsApp BSUIDs

### DIFF
--- a/app/models/concerns/smooch_capi.rb
+++ b/app/models/concerns/smooch_capi.rb
@@ -39,7 +39,8 @@ module SmoochCapi
     end
 
     def get_capi_uid(value)
-      "#{value.dig('metadata', 'display_phone_number')}:#{value.dig('contacts', 0, 'wa_id')}"
+      "#{value.dig('metadata', 'display_phone_number')}:#{value.dig('contacts', 0, 'wa_id')}" || # WhatsApp phone
+      "#{value.dig('metadata', 'display_phone_number')}:#{value.dig('contacts', 0, 'user_id')}" # WhatsApp BSUID (fallback)
     end
 
     def get_capi_message_text(message)
@@ -69,7 +70,8 @@ module SmoochCapi
     def handle_capi_system_message(message)
       if message.dig('system', 'type') == 'user_changed_number'
         old_uid = "#{self.config['capi_phone_number']}:#{message['from']}"
-        new_uid = "#{self.config['capi_phone_number']}:#{message['system']['wa_id']}"
+        new_uid = "#{self.config['capi_phone_number']}:#{message['system']['wa_id']}" ||
+        "#{self.config['capi_phone_number']}:#{message['system']['user_id']}"
         TiplineSubscription.where(uid: old_uid).find_each do |subscription|
           subscription.uid = new_uid
           subscription.save!

--- a/app/models/concerns/smooch_capi.rb
+++ b/app/models/concerns/smooch_capi.rb
@@ -70,9 +70,10 @@ module SmoochCapi
 
     def handle_capi_system_message(message)
       if message.dig('system', 'type') == 'user_changed_number'
-        old_uid = "#{self.config['capi_phone_number']}:#{message['from']}"
-        user_id = message['system']['wa_id'] || message['system']['user_id']
-        new_uid = "#{self.config['capi_phone_number']}:#{user_id}"
+        from_id = message['from'] || message['from_user_id']
+        old_uid = "#{self.config['capi_phone_number']}:#{from_id}"
+        bsuid = message['system']['wa_id'] || message['system']['user_id']
+        new_uid = "#{self.config['capi_phone_number']}:#{bsuid}"
         TiplineSubscription.where(uid: old_uid).find_each do |subscription|
           subscription.uid = new_uid
           subscription.save!
@@ -236,7 +237,6 @@ module SmoochCapi
         payload = {
           messaging_product: 'whatsapp',
           recipient_type: 'individual',
-          to: to,
           type: 'text',
           text: {
             preview_url: preview_url && !text.to_s.match(/https?:\/\//).nil?,
@@ -246,15 +246,13 @@ module SmoochCapi
       else
         payload = {
           messaging_product: 'whatsapp',
-          recipient_type: 'individual',
-          to: to
+          recipient_type: 'individual'
         }.merge(text)
       end
       if extra['type'] == 'image'
         payload = {
           messaging_product: 'whatsapp',
           recipient_type: 'individual',
-          to: to,
           type: 'image',
           image: {
             link: extra['mediaUrl'],
@@ -265,7 +263,6 @@ module SmoochCapi
         payload = {
           messaging_product: 'whatsapp',
           recipient_type: 'individual',
-          to: to,
           type: 'video',
           video: {
             link: extra['mediaUrl'],
@@ -273,6 +270,8 @@ module SmoochCapi
           }
         }
       end
+
+      payload.merge!(self.recipient_params(to))
       payload.merge!(extra.dig(:override, :whatsapp, :payload).to_h)
       payload.delete(:text) if payload[:type] == 'interactive'
       return if payload[:type] == 'text' && payload[:text][:body].blank?
@@ -320,6 +319,20 @@ module SmoochCapi
           components: components
         }
       }
+    end
+
+    # BSUIDs have the format "XX.alphanumeric" (e.g., "US.1349120865530274"),
+    # while phone numbers are purely numeric (with optional leading +).
+    def bsuid?(identifier)
+      identifier.to_s.match?(/\A[A-Z]{2}\./)
+    end
+
+    def recipient_params(identifier)
+      if self.bsuid?(identifier)
+        { recipient: identifier }
+      else
+        { to: identifier }
+      end
     end
   end
 end

--- a/app/models/concerns/smooch_capi.rb
+++ b/app/models/concerns/smooch_capi.rb
@@ -39,8 +39,9 @@ module SmoochCapi
     end
 
     def get_capi_uid(value)
-      "#{value.dig('metadata', 'display_phone_number')}:#{value.dig('contacts', 0, 'wa_id')}" || # WhatsApp phone
-      "#{value.dig('metadata', 'display_phone_number')}:#{value.dig('contacts', 0, 'user_id')}" # WhatsApp BSUID (fallback)
+      # Get WhatsApp phone and fallback to WhatsApp BSUID
+      user_id = value.dig('contacts', 0, 'wa_id') || value.dig('contacts', 0, 'user_id')
+      "#{value.dig('metadata', 'display_phone_number')}:#{user_id}"
     end
 
     def get_capi_message_text(message)
@@ -70,8 +71,8 @@ module SmoochCapi
     def handle_capi_system_message(message)
       if message.dig('system', 'type') == 'user_changed_number'
         old_uid = "#{self.config['capi_phone_number']}:#{message['from']}"
-        new_uid = "#{self.config['capi_phone_number']}:#{message['system']['wa_id']}" ||
-        "#{self.config['capi_phone_number']}:#{message['system']['user_id']}"
+        user_id = message['system']['wa_id'] || message['system']['user_id']
+        new_uid = "#{self.config['capi_phone_number']}:#{user_id}"
         TiplineSubscription.where(uid: old_uid).find_each do |subscription|
           subscription.uid = new_uid
           subscription.save!

--- a/test/models/concerns/smooch_capi_test.rb
+++ b/test/models/concerns/smooch_capi_test.rb
@@ -164,6 +164,16 @@ class SmoochCapiTest < ActiveSupport::TestCase
     assert_equal 'message:appUser', preprocessed_message[:trigger]
   end
 
+  test 'should preprocess incoming text and fallback to user_id' do
+    payload = JSON.parse(@incoming_text_message_payload.clone)
+    payload['entry'][0]['changes'][0]['value']['contacts'][0]['wa_id'] = nil
+    payload['entry'][0]['changes'][0]['value']['contacts'][0]['user_id'] = 'id:654321'
+    preprocessed_message = Bot::Smooch.preprocess_message(payload.to_json)
+    # Verify _id and authId include user_id when wa_id is nil
+    assert_equal "123456:id:654321", preprocessed_message.dig('appUser', '_id')
+    assert_equal "123456:id:654321", preprocessed_message.dig('messages', 0, 'authorId')
+  end
+
   test 'should preprocess message delivery event' do
     preprocessed_message = Bot::Smooch.preprocess_message(@message_delivery_payload)
     assert_equal @uid, preprocessed_message.dig('appUser', '_id') 

--- a/test/models/concerns/smooch_capi_test.rb
+++ b/test/models/concerns/smooch_capi_test.rb
@@ -165,13 +165,17 @@ class SmoochCapiTest < ActiveSupport::TestCase
   end
 
   test 'should preprocess incoming text and fallback to user_id' do
+    bsuid = "EG.1983693248898821"
     payload = JSON.parse(@incoming_text_message_payload.clone)
     payload['entry'][0]['changes'][0]['value']['contacts'][0]['wa_id'] = nil
-    payload['entry'][0]['changes'][0]['value']['contacts'][0]['user_id'] = 'id:654321'
+    payload['entry'][0]['changes'][0]['value']['contacts'][0]['user_id'] = bsuid
     preprocessed_message = Bot::Smooch.preprocess_message(payload.to_json)
     # Verify _id and authId include user_id when wa_id is nil
-    assert_equal "123456:id:654321", preprocessed_message.dig('appUser', '_id')
-    assert_equal "123456:id:654321", preprocessed_message.dig('messages', 0, 'authorId')
+    assert_equal "123456:#{bsuid}", preprocessed_message.dig('appUser', '_id')
+    assert_equal "123456:#{bsuid}", preprocessed_message.dig('messages', 0, 'authorId')
+    WebMock.stub_request(:post, 'https://graph.facebook.com/v15.0/123456/messages').to_return(status: 200, body: { id: '123456' }.to_json)
+    uid = "123456:#{bsuid}"
+    assert_equal 200, Bot::Smooch.send_message_to_user(uid, 'Test').code.to_i
   end
 
   test 'should preprocess message delivery event' do


### PR DESCRIPTION
## Description

Allow Check to send and receive WhatsApp messages using either a phone number or a BSUID

- [x] Fall back to user_id (BSUID) when wa_id (phone number) is not present in webhook contacts
- [x] Fall back to from_user_id when from is not present in webhook messages
- [x] Use to or recipient when sending messages depending on whether the identifier is a phone number or a BSUID

References: CV2-6650

## How to test?

Add unit test

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
