### PR TITLE
CV2-6719: Remove manage_pages permissions

### DIFF
--- a/app/controllers/concerns/facebook_authentication.rb
+++ b/app/controllers/concerns/facebook_authentication.rb
@@ -5,7 +5,7 @@ module FacebookAuthentication
     # pages_manage_metadata is for Facebook API > 7
     # manage_pages is for Facebook API < 7
     # An error will be displayed for Facebook users that are admins of the Facebook app, but should be transparent for other users
-    request.env['omniauth.strategy'].options[:scope] = 'pages_show_list,pages_read_engagement,pages_manage_metadata,manage_pages,pages_messaging,instagram_manage_messages,instagram_basic,pages_utility_messaging' if params[:context] == 'smooch'
+    request.env['omniauth.strategy'].options[:scope] = 'pages_show_list,pages_read_engagement,pages_manage_metadata,pages_messaging,instagram_manage_messages,instagram_basic,pages_utility_messaging' if params[:context] == 'smooch'
     prefix = facebook_context == 'smooch' ? 'smooch_' : ''
     request.env['omniauth.strategy'].options[:client_id] = CheckConfig.get("#{prefix}facebook_app_id")
     request.env['omniauth.strategy'].options[:client_secret] = CheckConfig.get("#{prefix}facebook_app_secret")


### PR DESCRIPTION
## Description

Remove manage_pages from the Facebook permissions, as it has been deprecated.

References: CV2-6719

## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
