### PR TITLE
CV2-6732: fix N+1 query

### DIFF
--- a/app/graph/loaders/team_loader.rb
+++ b/app/graph/loaders/team_loader.rb
@@ -1,0 +1,13 @@
+module Loaders
+  class TeamLoader < GraphQL::Batch::Loader
+    def perform(team_ids)
+      Team.where(id: team_ids).each do |team|
+        fulfill(team.id, team)
+      end
+
+      team_ids.each do |id|
+        fulfill(id, nil) unless fulfilled?(id)
+      end
+    end
+  end
+end

--- a/app/graph/types/project_media_type.rb
+++ b/app/graph/types/project_media_type.rb
@@ -9,7 +9,6 @@ class ProjectMediaType < DefaultObject
   field :user_id, GraphQL::Types::Int, null: true
   field :fact_check_id, GraphQL::Types::Int, null: true
   field :url, GraphQL::Types::String, null: true
-  field :full_url, GraphQL::Types::String, null: true
   field :quote, GraphQL::Types::String, null: true
   field :oembed_metadata, GraphQL::Types::String, null: true
   field :dbid, GraphQL::Types::Int, null: true
@@ -45,6 +44,15 @@ class ProjectMediaType < DefaultObject
   field :imported_from_feed_id, GraphQL::Types::Int, null: true
   field :imported_from_project_media_id, GraphQL::Types::Int, null: true
   field :pusher_channel, GraphQL::Types::String, null: true
+
+  field :full_url, GraphQL::Types::String, null: true
+
+  def full_url
+    Loaders::TeamLoader.for.load(object.team_id).then do |team|
+      object.full_url(team)
+    end
+  end
+
   field :imported_from_feed, FeedType, null: true
 
   def imported_from_feed

--- a/app/models/concerns/project_media_getters.rb
+++ b/app/models/concerns/project_media_getters.rb
@@ -59,8 +59,9 @@ module ProjectMediaGetters
     self.media.text
   end
 
-  def full_url
-    "#{CheckConfig.get('checkdesk_client')}/#{self.team.slug}/media/#{self.id}"
+  def full_url(team = nil)
+    team ||= self.team
+    "#{CheckConfig.get('checkdesk_client')}/#{team.slug}/media/#{self.id}"
   end
 
   def updated_at_timestamp


### PR DESCRIPTION
## Description

N+1 query triggered by executing the following query

  query PublishedReports($query: String!) {
    search(query: $query) {
      number_of_results
      medias {
        edges {
          node {
            full_url
          }
        }
      }
    }

so I added TeamLoader to load associated team

References: CV2-6732

## How to test?

Re-run unit tests 
## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
