### PR TITLE
CV2-6731: N+1 Query (get_fields)

### DIFF
--- a/app/models/concerns/annotation_base.rb
+++ b/app/models/concerns/annotation_base.rb
@@ -212,7 +212,7 @@ module AnnotationBase
 
   def get_fields
     if self.json_schema.blank?
-      DynamicAnnotation::Field.includes(:field_instance).where(annotation_id: self.id).to_a
+      DynamicAnnotation::Field.includes(:field_instance, :annotation).where(annotation_id: self.id).to_a
     else
       data = self.read_attribute(:data) || {}
       fields = []


### PR DESCRIPTION
## Description

N+1 query occurs when run this GraphQL query
```
query { 
  # ID for verification_status Annotation
  node(id: "QW5ub3RhdGlvbi80NDE0OTYzNw==\n") { 
    ...F0 
  } 
}
fragment F0 on Annotation { 
  content
}
```
Calling to_json on [fields](https://github.com/meedan/check-api/blob/develop/app/models/concerns/annotation_base.rb#L210) triggers an N+1 query because each DynamicAnnotation::Field belongs to [Annotation](https://github.com/meedan/check-api/blob/develop/app/models/dynamic_annotation/field.rb#L7). During serialization, to_json performs a separate lookup for each associated Annotations. Using includes(:field_instance, :annotation) eagerly loads the association, reducing the repeated queries to a single batched query.

References: CV2-6731

## How to test?

Re-run unit tests

## Checklist

- [ ] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
