### PR TITLE
CV2-6730: N+1 Query (task_response)

### DIFF
--- a/app/graph/loaders/first_response_loader.rb
+++ b/app/graph/loaders/first_response_loader.rb
@@ -1,0 +1,18 @@
+module Loaders
+  class FirstResponseLoader < GraphQL::Batch::Loader
+    def perform(task_ids)
+      responses = Annotation
+        .where(
+          annotated_type: 'Task',
+          annotated_id: task_ids
+        )
+        .where("annotation_type LIKE 'task_response%'")
+        .order(:created_at)
+        .group_by(&:annotated_id)
+
+      task_ids.each do |id|
+        fulfill(id, responses[id]&.first)
+      end
+    end
+  end
+end

--- a/app/graph/types/task_type.rb
+++ b/app/graph/types/task_type.rb
@@ -16,14 +16,19 @@ class TaskType < BaseObject
 
   def first_response
     obj = object.load || object
-    obj.nil? ? nil : obj.first_response_obj
+    obj.nil? ? nil : Loaders::FirstResponseLoader.for.load(obj.id)
   end
 
   field :first_response_value, GraphQL::Types::String, null: true
 
   def first_response_value
     obj = object.load || object
-    obj.nil? ? "" : obj.first_response
+    return "" if obj.nil?
+    Loaders::FirstResponseLoader.for.load(obj.id).then do |response|
+      next nil if response.nil?
+      field = response.get_fields.select{ |f| f.field_name =~ /^response/ }.first
+      field&.to_s
+    end
   end
 
   field :jsonoptions, GraphQL::Types::String, null: true


### PR DESCRIPTION
## Description

Both GraphQL fields `first_response` and `first_response_value`  executed a separate database query for each Task to return the response which cause N+1 query pattern.

Added a loader (FirstResponseLoader) that batches all requested task IDs into a single query and caches the results for the duration of the GraphQL request. Both fields use the same loader, allowing them to reuse the fetched Annotation without issuing additional queries.

References: CV2-6730

## How to test?

Re-run unit tests

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
