### PR TITLE
CV2-6723: add export rake task with readme file

### DIFF
--- a/lib/check_s3.rb
+++ b/lib/check_s3.rb
@@ -45,16 +45,17 @@ class CheckS3
     end
   end
 
-  def self.write(path, content_type, content)
+  def self.write(path, content_type, content, bucket=nil)
+    bucket ||= CheckConfig.get('storage_bucket')
     client = Aws::S3::Client.new
     client.put_object(
       acl: 'public-read',
       key: path,
       body: content,
-      bucket: CheckConfig.get('storage_bucket'),
+      bucket: bucket,
       content_type: content_type
     )
-    begin client.put_object_acl(acl: 'public-read', key: path, bucket: CheckConfig.get('storage_bucket')) rescue nil end
+    begin client.put_object_acl(acl: 'public-read', key: path, bucket: bucket) rescue nil end
   end
 
   def self.delete(*paths)
@@ -66,9 +67,9 @@ class CheckS3
     client.delete_objects(bucket: CheckConfig.get('storage_bucket'), delete: { objects: objects })
   end
 
-  def self.write_presigned(path, content_type, content, expires_in)
-    self.write(path, content_type, content)
-    bucket = CheckConfig.get('storage_bucket')
+  def self.write_presigned(path, content_type, content, expires_in, bucket=nil)
+    bucket ||= CheckConfig.get('storage_bucket')
+    self.write(path, content_type, content, bucket)
     client = Aws::S3::Client.new
     s3 = Aws::S3::Resource.new(client: client)
     obj = s3.bucket(bucket).object(path)

--- a/lib/check_s3.rb
+++ b/lib/check_s3.rb
@@ -45,8 +45,7 @@ class CheckS3
     end
   end
 
-  def self.write(path, content_type, content, bucket=nil)
-    is_public = bucket.nil?
+  def self.write(path, content_type, content, bucket=nil, acl = 'public-read')
     bucket ||= CheckConfig.get('storage_bucket')
     client = Aws::S3::Client.new
     object = {
@@ -55,9 +54,9 @@ class CheckS3
       bucket: bucket,
       content_type: content_type
     }
-    object[:acl] = 'public-read' if is_public
+    object[:acl] = acl unless acl.nil?
     client.put_object(object)
-    begin client.put_object_acl(acl: 'public-read', key: path, bucket: bucket) rescue nil end if is_public
+    begin client.put_object_acl(acl: 'public-read', key: path, bucket: bucket) rescue nil end unless acl.nil?
   end
 
   def self.delete(*paths)
@@ -69,9 +68,9 @@ class CheckS3
     client.delete_objects(bucket: CheckConfig.get('storage_bucket'), delete: { objects: objects })
   end
 
-  def self.write_presigned(path, content_type, content, expires_in, bucket=nil)
+  def self.write_presigned(path, content_type, content, expires_in, bucket=nil, acl = 'public-read')
     bucket ||= CheckConfig.get('storage_bucket')
-    self.write(path, content_type, content, bucket)
+    self.write(path, content_type, content, bucket, acl)
     client = Aws::S3::Client.new
     s3 = Aws::S3::Resource.new(client: client)
     obj = s3.bucket(bucket).object(path)

--- a/lib/check_s3.rb
+++ b/lib/check_s3.rb
@@ -56,7 +56,7 @@ class CheckS3
     }
     object[:acl] = acl unless acl.nil?
     client.put_object(object)
-    begin client.put_object_acl(acl: 'public-read', key: path, bucket: bucket) rescue nil end unless acl.nil?
+    begin client.put_object_acl(acl: acl, key: path, bucket: bucket) rescue nil end unless acl.nil?
   end
 
   def self.delete(*paths)

--- a/lib/check_s3.rb
+++ b/lib/check_s3.rb
@@ -46,16 +46,18 @@ class CheckS3
   end
 
   def self.write(path, content_type, content, bucket=nil)
+    is_public = bucket.nil?
     bucket ||= CheckConfig.get('storage_bucket')
     client = Aws::S3::Client.new
-    client.put_object(
-      acl: 'public-read',
+    object = {
       key: path,
       body: content,
       bucket: bucket,
       content_type: content_type
-    )
-    begin client.put_object_acl(acl: 'public-read', key: path, bucket: bucket) rescue nil end
+    }
+    object[:acl] = 'public-read' if is_public
+    client.put_object(object)
+    begin client.put_object_acl(acl: 'public-read', key: path, bucket: bucket) rescue nil end if is_public
   end
 
   def self.delete(*paths)

--- a/lib/tasks/data/check_sunset.rake
+++ b/lib/tasks/data/check_sunset.rake
@@ -199,7 +199,7 @@ namespace :check do
           'ID' => 'Unique identifier of the user.',
           'Name' => 'Name of the user.',
           'Email' => 'Email address of the user.',
-          'Joined data' => 'Date when the user joined the workspace.',
+          'Joined date' => 'Date when the user joined the workspace.',
           'Last access date' => 'Date when the user most recently accessed the workspace.',
           'Role' => 'User\'s role in the workspace.',
         }
@@ -349,7 +349,7 @@ namespace :check do
         headers = {
           'ID' => 'Unique identifier for the TiplineNewsletter.',
           'Header type' => 'Type of header used in the newsletter.',
-          'Hheader file' => 'File used as the newsletter header.',
+          'Header file' => 'File used as the newsletter header.',
           'Header overlay text' => 'Text displayed as an overlay on the newsletter header.',
           'Header media url' => 'URL of the media used in the newsletter header.',
           'Introduction' => 'Introduction text displayed in the newsletter.',
@@ -363,7 +363,7 @@ namespace :check do
           'Last sent at' => 'Date and time when the newsletter was last sent.',
           'Language' => 'Language of the TiplineNewsletter in two-letter format, such as en/ar/fr.',
           'Enabled' => 'Indicates whether the newsletter is enabled',
-          'Creation data' => 'Date and time when the newsletter was created.',
+          'Creation date' => 'Date and time when the newsletter was created.',
         }
         write_to_csv(file, headers.keys, data_csv)
         append_export_documentation(export_dir.join('README.txt'), 'workspace_tipline_newsletter_data.csv', 'Contains information about Tipline newsletters configured for the workspace.', headers)
@@ -437,13 +437,19 @@ namespace :check do
           compress_folder(folder_path, zip_path)
           # Save to S3
           bucket_name = ENV.fetch('EXPORT_OUTPUT_BUCKET')
-          zip_content = File.binread(zip_path)
-          s3_url = CheckS3.write_presigned("#{team.slug}/#{SecureRandom.hex(16)}/#{team.slug}.zip", 'application/zip', zip_content, 7.days.to_i, bucket_name)
-          key = Shortener::ShortenedUrl.generate!(s3_url).unique_key
-          download_url = CheckConfig.get('short_url_host') + '/' + key
-          puts "Download link (valid for 7 days): #{download_url}"
-          # Delete a directory for exported data and zip file
-          FileUtils.rm_rf(Rails.root.join('tmp', 'sunset'))
+          begin
+            zip_content = File.binread(zip_path)
+            s3_url = CheckS3.write_presigned("#{team.slug}/#{SecureRandom.hex(16)}/#{team.slug}.zip", 'application/zip', zip_content, 7.days.to_i, bucket_name, nil)
+            key = Shortener::ShortenedUrl.generate!(s3_url).unique_key
+            download_url = CheckConfig.get('short_url_host') + '/' + key
+            puts "Download link (valid for 7 days): #{download_url}"
+          rescue StandardError => e
+            puts "Failed to upload exported data #{e.message}"
+          ensure
+            # Delete a directory for exported data and zip file
+            FileUtils.rm_rf(folder_path)
+            File.delete(zip_path) if File.exist?(zip_path)
+          end
         end
       end
       minutes = ((Time.now.to_i - started) / 60).to_i

--- a/lib/tasks/data/check_sunset.rake
+++ b/lib/tasks/data/check_sunset.rake
@@ -439,7 +439,7 @@ namespace :check do
           bucket_name = ENV.fetch('EXPORT_OUTPUT_BUCKET')
           begin
             zip_content = File.binread(zip_path)
-            s3_url = CheckS3.write_presigned("#{team.slug}/#{SecureRandom.hex(16)}/#{team.slug}.zip", 'application/zip', zip_content, 7.days.to_i, bucket_name, nil)
+            s3_url = CheckS3.write_presigned("#{team.slug}/#{SecureRandom.hex(16)}/#{team.slug}.zip", 'application/zip', zip_content, 7.days.to_i, bucket_name, 'private')
             key = Shortener::ShortenedUrl.generate!(s3_url).unique_key
             download_url = CheckConfig.get('short_url_host') + '/' + key
             puts "Download link (valid for 7 days): #{download_url}"

--- a/lib/tasks/data/check_sunset.rake
+++ b/lib/tasks/data/check_sunset.rake
@@ -61,6 +61,11 @@ namespace :check do
           <<~README
             CSV Export Documentation
             ========================
+            This export contains information and data from the workspace in CSV format. Each CSV file contains a specific type of workspace data, such as workspace information, users, items, annotations, FactChecks, Explainers, and Tipline requests.
+
+            Media Files
+            ===========
+            Media files are not included directly in the CSV export. For items that contain media, the corresponding Media data or media URL in workspace_item_data.csv should be used to download the actual media files.
 
           README
         )
@@ -411,10 +416,10 @@ namespace :check do
         download_url = CheckS3.write_presigned("export/workspaces_data/#{team.slug}/#{Time.now.to_i}/#{team.slug}.zip", 'application/zip', zip_path, CheckConfig.get('export_csv_expire', 7.days.to_i, :integer))
         puts "Download link (valid 7 days): #{download_url}"
         # Send download link to workspace admins
-        # team.team_users.where(status: 'member').find_each do |tu|
-        #   puts "Sending email to #{tu.user.email}\n"
-        #   SunsetMailer.delay.notify(tu.user, tu.team.name)
-        # end
+        team.team_users.where(status: 'member').find_each do |tu|
+          puts "Sending email to #{tu.user.email}\n"
+          SunsetMailer.delay.notify(tu.user, tu.team.name)
+        end
       end
       minutes = ((Time.now.to_i - started) / 60).to_i
       puts "[#{Time.now}] Done in #{minutes} minutes."

--- a/lib/tasks/data/check_sunset.rake
+++ b/lib/tasks/data/check_sunset.rake
@@ -391,15 +391,16 @@ namespace :check do
       end
     end
 
-    # bundle exec rails check:sunset:export_upload_and_send_workspace_data[team-slug, email]
+    # bundle exec rails check:sunset:export_upload_and_send_workspace_data[team-slug, email] EXPORT_OUTPUT_BUCKET=XXXXX
     task :export_upload_and_send_workspace_data,[:slug, :email] => :environment do |_t, args|
       started = Time.now.to_i
       slug = args[:slug].to_s
       team = Team.find_by_slug slug
       unless team.nil?
         email = args[:email].to_s
+        puts "email:: #{email}"
         user = User.where(email: email).first
-        if team.team_users.where(user_id: user.id, role: 'admin', status: 'member').exists?
+        if user && team.team_users.where(user_id: user.id, role: 'admin', status: 'member').exists?
           # Call all exported tasks
           Rake::Task['check:sunset:export_workspace_init_readme'].invoke(args[:slug])
           Rake::Task['check:sunset:export_workspace_data'].invoke(args[:slug])
@@ -411,20 +412,20 @@ namespace :check do
           Rake::Task['check:sunset:export_workspace_item_data'].invoke(args[:slug])
           print_task_title 'Uploading workspace data'
           # compress & upload
-          folder_path = "#{Rails.root}/tmp/#{team.slug}"
-          zip_path = "#{Rails.root}/tmp/#{team.slug}.zip"
+          folder_path = Rails.root.join('tmp', team.slug)
+          zip_path = Rails.root.join('tmp', "#{team.slug}.zip")
           puts "Compressing #{folder_path} -> #{zip_path}"
           compress_folder(folder_path, zip_path)
           # Save to S3
+          bucket_name = ENV.fetch('EXPORT_OUTPUT_BUCKET')
           zip_content = File.binread(zip_path)
-          s3_url = CheckS3.write_presigned("export/workspaces_data/#{team.slug}.zip", 'application/zip', zip_content, CheckConfig.get('check_sunset_download_expire_days', 7, :integer).days.to_i)
+          s3_url = CheckS3.write_presigned("#{team.slug}/#{team.slug}.zip", 'application/zip', zip_content, 7.days.to_i, bucket_name)
           key = Shortener::ShortenedUrl.generate!(s3_url).unique_key
           download_url = CheckConfig.get('short_url_host') + '/' + key
-          puts "Download link (valid #{CheckConfig.get('check_sunset_download_expire_days', 7, :integer)} days): #{download_url}"
-          # Deleting exported files
-          puts "#{folder_path} -- #{zip_path}"
-          # File.delete(folder_path)
-          # File.delete(zip_path)
+          puts "Download link (valid for 7 days): #{download_url}"
+          # Delete a directory for exported data and zip file
+          FileUtils.rm_rf(folder_path)
+          File.delete(zip_path) if File.exist?(zip_path)
         end
       end
       minutes = ((Time.now.to_i - started) / 60).to_i

--- a/lib/tasks/data/check_sunset.rake
+++ b/lib/tasks/data/check_sunset.rake
@@ -54,7 +54,7 @@ namespace :check do
       slug = args[:slug].to_s
       team = Team.find_by_slug slug
       unless team.nil?
-        export_dir = Rails.root.join("public", team.slug)
+        export_dir = Rails.root.join("tmp", team.slug)
         FileUtils.mkdir_p(export_dir)
         File.write(
           export_dir.join("README.txt"),
@@ -132,7 +132,7 @@ namespace :check do
           last_active_non_meedan
         ]
         # Write to CSV
-        export_dir = Rails.root.join('public', team.slug)
+        export_dir = Rails.root.join('tmp', team.slug)
         file = export_dir.join('workspace_data.csv')
         headers = {
           'ID' => 'Unique identifier of the workspace.',
@@ -175,7 +175,7 @@ namespace :check do
             tu.role
           ]
         end
-        export_dir = Rails.root.join('public', team.slug)
+        export_dir = Rails.root.join('tmp', team.slug)
         file = export_dir.join('workspace_user_data.csv')
         headers = {
           'ID' => 'Unique identifier of the user.',
@@ -195,7 +195,7 @@ namespace :check do
       slug = args[:slug].to_s
       team = Team.find_by_slug slug
       unless team.nil?
-        export_dir = Rails.root.join('public', team.slug)
+        export_dir = Rails.root.join('tmp', team.slug)
         # Export FactChecks
         data_csv = FactCheck.get_exported_data({}, team).drop(1)
         file = export_dir.join('workspace_fact_checks_data.csv')
@@ -250,23 +250,23 @@ namespace :check do
             next if a_answer.empty?
             pm_raw = [pm.id]
             headers_id.each do |ttid|
-              pm_raw << a_answer[a_ttid[ttid]] || '-'
+              pm_raw << (a_answer[a_ttid[ttid]] || '-')
             end
             data_csv << pm_raw
           end
-          export_dir = Rails.root.join('public', team.slug)
+          export_dir = Rails.root.join('tmp', team.slug)
           file = export_dir.join('workspace_annotations_data.csv')
           headers = { 'Item ID' => 'Unique identifier of the item associated with the annotation.' }
           team_tasks.each do |tt|
-            headers[tt.label] = tt.description
+            headers["#{tt.label} (#{tt.id})"] = tt.description
           end
           write_to_csv(file, headers.keys, data_csv)
           append_export_documentation(export_dir.join('README.txt'), 'workspace_annotations_data.csv', 'Contains information about workspace annotations. Each column represents an annotation label, and each row contains the corresponding annotation value for an item.', headers)
         end
       end
     end
-    # bundle exec rails check:sunset:export_workspace_tipline_requets_data[team-slug]
-    task :export_workspace_tipline_requets_data,[:slug] => :environment do |_t, args|
+    # bundle exec rails check:sunset:export_workspace_tipline_requests_data[team-slug]
+    task :export_workspace_tipline_requests_data,[:slug] => :environment do |_t, args|
       print_task_title 'Exporting workspace TiplineRequests data'
       slug = args[:slug].to_s
       team = Team.find_by_slug slug
@@ -282,7 +282,7 @@ namespace :check do
             tr.smooch_data['text']
           ]
         end
-        export_dir = Rails.root.join('public', team.slug)
+        export_dir = Rails.root.join('tmp', team.slug)
         file = export_dir.join('workspace_tipline_requets_data.csv')
         headers = {
           'ID' => 'Unique identifier of the TiplineRequest.',
@@ -325,7 +325,7 @@ namespace :check do
             tn.created_at,
           ]
         end
-        export_dir = Rails.root.join('public', team.slug)
+        export_dir = Rails.root.join('tmp', team.slug)
         file = export_dir.join('workspace_tipline_newsletter_data.csv')
         headers = {
           'ID' => 'Unique identifier for the TiplineNewsletter.',
@@ -373,7 +373,7 @@ namespace :check do
             media_data
           ]
         end
-        export_dir = Rails.root.join('public', team.slug)
+        export_dir = Rails.root.join('tmp', team.slug)
         file = export_dir.join('workspace_item_data.csv')
         headers = {
           'ID' => 'Unique identifier of the item.',
@@ -391,38 +391,41 @@ namespace :check do
       end
     end
 
-    # bundle exec rails check:sunset:export_and_upload_workspace_data[team-slug]
-    task :export_and_upload_workspace_data,[:slug] => :environment do |_t, args|
+    # bundle exec rails check:sunset:export_upload_and_send_workspace_data[team-slug, email]
+    task :export_upload_and_send_workspace_data,[:slug, :email] => :environment do |_t, args|
       started = Time.now.to_i
       slug = args[:slug].to_s
       team = Team.find_by_slug slug
       unless team.nil?
-        # Call all exported tasks
-        Rake::Task['check:sunset:export_workspace_init_readme'].invoke(args[:slug])
-        Rake::Task['check:sunset:export_workspace_data'].invoke(args[:slug])
-        Rake::Task['check:sunset:export_workspace_user_data'].invoke(args[:slug])
-        Rake::Task['check:sunset:export_workspace_articles_data'].invoke(args[:slug])
-        Rake::Task['check:sunset:export_workspace_annotations_data'].invoke(args[:slug])
-        Rake::Task['check:sunset:export_workspace_tipline_requets_data'].invoke(args[:slug])
-        Rake::Task['check:sunset:export_workspace_tipline_newsletter_data'].invoke(args[:slug])
-        Rake::Task['check:sunset:export_workspace_item_data'].invoke(args[:slug])
-        print_task_title 'Uploading workspace data'
-        # compress & upload
-        folder_path = "#{Rails.root}/public/#{team.slug}"
-        zip_path = "#{Rails.root}/public/#{team.slug}-#{Time.now.to_i}.zip"
-        puts "Compressing #{folder_path} -> #{zip_path}"
-        compress_folder(folder_path, zip_path)
-        # Save to S3
-        zip_content = File.binread(zip_path)
-        s3_url = CheckS3.write_presigned("export/workspaces_data/#{team.slug}/#{Time.now.to_i}/#{team.slug}.zip", 'application/zip', zip_content, CheckConfig.get('check_sunset_download_expire_days', 7, :integer).days.to_i)
-        key = Shortener::ShortenedUrl.generate!(s3_url).unique_key
-        download_url = CheckConfig.get('short_url_host') + '/' + key
-        puts "Download link (valid #{CheckConfig.get('check_sunset_download_expire_days', 7, :integer)} days): #{download_url}"
-        # Send download link to workspace admins
-        # team.team_users.where(status: 'member').find_each do |tu|
-        #   puts "Sending email to #{tu.user.email}\n"
-        #   SunsetMailer.delay.notify('download', tu.user, tu.team.name)
-        # end
+        email = args[:email].to_s
+        user = User.where(email: email).first
+        if team.team_users.where(user_id: user.id, role: 'admin', status: 'member').exists?
+          # Call all exported tasks
+          Rake::Task['check:sunset:export_workspace_init_readme'].invoke(args[:slug])
+          Rake::Task['check:sunset:export_workspace_data'].invoke(args[:slug])
+          Rake::Task['check:sunset:export_workspace_user_data'].invoke(args[:slug])
+          Rake::Task['check:sunset:export_workspace_articles_data'].invoke(args[:slug])
+          Rake::Task['check:sunset:export_workspace_annotations_data'].invoke(args[:slug])
+          Rake::Task['check:sunset:export_workspace_tipline_requests_data'].invoke(args[:slug])
+          Rake::Task['check:sunset:export_workspace_tipline_newsletter_data'].invoke(args[:slug])
+          Rake::Task['check:sunset:export_workspace_item_data'].invoke(args[:slug])
+          print_task_title 'Uploading workspace data'
+          # compress & upload
+          folder_path = "#{Rails.root}/tmp/#{team.slug}"
+          zip_path = "#{Rails.root}/tmp/#{team.slug}.zip"
+          puts "Compressing #{folder_path} -> #{zip_path}"
+          compress_folder(folder_path, zip_path)
+          # Save to S3
+          zip_content = File.binread(zip_path)
+          s3_url = CheckS3.write_presigned("export/workspaces_data/#{team.slug}.zip", 'application/zip', zip_content, CheckConfig.get('check_sunset_download_expire_days', 7, :integer).days.to_i)
+          key = Shortener::ShortenedUrl.generate!(s3_url).unique_key
+          download_url = CheckConfig.get('short_url_host') + '/' + key
+          puts "Download link (valid #{CheckConfig.get('check_sunset_download_expire_days', 7, :integer)} days): #{download_url}"
+          # Deleting exported files
+          puts "#{folder_path} -- #{zip_path}"
+          # File.delete(folder_path)
+          # File.delete(zip_path)
+        end
       end
       minutes = ((Time.now.to_i - started) / 60).to_i
       puts "[#{Time.now}] Done in #{minutes} minutes."

--- a/lib/tasks/data/check_sunset.rake
+++ b/lib/tasks/data/check_sunset.rake
@@ -72,7 +72,7 @@ namespace :check do
       slug = args[:slug].to_s
       team = Team.find_by_slug slug
       unless team.nil?
-        export_dir = Rails.root.join("tmp", team.slug)
+        export_dir = Rails.root.join('tmp', 'sunset', team.slug)
         FileUtils.mkdir_p(export_dir)
         File.write(
           export_dir.join("README.txt"),
@@ -150,7 +150,7 @@ namespace :check do
           last_active_non_meedan
         ]
         # Write to CSV
-        export_dir = Rails.root.join('tmp', team.slug)
+        export_dir = Rails.root.join('tmp', 'sunset', team.slug)
         file = export_dir.join('workspace_data.csv')
         headers = {
           'ID' => 'Unique identifier of the workspace.',
@@ -193,7 +193,7 @@ namespace :check do
             tu.role
           ]
         end
-        export_dir = Rails.root.join('tmp', team.slug)
+        export_dir = Rails.root.join('tmp', 'sunset', team.slug)
         file = export_dir.join('workspace_user_data.csv')
         headers = {
           'ID' => 'Unique identifier of the user.',
@@ -213,7 +213,7 @@ namespace :check do
       slug = args[:slug].to_s
       team = Team.find_by_slug slug
       unless team.nil?
-        export_dir = Rails.root.join('tmp', team.slug)
+        export_dir = Rails.root.join('tmp', 'sunset', team.slug)
         # Export FactChecks
         data_csv = FactCheck.get_exported_data({}, team).drop(1)
         file = export_dir.join('workspace_fact_checks_data.csv')
@@ -272,7 +272,7 @@ namespace :check do
             end
             data_csv << pm_raw
           end
-          export_dir = Rails.root.join('tmp', team.slug)
+          export_dir = Rails.root.join('tmp', 'sunset', team.slug)
           file = export_dir.join('workspace_annotations_data.csv')
           headers = { 'Item ID' => 'Unique identifier of the item associated with the annotation.' }
           team_tasks.each do |tt|
@@ -295,13 +295,14 @@ namespace :check do
           data_csv << [
             tr.id,
             tr.language,
+            tr.platform,
             tr.created_at,
             tr.tipline_user_uid,
             tr.smooch_data['text']
           ]
         end
-        export_dir = Rails.root.join('tmp', team.slug)
-        file = export_dir.join('workspace_tipline_requets_data.csv')
+        export_dir = Rails.root.join('tmp', 'sunset', team.slug)
+        file = export_dir.join('workspace_tipline_requests_data.csv')
         headers = {
           'ID' => 'Unique identifier of the TiplineRequest.',
           'Language' => 'Language of the TiplineRequest in two-letter format, such as en/ar/fr.',
@@ -311,7 +312,7 @@ namespace :check do
           'Text' => 'Text submitted as part of the TiplineRequest.'
         }
         write_to_csv(file, headers.keys, data_csv)
-        append_export_documentation(export_dir.join('README.txt'), 'workspace_tipline_requets_data.csv', 'Contains information about requests submitted through workspace tiplines.', headers)
+        append_export_documentation(export_dir.join('README.txt'), 'workspace_tipline_requests_data.csv', 'Contains information about requests submitted through workspace tiplines.', headers)
       end
     end
     # bundle exec rails check:sunset:export_workspace_tipline_newsletter_data[team-slug]
@@ -343,7 +344,7 @@ namespace :check do
             tn.created_at,
           ]
         end
-        export_dir = Rails.root.join('tmp', team.slug)
+        export_dir = Rails.root.join('tmp', 'sunset', team.slug)
         file = export_dir.join('workspace_tipline_newsletter_data.csv')
         headers = {
           'ID' => 'Unique identifier for the TiplineNewsletter.',
@@ -391,7 +392,7 @@ namespace :check do
             media_data
           ]
         end
-        export_dir = Rails.root.join('tmp', team.slug)
+        export_dir = Rails.root.join('tmp', 'sunset', team.slug)
         file = export_dir.join('workspace_item_data.csv')
         headers = {
           'ID' => 'Unique identifier of the item.',
@@ -430,20 +431,19 @@ namespace :check do
           Rake::Task['check:sunset:export_workspace_item_data'].invoke(args[:slug])
           print_task_title 'Uploading workspace data'
           # compress & upload
-          folder_path = Rails.root.join('tmp', team.slug)
-          zip_path = Rails.root.join('tmp', "#{team.slug}.zip")
+          folder_path = Rails.root.join('tmp', 'sunset', team.slug)
+          zip_path = Rails.root.join('tmp', 'sunset', "#{team.slug}.zip")
           puts "Compressing #{folder_path} -> #{zip_path}"
           compress_folder(folder_path, zip_path)
           # Save to S3
           bucket_name = ENV.fetch('EXPORT_OUTPUT_BUCKET')
           zip_content = File.binread(zip_path)
-          s3_url = CheckS3.write_presigned("#{team.slug}/#{team.slug}.zip", 'application/zip', zip_content, 7.days.to_i, bucket_name)
+          s3_url = CheckS3.write_presigned("#{team.slug}/#{SecureRandom.hex(16)}/#{team.slug}.zip", 'application/zip', zip_content, 7.days.to_i, bucket_name)
           key = Shortener::ShortenedUrl.generate!(s3_url).unique_key
           download_url = CheckConfig.get('short_url_host') + '/' + key
           puts "Download link (valid for 7 days): #{download_url}"
           # Delete a directory for exported data and zip file
-          FileUtils.rm_rf(folder_path)
-          File.delete(zip_path) if File.exist?(zip_path)
+          FileUtils.rm_rf(Rails.root.join('tmp', 'sunset'))
         end
       end
       minutes = ((Time.now.to_i - started) / 60).to_i

--- a/lib/tasks/data/check_sunset.rake
+++ b/lib/tasks/data/check_sunset.rake
@@ -404,7 +404,7 @@ namespace :check do
         Rake::Task['check:sunset:export_workspace_articles_data'].invoke(args[:slug])
         Rake::Task['check:sunset:export_workspace_annotations_data'].invoke(args[:slug])
         Rake::Task['check:sunset:export_workspace_tipline_requets_data'].invoke(args[:slug])
-        Rake::Task['check:sunset:export_workspace_tipline_requets_data'].invoke(args[:slug])
+        Rake::Task['check:sunset:export_workspace_tipline_newsletter_data'].invoke(args[:slug])
         Rake::Task['check:sunset:export_workspace_item_data'].invoke(args[:slug])
         print_task_title 'Uploading workspace data'
         # compress & upload
@@ -414,14 +414,14 @@ namespace :check do
         compress_folder(folder_path, zip_path)
         # Save to S3
         zip_content = File.binread(zip_path)
-        s3_url = CheckS3.write_presigned("export/workspaces_data/#{team.slug}/#{Time.now.to_i}/#{team.slug}.zip", 'application/zip', zip_content, CheckConfig.get('export_csv_expire', 7.days.to_i, :integer))
+        s3_url = CheckS3.write_presigned("export/workspaces_data/#{team.slug}/#{Time.now.to_i}/#{team.slug}.zip", 'application/zip', zip_content, CheckConfig.get('check_sunset_download_expire_days', 7, :integer).days.to_i)
         key = Shortener::ShortenedUrl.generate!(s3_url).unique_key
         download_url = CheckConfig.get('short_url_host') + '/' + key
-        puts "Download link (valid 7 days): #{download_url}"
+        puts "Download link (valid #{CheckConfig.get('check_sunset_download_expire_days', 7, :integer)} days): #{download_url}"
         # Send download link to workspace admins
         # team.team_users.where(status: 'member').find_each do |tu|
         #   puts "Sending email to #{tu.user.email}\n"
-        #   SunsetMailer.delay.notify(tu.user, tu.team.name)
+        #   SunsetMailer.delay.notify('download', tu.user, tu.team.name)
         # end
       end
       minutes = ((Time.now.to_i - started) / 60).to_i

--- a/lib/tasks/data/check_sunset.rake
+++ b/lib/tasks/data/check_sunset.rake
@@ -1,0 +1,423 @@
+namespace :check do
+  namespace :sunset do
+    def print_task_title(title)
+      puts '----------------------------------------------------------------'
+      puts title.upcase + '...'
+      puts '----------------------------------------------------------------'
+      puts
+    end
+
+    def write_to_csv(file, headers, data_csv)
+      dir_path = File.dirname(file)
+      FileUtils.mkdir_p(dir_path)
+      CSV.open(file, 'w', write_headers: true, headers: headers) do |writer|
+        data_csv.each do |d|
+          writer << d
+        end
+      end
+    end
+
+    def compress_folder(folder_path, zip_path)
+      require 'zip'
+      FileUtils.rm_f(zip_path)
+      Zip::File.open(zip_path, Zip::File::CREATE) do |zipfile|
+        Dir.glob("#{folder_path}/**/**").each do |file|
+          relative_path = file.sub("#{folder_path}/", '')
+          next if relative_path.empty?
+          if File.directory?(file)
+            zipfile.mkdir(relative_path) unless zipfile.find_entry(relative_path)
+          else
+            zipfile.add(relative_path, file)
+          end
+        end
+      end
+    end
+
+    def append_export_documentation(readme_path, filename, description, headers)
+      File.open(readme_path, "a") do |file|
+        file.puts
+        file.puts filename
+        file.puts "-" * filename.length
+        file.puts "Description: #{description}"
+        file.puts
+        file.puts "Headers:"
+        headers.each do |key, description|
+          file.puts "- #{key}: #{description}"
+        end
+        file.puts
+      end
+    end
+
+    # Export workspace data
+    task :export_workspace_init_readme, [:slug] => :environment do |_t, args|
+      print_task_title 'CSV Export Documentation'
+      slug = args[:slug].to_s
+      team = Team.find_by_slug slug
+      unless team.nil?
+        export_dir = Rails.root.join("public", team.slug)
+        FileUtils.mkdir_p(export_dir)
+        File.write(
+          export_dir.join("README.txt"),
+          <<~README
+            CSV Export Documentation
+            ========================
+
+          README
+        )
+      end
+    end
+    # bundle exec rails check:sunset:export_workspace_data[team-slug]
+    task :export_workspace_data, [:slug] => :environment do |_t, args|
+      print_task_title 'Exporting workspace data'
+      slug = args[:slug].to_s
+      team = Team.find_by_slug slug
+      unless team.nil?
+        data_csv = []
+        smooch = BotUser.smooch_user
+        puts "Processing team #{team.slug}....."
+        puts "\nExport workspace data ..."
+        last_active = Version.from_partition(team.id).last&.created_at || team.created_at
+        users_count = team.team_users.where(status: 'member').count
+        items_count = team.project_medias.count
+        requests_count = TiplineRequest.where(team_id: team.id).count
+        fact_checks_count = team.fact_checks.count
+        explainers_count = team.explainers.count
+        tbi = team.team_bot_installations.where(user_id: smooch.id).first
+        tipline_wa = 'No'
+        tipline_non_wa = 'No'
+        has_tipline = 'No'
+        all_tiplines = ''
+        unless tbi.nil?
+          tiplines = tbi.smooch_enabled_integrations.keys
+          all_tiplines = tiplines.join('-')
+          if tiplines.length > 0
+            has_tipline = 'Yes'
+            tipline_wa = 'Yes' if tiplines.include?('whatsapp')
+            tiplines.delete('whatsapp')
+            tipline_non_wa = 'Yes' if tiplines.length > 0
+          end
+        end
+        # Check Active API
+        has_active_api = 'No'
+        api_keys = ApiKey.where(team_id: team.id).where('expire_at > ?', Time.now)
+        unless api_keys.empty?
+          webhook_installations = team.team_users.joins(:user).where('users.type' => 'BotUser', 'users.default' => false).select{ |team_user| team_user.user.events.present? && team_user.user.get_request_url.present? && !team_user.user.get_approved }
+          u_ids = webhook_installations.map(&:user_id)
+          bu_ids = api_keys.map(&:bot_user).compact.map(&:id)
+          has_active_api = 'Yes' unless (bu_ids - u_ids).empty?
+        end
+        # Last active for non Meedan users
+        last_active_non_meedan = team.team_users.joins(:user).where.not("users.email ILIKE ? OR users.email ILIKE ?", "%@meedan.com", "%@meedan.org").maximum(:last_active_at)
+        data_csv << [
+          team.id,
+          team.name,
+          team.url,
+          team.created_at,
+          last_active,
+          users_count,
+          items_count,
+          requests_count,
+          fact_checks_count,
+          explainers_count,
+          has_tipline,
+          tipline_wa,
+          tipline_non_wa,
+          all_tiplines,
+          has_active_api,
+          last_active_non_meedan
+        ]
+        # Write to CSV
+        export_dir = Rails.root.join('public', team.slug)
+        file = export_dir.join('workspace_data.csv')
+        headers = {
+          'ID' => 'Unique identifier of the workspace.',
+          'Name' => 'Name of the workspace.',
+          'URL' => 'URL used to access the workspace.',
+          'Created at' => 'Date when the workspace was created.',
+          'Last activity' => 'Date of the most recent activity in the workspace.',
+          'Users #' => 'Total number of users in the workspace.',
+          'Items #' => 'Total number of items in the workspace, including Claims, Links, Images, Videos, and Audio.',
+          'Requests #' => 'Total number of requests submitted through the workspace\'s tiplines.',
+          'FactChecks #' => 'Total number of FactChecks in the workspace.',
+          'Explainers #' => 'Total number of Explainers in the workspace.',
+          'Enabled tipline?' => 'Indicates whether the workspace has a tipline enabled (Yes/No).',
+          'Active WhatsApp integration?' => 'Indicates whether the workspace has an active WhatsApp integration (Yes/No).',
+          'Active non-WhatsApp integration?' => 'Indicates whether the workspace has any active tipline integration other than WhatsApp (Yes/No).',
+          'Active tiplines' => 'List of all active tiplines associated with the workspace, separated by -.',
+          'Active API?' => 'Indicates whether the workspace has an active API (Yes/No).',
+          'Last access' => 'Date of the most recent access to the workspace.',
+        }
+        write_to_csv(file, headers.keys, data_csv)
+        append_export_documentation(export_dir.join('README.txt'), 'workspace_data.csv', 'Contains workspace information and activity statistics.', headers)
+      end
+    end
+    # bundle exec rails check:sunset:export_workspace_user_data[team-slug]
+    task :export_workspace_user_data,[:slug] => :environment do |_t, args|
+      print_task_title 'Exporting workspace user data'
+      slug = args[:slug].to_s
+      team = Team.find_by_slug slug
+      unless team.nil?
+        data_csv = []
+        team.team_users.where(status: 'member').find_each do |tu|
+          print '.'
+          user = tu.user
+          data_csv << [
+            user.id,
+            user.name,
+            user.email,
+            tu.created_at,
+            tu.last_active_at,
+            tu.role
+          ]
+        end
+        export_dir = Rails.root.join('public', team.slug)
+        file = export_dir.join('workspace_user_data.csv')
+        headers = {
+          'ID' => 'Unique identifier of the user.',
+          'Name' => 'Name of the user.',
+          'Email' => 'Email address of the user.',
+          'Joined data' => 'Date when the user joined the workspace.',
+          'Last access date' => 'Date when the user most recently accessed the workspace.',
+          'Role' => 'User\'s role in the workspace.',
+        }
+        write_to_csv(file, headers.keys, data_csv)
+        append_export_documentation(export_dir.join('README.txt'), 'workspace_user_data.csv', 'Contains information about workspace users and their access.', headers)
+      end
+    end
+    # bundle exec rails check:sunset:export_workspace_articles_data[team-slug]
+    task :export_workspace_articles_data,[:slug] => :environment do |_t, args|
+      print_task_title 'Exporting workspace articles data (FactChecks & Explainers)'
+      slug = args[:slug].to_s
+      team = Team.find_by_slug slug
+      unless team.nil?
+        export_dir = Rails.root.join('public', team.slug)
+        # Export FactChecks
+        data_csv = FactCheck.get_exported_data({}, team).drop(1)
+        file = export_dir.join('workspace_fact_checks_data.csv')
+        headers = {
+          'ID' => 'Unique identifier of the FactCheck.',
+          'Title' => 'Title of the FactCheck',
+          'Summary' => 'Summary of the FactCheck',
+          'URL' => 'URL of the FactCheck',
+          'Language' => 'Language of the FactCheck in two-letter format, such as en/ar/fr.',
+          'Report Status' => 'Current status of the FactCheck report.',
+          'Imported?' => 'Indicates whether the FactCheck was imported into the workspace'
+        }
+        write_to_csv(file, headers.keys, data_csv)
+        append_export_documentation(export_dir.join('README.txt'), 'workspace_fact_checks_data.csv', 'Contains information about FactChecks in the workspace.', headers)
+        # Export Explainers
+        data_csv = Explainer.get_exported_data({}, team).drop(1)
+        headers = {
+          'ID' => 'Unique identifier of the Explainer.',
+          'Title' => 'Title of the Explainer',
+          'Description' => 'Description of the Explainer',
+          'URL' => 'URL of the Explainer',
+          'Language' => 'Language of the Explainer in two-letter format, such as en/ar/fr.',
+        }
+        file = export_dir.join('workspace_explainers_data.csv')
+        write_to_csv(file, headers.keys, data_csv)
+        append_export_documentation(export_dir.join('README.txt'), 'workspace_explainers_data.csv', 'Contains information about Explainers in the workspace.', headers)
+      end
+    end
+    # bundle exec rails check:sunset:export_workspace_annotations_data[team-slug]
+    task :export_workspace_annotations_data,[:slug] => :environment do |_t, args|
+      print_task_title 'Exporting workspace annotations data'
+      slug = args[:slug].to_s
+      team = Team.find_by_slug slug
+      unless team.nil?
+        team_tasks = team.team_tasks
+        unless team_tasks.empty?
+          headers_id = team_tasks.map(&:id)
+          data_csv = []
+          team.project_medias.find_each do |pm|
+            print '.'
+            a_ttid = {}
+            pm.get_annotations(['task']).find_each do |a|
+              a_ttid[a.data["team_task_id"]] = a.id
+            end
+            a_answer = {}
+            DynamicAnnotation::Field.select("a.annotated_id AS tid, dynamic_annotation_fields.value AS answer")
+            .joins("INNER JOIN annotations a ON a.id = dynamic_annotation_fields.annotation_id INNER JOIN annotations a2 ON a2.id = a.annotated_id")
+            .where("field_name LIKE 'response_%'")
+            .where('a.annotated_type' => 'Task', 'a2.annotated_type' => 'ProjectMedia', 'a2.annotated_id' => pm.id).each do |f|
+              a_answer[f.tid] = begin JSON.parse(f.answer) rescue f.answer end
+            end
+            next if a_answer.empty?
+            pm_raw = [pm.id]
+            headers_id.each do |ttid|
+              pm_raw << a_answer[a_ttid[ttid]] || '-'
+            end
+            data_csv << pm_raw
+          end
+          export_dir = Rails.root.join('public', team.slug)
+          file = export_dir.join('workspace_annotations_data.csv')
+          headers = { 'Item ID' => 'Unique identifier of the item associated with the annotation.' }
+          team_tasks.each do |tt|
+            headers[tt.label] = tt.description
+          end
+          write_to_csv(file, headers.keys, data_csv)
+          append_export_documentation(export_dir.join('README.txt'), 'workspace_annotations_data.csv', 'Contains information about workspace annotations. Each column represents an annotation label, and each row contains the corresponding annotation value for an item.', headers)
+        end
+      end
+    end
+    # bundle exec rails check:sunset:export_workspace_tipline_requets_data[team-slug]
+    task :export_workspace_tipline_requets_data,[:slug] => :environment do |_t, args|
+      print_task_title 'Exporting workspace TiplineRequests data'
+      slug = args[:slug].to_s
+      team = Team.find_by_slug slug
+      unless team.nil?
+        data_csv = []
+        TiplineRequest.where(team_id: team.id).find_each do |tr|
+          print '.'
+          data_csv << [
+            tr.id,
+            tr.language,
+            tr.created_at,
+            tr.tipline_user_uid,
+            tr.smooch_data['text']
+          ]
+        end
+        export_dir = Rails.root.join('public', team.slug)
+        file = export_dir.join('workspace_tipline_requets_data.csv')
+        headers = {
+          'ID' => 'Unique identifier of the TiplineRequest.',
+          'Language' => 'Language of the TiplineRequest in two-letter format, such as en/ar/fr.',
+          'Platform' => 'Platform through which the TiplineRequest was submitted.',
+          'Creation date' => 'Date and time when the TiplineRequest was created.',
+          'User UID' => 'Unique identifier of the tipline user who submitted the request.',
+          'Text' => 'Text submitted as part of the TiplineRequest.'
+        }
+        write_to_csv(file, headers.keys, data_csv)
+        append_export_documentation(export_dir.join('README.txt'), 'workspace_tipline_requets_data.csv', 'Contains information about requests submitted through workspace tiplines.', headers)
+      end
+    end
+    # bundle exec rails check:sunset:export_workspace_tipline_newsletter_data[team-slug]
+    task :export_workspace_tipline_newsletter_data,[:slug] => :environment do |_t, args|
+      print_task_title 'Exporting workspace TiplineNewsletter data'
+      slug = args[:slug].to_s
+      team = Team.find_by_slug slug
+      unless team.nil?
+        data_csv = []
+        team.tipline_newsletters.find_each do |tn|
+          print '.'
+          data_csv << [
+            tn.id,
+            tn.header_type,
+            tn.header_file,
+            tn.header_overlay_text,
+            tn.header_media_url,
+            tn.introduction,
+            tn.content_type,
+            tn.rss_feed_url,
+            tn.number_of_articles,
+            tn.first_article,
+            tn.second_article,
+            tn.third_article,
+            tn.footer,
+            tn.last_sent_at,
+            tn.language,
+            tn.enabled,
+            tn.created_at,
+          ]
+        end
+        export_dir = Rails.root.join('public', team.slug)
+        file = export_dir.join('workspace_tipline_newsletter_data.csv')
+        headers = {
+          'ID' => 'Unique identifier for the TiplineNewsletter.',
+          'Header type' => 'Type of header used in the newsletter.',
+          'Hheader file' => 'File used as the newsletter header.',
+          'Header overlay text' => 'Text displayed as an overlay on the newsletter header.',
+          'Header media url' => 'URL of the media used in the newsletter header.',
+          'Introduction' => 'Introduction text displayed in the newsletter.',
+          'Content type' => 'Type of content included in the newsletter.',
+          'RSS feed url' => 'URL of the RSS feed used to populate the newsletter content.',
+          'Number of articles' => 'Number of articles included in the newsletter.',
+          'First article' => 'Content of the first article',
+          'Second article' => 'Content of the second article',
+          'Third article' => 'Content of the third article',
+          'Footer' => 'Footer text displayed in the newsletter.',
+          'Last sent at' => 'Date and time when the newsletter was last sent.',
+          'Language' => 'Language of the TiplineNewsletter in two-letter format, such as en/ar/fr.',
+          'Enabled' => 'Indicates whether the newsletter is enabled',
+          'Creation data' => 'Date and time when the newsletter was created.',
+        }
+        write_to_csv(file, headers.keys, data_csv)
+        append_export_documentation(export_dir.join('README.txt'), 'workspace_tipline_newsletter_data.csv', 'Contains information about Tipline newsletters configured for the workspace.', headers)
+      end
+    end
+    # bundle exec rails check:sunset:export_workspace_item_data[team-slug]
+    task :export_workspace_item_data,[:slug] => :environment do |_t, args|
+      print_task_title 'Exporting workspace item data'
+      slug = args[:slug].to_s
+      team = Team.find_by_slug slug
+      unless team.nil?
+        data_csv = []
+        team.project_medias.includes(:source, :media).find_each do |pm|
+          print '.'
+          media = pm.media
+          media_data = media.quote || media.url || media.file&.url
+          data_csv << [
+            pm.id,
+            pm.title,
+            pm.description,
+            pm.created_at,
+            pm.tags_as_sentence,
+            pm.status,
+            pm.source&.name,
+            media.type,
+            media_data
+          ]
+        end
+        export_dir = Rails.root.join('public', team.slug)
+        file = export_dir.join('workspace_item_data.csv')
+        headers = {
+          'ID' => 'Unique identifier of the item.',
+          'Title' => 'Title of the item',
+          'Description' => 'Description of the item',
+          'Creation date' => 'Date and time when the item was created.',
+          'Tags' => 'Tags associated with the item',
+          'Status' => 'Current status of the item.',
+          'Source' => 'Source associated with the item',
+          'Media type' => 'Type of the item, such as Claim, Link, Image, Video, or Audio.',
+          'Media data' => 'Content or reference associated with the item, such as a Quote, URL, or file path.',
+        }
+        write_to_csv(file, headers.keys, data_csv)
+        append_export_documentation(export_dir.join('README.txt'), 'workspace_item_data.csv', 'Contains information about workspace items, including Claims, Links, and Media.', headers)
+      end
+    end
+
+    # bundle exec rails check:sunset:export_and_upload_workspace_data[team-slug]
+    task :export_and_upload_workspace_data,[:slug] => :environment do |_t, args|
+      started = Time.now.to_i
+      slug = args[:slug].to_s
+      team = Team.find_by_slug slug
+      unless team.nil?
+        # Call all exported tasks
+        Rake::Task['check:sunset:export_workspace_init_readme'].invoke(args[:slug])
+        Rake::Task['check:sunset:export_workspace_data'].invoke(args[:slug])
+        Rake::Task['check:sunset:export_workspace_user_data'].invoke(args[:slug])
+        Rake::Task['check:sunset:export_workspace_articles_data'].invoke(args[:slug])
+        Rake::Task['check:sunset:export_workspace_annotations_data'].invoke(args[:slug])
+        Rake::Task['check:sunset:export_workspace_tipline_requets_data'].invoke(args[:slug])
+        Rake::Task['check:sunset:export_workspace_tipline_requets_data'].invoke(args[:slug])
+        Rake::Task['check:sunset:export_workspace_item_data'].invoke(args[:slug])
+        print_task_title 'Uploading workspace data'
+        # compress & upload
+        folder_path = "#{Rails.root}/public/#{team.slug}"
+        zip_path = "#{Rails.root}/public/#{team.slug}-#{Time.now.to_i}.zip"
+        puts "Compressing #{folder_path} -> #{zip_path}"
+        compress_folder(folder_path, zip_path)
+        # Save to S3
+        download_url = CheckS3.write_presigned("export/workspaces_data/#{team.slug}/#{Time.now.to_i}/#{team.slug}.zip", 'application/zip', zip_path, CheckConfig.get('export_csv_expire', 7.days.to_i, :integer))
+        puts "Download link (valid 7 days): #{download_url}"
+        # Send download link to workspace admins
+        # team.team_users.where(status: 'member').find_each do |tu|
+        #   puts "Sending email to #{tu.user.email}\n"
+        #   SunsetMailer.delay.notify(tu.user, tu.team.name)
+        # end
+      end
+      minutes = ((Time.now.to_i - started) / 60).to_i
+      puts "[#{Time.now}] Done in #{minutes} minutes."
+    end
+  end
+end

--- a/lib/tasks/data/check_sunset.rake
+++ b/lib/tasks/data/check_sunset.rake
@@ -413,13 +413,16 @@ namespace :check do
         puts "Compressing #{folder_path} -> #{zip_path}"
         compress_folder(folder_path, zip_path)
         # Save to S3
-        download_url = CheckS3.write_presigned("export/workspaces_data/#{team.slug}/#{Time.now.to_i}/#{team.slug}.zip", 'application/zip', zip_path, CheckConfig.get('export_csv_expire', 7.days.to_i, :integer))
+        zip_content = File.binread(zip_path)
+        s3_url = CheckS3.write_presigned("export/workspaces_data/#{team.slug}/#{Time.now.to_i}/#{team.slug}.zip", 'application/zip', zip_content, CheckConfig.get('export_csv_expire', 7.days.to_i, :integer))
+        key = Shortener::ShortenedUrl.generate!(s3_url).unique_key
+        download_url = CheckConfig.get('short_url_host') + '/' + key
         puts "Download link (valid 7 days): #{download_url}"
         # Send download link to workspace admins
-        team.team_users.where(status: 'member').find_each do |tu|
-          puts "Sending email to #{tu.user.email}\n"
-          SunsetMailer.delay.notify(tu.user, tu.team.name)
-        end
+        # team.team_users.where(status: 'member').find_each do |tu|
+        #   puts "Sending email to #{tu.user.email}\n"
+        #   SunsetMailer.delay.notify(tu.user, tu.team.name)
+        # end
       end
       minutes = ((Time.now.to_i - started) / 60).to_i
       puts "[#{Time.now}] Done in #{minutes} minutes."


### PR DESCRIPTION
## Description

Add rake tasks to export workspace data

- rails check:sunset:export_workspace_data[team-slug]
- rails check:sunset:export_workspace_user_data[team-slug]
- rails check:sunset:export_workspace_articles_data[team-slug]
- rails check:sunset:export_workspace_annotations_data[team-slug]
- rails check:sunset:export_workspace_tipline_requets_data[team-slug]
- rails check:sunset:export_workspace_tipline_newsletter_data[team-slug]
- rails check:sunset:export_workspace_item_data[team-slug]

There is a main rake task to do the export and sent an email with download link `check:sunset:export_and_upload_workspace_data[team-slug]`

Sample of README.txt file
[README.txt](https://github.com/user-attachments/files/31515891/README.txt)


## How to test?

Please describe how to test the changes (manually and/or automatically).

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
