### PR TITLE
CV2-6177: Sentry error PG::UntranslatableCharacter Error

### DIFF
--- a/app/models/annotations/dynamic.rb
+++ b/app/models/annotations/dynamic.rb
@@ -49,7 +49,7 @@ class Dynamic < ApplicationRecord
     f.skip_check_ability = true
     f.disable_es_callbacks = self.disable_es_callbacks || value.blank?
     f.field_name = name
-    value.gsub!('\u0000', '') if value.is_a?(String) # Avoid PG::UntranslatableCharacter exception
+    value.gsub!("\u0000", '') if value.is_a?(String) # Avoid PG::UntranslatableCharacter exception
     f.value = value
     f.annotation_id = self.id
     f

--- a/app/models/annotations/dynamic.rb
+++ b/app/models/annotations/dynamic.rb
@@ -49,7 +49,7 @@ class Dynamic < ApplicationRecord
     f.skip_check_ability = true
     f.disable_es_callbacks = self.disable_es_callbacks || value.blank?
     f.field_name = name
-    value.gsub!("\u0000", '') if value.is_a?(String) # Avoid PG::UntranslatableCharacter exception
+    value.gsub!('\u0000', '') if value.is_a?(String) # Avoid PG::UntranslatableCharacter exception
     f.value = value
     f.annotation_id = self.id
     f

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -292,7 +292,7 @@ module SmoochMessages
       # Define a text variable to hold short text
       text = []
       list.collect{ |m| JSON.parse(m) }.sort_by{ |m| m['received'].to_f }.each do |message|
-        message['text'].gsub!('\u0000', '') # Avoid PG::UntranslatableCharacter exception
+        message['text']&.gsub!('\u0000', '') # Avoid PG::UntranslatableCharacter exception
         if message['type'] == 'text'
           # Get an item for long text (message that match number of words condition)
           if message['payload'].nil?

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -292,6 +292,7 @@ module SmoochMessages
       # Define a text variable to hold short text
       text = []
       list.collect{ |m| JSON.parse(m) }.sort_by{ |m| m['received'].to_f }.each do |message|
+        message['text'].gsub!('\u0000', '') # Avoid PG::UntranslatableCharacter exception
         if message['type'] == 'text'
           # Get an item for long text (message that match number of words condition)
           if message['payload'].nil?

--- a/app/models/concerns/smooch_messages.rb
+++ b/app/models/concerns/smooch_messages.rb
@@ -292,7 +292,7 @@ module SmoochMessages
       # Define a text variable to hold short text
       text = []
       list.collect{ |m| JSON.parse(m) }.sort_by{ |m| m['received'].to_f }.each do |message|
-        message['text']&.gsub!('\u0000', '') # Avoid PG::UntranslatableCharacter exception
+        message['text']&.gsub!("\u0000", '') # Avoid PG::UntranslatableCharacter exception
         if message['type'] == 'text'
           # Get an item for long text (message that match number of words condition)
           if message['payload'].nil?

--- a/app/models/tipline_request.rb
+++ b/app/models/tipline_request.rb
@@ -79,7 +79,7 @@ class TiplineRequest < ApplicationRecord
   def set_smooch_data_fields
     unless self.smooch_data.blank?
       # Avoid PG::UntranslatableCharacter exception
-      value = self.smooch_data.to_json.gsub('\u0000', '')
+      value = self.smooch_data.to_json.gsub("\u0000", '')
       self.smooch_data = JSON.parse(value)
       self.tipline_user_uid ||= self.smooch_data.dig('authorId')
       self.language ||= self.smooch_data.dig('language')


### PR DESCRIPTION
## Description

Remove `'\u0000'` from message text to avoid PG::Untranslatable error

References: CV2-6177

## How to test?

Re-run automated tests

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
