### PR TITLE
CV2-6740: Add a download button for the Check export

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,6 @@ ENV LANGUAGE=C.UTF-8
 ENV DEPLOYUSER=checkdeploy
 RUN useradd ${DEPLOYUSER} -s /bin/bash -m
 
-
-RUN apt-get update -qq && apt-get install -y --no-install-recommends curl
-
 # Use Debian Snapshot because Bullseye reached EOL on August 31, 2026.
 RUN printf '%s\n' \
     'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20260805T215856Z bullseye main' \
@@ -29,6 +26,7 @@ RUN printf '%s\n' \
     && apt-get update
 
 RUN apt-get install --no-install-recommends -y \
+        curl \
         build-essential \
         ffmpegthumbnailer \
         ffmpeg \

--- a/app/graph/types/me_type.rb
+++ b/app/graph/types/me_type.rb
@@ -171,4 +171,14 @@ class MeType < DefaultObject
     FeedInvitation.where(email: object.email)
   end
 
+  field :workspaces_download_url, JsonStringType, null: true
+
+  def workspaces_download_url
+    ability = context[:ability] || Ability.new
+    ret = {}
+    object.check_data_exports.includes(:team).find_each do |de|
+      ret[de.team.name] = de.download_url if ability.can?(:read, de)
+    end
+    ret
+  end
 end

--- a/app/graph/types/me_type.rb
+++ b/app/graph/types/me_type.rb
@@ -174,10 +174,12 @@ class MeType < DefaultObject
   field :workspaces_download_url, JsonStringType, null: true
 
   def workspaces_download_url
-    ability = context[:ability] || Ability.new
     ret = {}
+    ability = context[:ability] || Ability.new
+    expire_days = CheckConfig.get('check_sunset_download_expire_days', 15, :integer)
     object.check_data_exports.includes(:team).find_each do |de|
-      ret[de.team.name] = de.download_url if ability.can?(:read, de)
+      expired = Time.current > de.generated_at + expire_days.days
+      ret[de.team.name] = de.download_url if !expired && ability.can?(:read, de)
     end
     ret
   end

--- a/app/graph/types/me_type.rb
+++ b/app/graph/types/me_type.rb
@@ -178,8 +178,7 @@ class MeType < DefaultObject
     ret = {}
     ability = context[:ability] || Ability.new
     object.check_data_exports.includes(:team).find_each do |de|
-      expired = Time.current > de.expired_at
-      ret[de.team.name] = de.download_url if !expired && ability.can?(:read, de)
+      ret[de.team.name] = de.download_url if ability.can?(:read, de)
     end
     ret
   end

--- a/app/graph/types/me_type.rb
+++ b/app/graph/types/me_type.rb
@@ -171,14 +171,14 @@ class MeType < DefaultObject
     FeedInvitation.where(email: object.email)
   end
 
-  field :workspaces_download_url, JsonStringType, null: true
+  field :workspaces_data_export_url, JsonStringType, null: true
 
-  def workspaces_download_url
+  def workspaces_data_export_url
+    # List the CheckDataExport download URL for each workspace based on permissions and expiration date, using the key => value format
     ret = {}
     ability = context[:ability] || Ability.new
-    expire_days = CheckConfig.get('check_sunset_download_expire_days', 15, :integer)
     object.check_data_exports.includes(:team).find_each do |de|
-      expired = Time.current > de.generated_at + expire_days.days
+      expired = Time.current > de.expired_at
       ret[de.team.name] = de.download_url if !expired && ability.can?(:read, de)
     end
     ret

--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -432,4 +432,12 @@ class TeamType < DefaultObject
     webhook_installations = object.team_users.joins(:user).where('users.type' => 'BotUser', 'users.default' => false).select{ |team_user| team_user.user.events.present? && team_user.user.get_request_url.present? && !team_user.user.get_approved }
     webhook_installations.map(&:user)
   end
+
+  field :data_export_download_url, GraphQL::Types::String, null: true
+
+  def data_export_download_url
+    ability = context[:ability] || Ability.new
+    de = object.check_data_export
+    (de && ability.can?(:read, de)) ? de.download_url : ''
+  end
 end

--- a/app/graph/types/team_type.rb
+++ b/app/graph/types/team_type.rb
@@ -432,12 +432,4 @@ class TeamType < DefaultObject
     webhook_installations = object.team_users.joins(:user).where('users.type' => 'BotUser', 'users.default' => false).select{ |team_user| team_user.user.events.present? && team_user.user.get_request_url.present? && !team_user.user.get_approved }
     webhook_installations.map(&:user)
   end
-
-  field :data_export_download_url, GraphQL::Types::String, null: true
-
-  def data_export_download_url
-    ability = context[:ability] || Ability.new
-    de = object.check_data_export
-    (de && ability.can?(:read, de)) ? de.download_url : ''
-  end
 end

--- a/app/mailers/sunset_mailer.rb
+++ b/app/mailers/sunset_mailer.rb
@@ -4,7 +4,13 @@ class SunsetMailer < ApplicationMailer
   def notify(type, user, workspace, workspace_url)
     @name = user.name
     # Set subject based on type (notify or download)
-    subject = (type == 'download') ? "#{CheckConfig.get('app_name')} exported data for #{workspace} workspace is ready to download" : "Sunset alert: #{CheckConfig.get('app_name')} sunset for #{workspace} workspace"
+    if type == 'download'
+      subject = "#{CheckConfig.get('app_name')} exported data for #{workspace} workspace is ready to download"
+    elsif type == 'notify_low_usage'
+      subject = "Housekeeping update for inactive #{CheckConfig.get('app_name')} workspaces (#{workspace})"
+    else
+      subject = "Sunset alert: #{CheckConfig.get('app_name')} sunset for #{workspace} workspace"
+    end
     # Dates for low usage workspaces
     low_usage_end_date = begin Time.parse(CheckConfig.get('check_sunset_low_usage_date')) rescue Time.parse('2026-11-03') end
     low_usage_download_link_date = begin Time.parse(CheckConfig.get('check_sunset_low_usage_download_link_date')) rescue Time.parse('2026-11-04') end
@@ -17,7 +23,7 @@ class SunsetMailer < ApplicationMailer
       low_usage_download_link_date: low_usage_download_link_date,
       workspace: workspace,
       workspace_url: workspace_url,
-      download_expire_days: CheckConfig.get('check_sunset_download_expire_days', 14, :integer),
+      download_expire_days: CheckConfig.get('check_sunset_download_expire_days', 15, :integer),
       download_expire_extended_days: CheckConfig.get('check_sunset_download_expire_extended_days', 10, :integer),
     }
     mail(to: user.email, subject: subject)

--- a/app/mailers/sunset_mailer.rb
+++ b/app/mailers/sunset_mailer.rb
@@ -1,4 +1,4 @@
-class SunsetMailer < ApplicationMailer
+  class SunsetMailer < ApplicationMailer
   layout nil
 
   def notify(type, user, workspace, workspace_url)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -66,9 +66,6 @@ class Ability
     can :destroy, [Dynamic, DynamicAnnotation::Field] do |obj|
       obj.team.present? && obj.team == @context_team
     end
-    can :read, CheckDataExport do |obj|
-      obj.team_id == @context_team.id && obj.user_id == @user.id
-    end
   end
 
   def editor_perms

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -66,6 +66,9 @@ class Ability
     can :destroy, [Dynamic, DynamicAnnotation::Field] do |obj|
       obj.team.present? && obj.team == @context_team
     end
+    can :read, CheckDataExport do |obj|
+      obj.team_id == @context_team.id && obj.user_id == @user.id
+    end
   end
 
   def editor_perms

--- a/app/models/check_data_export.rb
+++ b/app/models/check_data_export.rb
@@ -1,0 +1,17 @@
+class CheckDataExport < ApplicationRecord
+  belongs_to :team
+  belongs_to :user
+
+  validates_presence_of :team_id, :user_id
+  validates_uniqueness_of :team_id
+
+  validate :user_is_admin_member
+
+  private
+
+  def user_is_admin_member
+    if self.team && self.user
+      errors.add(:user_id, I18n.t(:"errors.messages.check_export_data_user_must_be_admin_member")) unless self.team.team_users.where(user_id: self.user.id, role: 'admin', status: 'member').exists?
+    end
+  end
+end

--- a/app/models/check_data_export.rb
+++ b/app/models/check_data_export.rb
@@ -16,10 +16,9 @@ class CheckDataExport < ApplicationRecord
     shortened_url = Shortener::ShortenedUrl.find_by(unique_key: unique_key)
     unless shortened_url.nil?
       max_s3_allowed_days = CheckConfig.get('check_sunset_s3_max_expire_days', 7, :integer)
-      expired_at = self.expired_at
       current_time = Time.current
-      # Get days diff to determine if we still need to schedule another job to regenerate S3 URL
-      days_diff = (expired_at.to_date - current_time.to_date).to_i
+      # Calculate the days difference to determine whether we need to schedule another job to regenerate the S3 URL.
+      days_diff = (self.expired_at.to_date - current_time.to_date).to_i
       # Regenerate S3 URL
       s3_url = CheckS3.presigned_url(self.s3_key,[max_s3_allowed_days, days_diff].min.days.to_i, CheckConfig.get('check_sunset_s3_bucket'))
       # Update target url in Shortener::ShortenedUrl

--- a/app/models/check_data_export.rb
+++ b/app/models/check_data_export.rb
@@ -2,10 +2,34 @@ class CheckDataExport < ApplicationRecord
   belongs_to :team
   belongs_to :user
 
-  validates_presence_of :team_id, :user_id
+  validates_presence_of :team_id, :user_id, :download_url
   validates_uniqueness_of :team_id
 
   validate :user_is_admin_member
+
+  after_save :enqueue_regenerate_download_url, if: proc { |de| de.auto_extend_url_expiry && de.saved_change_to_generated_at? }
+
+  def regenerate_download_url
+    # 1. Extract the unique key from the download URL string
+    download_url = self.download_url
+    unique_key = File.basename(URI.parse(download_url).path)
+    shortened_url = Shortener::ShortenedUrl.find_by(unique_key: unique_key)
+    unless shortened_url.nil?
+      max_s3_allowed_days = CheckConfig.get('check_sunset_s3_max_expire_days', 7, :integer)
+      expired_at = self.expired_at
+      current_time = Time.current
+      # Get days diff to determine if we still need to schedule another job to regenerate S3 URL
+      days_diff = (expired_at.to_date - current_time.to_date).to_i
+      # Regenerate S3 URL
+      s3_url = CheckS3.presigned_url(self.s3_key,[max_s3_allowed_days, days_diff].min.days.to_i, CheckConfig.get('check_sunset_s3_bucket'))
+      # Update target url in Shortener::ShortenedUrl
+      shortened_url.update_column(:url, s3_url)
+      self.generated_at = current_time
+      self.auto_extend_url_expiry = days_diff > max_s3_allowed_days
+      self.skip_check_ability = true
+      begin self.save! rescue Rails.logger.info "[CheckDataExport] Unable to regenerate download URL for workspace #{self.team.slug} [ID: #{self.id}]" end
+    end
+  end
 
   private
 
@@ -13,5 +37,10 @@ class CheckDataExport < ApplicationRecord
     if self.team && self.user
       errors.add(:user_id, I18n.t(:"errors.messages.check_export_data_user_must_be_admin_member")) unless self.team.team_users.where(user_id: self.user.id, role: 'admin', status: 'member').exists?
     end
+  end
+
+  def enqueue_regenerate_download_url
+    # Schedule regenerate S3 URL to run before existing URL expires
+    CheckDataExportWorker.perform_in(CheckConfig.get('check_sunset_s3_max_expire_days', 7, :integer).days, self.id)
   end
 end

--- a/app/models/concerns/team_associations.rb
+++ b/app/models/concerns/team_associations.rb
@@ -23,6 +23,7 @@ module TeamAssociations
     has_many :explainers, dependent: :destroy
     has_many :claim_descriptions
     has_many :api_keys
+    has_one :check_data_export, dependent: :destroy
 
     has_annotations
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,7 @@ class User < ApplicationRecord
   has_many :tipline_requests
   has_many :api_keys
   has_many :explainers
+  has_many :check_data_exports
 
   devise :recoverable, :rememberable, :trackable, :validatable, :confirmable,
          :omniauthable, omniauth_providers: [:facebook, :google_oauth2]

--- a/app/views/sunset_mailer/_notify_low_usage_copy.html.erb
+++ b/app/views/sunset_mailer/_notify_low_usage_copy.html.erb
@@ -1,19 +1,34 @@
+ <style>
+    p {
+      margin-top: 0;          /* Removes default top space */
+      margin-bottom: 24px;    /* Adds custom space below each paragraph */
+      line-height: 1.6;       /* Optional: Makes the text easier to read */
+    }
+ </style>
 <div class="container wide" width="600" style="margin: 0 auto; text-align: <%= @direction[:align] %>; width: 600px;">
 	<p>
-		<span style="font-weight: normal;">We're writing to let you know about some housekeeping we're doing across <%= CheckConfig.get('app_name') %>.</span>
+		<span style="font-weight: normal;">
+			We're writing to let you know about some housekeeping we're doing across <%= CheckConfig.get('app_name') %>.
+		</span>
 	</p>
 	<p>
-		<span style="font-weight: normal;">To keep the platform running smoothly and securely for everyone, we're reviewing workspace activity across Check and closing out accounts that have gone unused for an extended period. This helps keep our systems lean and focus our infrastructure on active workspaces. Based on our records, the workspace <%= link_to(@info[:workspace], @info[:workspace_url], :class => 'link', :style => "color: #0d6cf7 !important; text-decoration: none;") %>, which you&rsquo;re an admin of, hasn't seen recent activity and falls into this group.</span>
+		<span style="font-weight: normal;">
+			To keep the platform running smoothly and securely for everyone, we're reviewing workspace activity across Check and closing out workspaces that have gone unused for the past 6 months. This helps us to keep our infrastructure lean and focused on active workspaces. Based on our records, the workspace <%= link_to(@info[:workspace], @info[:workspace_url], :class => 'link', :style => "color: #0d6cf7 !important; text-decoration: none;") %>, for which you are an admin, has seen no recent activity and thus falls into this group.
+		</span>
 	</p>
-	<p><strong>What this means</strong></p>
 	<p>
-		<span style="font-weight: normal;">Your Check workspace will be unavailable starting on </span><strong><%= @info[:low_usage_end_date].strftime("%B %-d") %></strong><span style="font-weight: normal;">. After this date, you'll no longer be able to access the platform with this account.</span>
+		<strong>What this means for you:</strong>
+		<span style="font-weight: normal;">
+			The Check workspace mentioned above will be unavailable starting on <%= @info[:low_usage_end_date].strftime("%B %-d") %>. After this date, admins will retain limited access only to download workspace data, as described below.
+		</span>
 	</p>
-	<p><strong>Your data</strong></p>
 	<p>
-		<span style="font-weight: normal;">If you'd like to keep a copy of your workspace data, you'll need to download it before it's removed. On </span>
-		<strong><%= @info[:low_usage_download_link_date].strftime("%B %-d") %></strong><span style="font-weight: normal;">, we'll send workspace admins a link to download a ZIP export containing:</span>
+		<strong>Your data:</strong>
+		<span style="font-weight: normal;">
+			If you'd like to keep your workspace data, you'll need to download it before we discontinue your workspace. On <%= @info[:low_usage_download_link_date].strftime("%B %-d") %>, an email will be sent notifying you that the data is available for download. After authentication, all workspace data can be downloaded directly from the workspace by admins only. Data will include:
+		</span>
 	</p>
+
 	<ul>
 		<li style="font-weight: normal;">
 			<span style="font-weight: normal;">Workspace information &mdash; name, URL, creation date, activity, users, and integrations</span>
@@ -34,18 +49,22 @@
 			<span style="font-weight: normal;">Tasks and claim assessments &mdash; tasks and answers for each item</span>
 		</li>
 		<li style="font-weight: normal;">
-			<span style="font-weight: normal;">Newsletter and Annotation data</span>
+			<span style="font-weight: normal;">Newsletter and annotation data</span>
 		</li>
 	</ul>
-	<p><span style="font-weight: normal;">Please note:</span></p>
-	<ul>
-		<li style="font-weight: normal;">
-			<span style="font-weight: normal;">The download link will expire </span><strong><%= @info[:download_expire_days] %> days</strong><span style="font-weight: normal;"> after it's sent, so download and store the file securely before then.</span>
-		</li>
-		<li style="font-weight: normal;">
-			<span style="font-weight: normal;">Your data will remain available for an extra </span><strong><%= @info[:download_expire_extended_days] %> days</strong><span style="font-weight: normal;"> after the link expires. After that, the data will be permanently deleted and cannot be recovered.</span>
-		</li>
-	</ul>
+	<p><strong>Please note:</strong></p>
+	<p>
+		<span style="font-weight: normal;">
+			The download option will be available for <strong><%= @info[:download_expire_days] %> days</strong>. Please download and store the file securely during that time.<br>
+			Your data will remain available for an extra <strong><%= @info[:download_expire_extended_days] %> days</strong> after this period. After that, the data will be permanently deleted and cannot be recovered.
+
+		</span>
+	</p>
+
 	<p><strong>Still using Check?</strong></p>
-	<p><span style="font-weight: normal;">If your workspace is active and you believe you're receiving this message in error, please reach out to us at <%= CheckConfig.get('support_email') %> as soon as possible so we can look into it.</span></p>
+	<p>
+		<span style="font-weight: normal;">
+			If your workspace is active and you believe you're receiving this message in error, please reach out to us at <%= CheckConfig.get('support_email') %> as soon as possible, and we will respond accordingly.
+		</span>
+	</p>
 </div>

--- a/app/views/sunset_mailer/_notify_low_usage_copy.html.erb
+++ b/app/views/sunset_mailer/_notify_low_usage_copy.html.erb
@@ -25,7 +25,7 @@
 	<p>
 		<strong>Your data:</strong>
 		<span style="font-weight: normal;">
-			If you'd like to keep your workspace data, you'll need to download it before we discontinue your workspace. On <%= @info[:low_usage_download_link_date].strftime("%B %-d") %>, an email will be sent notifying you that the data is available for download. After authentication, all workspace data can be downloaded directly from the workspace by admins only. Data will include:
+			If you'd like to keep your workspace data, you'll need to download it before we discontinue your workspace. On <%= @info[:low_usage_download_link_date].strftime("%B %-d") %>, an email will be sent notifying you with instructions to download it. Data will include:
 		</span>
 	</p>
 

--- a/app/views/sunset_mailer/_notify_low_usage_copy.text.erb
+++ b/app/views/sunset_mailer/_notify_low_usage_copy.text.erb
@@ -1,26 +1,24 @@
 We're writing to let you know about some housekeeping we're doing across <%= CheckConfig.get('app_name') %>.
+To keep the platform running smoothly and securely for everyone, we're reviewing workspace activity across Check and closing out workspaces that have gone unused for the past 6 months. This helps us to keep our infrastructure lean and focused on active workspaces. Based on our records, the workspace <%= link_to(@info[:workspace], @info[:workspace_url], :class => 'link', :style => "color: #0d6cf7 !important; text-decoration: none;") %>, for which you are an admin, has seen no recent activity and thus falls into this group.
 
-To keep the platform running smoothly and securely for everyone, we're reviewing workspace activity across Check and closing out accounts that have gone unused for an extended period. This helps keep our systems lean and focus our infrastructure on active workspaces. Based on our records, the workspace <%= link_to(@info[:workspace], @info[:workspace_url]) %>, which you&rsquo;re an admin of, hasn't seen recent activity and falls into this group.
+What this means for you:
+The Check workspace mentioned above will be unavailable starting on <%= @info[:low_usage_end_date].strftime("%B %-d") %>. After this date, admins will retain limited access only to download workspace data, as described below.
 
-What this means
+Your data:
+If you'd like to keep your workspace data, you'll need to download it before we discontinue your workspace. On <%= @info[:low_usage_download_link_date].strftime("%B %-d") %>, an email will be sent notifying you that the data is available for download. After authentication, all workspace data can be downloaded directly from the workspace by admins only. Data will include:
+- Workspace information &mdash; name, URL, creation date, activity, users, and integrations
+- Users and access &mdash; names, emails, roles, join dates, and access details
+- Articles &mdash; titles, summaries, URLs, languages, and report status
+- Claims, links, and media &mdash; titles, descriptions, dates, tags, status, sources, and media info
+- Tipline requests &mdash; submitted text, language, platform, date, and associated items
+- Tasks and claim assessments &mdash; tasks and answers for each item
 
-	Your Check workspace will be unavailable starting on <%= @info[:low_usage_end_date].strftime("%B %-d") %>. After this date, you'll no longer be able to access the platform with this account.
+Newsletter and annotation data
 
-Your data
-
-	If you'd like to keep a copy of your workspace data, you'll need to download it before it's removed. On 
-	<%= @info[:low_usage_download_link_date].strftime("%B %-d") %>, we'll send workspace admins a link to download a ZIP export containing:
-	
-	- Workspace information &mdash; name, URL, creation date, activity, users, and integrations
-	- Users and access &mdash; names, emails, roles, join dates, and access details
-	- Articles &mdash; titles, summaries, URLs, languages, and report status
-	- Claims, links, and media &mdash; titles, descriptions, dates, tags, status, sources, and media info
-	- Tipline requests &mdash; submitted text, language, platform, date, and associated items
-	- Tasks and claim assessments &mdash; tasks and answers for each item
-	- Newsletter and Annotation data
 Please note:
-	- The download link will expire <%= @info[:download_expire_days] %> days after it's sent, so download and store the file securely before then.
-	- Your data will remain available for an extra <%= @info[:download_expire_extended_days] %> days after the link expires. After that, the data will be permanently deleted and cannot be recovered.
-	
+The download option will be available for <%= @info[:download_expire_days] %> days. Please download and store the file securely during that time.
+Your data will remain available for an extra <%= @info[:download_expire_extended_days] %> days after this period. After that, the data will be permanently deleted and cannot be recovered.
+
 Still using Check?
-	If your workspace is active and you believe you're receiving this message in error, please reach out to us at <%= CheckConfig.get('support_email') %> as soon as possible so we can look into it.
+
+If your workspace is active and you believe you're receiving this message in error, please reach out to us at <%= CheckConfig.get('support_email') %> as soon as possible, and we will respond accordingly.

--- a/app/views/sunset_mailer/_notify_low_usage_copy.text.erb
+++ b/app/views/sunset_mailer/_notify_low_usage_copy.text.erb
@@ -5,7 +5,7 @@ What this means for you:
 The Check workspace mentioned above will be unavailable starting on <%= @info[:low_usage_end_date].strftime("%B %-d") %>. After this date, admins will retain limited access only to download workspace data, as described below.
 
 Your data:
-If you'd like to keep your workspace data, you'll need to download it before we discontinue your workspace. On <%= @info[:low_usage_download_link_date].strftime("%B %-d") %>, an email will be sent notifying you that the data is available for download. After authentication, all workspace data can be downloaded directly from the workspace by admins only. Data will include:
+If you'd like to keep your workspace data, you'll need to download it before we discontinue your workspace. On <%= @info[:low_usage_download_link_date].strftime("%B %-d") %>, an email will be sent notifying you with instructions to download it. Data will include:
 - Workspace information &mdash; name, URL, creation date, activity, users, and integrations
 - Users and access &mdash; names, emails, roles, join dates, and access details
 - Articles &mdash; titles, summaries, URLs, languages, and report status

--- a/app/workers/check_data_export_worker.rb
+++ b/app/workers/check_data_export_worker.rb
@@ -1,0 +1,10 @@
+class CheckDataExportWorker
+  include Sidekiq::Worker
+
+  sidekiq_options retry: 0
+
+  def perform(id)
+    de = CheckDataExport.find_by_id(id)
+    de.regenerate_download_url unless de.nil?
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -115,6 +115,7 @@ en:
       platform_allowed_values_error: 'cannot be of type %{type}, allowed types: %{allowed_types}'
       restrict_registration_to_invited_users_only: 'Looks like you don’t have an invitation yet. Please request one from your workspace.'
       article_character_limit_reached: Character Limit Reached.
+      check_export_data_user_must_be_admin_member: Sorry, the user must be an admin member of the workspace.
   activerecord:
     models:
       link: Link

--- a/db/migrate/20260901165331_create_check_data_exports.rb
+++ b/db/migrate/20260901165331_create_check_data_exports.rb
@@ -1,0 +1,13 @@
+class CreateCheckDataExports < ActiveRecord::Migration[6.1]
+  def change
+    create_table :check_data_exports do |t|
+      t.references :user, foreign_key: true
+      t.references :team, foreign_key: true
+      t.string :download_url
+      t.datetime :generated_at
+      t.datetime :expired_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260901165331_create_check_data_exports.rb
+++ b/db/migrate/20260901165331_create_check_data_exports.rb
@@ -2,11 +2,11 @@ class CreateCheckDataExports < ActiveRecord::Migration[6.1]
   def change
     create_table :check_data_exports do |t|
       t.references :user, foreign_key: true
-      t.references :team, foreign_key: true
+      t.references :team, null: false, foreign_key: true, index: { unique: true }
       t.string :s3_key
       t.string :download_url, null: false
       t.datetime :generated_at
-      t.datetime :expired_at
+      t.datetime :expired_at, null: false
       t.boolean :auto_extend_url_expiry, default: false
       t.timestamps
     end

--- a/db/migrate/20260901165331_create_check_data_exports.rb
+++ b/db/migrate/20260901165331_create_check_data_exports.rb
@@ -3,10 +3,11 @@ class CreateCheckDataExports < ActiveRecord::Migration[6.1]
     create_table :check_data_exports do |t|
       t.references :user, foreign_key: true
       t.references :team, foreign_key: true
-      t.string :download_url
+      t.string :s3_key
+      t.string :download_url, null: false
       t.datetime :generated_at
       t.datetime :expired_at
-
+      t.boolean :auto_extend_url_expiry, default: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2026_03_25_140013) do
+ActiveRecord::Schema.define(version: 2026_09_01_165331) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -236,6 +236,18 @@ ActiveRecord::Schema.define(version: 2026_03_25_140013) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_bounces_on_email", unique: true
+  end
+
+  create_table "check_data_exports", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "team_id"
+    t.string "download_url"
+    t.datetime "generated_at"
+    t.datetime "expired_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["team_id"], name: "index_check_data_exports_on_team_id"
+    t.index ["user_id"], name: "index_check_data_exports_on_user_id"
   end
 
   create_table "claim_descriptions", force: :cascade do |t|
@@ -983,6 +995,8 @@ ActiveRecord::Schema.define(version: 2026_03_25_140013) do
     t.index ["team_id"], name: "index_versions_on_team_id"
   end
 
+  add_foreign_key "check_data_exports", "teams"
+  add_foreign_key "check_data_exports", "users"
   add_foreign_key "claim_descriptions", "project_medias"
   add_foreign_key "claim_descriptions", "users"
   add_foreign_key "explainer_items", "explainers"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -240,15 +240,15 @@ ActiveRecord::Schema.define(version: 2026_09_01_165331) do
 
   create_table "check_data_exports", force: :cascade do |t|
     t.bigint "user_id"
-    t.bigint "team_id"
+    t.bigint "team_id", null: false
     t.string "s3_key"
-    t.string "download_url"
+    t.string "download_url", null: false
     t.datetime "generated_at"
-    t.datetime "expired_at"
+    t.datetime "expired_at", null: false
     t.boolean "auto_extend_url_expiry", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["team_id"], name: "index_check_data_exports_on_team_id"
+    t.index ["team_id"], name: "index_check_data_exports_on_team_id", unique: true
     t.index ["user_id"], name: "index_check_data_exports_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -241,9 +241,11 @@ ActiveRecord::Schema.define(version: 2026_09_01_165331) do
   create_table "check_data_exports", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "team_id"
+    t.string "s3_key"
     t.string "download_url"
     t.datetime "generated_at"
     t.datetime "expired_at"
+    t.boolean "auto_extend_url_expiry", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["team_id"], name: "index_check_data_exports_on_team_id"

--- a/lib/check_basic_abilities.rb
+++ b/lib/check_basic_abilities.rb
@@ -39,6 +39,11 @@ module CheckBasicAbilities
       tmp.archived = CheckArchivedFlags::FlagCodes::NONE
       can?(:update, tmp)
     end
+
+    can :read, CheckDataExport do |obj|
+      is_admin_member = TeamUser.where(user_id: @user.id, team_id: obj.team_id, role: 'admin', status: 'member').exists?
+      obj.user_id == @user.id && is_admin_member
+    end
   end
 
   # Extra permissions for all users

--- a/lib/check_basic_abilities.rb
+++ b/lib/check_basic_abilities.rb
@@ -42,7 +42,7 @@ module CheckBasicAbilities
 
     can :read, CheckDataExport do |obj|
       is_admin_member = TeamUser.where(user_id: @user.id, team_id: obj.team_id, role: 'admin', status: 'member').exists?
-      obj.user_id == @user.id && is_admin_member
+      obj.user_id == @user.id && is_admin_member && Time.current < obj.expired_at
     end
   end
 

--- a/lib/check_s3.rb
+++ b/lib/check_s3.rb
@@ -68,12 +68,17 @@ class CheckS3
     client.delete_objects(bucket: CheckConfig.get('storage_bucket'), delete: { objects: objects })
   end
 
-  def self.write_presigned(path, content_type, content, expires_in, bucket=nil, acl = 'public-read')
+  def self.presigned_url(path, expires_in, bucket = nil)
     bucket ||= CheckConfig.get('storage_bucket')
-    self.write(path, content_type, content, bucket, acl)
     client = Aws::S3::Client.new
     s3 = Aws::S3::Resource.new(client: client)
     obj = s3.bucket(bucket).object(path)
     obj.presigned_url(:get, expires_in: expires_in)
+  end
+
+  def self.write_presigned(path, content_type, content, expires_in, bucket=nil, acl = 'public-read')
+    bucket ||= CheckConfig.get('storage_bucket')
+    self.write(path, content_type, content, bucket, acl)
+    self.presigned_url(path, expires_in, bucket)
   end
 end

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -8675,6 +8675,7 @@ type Me implements Node {
   updated_at: String
   user_teams: String
   uuid: String
+  workspaces_download_url: JsonStringType
 }
 
 """

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -12539,6 +12539,7 @@ type Team implements Node {
   check_search_trash: CheckSearch
   check_search_unconfirmed: CheckSearch
   created_at: String
+  data_export_download_url: String
   data_report: JsonStringType
   dbid: Int
   description: String

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -8675,7 +8675,7 @@ type Me implements Node {
   updated_at: String
   user_teams: String
   uuid: String
-  workspaces_download_url: JsonStringType
+  workspaces_data_export_url: JsonStringType
 }
 
 """

--- a/lib/relay.idl
+++ b/lib/relay.idl
@@ -12540,7 +12540,6 @@ type Team implements Node {
   check_search_trash: CheckSearch
   check_search_unconfirmed: CheckSearch
   created_at: String
-  data_export_download_url: String
   data_report: JsonStringType
   dbid: Int
   description: String

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -1170,4 +1170,16 @@ module SampleData
     rr.save!
     rr.reload
   end
+
+  def create_check_data_export(options = {})
+    options[:team] = create_team unless options.has_key?(:team)
+    options[:user] = create_user unless options.has_key?(:user)
+    de = CheckDataExport.new
+    options.each do |k, v|
+      de.send("#{k}=", v) if de.respond_to?("#{k}=")
+    end
+    de.skip_check_ability = true
+    de.save!
+    de.reload
+  end
 end

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -1174,6 +1174,7 @@ module SampleData
   def create_check_data_export(options = {})
     options[:team] = create_team unless options.has_key?(:team)
     options[:user] = create_user unless options.has_key?(:user)
+    options[:download_url] = random_url unless options.has_key?(:download_url)
     de = CheckDataExport.new
     options.each do |k, v|
       de.send("#{k}=", v) if de.respond_to?("#{k}=")

--- a/lib/sample_data.rb
+++ b/lib/sample_data.rb
@@ -1175,6 +1175,7 @@ module SampleData
     options[:team] = create_team unless options.has_key?(:team)
     options[:user] = create_user unless options.has_key?(:user)
     options[:download_url] = random_url unless options.has_key?(:download_url)
+    options[:expired_at] = Time.current unless options.has_key?(:expired_at)
     de = CheckDataExport.new
     options.each do |k, v|
       de.send("#{k}=", v) if de.respond_to?("#{k}=")

--- a/lib/tasks/data/check_sunset.rake
+++ b/lib/tasks/data/check_sunset.rake
@@ -48,6 +48,19 @@ namespace :check do
       end
     end
 
+    def save_download_url(team_id, user_id, download_url)
+      current_time = Time.now.utc
+      de = CheckDataExport.where(team_id: team_id).first
+      de ||= CheckDataExport.new
+      de.user_id = user_id
+      de.team_id = team_id
+      de.download_url = download_url
+      de.generated_at = current_time
+      de.expired_at = current_time + 7.days
+      de.skip_check_ability = true
+      de.save!
+    end
+
     # bundle exec rails check:sunset:notify_workspace_admins[team-slug, high:low]
     task :notify_workspace_admins, [:slug, :priority] => :environment do |_t, args|
       slug = args[:slug].to_s
@@ -442,6 +455,8 @@ namespace :check do
             s3_url = CheckS3.write_presigned("#{team.slug}/#{SecureRandom.hex(16)}/#{team.slug}.zip", 'application/zip', zip_content, 7.days.to_i, bucket_name, 'private')
             key = Shortener::ShortenedUrl.generate!(s3_url).unique_key
             download_url = CheckConfig.get('short_url_host') + '/' + key
+            # Save Download URL
+            save_download_url(team.id, user.id, download_url)
             puts "Download link (valid for 7 days): #{download_url}"
           rescue StandardError => e
             puts "Failed to upload exported data #{e.message}"

--- a/lib/tasks/data/check_sunset.rake
+++ b/lib/tasks/data/check_sunset.rake
@@ -48,15 +48,19 @@ namespace :check do
       end
     end
 
-    def save_download_url(team_id, user_id, download_url)
-      current_time = Time.now.utc
+    def save_download_url(team_id, user_id, s3_key, download_url)
+      current_time = Time.current
+      download_expire_days = CheckConfig.get('check_sunset_download_expire_days', 15, :integer)
+      max_s3_allowed_days = CheckConfig.get('check_sunset_s3_max_expire_days', 7, :integer)
       de = CheckDataExport.where(team_id: team_id).first
       de ||= CheckDataExport.new
       de.user_id = user_id
       de.team_id = team_id
+      de.s3_key = s3_key
       de.download_url = download_url
       de.generated_at = current_time
-      de.expired_at = current_time + 7.days
+      de.expired_at = current_time + download_expire_days.days
+      de.auto_extend_url_expiry = download_expire_days > max_s3_allowed_days
       de.skip_check_ability = true
       de.save!
     end
@@ -452,12 +456,14 @@ namespace :check do
           bucket_name = ENV.fetch('EXPORT_OUTPUT_BUCKET')
           begin
             zip_content = File.binread(zip_path)
-            s3_url = CheckS3.write_presigned("#{team.slug}/#{SecureRandom.hex(16)}/#{team.slug}.zip", 'application/zip', zip_content, 7.days.to_i, bucket_name, 'private')
+            s3_key = "#{team.slug}/#{SecureRandom.hex(16)}/#{team.slug}.zip"
+            expire_days = [CheckConfig.get('check_sunset_s3_max_expire_days', 7, :integer), CheckConfig.get('check_sunset_download_expire_days', 15, :integer)].min
+            s3_url = CheckS3.write_presigned(s3_key, 'application/zip', zip_content, expire_days.days.to_i, bucket_name, 'private')
             key = Shortener::ShortenedUrl.generate!(s3_url).unique_key
             download_url = CheckConfig.get('short_url_host') + '/' + key
             # Save Download URL
-            save_download_url(team.id, user.id, download_url)
-            puts "Download link (valid for 7 days): #{download_url}"
+            save_download_url(team.id, user.id, s3_key, download_url)
+            puts "Download link (valid for #{expire_days} days): #{download_url}"
           rescue StandardError => e
             puts "Failed to upload exported data #{e.message}"
           ensure

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -19,8 +19,6 @@ ENV LANGUAGE=C.UTF-8
 #
 RUN useradd ${DEPLOYUSER} -s /bin/bash -m
 
-RUN apt-get update -qq && apt-get install -y curl
-
 # Use Debian Snapshot because Bullseye reached EOL on August 31, 2026.
 RUN printf '%s\n' \
     'deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20260805T215856Z bullseye main' \
@@ -31,6 +29,7 @@ RUN printf '%s\n' \
     && apt-get update
 
 RUN apt-get install --no-install-recommends -y \
+        curl \
         build-essential \
         ffmpegthumbnailer \
         ffmpeg \

--- a/public/relay.json
+++ b/public/relay.json
@@ -65381,6 +65381,20 @@
               "deprecationReason": null
             },
             {
+              "name": "data_export_download_url",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
+            },
+            {
               "name": "data_report",
               "description": null,
               "args": [

--- a/public/relay.json
+++ b/public/relay.json
@@ -46360,6 +46360,20 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "workspaces_download_url",
+              "description": null,
+              "args": [
+
+              ],
+              "type": {
+                "kind": "SCALAR",
+                "name": "JsonStringType",
+                "ofType": null
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,

--- a/public/relay.json
+++ b/public/relay.json
@@ -46362,7 +46362,7 @@
               "deprecationReason": null
             },
             {
-              "name": "workspaces_download_url",
+              "name": "workspaces_data_export_url",
               "description": null,
               "args": [
 

--- a/public/relay.json
+++ b/public/relay.json
@@ -65395,20 +65395,6 @@
               "deprecationReason": null
             },
             {
-              "name": "data_export_download_url",
-              "description": null,
-              "args": [
-
-              ],
-              "type": {
-                "kind": "SCALAR",
-                "name": "String",
-                "ofType": null
-              },
-              "isDeprecated": false,
-              "deprecationReason": null
-            },
-            {
               "name": "data_report",
               "description": null,
               "args": [

--- a/test/models/check_data_export_test.rb
+++ b/test/models/check_data_export_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class CheckDataExportTest < ActiveSupport::TestCase
+  test "should create data export" do
+    t = create_team
+    u = create_user
+    create_team_user team: t, user: u, role: 'admin'
+    assert_difference 'CheckDataExport.count' do
+      create_check_data_export team: t, user: u
+    end
+  end
+
+  test "Should set team and CheckDataExport" do
+    t = create_team
+    u = create_user
+    create_team_user team: t, user: u, role: 'admin'
+    assert_no_difference 'CheckDataExport.count' do
+      assert_raises ActiveRecord::RecordInvalid do
+        create_check_data_export team: nil
+      end
+    end
+    assert_no_difference 'CheckDataExport.count' do
+      assert_raises ActiveRecord::RecordInvalid do
+        create_check_data_export user: nil
+      end
+    end
+  end
+
+  test "should not duplicate team" do
+    t = create_team
+    u = create_user
+    create_team_user team: t, user: u, role: 'admin'
+    create_check_data_export team: t, user: u
+    assert_no_difference 'CheckDataExport.count' do
+      assert_raises ActiveRecord::RecordInvalid do
+        create_check_data_export team: t, user: u
+      end
+    end
+  end
+
+  test "should be an admin member in team" do
+    t = create_team
+    u = create_user
+    create_team_user team: t, user: u, role: 'editor'
+    assert_no_difference 'CheckDataExport.count' do
+      assert_raises ActiveRecord::RecordInvalid do
+        create_check_data_export team: t, user: u
+      end
+    end
+  end
+end

--- a/test/models/check_data_export_test.rb
+++ b/test/models/check_data_export_test.rb
@@ -68,6 +68,7 @@ class CheckDataExportTest < ActiveSupport::TestCase
         travel_to(current_time + 7.days) do
           new_url = random_url
           CheckS3.stubs(:presigned_url).returns(new_url)
+          # Run existing background job should trigger another job and set auto_extend_url_expiry = true
           CheckDataExportWorker.perform_one
           assert de.reload.auto_extend_url_expiry
           assert_equal new_url, short_url.reload.url
@@ -76,6 +77,7 @@ class CheckDataExportTest < ActiveSupport::TestCase
         travel_to(current_time + 14.days) do
            new_url = random_url
           CheckS3.stubs(:presigned_url).returns(new_url)
+          # Run existing background job should not trigger another job and set auto_extend_url_expiry = false
           CheckDataExportWorker.perform_one
           assert_not de.reload.auto_extend_url_expiry
           assert_equal new_url, short_url.reload.url

--- a/test/models/check_data_export_test.rb
+++ b/test/models/check_data_export_test.rb
@@ -48,4 +48,40 @@ class CheckDataExportTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test "should regenerate download url" do
+    t = create_team
+    u = create_user
+    create_team_user team: t, user: u, role: 'admin'
+    s3_url = random_url
+    short_url = Shortener::ShortenedUrl.generate!(s3_url)
+    download_url = CheckConfig.get('short_url_host') + '/' + short_url.unique_key
+    stub_configs({ 'check_sunset_download_expire_days' => 15, 'check_sunset_s3_max_expire_days' => 7 }) do
+      Sidekiq::Testing.fake! do
+        Sidekiq::Worker.clear_all
+        assert_equal 0, CheckDataExportWorker.jobs.size
+        current_time = Time.current
+        download_expire_days = CheckConfig.get('check_sunset_download_expire_days', 15, :integer)
+        expired_at = current_time + download_expire_days.days
+        de = create_check_data_export team: t, user: u, download_url: download_url, generated_at: current_time, expired_at: expired_at, auto_extend_url_expiry: true
+        assert_equal 1, CheckDataExportWorker.jobs.size
+        travel_to(current_time + 7.days) do
+          new_url = random_url
+          CheckS3.stubs(:presigned_url).returns(new_url)
+          CheckDataExportWorker.perform_one
+          assert de.reload.auto_extend_url_expiry
+          assert_equal new_url, short_url.reload.url
+          assert_equal 1, CheckDataExportWorker.jobs.size
+        end
+        travel_to(current_time + 14.days) do
+           new_url = random_url
+          CheckS3.stubs(:presigned_url).returns(new_url)
+          CheckDataExportWorker.perform_one
+          assert_not de.reload.auto_extend_url_expiry
+          assert_equal new_url, short_url.reload.url
+          assert_equal 0, CheckDataExportWorker.jobs.size
+        end
+      end
+    end
+  end
 end

--- a/test/models/check_data_export_test.rb
+++ b/test/models/check_data_export_test.rb
@@ -49,6 +49,32 @@ class CheckDataExportTest < ActiveSupport::TestCase
     end
   end
 
+  test "read ability for CheckDataExport" do
+    u = create_user
+    t = create_team
+    u2 = create_user
+    tu = create_team_user user: u , team: t, role: 'admin'
+    create_team_user user: u2 , team: t, role: 'admin'
+    de = create_check_data_export team: t, user: u, expired_at: Time.current + 7.days
+    with_current_user_and_team(u, t) do
+      ability = Ability.new
+      assert ability.can?(:read, de)
+      de.expired_at = Time.current - 7.days
+      de.save!
+      assert ability.cannot?(:read, de)
+    end
+    with_current_user_and_team(u2, t) do
+      ability = Ability.new
+      assert ability.cannot?(:read, de)
+    end
+    tu.role = 'editor'
+    tu.save!
+    with_current_user_and_team(u, t) do
+      ability = Ability.new
+      assert ability.cannot?(:read, de)
+    end
+  end
+
   test "should regenerate download url" do
     t = create_team
     u = create_user


### PR DESCRIPTION
## Description

Add a download link to Check app to allow admin user to download exported data

- [x] Update the `export_upload_and_send_workspace_data` rake task to accept workspace slug and email.
- [x] Verify that the email belongs to an active member of that workspace with admin role.
- [x] Add a new CheckExportedData model
- [x] Regenerate a download link 
- [x] Modify notification email copy

References: CV2-6740

## How to test?

Add unit tests

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
