### PR TITLE
CV2-6729: N+1 query

### DIFF
--- a/app/models/annotations/annotation.rb
+++ b/app/models/annotations/annotation.rb
@@ -13,6 +13,25 @@ class Annotation < ApplicationRecord
     klass.where(id: self.id).last
   end
 
+  def self.load_edge_nodes(edge_nodes)
+    edge_nodes
+    .group_by { |node| self.annotation_class(node) }
+    .flat_map do |klass, nodes|
+      records = klass.where(id: nodes.map(&:id)).index_by(&:id)
+      nodes.map { |node| records[node.id] }
+    end
+  end
+
+  def self.annotation_class(node)
+    klass = nil
+    begin
+      klass = node.annotation_type.camelize.constantize
+    rescue NameError
+      klass = Dynamic
+    end
+    klass
+  end
+
   def destroy
     dec = self.disable_es_callbacks
     skip_ability = self.skip_check_ability

--- a/config/initializers/graphql_extensions.rb
+++ b/config/initializers/graphql_extensions.rb
@@ -26,7 +26,7 @@ module GraphQL
 
       def edge_nodes
         @edge_nodes ||= paged_nodes
-        @edge_nodes = @edge_nodes.map(&:load) if @field.name == 'annotations'
+        @edge_nodes = Annotation.load_edge_nodes(@edge_nodes) if @field.name == "annotations"
         @edge_nodes
       end
 


### PR DESCRIPTION
## Description

Add a new method that accepts all edge nodes, groups them by annotation type, and loads each group with a single WHERE id IN (...) query. This reduces the number of database queries from one per node to one per annotation type,

References: CV2-6729

## How to test?

Re-run unit tests

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
