### PR TITLE
CV2-6172: Prevent duplicate Sidekiq jobs

### DIFF
--- a/app/lib/check_elastic_search.rb
+++ b/app/lib/check_elastic_search.rb
@@ -34,7 +34,7 @@ module CheckElasticSearch
     return if self.disable_es_callbacks || RequestStore.store[:disable_es_callbacks]
     options = { keys: keys, data: data, pm_id: pm_id, skip_get_data: skip_get_data }
     model = { klass: self.class.name, id: self.id }
-    ElasticSearchWorker.perform_in(1.second, YAML::dump(model), YAML::dump(options), 'update_doc')
+    ElasticSearchWorker.perform_in(1.second, YAML::dump(model), YAML::dump(options), 'update_doc', Time.now.utc.to_i)
   end
 
   def update_recent_activity(obj)
@@ -50,13 +50,13 @@ module CheckElasticSearch
     fields = {}
     options[:keys].each do |k|
       if data[k].class.to_s == 'Hash'
-        value = get_fresh_value(data[k].with_indifferent_access)
-        fields[k] = value
+        value = get_fresh_value(data[k].with_indifferent_access, options[:enqueued_at])
+        fields[k] = value unless value.nil?
       else
         fields[k] = data[k]
       end
     end
-    if fields.count
+    if fields.with_indifferent_access.except('updated_at').count
       create_doc_if_not_exists(options)
       sleep 1
       $repository.client.update index: CheckElasticSearchModel.get_index_alias, id: options[:doc_id], body: { doc: fields }
@@ -64,14 +64,18 @@ module CheckElasticSearch
   end
 
   # Get a fresh data based on data(Hash)
-  def get_fresh_value(data)
+  def get_fresh_value(data, enqueued_at)
     value = data['default']
     klass = data['klass']
     obj = klass.constantize.find_by_id data['id'] unless klass.blank?
     unless obj.nil?
-      callback = data['method']
-      value = obj.send(callback) if !callback.blank? && obj.respond_to?(callback)
-      value = value.to_i if data['type'] == 'int'
+      if obj.updated_at.to_i > enqueued_at
+        value = nil
+      else
+        callback = data['method']
+        value = obj.send(callback) if !callback.blank? && obj.respond_to?(callback)
+        value = value.to_i if data['type'] == 'int'
+      end
     end
     value
   end

--- a/app/lib/check_elastic_search.rb
+++ b/app/lib/check_elastic_search.rb
@@ -30,11 +30,11 @@ module CheckElasticSearch
     $repository.refresh_index! if CheckConfig.get('elasticsearch_sync')
   end
 
-  def update_elasticsearch_doc(keys, data = {}, pm_id = nil, skip_get_data = false)
+  def update_elasticsearch_doc(keys, data = {}, pm_id = nil, skip_get_data = false, enqueued_at = 0)
     return if self.disable_es_callbacks || RequestStore.store[:disable_es_callbacks]
     options = { keys: keys, data: data, pm_id: pm_id, skip_get_data: skip_get_data }
     model = { klass: self.class.name, id: self.id }
-    ElasticSearchWorker.perform_in(1.second, YAML::dump(model), YAML::dump(options), 'update_doc', Time.now.utc.to_i)
+    ElasticSearchWorker.perform_in(1.second, YAML::dump(model), YAML::dump(options), 'update_doc', enqueued_at)
   end
 
   def update_recent_activity(obj)
@@ -50,8 +50,8 @@ module CheckElasticSearch
     fields = {}
     options[:keys].each do |k|
       if data[k].class.to_s == 'Hash'
-        value = get_fresh_value(data[k].with_indifferent_access, options[:enqueued_at])
-        fields[k] = value unless value.nil?
+        value = get_fresh_value(data[k].with_indifferent_access)
+        fields[k] = value
       else
         fields[k] = data[k]
       end
@@ -64,18 +64,14 @@ module CheckElasticSearch
   end
 
   # Get a fresh data based on data(Hash)
-  def get_fresh_value(data, enqueued_at)
+  def get_fresh_value(data)
     value = data['default']
     klass = data['klass']
     obj = klass.constantize.find_by_id data['id'] unless klass.blank?
     unless obj.nil?
-      if obj.updated_at.to_i > enqueued_at
-        value = nil
-      else
-        callback = data['method']
-        value = obj.send(callback) if !callback.blank? && obj.respond_to?(callback)
-        value = value.to_i if data['type'] == 'int'
-      end
+      callback = data['method']
+      value = obj.send(callback) if !callback.blank? && obj.respond_to?(callback)
+      value = value.to_i if data['type'] == 'int'
     end
     value
   end

--- a/app/lib/check_elastic_search.rb
+++ b/app/lib/check_elastic_search.rb
@@ -56,7 +56,7 @@ module CheckElasticSearch
         fields[k] = data[k]
       end
     end
-    if fields.with_indifferent_access.except('updated_at').count
+    if fields.count
       create_doc_if_not_exists(options)
       sleep 1
       $repository.client.update index: CheckElasticSearchModel.get_index_alias, id: options[:doc_id], body: { doc: fields }

--- a/app/models/annotations/dynamic.rb
+++ b/app/models/annotations/dynamic.rb
@@ -110,7 +110,7 @@ class Dynamic < ApplicationRecord
   def handle_report_fields
     if self.annotated_type == 'ProjectMedia' && self.annotation_type == 'report_design'
       data = { 'report_published_at' => self.data['last_published'], 'report_language' => self.report_design_field_value('language') }
-      self.update_elasticsearch_doc(data.keys, data, self.annotated_id, true)
+      self.update_elasticsearch_doc(data.keys, data, self.annotated_id, true, Time.now.utc.to_i)
     end
   end
 
@@ -139,7 +139,7 @@ class Dynamic < ApplicationRecord
         end
         uids.uniq!
         Rails.cache.write(key, uids)
-        task.update_elasticsearch_doc(['annotated_by'], { 'annotated_by' => uids }, pm.id, true)
+        task.update_elasticsearch_doc(['annotated_by'], { 'annotated_by' => uids }, pm.id, true, Time.now.utc.to_i)
       end
     end
   end

--- a/app/models/workflow/concerns/dynamic_annotation_field_concern.rb
+++ b/app/models/workflow/concerns/dynamic_annotation_field_concern.rb
@@ -30,25 +30,25 @@ module Workflow
           end
         end
 
-        def index_on_es_foreground
-          return if self.disable_es_callbacks || RequestStore.store[:disable_es_callbacks]
-          obj = self&.annotation&.annotated
-          if !obj.nil? && obj.class.name == 'ProjectMedia'
-            data = { self.annotation_type => self.value }
-            if User.current.present?
-              updated_at = Time.now
-              obj.update_columns(updated_at: updated_at)
-              data['updated_at'] = updated_at.utc
-            end
-            options = {
-              keys: data.keys,
-              data: data,
-              pm_id: obj.id,
-              doc_id: Base64.encode64("#{obj.class.name}/#{obj.id}")
-            }
-            self.update_elasticsearch_doc_bg(options)
-          end
-        end
+        # def index_on_es_foreground
+        #   return if self.disable_es_callbacks || RequestStore.store[:disable_es_callbacks]
+        #   obj = self&.annotation&.annotated
+        #   if !obj.nil? && obj.class.name == 'ProjectMedia'
+        #     data = { self.annotation_type => self.value }
+        #     if User.current.present?
+        #       updated_at = Time.now
+        #       obj.update_columns(updated_at: updated_at)
+        #       data['updated_at'] = updated_at.utc
+        #     end
+        #     options = {
+        #       keys: data.keys,
+        #       data: data,
+        #       pm_id: obj.id,
+        #       doc_id: Base64.encode64("#{obj.class.name}/#{obj.id}")
+        #     }
+        #     self.update_elasticsearch_doc_bg(options)
+        #   end
+        # end
 
         ::Workflow::Workflow.workflow_ids.each do |id|
           define_method "field_formatter_name_#{id}_status" do

--- a/app/models/workflow/concerns/dynamic_annotation_field_concern.rb
+++ b/app/models/workflow/concerns/dynamic_annotation_field_concern.rb
@@ -30,26 +30,6 @@ module Workflow
           end
         end
 
-        # def index_on_es_foreground
-        #   return if self.disable_es_callbacks || RequestStore.store[:disable_es_callbacks]
-        #   obj = self&.annotation&.annotated
-        #   if !obj.nil? && obj.class.name == 'ProjectMedia'
-        #     data = { self.annotation_type => self.value }
-        #     if User.current.present?
-        #       updated_at = Time.now
-        #       obj.update_columns(updated_at: updated_at)
-        #       data['updated_at'] = updated_at.utc
-        #     end
-        #     options = {
-        #       keys: data.keys,
-        #       data: data,
-        #       pm_id: obj.id,
-        #       doc_id: Base64.encode64("#{obj.class.name}/#{obj.id}")
-        #     }
-        #     self.update_elasticsearch_doc_bg(options)
-        #   end
-        # end
-
         ::Workflow::Workflow.workflow_ids.each do |id|
           define_method "field_formatter_name_#{id}_status" do
             value = nil

--- a/app/models/workflow/concerns/dynamic_annotation_field_concern.rb
+++ b/app/models/workflow/concerns/dynamic_annotation_field_concern.rb
@@ -26,7 +26,7 @@ module Workflow
               obj.update_columns(updated_at: updated_at)
               data['updated_at'] = updated_at.utc
             end
-            self.update_elasticsearch_doc(data.keys, data, obj.id)
+            self.update_elasticsearch_doc(data.keys, data, obj.id, false, Time.now.utc.to_i)
           end
         end
 

--- a/app/models/workflow/verification_status.rb
+++ b/app/models/workflow/verification_status.rb
@@ -4,7 +4,6 @@ class Workflow::VerificationStatus < Workflow::Base
 
   check_workflow from: :any, to: :any, actions: [:check_if_item_is_published, :apply_rules, :update_report_design_if_needed, :replicate_status_to_children]
   check_workflow on: :save, actions: :index_on_es_background
-  # check_workflow on: :update, actions: :index_on_es_foreground
 
   def self.core_default_value
     'undetermined'

--- a/app/models/workflow/verification_status.rb
+++ b/app/models/workflow/verification_status.rb
@@ -3,8 +3,8 @@ class Workflow::VerificationStatus < Workflow::Base
   check_default_project_media_workflow
 
   check_workflow from: :any, to: :any, actions: [:check_if_item_is_published, :apply_rules, :update_report_design_if_needed, :replicate_status_to_children]
-  check_workflow on: :create, actions: :index_on_es_background
-  check_workflow on: :update, actions: :index_on_es_foreground
+  check_workflow on: :save, actions: :index_on_es_background
+  # check_workflow on: :update, actions: :index_on_es_foreground
 
   def self.core_default_value
     'undetermined'

--- a/app/workers/elastic_search_worker.rb
+++ b/app/workers/elastic_search_worker.rb
@@ -6,7 +6,7 @@ class ElasticSearchWorker
 
   sidekiq_retry_in { |_count, _e| 3 }
 
-  def perform(model_data, options, type, enqueued_at = Time.now.utc.to_i)
+  def perform(model_data, options, type, enqueued_at = 0)
     model_data = begin YAML::load(model_data) rescue nil end
     unless model_data.nil?
       model = model_data[:klass].constantize.find_by_id model_data[:id]
@@ -24,7 +24,7 @@ class ElasticSearchWorker
             options[:model_id] = model_data[:id]
             model_data[:klass].constantize.send(ops[type],options)
           else
-            model.send(ops[type], options) if enqueued_at >= model.updated_at.to_i
+            model.send(ops[type], options) if enqueued_at == 0 || enqueued_at >= model.updated_at.to_i
           end
         end
       end

--- a/app/workers/elastic_search_worker.rb
+++ b/app/workers/elastic_search_worker.rb
@@ -11,7 +11,7 @@ class ElasticSearchWorker
     unless model_data.nil?
       model = model_data[:klass].constantize.find_by_id model_data[:id]
       if !model.nil? || ['destroy_doc', 'destroy_doc_nested'].include?(type)
-        options = set_options(model, options, type, enqueued_at)
+        options = set_options(model, options, type)
         ops = {
           'create_doc' => 'create_elasticsearch_doc_bg',
           'update_doc' => 'update_elasticsearch_doc_bg',
@@ -44,7 +44,7 @@ class ElasticSearchWorker
     action
   end
 
-  def set_options(model, options, type, enqueued_at)
+  def set_options(model, options, type)
     options = YAML::load(options)
     if ['destroy_doc', 'destroy_doc_nested'].include?(type)
       options[:doc_id] = Base64.encode64("ProjectMedia/#{options[:pm_id]}")
@@ -54,7 +54,6 @@ class ElasticSearchWorker
     options[:skip_get_data] = false unless options.has_key?(:skip_get_data)
     options[:pm_id] = model.get_es_doc_obj unless options.has_key?(:pm_id)
     options[:doc_id] = model.get_es_doc_id(options[:pm_id]) unless options.has_key?(:doc_id)
-    options[:enqueued_at] = enqueued_at
     options
   end
 end

--- a/app/workers/elastic_search_worker.rb
+++ b/app/workers/elastic_search_worker.rb
@@ -24,7 +24,7 @@ class ElasticSearchWorker
             options[:model_id] = model_data[:id]
             model_data[:klass].constantize.send(ops[type],options)
           else
-            model.send(ops[type], options)
+            model.send(ops[type], options) if enqueued_at >= model.updated_at.to_i
           end
         end
       end

--- a/app/workers/elastic_search_worker.rb
+++ b/app/workers/elastic_search_worker.rb
@@ -6,16 +6,15 @@ class ElasticSearchWorker
 
   sidekiq_retry_in { |_count, _e| 3 }
 
-  def perform(model_data, options, type)
+  def perform(model_data, options, type, enqueued_at = Time.now.utc.to_i)
     model_data = begin YAML::load(model_data) rescue nil end
     unless model_data.nil?
       model = model_data[:klass].constantize.find_by_id model_data[:id]
       if !model.nil? || ['destroy_doc', 'destroy_doc_nested'].include?(type)
-        options = set_options(model, options, type)
+        options = set_options(model, options, type, enqueued_at)
         ops = {
           'create_doc' => 'create_elasticsearch_doc_bg',
           'update_doc' => 'update_elasticsearch_doc_bg',
-          'update_doc_team' => 'update_elasticsearch_doc_team_bg',
           'create_update_doc_nested' => 'create_update_nested_obj_bg',
           'destroy_doc' => 'destroy_elasticsearch_doc',
           'destroy_doc_nested' => 'destroy_elasticsearch_doc_nested',
@@ -37,7 +36,7 @@ class ElasticSearchWorker
   def should_perform_es_action?(type, options, model, op)
     # Verify that object still exists in PG (should skip destroy operation)
     action = false
-    if ['destroy_doc', 'destroy_doc_nested', 'update_doc_team'].include?(type)
+    if ['destroy_doc', 'destroy_doc_nested'].include?(type)
       action = true
     elsif !options[:doc_id].blank? && !options[:pm_id].nil?
       action = ProjectMedia.exists?(options[:pm_id]) && model.respond_to?(op)
@@ -45,7 +44,7 @@ class ElasticSearchWorker
     action
   end
 
-  def set_options(model, options, type)
+  def set_options(model, options, type, enqueued_at)
     options = YAML::load(options)
     if ['destroy_doc', 'destroy_doc_nested'].include?(type)
       options[:doc_id] = Base64.encode64("ProjectMedia/#{options[:pm_id]}")
@@ -55,6 +54,7 @@ class ElasticSearchWorker
     options[:skip_get_data] = false unless options.has_key?(:skip_get_data)
     options[:pm_id] = model.get_es_doc_obj unless options.has_key?(:pm_id)
     options[:doc_id] = model.get_es_doc_id(options[:pm_id]) unless options.has_key?(:doc_id)
+    options[:enqueued_at] = enqueued_at
     options
   end
 end

--- a/test/controllers/elastic_search_5_test.rb
+++ b/test/controllers/elastic_search_5_test.rb
@@ -106,6 +106,8 @@ class ElasticSearch5Test < ActionController::TestCase
 
   test "should create update elasticsearch status" do
     m = create_valid_media
+    s = nil
+    pm = nil
     Sidekiq::Testing.inline! do
       pm = create_project_media media: m, disable_es_callbacks: false
       sleep 2
@@ -119,6 +121,20 @@ class ElasticSearch5Test < ActionController::TestCase
       ms = $repository.find(get_es_id(pm))
       assert_equal 'verified', ms['verification_status']
     end
+    assert_equal 'verified', s.reload.status
+    Sidekiq::Testing.fake! do
+      s.status = 'in_progress'
+      s.save!
+    end
+    sleep 2
+    Sidekiq::Testing.inline! do
+      s.status = 'false'
+      s.save!
+    end
+    Sidekiq::Worker.drain_all
+    sleep 2
+    ms = $repository.find(get_es_id(pm))
+    assert_equal 'false', ms['verification_status']
   end
 
   test "should create parent if not exists" do


### PR DESCRIPTION
## Description

Added a new argument to ElasticSearchWorker  `enqueued_at` so I can skip job execution if the job is outdated.

References: CV2-6172

## How to test?

Added unit test

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
