### PR TITLE
CV2-6719: Facebook authorize URL 

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -39,7 +39,7 @@ Devise.setup do |config|
   config.reset_password_within = 6.hours
   config.sign_in_after_reset_password = false
   config.sign_out_via = :delete
-  config.omniauth :facebook, CheckConfig.get('facebook_app_id'), CheckConfig.get('facebook_app_secret'), scope: 'email,public_profile', info_fields: 'name,email,picture', setup: true
+  config.omniauth :facebook, CheckConfig.get('facebook_app_id'), CheckConfig.get('facebook_app_secret'), scope: 'email,public_profile', info_fields: 'name,email,picture', client_options: { site: 'https://graph.facebook.com/v25.0', authorize_url: 'https://www.facebook.com/v25.0/dialog/oauth' }, auth_type: 'rerequest', setup: true
   google_auth_config = { access_type: 'offline', approval_prompt: '',  provider_ignores_state: true }
   config.omniauth :google_oauth2, CheckConfig.get('google_client_id'), CheckConfig.get('google_client_secret'), google_auth_config
   config.skip_session_storage = [:http_auth, :token_auth]


### PR DESCRIPTION
## Description

I found that the Facebook authorization URL was using an old API version: `https://www.facebook.com/v5.0/dialog/oauth`, which may not support or recognize the `pages_utility_messaging` permission. I updated the URL to the latest version, `v25.0`.

References: CV2-6719

## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
