### PR TITLE
CV2-6724: Exclude Meedan emails from sunset notification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN printf '%s\n' \
     && apt-get update
 
 RUN apt-get install --no-install-recommends -y \
+        screen \
+        vim \
         curl \
         build-essential \
         ffmpegthumbnailer \

--- a/lib/tasks/data/check_sunset.rake
+++ b/lib/tasks/data/check_sunset.rake
@@ -76,7 +76,9 @@ namespace :check do
         mail_type = "notify_#{priority}_usage"
         to_mails = team.team_users.where(status: 'member', role: 'admin').map(&:user).map(&:email).compact
         # Send email
-        User.where(email: to_mails).find_each do |user|
+        User.where(email: to_mails)
+        .where.not("email ILIKE ? OR email ILIKE ?", "%@meedan.com", "%@meedan.org")
+        .find_each do |user|
           puts "Sending email to #{user.email}\n"
           SunsetMailer.delay.notify(mail_type, user, team.name, team.url)
         end

--- a/production/Dockerfile
+++ b/production/Dockerfile
@@ -29,6 +29,8 @@ RUN printf '%s\n' \
     && apt-get update
 
 RUN apt-get install --no-install-recommends -y \
+        screen \
+        vim \
         curl \
         build-essential \
         ffmpegthumbnailer \


### PR DESCRIPTION
## Description

- Exclude Meedan emails `@meedan.org` and `@meedan.com` form sunsetting notification 
- Add screen and vim to apt-get install as I could not install these packages as Debian 11 reached its standard End-of-Life (EOL)

References: CV2-6724

## How to test?

Re-run tests

## Checklist

- [x] I have performed a self-review of my code and ensured that it is safe and runnable, that code coverage has not decreased, and that there are no new Code Climate issues. I have also followed [Meedan's internal coding guidelines](https://meedan.atlassian.net/wiki/spaces/ENG/pages/1309605889/Coding+guidelines).
