### PR TITLE
CV2-6713: Disable Tipline for inactive teams

### DIFF
--- a/lib/tasks/data/team.rake
+++ b/lib/tasks/data/team.rake
@@ -25,6 +25,7 @@ namespace :check do
     # bundle exec rails check:team:deactivate['slug-1|slug-2|...|slug-N']
     task :deactivate, [:slugs] => :environment do |_t, args|
       slugs = args[:slugs].to_s.split('|')
+      smooch = BotUser.smooch_user
       Team.where(slug: slugs, inactive: false).find_each do |team|
         puts "\nProcessing team #{team.slug}....\n"
         print '.'
@@ -37,6 +38,13 @@ namespace :check do
           puts "\nDeleting webhook #{bu.name}....\n"
           puts "\nWebhook settings: #{bu.settings.inspect}"
           bu.destroy
+        end
+        # Disable Tipline
+        tbi = team.team_bot_installations.where(user_id: smooch.id).first
+        unless tbi.nil?
+          puts "Inactivate Tipline #{team.slug} ..."
+          tbi.set_smooch_disabled = true
+          tbi.save!
         end
         team.inactive = true
         team.save!


### PR DESCRIPTION
## Description

Disable Tipline for `check:team:deactivate` rake task

References: CV2-6713

## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
