### PR TITLE
CV2-6721: JWT::DecodeError: HMAC key cannot be empty

### DIFF
--- a/app/models/concerns/smooch_zendesk.rb
+++ b/app/models/concerns/smooch_zendesk.rb
@@ -41,7 +41,8 @@ module SmoochZendesk
     def zendesk_api_client
       payload = { scope: 'app' }
       jwt_header = { kid: self.config['smooch_secret_key_key_id'] }
-      token = JWT.encode payload, self.config['smooch_secret_key_secret'], 'HS256', jwt_header
+      smooch_secret_key_secret =  self.config['smooch_secret_key_secret'] || ' '
+      token = JWT.encode payload, smooch_secret_key_secret, 'HS256', jwt_header
       config = SmoochApi::Configuration.new
       config.api_key['Authorization'] = token
       config.api_key_prefix['Authorization'] = 'Bearer'

--- a/test/controllers/graphql_controller_7_test.rb
+++ b/test/controllers/graphql_controller_7_test.rb
@@ -115,7 +115,7 @@ class GraphqlController7Test < ActionController::TestCase
     t = create_team private: true
     b = create_team_bot login: 'smooch', set_approved: true
     app_id = random_string
-    tbi = create_team_bot_installation team_id: t.id, user_id: b.id, settings: { smooch_app_id: app_id, smooch_secret_key_secret: random_string }
+    tbi = create_team_bot_installation team_id: t.id, user_id: b.id, settings: { smooch_app_id: app_id }
     u = create_user
     create_team_user user: u, team: t, role: 'admin'
 
@@ -148,7 +148,7 @@ class GraphqlController7Test < ActionController::TestCase
     t = create_team private: true
     b = create_team_bot login: 'smooch', set_approved: true
     app_id = random_string
-    tbi = create_team_bot_installation team_id: t.id, user_id: b.id, settings: { smooch_app_id: app_id, smooch_secret_key_secret: random_string}
+    tbi = create_team_bot_installation team_id: t.id, user_id: b.id, settings: { smooch_app_id: app_id }
     u = create_user
     create_team_user user: u, team: t, role: 'admin'
 

--- a/test/models/concerns/smooch_zendesk_test.rb
+++ b/test/models/concerns/smooch_zendesk_test.rb
@@ -7,7 +7,7 @@ class FakeSmoochZendesk
     # Mock out config, which is normally set in the Smooch class as
     # RequestStore.store[:smooch_bot_settings]
     def config
-      { "smooch_app_id" => 'app-id', "smooch_secret_key_secret" => 'app-secret-key' }
+      { "smooch_app_id" => 'app-id' }
     end
 
     def replace_placeholders(uid, text)


### PR DESCRIPTION
## Description

Set `smooch_secret_key_secret` with ' ' value as JWT.encode does not accept empty value
References: CV2-6721

## How to test?

Re-run automated  tests
 
## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
